### PR TITLE
Refactor: Extract process_tile closure to method

### DIFF
--- a/src/tiling.rs
+++ b/src/tiling.rs
@@ -1,4 +1,5 @@
 use crate::Polygonizer;
+use geo::algorithm::centroid::Centroid;
 use geo::bounding_rect::BoundingRect;
 use geo::intersects::Intersects;
 use geo::Area;
@@ -32,6 +33,68 @@ impl TiledPolygonizer {
         self.geometries.push(geom);
     }
 
+    fn process_tile(&self, tile_bbox: Rect<f64>) -> Vec<Polygon<f64>> {
+        let mut local_poly = Polygonizer::new();
+        local_poly.node_input = true;
+
+        // Define buffered bbox
+        let buffered_bbox = Rect::new(
+            Coord {
+                x: tile_bbox.min().x - self.buffer,
+                y: tile_bbox.min().y - self.buffer,
+            },
+            Coord {
+                x: tile_bbox.max().x + self.buffer,
+                y: tile_bbox.max().y + self.buffer,
+            },
+        );
+
+        // Filter geometries intersecting the BUFFERED tile
+        let mut relevant_lines = 0;
+        for geom in &self.geometries {
+            if geom
+                .bounding_rect()
+                .map(|b| b.intersects(&buffered_bbox))
+                .unwrap_or(false)
+            {
+                local_poly.add_geometry(geom.clone());
+                relevant_lines += 1;
+            }
+        }
+
+        if relevant_lines == 0 {
+            return Vec::new();
+        }
+
+        // Run polygonization
+        if let Ok(polys) = local_poly.polygonize() {
+            // Ownership check:
+            let mut valid_polys = Vec::new();
+            for poly in polys {
+                if let Some(pt) = poly.centroid() {
+                    let c = pt;
+                    let area = poly.unsigned_area();
+
+                    // Filter slivers
+                    if area < 1e-6 {
+                        continue;
+                    }
+
+                    // Check inclusion [min, max)
+                    let in_x = c.x() >= tile_bbox.min().x && c.x() < tile_bbox.max().x;
+                    let in_y = c.y() >= tile_bbox.min().y && c.y() < tile_bbox.max().y;
+
+                    if in_x && in_y {
+                        valid_polys.push(poly);
+                    }
+                }
+            }
+            valid_polys
+        } else {
+            Vec::new()
+        }
+    }
+
     pub fn polygonize(&self) -> Vec<Polygon<f64>> {
         // 1. Generate tiles
         let min = self.bbox.min();
@@ -55,77 +118,20 @@ impl TiledPolygonizer {
         }
 
         // 2. Process tiles in parallel or sequential
-        let process_tile = |tile_bbox: Rect<f64>| -> Vec<Polygon<f64>> {
-            let mut local_poly = Polygonizer::new();
-            local_poly.node_input = true;
-
-            // Define buffered bbox
-            let buffered_bbox = Rect::new(
-                Coord {
-                    x: tile_bbox.min().x - self.buffer,
-                    y: tile_bbox.min().y - self.buffer,
-                },
-                Coord {
-                    x: tile_bbox.max().x + self.buffer,
-                    y: tile_bbox.max().y + self.buffer,
-                },
-            );
-
-            // Filter geometries intersecting the BUFFERED tile
-            let mut relevant_lines = 0;
-            for geom in &self.geometries {
-                if geom
-                    .bounding_rect()
-                    .map(|b| b.intersects(&buffered_bbox))
-                    .unwrap_or(false)
-                {
-                    local_poly.add_geometry(geom.clone());
-                    relevant_lines += 1;
-                }
-            }
-
-            if relevant_lines == 0 {
-                return Vec::new();
-            }
-
-            // Run polygonization
-            if let Ok(polys) = local_poly.polygonize() {
-                // Ownership check:
-                let mut valid_polys = Vec::new();
-                for poly in polys {
-                    use geo::algorithm::centroid::Centroid;
-                    if let Some(pt) = poly.centroid() {
-                        let c = pt;
-                        let area = poly.unsigned_area();
-
-                        // Filter slivers
-                        if area < 1e-6 {
-                            continue;
-                        }
-
-                        // Check inclusion [min, max)
-                        let in_x = c.x() >= tile_bbox.min().x && c.x() < tile_bbox.max().x;
-                        let in_y = c.y() >= tile_bbox.min().y && c.y() < tile_bbox.max().y;
-
-                        if in_x && in_y {
-                            valid_polys.push(poly);
-                        }
-                    }
-                }
-                valid_polys
-            } else {
-                Vec::new()
-            }
-        };
-
         let result_polygons: Vec<Polygon<f64>>;
         #[cfg(feature = "parallel")]
         {
-            result_polygons = tiles.into_par_iter().flat_map(process_tile).collect();
+            result_polygons = tiles
+                .into_par_iter()
+                .flat_map(|tile| self.process_tile(tile))
+                .collect();
         }
         #[cfg(not(feature = "parallel"))]
         {
-            result_polygons = tiles.into_iter().flat_map(process_tile).collect();
+            result_polygons = tiles
+                .into_iter()
+                .flat_map(|tile| self.process_tile(tile))
+                .collect();
         }
 
         result_polygons


### PR DESCRIPTION
Extracted the `process_tile` closure from `TiledPolygonizer::polygonize` into a private method `process_tile`. This improves code organization and readability. Verified with existing tests including parallel execution.

---
*PR created automatically by Jules for task [16888111815102977298](https://jules.google.com/task/16888111815102977298) started by @graydonpleasants*