### PR TITLE
🧹 Deduplicate Intersection Handling Logic

### DIFF
--- a/src/noding/grid.rs
+++ b/src/noding/grid.rs
@@ -177,14 +177,16 @@ impl UniformGrid {
                                             || (r == self.rows - 1 && pt.y <= cell_max_y));
 
                                     if is_in_x && is_in_y {
-                                        let snapped = snap_noder.snap(pt);
-                                        // Record splits
-                                        if snapped != l1.start && snapped != l1.end {
-                                            splits.entry(idx1).or_default().push(snapped);
-                                        }
-                                        if snapped != l2.start && snapped != l2.end {
-                                            splits.entry(idx2).or_default().push(snapped);
-                                        }
+                                        snap_noder.handle_intersection(
+                                            res,
+                                            idx1,
+                                            idx2,
+                                            l1,
+                                            l2,
+                                            |idx, pt| {
+                                                splits.entry(idx).or_default().push(pt);
+                                            },
+                                        );
                                     }
                                 }
                                 LineIntersection::Collinear {
@@ -192,22 +194,22 @@ impl UniformGrid {
                                 } => {
                                     // Collinear is rare. Just process start/end and let HashMap dedup later.
                                     let p1 = snap_noder.snap(overlap.start);
-                                    let p2 = snap_noder.snap(overlap.end);
                                     // Simplified ownership: Check if p1 is in cell
                                     let p1_in = p1.x >= cell_min_x
                                         && p1.x < cell_max_x
                                         && p1.y >= cell_min_y
                                         && p1.y < cell_max_y;
                                     if p1_in || (c == 0 && r == 0) {
-                                        // Fallback to process at least once
-                                        for p in [p1, p2] {
-                                            if p != l1.start && p != l1.end {
-                                                splits.entry(idx1).or_default().push(p);
-                                            }
-                                            if p != l2.start && p != l2.end {
-                                                splits.entry(idx2).or_default().push(p);
-                                            }
-                                        }
+                                        snap_noder.handle_intersection(
+                                            res,
+                                            idx1,
+                                            idx2,
+                                            l1,
+                                            l2,
+                                            |idx, pt| {
+                                                splits.entry(idx).or_default().push(pt);
+                                            },
+                                        );
                                     }
                                 }
                             }

--- a/src/noding/snap.rs
+++ b/src/noding/snap.rs
@@ -138,6 +138,47 @@ impl SnapNoder {
         }
     }
 
+    #[inline]
+    pub(crate) fn handle_intersection<F>(
+        &self,
+        res: LineIntersection<f64>,
+        i: usize,
+        j: usize,
+        l1: Line<f64>,
+        l2: Line<f64>,
+        mut handler: F,
+    ) where
+        F: FnMut(usize, Coord<f64>),
+    {
+        match res {
+            LineIntersection::SinglePoint {
+                intersection: pt, ..
+            } => {
+                let snapped = self.snap(pt);
+                if snapped != l1.start && snapped != l1.end {
+                    handler(i, snapped);
+                }
+                if snapped != l2.start && snapped != l2.end {
+                    handler(j, snapped);
+                }
+            }
+            LineIntersection::Collinear {
+                intersection: overlap,
+            } => {
+                let p1 = self.snap(overlap.start);
+                let p2 = self.snap(overlap.end);
+                for p in [p1, p2] {
+                    if p != l1.start && p != l1.end {
+                        handler(i, p);
+                    }
+                    if p != l2.start && p != l2.end {
+                        handler(j, p);
+                    }
+                }
+            }
+        }
+    }
+
     fn find_splits_simd(&self, lines: &[Line<f64>]) -> HashMap<usize, Vec<Coord<f64>>> {
         let soa = SoALines::new(lines);
 
@@ -284,33 +325,9 @@ impl SnapNoder {
         let l2 = lines[j];
 
         if let Some(res) = geo::algorithm::line_intersection::line_intersection(l1, l2) {
-            match res {
-                LineIntersection::SinglePoint {
-                    intersection: pt, ..
-                } => {
-                    let snapped = self.snap(pt);
-                    if snapped != l1.start && snapped != l1.end {
-                        splits.entry(i).or_default().push(snapped);
-                    }
-                    if snapped != l2.start && snapped != l2.end {
-                        splits.entry(j).or_default().push(snapped);
-                    }
-                }
-                LineIntersection::Collinear {
-                    intersection: overlap,
-                } => {
-                    let p1 = self.snap(overlap.start);
-                    let p2 = self.snap(overlap.end);
-                    for p in [p1, p2] {
-                        if p != l1.start && p != l1.end {
-                            splits.entry(i).or_default().push(p);
-                        }
-                        if p != l2.start && p != l2.end {
-                            splits.entry(j).or_default().push(p);
-                        }
-                    }
-                }
-            }
+            self.handle_intersection(res, i, j, l1, l2, |idx, pt| {
+                splits.entry(idx).or_default().push(pt);
+            });
         }
     }
 
@@ -324,33 +341,9 @@ impl SnapNoder {
         l2: Line<f64>,
         events: &mut Vec<(usize, Coord<f64>)>,
     ) {
-        match res {
-            LineIntersection::SinglePoint {
-                intersection: pt, ..
-            } => {
-                let snapped = self.snap(pt);
-                if snapped != l1.start && snapped != l1.end {
-                    events.push((i, snapped));
-                }
-                if snapped != l2.start && snapped != l2.end {
-                    events.push((j, snapped));
-                }
-            }
-            LineIntersection::Collinear {
-                intersection: overlap,
-            } => {
-                let p1 = self.snap(overlap.start);
-                let p2 = self.snap(overlap.end);
-                for p in [p1, p2] {
-                    if p != l1.start && p != l1.end {
-                        events.push((i, p));
-                    }
-                    if p != l2.start && p != l2.end {
-                        events.push((j, p));
-                    }
-                }
-            }
-        }
+        self.handle_intersection(res, i, j, l1, l2, |idx, pt| {
+            events.push((idx, pt));
+        });
     }
 }
 


### PR DESCRIPTION
This PR deduplicates the intersection handling logic in the `noding` module.

### Changes:
- Created a shared `pub(crate)` method `handle_intersection` in `SnapNoder` (`src/noding/snap.rs`).
- Refactored `SnapNoder::check_intersection` and `SnapNoder::collect_intersection_events` to use the new helper.
- Refactored `UniformGrid::find_splits` in `src/noding/grid.rs` to use the new helper, while preserving its specific ownership check logic.
- Ensured consistent snapping and endpoint filtering across all intersection processing paths.

### Verification:
- Manual code review confirms that the logic remains identical to the original implementation.
- `cargo fmt` was run to ensure code style consistency.
- (Note: `cargo test` and `npm test` could not be run due to sandbox network limitations and missing pre-installed dependencies.)

---
*PR created automatically by Jules for task [401127099797806036](https://jules.google.com/task/401127099797806036) started by @graydonpleasants*