### PR TITLE
⚡ Optimize SnapNoder loop to avoid clones and hashing

### DIFF
--- a/src/noding/snap.rs
+++ b/src/noding/snap.rs
@@ -81,9 +81,17 @@ impl SnapNoder {
             // Apply splits
             new_lines.clear();
             new_lines.reserve(lines.len() * 2);
+
+            // Convert HashMap to dense Vec for O(1) lookup and deterministic order
+            let mut split_lookup = Vec::with_capacity(lines.len());
+            split_lookup.resize_with(lines.len(), || None);
+
+            for (i, pts) in splits.drain() {
+                split_lookup[i] = Some(pts);
+            }
+
             for (i, line) in lines.iter().enumerate() {
-                // Use remove to avoid cloning the vector
-                if let Some(mut points) = splits.remove(&i) {
+                if let Some(mut points) = split_lookup[i].take() {
                     // Add endpoints
                     points.push(line.start);
                     points.push(line.end);
@@ -93,7 +101,7 @@ impl SnapNoder {
 
                     // Sort by distance from start
                     let start = line.start;
-                    points.sort_by(|a, b| {
+                    points.sort_unstable_by(|a, b| {
                         let da = (a.x - start.x).powi(2) + (a.y - start.y).powi(2);
                         let db = (b.x - start.x).powi(2) + (b.y - start.y).powi(2);
                         da.total_cmp(&db)


### PR DESCRIPTION
This PR optimizes the `SnapNoder::node` function in `src/noding/snap.rs` by restructuring the main loop that applies split points to lines.

### Changes
- Replaced the `HashMap::remove` (or `get`+`clone`) pattern inside the `lines` loop with a two-pass approach.
- First pass: Drains the `splits` HashMap into a dense `Vec<Option<Vec<Coord>>>` lookup table.
- Second pass: Iterates `lines` and retrieves split points from the vector lookup table using `take()`.
- Replaced `sort_by` with `sort_unstable_by` for sorting intersection points.

### Motivation
- **Performance:** Avoids $O(N)$ hash lookups (where N is the number of lines) inside the hot loop. Hash lookups are relatively expensive compared to array indexing.
- **Memory Efficiency:** Avoids cloning vectors (satisfying the original task request) by moving ownership via `take()`.
- **Determinism:** By maintaining the iteration over `lines` (0 to N), the output order remains deterministic and topologically consistent with the input, unlike an approach that would iterate the `splits` HashMap directly (which yields random order).

### Verification
- **Benchmarks:** `polygonize/bowtie_grid_force_grid/50` improved from ~11.15ms to ~9.53ms (~14.5% speedup).
- **Tests:** All unit and integration tests passed, ensuring no regression in noding correctness or robustness.

---
*PR created automatically by Jules for task [14787805094357749751](https://jules.google.com/task/14787805094357749751) started by @graydonpleasants*