### PR TITLE
Refactor TiledPolygonizer tile generation

### DIFF
--- a/src/tiling.rs
+++ b/src/tiling.rs
@@ -95,8 +95,7 @@ impl TiledPolygonizer {
         }
     }
 
-    pub fn polygonize(&self) -> Vec<Polygon<f64>> {
-        // 1. Generate tiles
+    fn generate_tiles(&self) -> Vec<Rect<f64>> {
         let min = self.bbox.min();
         let max = self.bbox.max();
         let width = max.x - min.x;
@@ -116,8 +115,13 @@ impl TiledPolygonizer {
                 tiles.push(Rect::new(Coord { x: x0, y: y0 }, Coord { x: x1, y: y1 }));
             }
         }
+        tiles
+    }
 
-        // 2. Process tiles in parallel or sequential
+    pub fn polygonize(&self) -> Vec<Polygon<f64>> {
+        let tiles = self.generate_tiles();
+
+        // Process tiles in parallel or sequential
         let result_polygons: Vec<Polygon<f64>>;
         #[cfg(feature = "parallel")]
         {


### PR DESCRIPTION
Extracted tile generation logic into `generate_tiles` method in `src/tiling.rs`.
This improves code clarity and maintainability by separating tile generation from processing orchestration.
Verified with `cargo test`.

---
*PR created automatically by Jules for task [3527561007657158796](https://jules.google.com/task/3527561007657158796) started by @graydonpleasants*