### PR TITLE
Integrate rust-magic-linter rules and fix unwrap/expect usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,3 +52,14 @@ strip = true    # Removes symbols
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false
+
+[lints.clippy]
+# pedantic = { level = "warn", priority = -1 } # Uncomment to enable pedantic lints
+unwrap_used = "deny"
+expect_used = "deny"
+panic = "deny"
+allow_attributes = "deny"
+dbg_macro = "deny"
+todo = "deny"
+print_stdout = "deny"
+print_stderr = "deny"

--- a/src/graph/tests.rs
+++ b/src/graph/tests.rs
@@ -4,7 +4,7 @@ mod tests {
     use geo_types::{Coord, LineString};
 
     #[test]
-    fn test_graph_construction() {
+    fn test_graph_construction() -> Result<(), Box<dyn std::error::Error>> {
         let mut graph = PlanarGraph::new();
         let l1 = LineString::from(vec![(0.0, 0.0), (10.0, 0.0)]);
         let l2 = LineString::from(vec![(0.0, 0.0), (0.0, 10.0)]);
@@ -17,12 +17,16 @@ mod tests {
         assert_eq!(graph.directed_edges.len(), 4);
 
         // Node at (0,0) should have 2 outgoing edges
-        let center_node_idx = graph.node_map.get(&Coord::from((0.0, 0.0)).into()).unwrap();
+        let center_node_idx = graph
+            .node_map
+            .get(&Coord::from((0.0, 0.0)).into())
+            .ok_or("Node not found")?;
         assert_eq!(graph.nodes_outgoing[*center_node_idx].len(), 2);
+        Ok(())
     }
 
     #[test]
-    fn test_edge_sorting() {
+    fn test_edge_sorting() -> Result<(), Box<dyn std::error::Error>> {
         let mut graph = PlanarGraph::new();
         // Add 4 edges radiating from (0,0)
         // 1. Right (0 degrees) -> dx=10, dy=0
@@ -36,7 +40,10 @@ mod tests {
 
         graph.sort_edges();
 
-        let center_node_idx = graph.node_map.get(&Coord::from((0.0, 0.0)).into()).unwrap();
+        let center_node_idx = graph
+            .node_map
+            .get(&Coord::from((0.0, 0.0)).into())
+            .ok_or("Node not found")?;
 
         let edges = &graph.nodes_outgoing[*center_node_idx];
         assert_eq!(edges.len(), 4);
@@ -78,10 +85,11 @@ mod tests {
             "Expected Down (0, -10), got {:?}",
             dst3
         );
+        Ok(())
     }
 
     #[test]
-    fn test_dangle_pruning() {
+    fn test_dangle_pruning() -> Result<(), Box<dyn std::error::Error>> {
         let mut graph = PlanarGraph::new();
         // Triangle with a dangle
         graph.add_line_string(LineString::from(vec![(0.0, 0.0), (10.0, 0.0)]));
@@ -99,8 +107,9 @@ mod tests {
         let b_idx = graph
             .node_map
             .get(&Coord::from((10.0, 0.0)).into())
-            .unwrap();
+            .ok_or("Node not found")?;
         assert_eq!(graph.nodes_degree[*b_idx], 2);
+        Ok(())
     }
 
     #[test]

--- a/src/noding/snap.rs
+++ b/src/noding/snap.rs
@@ -379,14 +379,19 @@ mod tests {
         );
 
         for (idx, points_rtree) in &splits_rtree {
-            let points_simd = splits_simd.get(idx).expect("Index missing in SIMD splits");
+            // Check existence first to avoid panic if missing (though indexing would panic too)
+            assert!(
+                splits_simd.contains_key(idx),
+                "Index missing in SIMD splits"
+            );
+            let points_simd = &splits_simd[idx];
 
             // Sort points to ensure order independence
             let mut p_rtree = points_rtree.clone();
-            p_rtree.sort_by(|a, b| (a.x, a.y).partial_cmp(&(b.x, b.y)).unwrap());
+            p_rtree.sort_by(|a, b| a.x.total_cmp(&b.x).then(a.y.total_cmp(&b.y)));
 
             let mut p_simd = points_simd.clone();
-            p_simd.sort_by(|a, b| (a.x, a.y).partial_cmp(&(b.x, b.y)).unwrap());
+            p_simd.sort_by(|a, b| a.x.total_cmp(&b.x).then(a.y.total_cmp(&b.y)));
 
             assert_eq!(p_rtree, p_simd, "Split points differ for line {}", idx);
         }

--- a/src/polygonizer.rs
+++ b/src/polygonizer.rs
@@ -3,7 +3,7 @@ use crate::graph::PlanarGraph;
 use geo::algorithm::centroid::Centroid;
 use geo::bounding_rect::BoundingRect;
 use geo::Area;
-use geo_types::{Coord, Geometry, LineString, Point, Polygon};
+use geo_types::{Coord, Geometry, LineString, Point, Polygon, Rect};
 use rstar::{RTree, RTreeObject, AABB};
 
 use crate::noding::snap::SnapNoder;
@@ -18,7 +18,10 @@ impl RTreeObject for IndexedPolygon {
     type Envelope = AABB<[f64; 2]>;
 
     fn envelope(&self) -> Self::Envelope {
-        let bbox = self.0.bounding_rect().unwrap();
+        let bbox = self
+            .0
+            .bounding_rect()
+            .unwrap_or(Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 0.0, y: 0.0 }));
         AABB::from_corners([bbox.min().x, bbox.min().y], [bbox.max().x, bbox.max().y])
     }
 }
@@ -254,7 +257,9 @@ impl Polygonizer {
         let process_hole_assignment =
             |hole_poly: &Polygon<f64>| -> Option<(usize, LineString<f64>)> {
                 let hole_ring = hole_poly.exterior();
-                let bbox = hole_poly.bounding_rect().unwrap();
+                let bbox = hole_poly
+                    .bounding_rect()
+                    .unwrap_or(Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 0.0, y: 0.0 }));
                 let hole_aabb =
                     AABB::from_corners([bbox.min().x, bbox.min().y], [bbox.max().x, bbox.max().y]);
 

--- a/src/polygonizer_tests.rs
+++ b/src/polygonizer_tests.rs
@@ -5,22 +5,23 @@ mod tests {
     use geo_types::LineString;
 
     #[test]
-    fn test_polygonize_simple_triangle() {
+    fn test_polygonize_simple_triangle() -> Result<(), Box<dyn std::error::Error>> {
         let mut poly = Polygonizer::new();
         poly.add_geometry(LineString::from(vec![(0.0, 0.0), (10.0, 0.0)]).into());
         poly.add_geometry(LineString::from(vec![(10.0, 0.0), (0.0, 10.0)]).into());
         poly.add_geometry(LineString::from(vec![(0.0, 10.0), (0.0, 0.0)]).into());
 
-        let polygons = poly.polygonize().unwrap();
+        let polygons = poly.polygonize()?;
         assert!(polygons.len() >= 1);
         let triangle = polygons
             .iter()
             .find(|p| p.unsigned_area() > 49.0 && p.unsigned_area() < 51.0);
         assert!(triangle.is_some());
+        Ok(())
     }
 
     #[test]
-    fn test_polygonize_hole() {
+    fn test_polygonize_hole() -> Result<(), Box<dyn std::error::Error>> {
         let mut poly = Polygonizer::new();
         // Outer square
         poly.add_geometry(
@@ -46,7 +47,7 @@ mod tests {
             .into(),
         );
 
-        let polygons = poly.polygonize().unwrap();
+        let polygons = poly.polygonize()?;
         assert_eq!(
             polygons.len(),
             2,
@@ -56,18 +57,19 @@ mod tests {
 
         let donut = polygons
             .iter()
-            .find(|p| (p.unsigned_area() - 64.0).abs() < 1.0);
-        assert!(donut.is_some(), "Donut polygon not found");
-        assert_eq!(donut.unwrap().interiors().len(), 1);
+            .find(|p| (p.unsigned_area() - 64.0).abs() < 1.0)
+            .ok_or("Donut polygon not found")?;
+        assert_eq!(donut.interiors().len(), 1);
 
         let island = polygons
             .iter()
             .find(|p| (p.unsigned_area() - 36.0).abs() < 1.0);
         assert!(island.is_some(), "Island polygon not found");
+        Ok(())
     }
 
     #[test]
-    fn test_noding_crossing_lines() {
+    fn test_noding_crossing_lines() -> Result<(), Box<dyn std::error::Error>> {
         let mut poly = Polygonizer::new();
         poly.node_input = true;
 
@@ -87,7 +89,7 @@ mod tests {
         poly.add_geometry(LineString::from(vec![(0.0, 0.0), (10.0, 10.0)]).into());
         poly.add_geometry(LineString::from(vec![(0.0, 10.0), (10.0, 0.0)]).into());
 
-        let polygons = poly.polygonize().expect("Polygonization failed");
+        let polygons = poly.polygonize()?;
         // Frame (empty because triangles are holes) + 4 Triangles
         // Wait, the logic assigns holes to shells.
         // Frame is OuterCCW (100) and OuterCW (-100).
@@ -113,10 +115,11 @@ mod tests {
             .filter(|p| (p.unsigned_area() - 25.0).abs() < 1e-6)
             .count();
         assert_eq!(triangles_count, 4, "Expected 4 triangles of area 25");
+        Ok(())
     }
 
     #[test]
-    fn test_noding_collinear_lines() {
+    fn test_noding_collinear_lines() -> Result<(), Box<dyn std::error::Error>> {
         let mut poly = Polygonizer::new();
         poly.node_input = true;
 
@@ -139,7 +142,7 @@ mod tests {
             LineString::from(vec![(10.0, 0.0), (10.0, 10.0), (5.0, 10.0), (5.0, 0.0)]).into(),
         );
 
-        let polygons = poly.polygonize().expect("Polygonization failed");
+        let polygons = poly.polygonize()?;
 
         // Should find the rectangle of area 50.
         let rect = polygons
@@ -149,5 +152,6 @@ mod tests {
             rect.is_some(),
             "Expected rectangle of area 50 from collinear overlap"
         );
+        Ok(())
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -4,7 +4,7 @@ use geo_types::{Coord, LineString};
 use std::f64::consts::PI;
 
 #[test]
-fn test_nested_holes() {
+fn test_nested_holes() -> Result<(), Box<dyn std::error::Error>> {
     let mut poly = Polygonizer::new();
 
     // Outer Box (0,0) - (100,100)
@@ -43,7 +43,7 @@ fn test_nested_holes() {
         .into(),
     );
 
-    let polygons = poly.polygonize().unwrap();
+    let polygons = poly.polygonize()?;
 
     // The polygonizer produces a full mesh:
     // 1. The Donut (Outer - Hole). Area = 10000 - 3600 = 6400.
@@ -69,11 +69,12 @@ fn test_nested_holes() {
         .iter()
         .find(|p| (p.unsigned_area() - 400.0).abs() < 1e-6);
     assert!(island.is_some(), "Island polygon with area 400 not found");
+    Ok(())
 }
 
 #[test]
 #[ignore]
-fn test_touching_polygons() {
+fn test_touching_polygons() -> Result<(), Box<dyn std::error::Error>> {
     let mut poly = Polygonizer::new();
     poly.node_input = true; // Required to deduplicate the shared edge
 
@@ -102,7 +103,7 @@ fn test_touching_polygons() {
         .into(),
     );
 
-    let polygons = poly.polygonize().unwrap();
+    let polygons = poly.polygonize()?;
 
     // Should find 3 polygons (Mesh behavior):
     // 1. Square 1 (Area 2500)
@@ -116,10 +117,11 @@ fn test_touching_polygons() {
         .filter(|p| (p.unsigned_area() - 2500.0).abs() < 1e-6)
         .count();
     assert_eq!(squares_count, 2, "Expected 2 squares of area 2500");
+    Ok(())
 }
 
 #[test]
-fn test_dangles() {
+fn test_dangles() -> Result<(), Box<dyn std::error::Error>> {
     let mut poly = Polygonizer::new();
     // A square with a tail
     poly.add_geometry(
@@ -136,13 +138,14 @@ fn test_dangles() {
     // Tail
     poly.add_geometry(LineString::from(vec![(10.0, 10.0), (20.0, 20.0)]).into());
 
-    let polygons = poly.polygonize().unwrap();
+    let polygons = poly.polygonize()?;
     assert_eq!(polygons.len(), 1);
     assert!((polygons[0].unsigned_area() - 100.0).abs() < 1e-6);
+    Ok(())
 }
 
 #[test]
-fn test_bowtie() {
+fn test_bowtie() -> Result<(), Box<dyn std::error::Error>> {
     let mut poly = Polygonizer::new();
     poly.node_input = true;
 
@@ -159,7 +162,7 @@ fn test_bowtie() {
         .into(),
     );
 
-    let polygons = poly.polygonize().unwrap();
+    let polygons = poly.polygonize()?;
 
     // Produces:
     // 1. Triangle 1 (Shell). Area 25.
@@ -173,6 +176,7 @@ fn test_bowtie() {
         .filter(|p| (p.unsigned_area() - 25.0).abs() < 1e-6)
         .count();
     assert_eq!(triangles, 2);
+    Ok(())
 }
 
 fn create_circle(x: f64, y: f64, r: f64, points: usize) -> LineString<f64> {
@@ -189,7 +193,7 @@ fn create_circle(x: f64, y: f64, r: f64, points: usize) -> LineString<f64> {
 }
 
 #[test]
-fn test_overlapping_circles() {
+fn test_overlapping_circles() -> Result<(), Box<dyn std::error::Error>> {
     let mut poly = Polygonizer::new();
     poly.node_input = true;
 
@@ -202,13 +206,14 @@ fn test_overlapping_circles() {
     poly.add_geometry(c2.into());
     poly.add_geometry(c3.into());
 
-    let polygons = poly.polygonize().unwrap();
+    let polygons = poly.polygonize()?;
     // Expect 8 (7 regions + 1 union).
     assert!(polygons.len() >= 7 && polygons.len() <= 8);
+    Ok(())
 }
 
 #[test]
-fn test_curved_holes() {
+fn test_curved_holes() -> Result<(), Box<dyn std::error::Error>> {
     let mut poly = Polygonizer::new();
     poly.node_input = true;
 
@@ -225,8 +230,9 @@ fn test_curved_holes() {
     poly.add_geometry(h3.into());
     poly.add_geometry(h4.into());
 
-    let polygons = poly.polygonize().unwrap();
+    let polygons = poly.polygonize()?;
 
     // Expect 5 (Outer + 4 holes).
     assert!(polygons.len() >= 5);
+    Ok(())
 }

--- a/tests/robustness.rs
+++ b/tests/robustness.rs
@@ -3,7 +3,7 @@ use geo_polygonize::Polygonizer;
 use geo_types::{Coord, LineString};
 
 #[test]
-fn test_bowtie_noding() {
+fn test_bowtie_noding() -> Result<(), Box<dyn std::error::Error>> {
     // A bowtie shape: (0,0) -> (10,10) -> (10,0) -> (0,10) -> (0,0)
     // Intersection at (5,5).
     let ls = LineString(vec![
@@ -19,18 +19,14 @@ fn test_bowtie_noding() {
     poly.snap_grid_size = 1e-6;
     poly.add_geometry(Geometry::LineString(ls));
 
-    let results = poly.polygonize().expect("Polygonization failed");
-
-    println!("Bowtie Results: {}", results.len());
-    for (i, p) in results.iter().enumerate() {
-        println!("Poly {}: {:?}", i, p);
-    }
+    let results = poly.polygonize()?;
 
     assert_eq!(results.len(), 2, "Expected 2 polygons from bowtie");
+    Ok(())
 }
 
 #[test]
-fn test_duplicate_edge_removal() {
+fn test_duplicate_edge_removal() -> Result<(), Box<dyn std::error::Error>> {
     let mut poly = Polygonizer::new();
     poly.node_input = true;
     poly.snap_grid_size = 1e-6;
@@ -57,6 +53,7 @@ fn test_duplicate_edge_removal() {
         Coord { x: 0.0, y: 0.0 },
     ])));
 
-    let results = poly.polygonize().expect("Polygonization failed");
+    let results = poly.polygonize()?;
     assert_eq!(results.len(), 1);
+    Ok(())
 }


### PR DESCRIPTION
Integrated `rust-magic-linter` rules to enforce stricter coding standards, focusing on panic safety. 

Key changes:
- Added `[lints.clippy]` configuration to `Cargo.toml` denying `unwrap_used`, `expect_used`, and `panic`. `pedantic` is currently commented out to avoid excessive noise/CI breakage.
- Fixed `unwrap()` usage in `src/polygonizer.rs` by providing safe fallbacks for bounding box calculations.
- Refactored tests in `src/noding/snap.rs`, `src/graph/tests.rs`, `src/polygonizer_tests.rs`, `tests/integration_tests.rs`, and `tests/robustness.rs` to return `Result<(), Box<dyn std::error::Error>>` and use the `?` operator instead of panicking methods.
- Replaced `partial_cmp().unwrap()` with robust `total_cmp` logic in `src/noding/snap.rs`.


---
*PR created automatically by Jules for task [6110156824672888364](https://jules.google.com/task/6110156824672888364) started by @graydonpleasants*