### PR TITLE
test: add edge case test for empty UniformGrid find_splits

### DIFF
--- a/src/noding/grid.rs
+++ b/src/noding/grid.rs
@@ -238,6 +238,14 @@ mod tests {
     }
 
     #[test]
+    fn test_empty_grid_find_splits() {
+        let grid = UniformGrid::new(&[]);
+        let noder = SnapNoder::new(1e-6);
+        let splits = grid.find_splits(&[], &noder);
+        assert!(splits.is_empty());
+    }
+
+    #[test]
     fn test_grid_dimensions() {
         let lines = vec![
             Line::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 10.0, y: 0.0 }),


### PR DESCRIPTION
Adds a new unit test `test_empty_grid_find_splits` in `src/noding/grid.rs` to verify that `UniformGrid::find_splits` behaves correctly (returns empty result, no panic) when the grid is initialized with an empty line list. This complements the existing `test_empty_grid` which checks initialization properties.

---
*PR created automatically by Jules for task [11801925314334589865](https://jules.google.com/task/11801925314334589865) started by @graydonpleasants*