### PR TITLE
Fix panic in Polygonizer on invalid (NaN) input

### DIFF
--- a/src/polygonizer.rs
+++ b/src/polygonizer.rs
@@ -207,8 +207,8 @@ impl Polygonizer {
             let poly = Polygon::new(ring, vec![]);
             let area = poly.signed_area();
 
-            if area.abs() < 1e-9 {
-                continue; // Degenerate
+            if !area.is_finite() || area.abs() < 1e-9 {
+                continue; // Degenerate or invalid
             }
 
             if area > 0.0 {

--- a/tests/regression_nan_panic.rs
+++ b/tests/regression_nan_panic.rs
@@ -1,0 +1,15 @@
+use geo::LineString;
+use geo_polygonize::Polygonizer;
+
+#[test]
+fn test_nan_polygon_panic() {
+    let mut polygonizer = Polygonizer::new();
+    // Add geometry with NaN
+    // This previously caused a panic in process_holes due to assuming valid geometry
+    polygonizer.add_geometry(
+        LineString::from(vec![(0.0, 0.0), (f64::NAN, 0.0), (0.0, 10.0), (0.0, 0.0)]).into(),
+    );
+
+    // This should handle it gracefully or return Err, but NOT panic.
+    let _result = polygonizer.polygonize();
+}


### PR DESCRIPTION
This PR addresses a security vulnerability related to panic on invalid polygon inputs.
Although the specific `IndexedPolygon` struct mentioned in the task seems to have been replaced by `IndexedEnvelope` (which handles `bounding_rect` safely), a related panic was identified when `make_ccw_winding` is called on polygons with NaN coordinates.

The fix involves explicitly filtering out polygons with non-finite area in the `polygonize` loop. This prevents invalid geometry from propagating to downstream logic (hole processing and R-Tree indexing), ensuring robust handling of malformed inputs.

A regression test `tests/regression_nan_panic.rs` is added to verify the fix.

---
*PR created automatically by Jules for task [14152901198449696613](https://jules.google.com/task/14152901198449696613) started by @graydonpleasants*