### PR TITLE
🔒 Fix potential panic in hole assignment (DoS)

### DIFF
--- a/src/polygonizer.rs
+++ b/src/polygonizer.rs
@@ -267,7 +267,7 @@ impl Polygonizer {
         let process_hole_assignment =
             |hole_poly: &Polygon<f64>| -> Option<(usize, LineString<f64>)> {
                 let hole_ring = hole_poly.exterior();
-                let bbox = hole_poly.bounding_rect().unwrap();
+                let bbox = hole_poly.bounding_rect()?;
                 let hole_aabb =
                     AABB::from_corners([bbox.min().x, bbox.min().y], [bbox.max().x, bbox.max().y]);
 


### PR DESCRIPTION
This PR fixes a potential Denial of Service (DoS) vulnerability in `src/polygonizer.rs`.

**Vulnerability:**
The `process_hole_assignment` closure used `hole_poly.bounding_rect().unwrap()`. If `hole_poly` was empty or degenerate such that `bounding_rect()` returned `None`, the application would panic.

**Fix:**
Replaced `.unwrap()` with the `?` operator. This causes the closure to return `None` (skipping the hole assignment) if the bounding box cannot be computed, which is the correct and safe behavior for degenerate inputs.

**Verification:**
- Verified that existing tests pass (`cargo test`).
- Verified that `clippy` reports no issues.
- Code review confirmed the fix is correct and idiomatic.

---
*PR created automatically by Jules for task [15965872287957100802](https://jules.google.com/task/15965872287957100802) started by @graydonpleasants*