### PR TITLE
⚡ Bolt: Optimize SnapNoder splits storage

### DIFF
--- a/src/noding/grid.rs
+++ b/src/noding/grid.rs
@@ -127,6 +127,96 @@ impl UniformGrid {
         }
     }
 
+    /// Finds all intersections (Dense Version).
+    /// Returns (splits, has_intersections)
+    pub fn find_splits_dense(
+        &self,
+        lines: &[Line<f64>],
+        snap_noder: &SnapNoder,
+    ) -> (Vec<Vec<Coord<f64>>>, bool) {
+        let mut splits = vec![Vec::new(); lines.len()];
+        let mut has_intersections = false;
+
+        for r in 0..self.rows {
+            for c in 0..self.cols {
+                let cell_indices = &self.cells[r * self.cols + c];
+                if cell_indices.len() < 2 {
+                    continue;
+                }
+
+                // Define current cell bounds
+                let cell_min_x = self.bounds_min.x + c as f64 * self.cell_size;
+                let cell_min_y = self.bounds_min.y + r as f64 * self.cell_size;
+                let cell_max_x = cell_min_x + self.cell_size;
+                let cell_max_y = cell_min_y + self.cell_size;
+
+                // Brute force pairs within the cell
+                for i in 0..cell_indices.len() {
+                    for j in (i + 1)..cell_indices.len() {
+                        let idx1 = cell_indices[i];
+                        let idx2 = cell_indices[j];
+
+                        let l1 = lines[idx1];
+                        let l2 = lines[idx2];
+
+                        if let Some(res) = line_intersection(l1, l2) {
+                            match res {
+                                LineIntersection::SinglePoint {
+                                    intersection: pt, ..
+                                } => {
+                                    // OWNERSHIP CHECK
+                                    let is_in_x = pt.x >= cell_min_x
+                                        && (pt.x < cell_max_x
+                                            || (c == self.cols - 1 && pt.x <= cell_max_x));
+                                    let is_in_y = pt.y >= cell_min_y
+                                        && (pt.y < cell_max_y
+                                            || (r == self.rows - 1 && pt.y <= cell_max_y));
+
+                                    if is_in_x && is_in_y {
+                                        snap_noder.handle_intersection(
+                                            res,
+                                            idx1,
+                                            idx2,
+                                            l1,
+                                            l2,
+                                            |idx, pt| {
+                                                splits[idx].push(pt);
+                                                has_intersections = true;
+                                            },
+                                        );
+                                    }
+                                }
+                                LineIntersection::Collinear {
+                                    intersection: overlap,
+                                } => {
+                                    let p1 = snap_noder.snap(overlap.start);
+                                    let p1_in = p1.x >= cell_min_x
+                                        && p1.x < cell_max_x
+                                        && p1.y >= cell_min_y
+                                        && p1.y < cell_max_y;
+                                    if p1_in || (c == 0 && r == 0) {
+                                        snap_noder.handle_intersection(
+                                            res,
+                                            idx1,
+                                            idx2,
+                                            l1,
+                                            l2,
+                                            |idx, pt| {
+                                                splits[idx].push(pt);
+                                                has_intersections = true;
+                                            },
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        (splits, has_intersections)
+    }
+
     /// Finds all intersections. Uses "Intersection Ownership" to deduplicate checks.
     pub fn find_splits(
         &self,

--- a/src/noding/snap.rs
+++ b/src/noding/snap.rs
@@ -65,16 +65,16 @@ impl SnapNoder {
                 NodingStrategy::Scalar => false, // Fallback to SIMD logic which handles scalar internally
             };
 
-            let mut splits = if !use_grid {
+            let (mut splits, has_intersections) = if !use_grid {
                 // STRATEGY A: Small Input -> SIMD Brute Force
                 self.find_splits_simd(&lines)
             } else {
                 // STRATEGY B: Large Input -> Uniform Grid
                 let grid = UniformGrid::new(&lines);
-                grid.find_splits(&lines, self)
+                grid.find_splits_dense(&lines, self)
             };
 
-            if splits.is_empty() {
+            if !has_intersections {
                 break;
             }
 
@@ -82,8 +82,8 @@ impl SnapNoder {
             new_lines.clear();
             new_lines.reserve(lines.len() * 2);
             for (i, line) in lines.iter().enumerate() {
-                // Use remove to avoid cloning the vector
-                if let Some(mut points) = splits.remove(&i) {
+                let points = &mut splits[i];
+                if !points.is_empty() {
                     // Add endpoints
                     points.push(line.start);
                     points.push(line.end);
@@ -200,8 +200,10 @@ impl SnapNoder {
         }
     }
 
-    fn find_splits_simd(&self, lines: &[Line<f64>]) -> HashMap<usize, Vec<Coord<f64>>> {
+    fn find_splits_simd(&self, lines: &[Line<f64>]) -> (Vec<Vec<Coord<f64>>>, bool) {
         let soa = SoALines::new(lines);
+        let mut splits = vec![Vec::new(); lines.len()];
+        let mut has_intersections = false;
 
         #[cfg(feature = "parallel")]
         {
@@ -215,25 +217,28 @@ impl SnapNoder {
                 })
                 .collect();
 
-            // Aggregate results into HashMap
-            let mut splits: HashMap<usize, Vec<Coord<f64>>> = HashMap::new();
-            for (idx, pt) in all_splits {
-                splits.entry(idx).or_default().push(pt);
+            // Aggregate results into Vec
+            if !all_splits.is_empty() {
+                has_intersections = true;
+                for (idx, pt) in all_splits {
+                    splits[idx].push(pt);
+                }
             }
-            splits
         }
 
         #[cfg(not(feature = "parallel"))]
         {
-            let mut splits: HashMap<usize, Vec<Coord<f64>>> = HashMap::new();
             for (i, &query_line) in lines.iter().enumerate() {
                 let events = self.check_intersection_simd(query_line, i, lines, &soa);
-                for (idx, pt) in events {
-                    splits.entry(idx).or_default().push(pt);
+                if !events.is_empty() {
+                    has_intersections = true;
+                    for (idx, pt) in events {
+                        splits[idx].push(pt);
+                    }
                 }
             }
-            splits
         }
+        (splits, has_intersections)
     }
 
     // Helper to check one line against all others using SIMD SoA
@@ -401,19 +406,19 @@ mod tests {
 
         // Grid Logic (Force use by calling directly)
         let grid = UniformGrid::new(&lines);
-        let splits_grid = grid.find_splits(&lines, &noder);
+        let (splits_grid, _) = grid.find_splits_dense(&lines, &noder);
 
         // SIMD Logic
-        let splits_simd = noder.find_splits_simd(&lines);
+        let (splits_simd, _) = noder.find_splits_simd(&lines);
 
-        assert_eq!(
-            splits_grid.len(),
-            splits_simd.len(),
-            "Different number of lines with splits"
-        );
+        assert_eq!(splits_grid.len(), splits_simd.len());
 
-        for (idx, points_grid) in &splits_grid {
-            let points_simd = splits_simd.get(idx).expect("Index missing in SIMD splits");
+        for (i, points_grid) in splits_grid.iter().enumerate() {
+            let points_simd = &splits_simd[i];
+
+            if points_grid.is_empty() && points_simd.is_empty() {
+                continue;
+            }
 
             // Sort points to ensure order independence
             let mut p_grid = points_grid.clone();
@@ -423,6 +428,8 @@ mod tests {
             let mut p_simd = points_simd.clone();
             p_simd.sort_by(|a, b| (a.x, a.y).partial_cmp(&(b.x, b.y)).unwrap());
             p_simd.dedup();
+
+            assert_eq!(p_grid.len(), p_simd.len(), "Mismatch count for line {}", i);
 
             for (p_g, p_s) in p_grid.iter().zip(p_simd.iter()) {
                 assert!(


### PR DESCRIPTION
💡 What: Replaced `HashMap` with `Vec<Vec<Coord>>` for storing intersection splits in `SnapNoder`.
🎯 Why: To reduce hashing overhead and improve performance in the hot noding loop.
📊 Impact: Faster intersection aggregation and processing, especially for large inputs with many segments.
🔬 Measurement: Verified with `cargo run --release --example bench_noding` (created temporarily) and existing tests.

---
*PR created automatically by Jules for task [3620969255208523149](https://jules.google.com/task/3620969255208523149) started by @graydonpleasants*