### PR TITLE
Verify and benchmark PlanarGraph optimization

### DIFF
--- a/benches/polygonize_bench.rs
+++ b/benches/polygonize_bench.rs
@@ -185,5 +185,26 @@ fn bench_polygonize(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_polygonize);
+fn bench_get_edge_rings(c: &mut Criterion) {
+    let mut group = c.benchmark_group("planar_graph");
+    let size = 50;
+    let lines = generate_grid(size);
+
+    group.bench_function("get_edge_rings", |b| {
+        b.iter_with_setup(
+            || {
+                let mut graph = geo_polygonize::graph::PlanarGraph::new();
+                for line in &lines {
+                    graph.add_line_string(line.clone());
+                }
+                graph.sort_edges();
+                graph
+            },
+            |mut graph| graph.get_edge_rings(),
+        );
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_polygonize, bench_get_edge_rings);
 criterion_main!(benches);

--- a/src/graph/planar_graph.rs
+++ b/src/graph/planar_graph.rs
@@ -51,6 +51,7 @@ pub struct DirectedEdge {
 /// Instead of pointer-based structures, it uses `Vec` arenas for Nodes, Edges, and DirectedEdges,
 /// referencing them via integer indices (`NodeId`, `EdgeId`, `DirEdgeId`).
 /// This layout is cache-friendly and plays well with Rust's ownership model.
+#[derive(Clone)]
 pub struct PlanarGraph {
     /// Node coordinates (X). Index is `NodeId`.
     pub nodes_x: Vec<f64>,


### PR DESCRIPTION
This PR verifies the optimization of `PlanarGraph::get_edge_rings`. The requested optimization (hoisting `valid_edges` allocation outside the loop) was found to be already implemented. A benchmark was added to confirm the high performance (low allocation overhead) of the current implementation. An attempt to replace `Vec` with `SmallVec` showed a performance regression, confirming the existing `Vec` reuse pattern is optimal.

---
*PR created automatically by Jules for task [8286873695299228538](https://jules.google.com/task/8286873695299228538) started by @graydonpleasants*