### PR TITLE
Fix collinear overlap ownership gaps in UniformGrid noding

### DIFF
--- a/src/noding/grid.rs
+++ b/src/noding/grid.rs
@@ -127,6 +127,17 @@ impl UniformGrid {
         }
     }
 
+    #[inline]
+    fn owner_cell_for_point(&self, pt: Coord<f64>) -> (usize, usize) {
+        let col = ((pt.x - self.bounds_min.x) / self.cell_size).floor() as isize;
+        let row = ((pt.y - self.bounds_min.y) / self.cell_size).floor() as isize;
+
+        let col = col.clamp(0, self.cols.saturating_sub(1) as isize) as usize;
+        let row = row.clamp(0, self.rows.saturating_sub(1) as isize) as usize;
+
+        (col, row)
+    }
+
     /// Finds all intersections. Uses "Intersection Ownership" to deduplicate checks.
     pub fn find_splits(
         &self,
@@ -193,13 +204,10 @@ impl UniformGrid {
                                     // Collinear is rare. Just process start/end and let HashMap dedup later.
                                     let p1 = snap_noder.snap(overlap.start);
                                     let p2 = snap_noder.snap(overlap.end);
-                                    // Simplified ownership: Check if p1 is in cell
-                                    let p1_in = p1.x >= cell_min_x
-                                        && p1.x < cell_max_x
-                                        && p1.y >= cell_min_y
-                                        && p1.y < cell_max_y;
-                                    if p1_in || (c == 0 && r == 0) {
-                                        // Fallback to process at least once
+                                    // Deterministic ownership: map p1 to a canonical owner cell.
+                                    // This avoids the non-origin fallback gap for boundary points.
+                                    let (owner_c, owner_r) = self.owner_cell_for_point(p1);
+                                    if c == owner_c && r == owner_r {
                                         for p in [p1, p2] {
                                             if p != l1.start && p != l1.end {
                                                 splits.entry(idx1).or_default().push(p);


### PR DESCRIPTION
### Motivation
- The previous collinear ownership rule used a `p1` containment check with a `(c == 0 && r == 0)` fallback which can miss collinear split events when no iterated cell claims a boundary/precision point, leading to under-segmentation. 
- The change makes ownership deterministic so each collinear overlap is assigned to exactly one canonical cell and therefore processed once.

### Description
- Add `owner_cell_for_point` to `UniformGrid` to map a snapped point to a canonical owner cell using `floor` on grid coordinates and clamped indices. 
- Replace the collinear-path fallback in `UniformGrid::find_splits` with a check that processes the overlap only when the current `(c,r)` equals the computed owner cell. 
- Implementation is contained in `src/noding/grid.rs` and retains the existing split recording and HashMap-based deduplication.

### Testing
- Ran `cargo test test_grid_vs_simd_equivalence`, which passed. 
- Ran the full test suite with `cargo test`, and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69974be230f4832fb0a921fee50f7725)