### PR TITLE
🧪 [testing improvement] Add edge case tests for empty Polygonizer input

### DIFF
--- a/src/polygonizer_tests.rs
+++ b/src/polygonizer_tests.rs
@@ -150,4 +150,37 @@ mod tests {
             "Expected rectangle of area 50 from collinear overlap"
         );
     }
+
+    #[test]
+    fn test_polygonize_empty_input() {
+        let mut poly = Polygonizer::new();
+        let polygons = poly
+            .polygonize()
+            .expect("Polygonization should not fail on empty input");
+        assert_eq!(polygons.len(), 0);
+    }
+
+    #[test]
+    fn test_polygonize_empty_linestring() {
+        let mut poly = Polygonizer::new();
+        // Add an empty LineString
+        poly.add_geometry(geo_types::Geometry::LineString(geo_types::LineString::new(
+            vec![],
+        )));
+        let polygons = poly
+            .polygonize()
+            .expect("Polygonization should not fail on empty LineString");
+        assert_eq!(polygons.len(), 0);
+    }
+
+    #[test]
+    fn test_polygonize_point() {
+        let mut poly = Polygonizer::new();
+        // Add a single point (should be ignored by extract_lines)
+        poly.add_geometry(geo_types::Geometry::Point(geo_types::Point::new(0.0, 0.0)));
+        let polygons = poly
+            .polygonize()
+            .expect("Polygonization should not fail on Point input");
+        assert_eq!(polygons.len(), 0);
+    }
 }


### PR DESCRIPTION
This PR adds edge case tests for the `Polygonizer` to ensure it handles empty inputs, empty `LineString` geometries, and `Point` geometries gracefully. The tests were added to `src/polygonizer_tests.rs` and verify that an empty vector is returned in these scenarios. While `cargo test` failed in the current environment due to missing dependencies, the logic was manually verified against the implementation in `src/polygonizer.rs` and `src/graph/planar_graph.rs`.

---
*PR created automatically by Jules for task [678099223826405695](https://jules.google.com/task/678099223826405695) started by @graydonpleasants*