### PR TITLE
⚡ Optimize hot loops by reusing vectors and avoiding clones

### DIFF
--- a/src/graph/planar_graph.rs
+++ b/src/graph/planar_graph.rs
@@ -576,17 +576,20 @@ impl PlanarGraph {
         // edge after the incoming edge (sym) in CCW order at the node.
         let mut next_pointers = vec![usize::MAX; self.directed_edges.len()];
 
+        let mut valid_edges = Vec::new();
         for (i, degree) in self.nodes_degree.iter().enumerate() {
             if *degree == 0 {
                 continue;
             }
 
             // Filter out marked edges from the adjacency list
-            let valid_edges: Vec<usize> = self.nodes_outgoing[i]
-                .iter()
-                .cloned()
-                .filter(|&idx| !self.directed_edges[idx].is_marked)
-                .collect();
+            valid_edges.clear();
+            valid_edges.extend(
+                self.nodes_outgoing[i]
+                    .iter()
+                    .cloned()
+                    .filter(|&idx| !self.directed_edges[idx].is_marked),
+            );
 
             if valid_edges.is_empty() {
                 continue;

--- a/src/noding/snap.rs
+++ b/src/noding/snap.rs
@@ -51,6 +51,7 @@ impl SnapNoder {
         self.normalize_and_dedup(&mut lines);
 
         // 2. Iterative Noding
+        let mut new_lines = Vec::new();
         for _iter in 0..self.max_iter {
             let use_grid = match self.strategy {
                 NodingStrategy::Auto => lines.len() >= 256,
@@ -59,7 +60,7 @@ impl SnapNoder {
                 NodingStrategy::Scalar => false, // Fallback to SIMD logic which handles scalar internally
             };
 
-            let splits = if !use_grid {
+            let mut splits = if !use_grid {
                 // STRATEGY A: Small Input -> SIMD Brute Force
                 self.find_splits_simd(&lines)
             } else {
@@ -73,10 +74,10 @@ impl SnapNoder {
             }
 
             // Apply splits
-            let mut new_lines = Vec::with_capacity(lines.len() * 2);
+            new_lines.clear();
+            new_lines.reserve(lines.len() * 2);
             for (i, line) in lines.iter().enumerate() {
-                if let Some(splits) = splits.get(&i) {
-                    let mut points = splits.clone();
+                if let Some(mut points) = splits.remove(&i) {
                     // Add endpoints
                     points.push(line.start);
                     points.push(line.end);
@@ -105,7 +106,7 @@ impl SnapNoder {
             }
 
             self.normalize_and_dedup(&mut new_lines);
-            lines = new_lines;
+            std::mem::swap(&mut lines, &mut new_lines);
         }
 
         lines

--- a/src/polygonizer.rs
+++ b/src/polygonizer.rs
@@ -321,8 +321,7 @@ impl Polygonizer {
         }
 
         let mut result = Vec::new();
-        for (i, shell) in shells.into_iter().enumerate() {
-            let holes = shell_holes[i].clone();
+        for (shell, holes) in shells.into_iter().zip(shell_holes.into_iter()) {
             let p = Polygon::new(shell.exterior().clone(), holes);
             if p.unsigned_area() > 1e-6 {
                 result.push(p);


### PR DESCRIPTION
This PR implements several performance optimizations focused on reducing heap allocations and memory pressure in the library's core algorithms.

### Key Changes:

*   **`src/graph/planar_graph.rs`**: The `valid_edges` vector in `get_edge_rings` was being re-allocated for every node in the graph. It is now moved outside the loop and reused, reducing allocations from O(Nodes) to a single allocation.
*   **`src/polygonizer.rs`**: In the final polygon assembly step, hole vectors were being cloned for each shell. By using a consuming `zip` iterator, we now move ownership of the hole vectors directly, eliminating O(Shells) clones.
*   **`src/noding/snap.rs`**:
    *   The iterative noding process now uses a buffer-swapping strategy (via `std::mem::swap`) to reuse the `new_lines` vector capacity across multiple noding passes.
    *   Split point vectors are now moved out of the `splits` HashMap using `remove()` instead of being cloned, avoiding expensive vector copies during the segment-splitting phase.

### Performance Impact:
While build-environment limitations prevented direct benchmarking in this session, these optimizations target high-frequency allocations in the O(N) parts of the algorithm. Reusing capacities and avoiding clones in these paths is a well-established method for improving throughput and reducing latency in Rust geometric processing.

### Verification:
*   Static analysis confirms logic parity.
*   Code reviewed for ownership and borrow-checker compliance.
*   `cargo fmt` applied for style consistency.

---
*PR created automatically by Jules for task [13414513835763507298](https://jules.google.com/task/13414513835763507298) started by @graydonpleasants*