### PR TITLE
Optimize noding memory usage with flat event list

### DIFF
--- a/benches/polygonize_bench.rs
+++ b/benches/polygonize_bench.rs
@@ -99,7 +99,7 @@ fn bench_polygonize(c: &mut Criterion) {
 
     // Stress Test: Bowtie/Dirty Grid
     // Compare Strategies
-    let dirty_sizes = [10, 20, 50];
+    let dirty_sizes = [10, 20, 50, 100];
     for &size in dirty_sizes.iter() {
         let lines = generate_bowtie_grid(size);
 

--- a/src/noding/grid.rs
+++ b/src/noding/grid.rs
@@ -127,8 +127,13 @@ impl UniformGrid {
     }
 
     /// Finds all intersections. Uses "Intersection Ownership" to deduplicate checks.
-    pub fn find_splits(&self, lines: &[Line<f64>], snap_noder: &SnapNoder) -> Vec<Vec<Coord<f64>>> {
-        let mut splits = vec![Vec::new(); lines.len()];
+    /// Returns a flat list of (line_index, split_point) events.
+    pub fn find_splits(
+        &self,
+        lines: &[Line<f64>],
+        snap_noder: &SnapNoder,
+    ) -> Vec<(usize, Coord<f64>)> {
+        let mut splits = Vec::new();
 
         for r in 0..self.rows {
             for c in 0..self.cols {
@@ -179,7 +184,7 @@ impl UniformGrid {
                                             l1,
                                             l2,
                                             |idx, pt| {
-                                                splits[idx].push(pt);
+                                                splits.push((idx, pt));
                                             },
                                         );
                                     }
@@ -202,7 +207,7 @@ impl UniformGrid {
                                             l1,
                                             l2,
                                             |idx, pt| {
-                                                splits[idx].push(pt);
+                                                splits.push((idx, pt));
                                             },
                                         );
                                     }
@@ -312,11 +317,13 @@ mod tests {
         let splits = grid.find_splits(&lines, &noder);
 
         // Both lines should be split at (5, 5)
-        assert!(!splits[0].is_empty());
-        assert!(!splits[1].is_empty());
+        let count_0 = splits.iter().filter(|(i, _)| *i == 0).count();
+        let count_1 = splits.iter().filter(|(i, _)| *i == 1).count();
+        assert!(count_0 > 0);
+        assert!(count_1 > 0);
 
-        let p0 = splits[0][0];
-        let p1 = splits[1][0];
+        let p0 = splits.iter().find(|(i, _)| *i == 0).unwrap().1;
+        let p1 = splits.iter().find(|(i, _)| *i == 1).unwrap().1;
 
         assert_relative_eq!(p0.x, 5.0);
         assert_relative_eq!(p0.y, 5.0);
@@ -335,7 +342,7 @@ mod tests {
         let noder = SnapNoder::new(0.0);
 
         let splits = grid.find_splits(&lines, &noder);
-        assert!(splits.iter().all(|v| v.is_empty()));
+        assert!(splits.is_empty());
     }
 
     #[test]

--- a/src/noding/snap.rs
+++ b/src/noding/snap.rs
@@ -73,7 +73,7 @@ impl SnapNoder {
                 grid.find_splits(&lines, self)
             };
 
-            if splits.iter().all(|v| v.is_empty()) {
+            if splits.is_empty() {
                 break;
             }
 
@@ -81,8 +81,32 @@ impl SnapNoder {
             new_lines.clear();
             new_lines.reserve(lines.len() * 2);
 
+            // Sort events by line index
+            // Use parallel sort if available, though stable/unstable distinction matters less for usize keys
+            #[cfg(feature = "parallel")]
+            splits.par_sort_unstable_by_key(|e| e.0);
+            #[cfg(not(feature = "parallel"))]
+            splits.sort_unstable_by_key(|e| e.0);
+
+            let mut event_idx = 0;
+            // Points buffer reuse
+            let mut points = Vec::with_capacity(4);
+
             for (i, line) in lines.iter().enumerate() {
-                let mut points = std::mem::take(&mut splits[i]);
+                // Collect points for line i
+                points.clear();
+
+                // Fast-forward to current line
+                // Since splits is sorted, we can just check current index
+                while event_idx < splits.len() && splits[event_idx].0 < i {
+                    event_idx += 1;
+                }
+
+                while event_idx < splits.len() && splits[event_idx].0 == i {
+                    points.push(splits[event_idx].1);
+                    event_idx += 1;
+                }
+
                 if !points.is_empty() {
                     // Add endpoints
                     points.push(line.start);
@@ -200,37 +224,28 @@ impl SnapNoder {
         }
     }
 
-    fn find_splits_simd(&self, lines: &[Line<f64>]) -> Vec<Vec<Coord<f64>>> {
+    fn find_splits_simd(&self, lines: &[Line<f64>]) -> Vec<(usize, Coord<f64>)> {
         let soa = SoALines::new(lines);
 
         #[cfg(feature = "parallel")]
         {
             // Parallel execution: each thread processes a subset of query lines
             // and returns a list of split events (line_index, point).
-            let all_splits: Vec<(usize, Coord<f64>)> = lines
+            lines
                 .par_iter()
                 .enumerate()
                 .flat_map(|(i, &query_line)| {
                     self.check_intersection_simd(query_line, i, lines, &soa)
                 })
-                .collect();
-
-            // Aggregate results into dense Vec
-            let mut splits = vec![Vec::new(); lines.len()];
-            for (idx, pt) in all_splits {
-                splits[idx].push(pt);
-            }
-            splits
+                .collect()
         }
 
         #[cfg(not(feature = "parallel"))]
         {
-            let mut splits = vec![Vec::new(); lines.len()];
+            let mut splits = Vec::new();
             for (i, &query_line) in lines.iter().enumerate() {
                 let events = self.check_intersection_simd(query_line, i, lines, &soa);
-                for (idx, pt) in events {
-                    splits[idx].push(pt);
-                }
+                splits.extend(events);
             }
             splits
         }
@@ -335,7 +350,7 @@ impl SnapNoder {
         lines: &[Line<f64>],
         i: usize,
         j: usize,
-        splits: &mut [Vec<Coord<f64>>],
+        splits: &mut Vec<(usize, Coord<f64>)>,
     ) {
         if i >= lines.len() || j >= lines.len() {
             return;
@@ -345,7 +360,7 @@ impl SnapNoder {
         let l2 = lines[j];
 
         self.process_intersection(l1, l2, i, j, |idx, pt| {
-            splits[idx].push(pt);
+            splits.push((idx, pt));
         });
     }
 }
@@ -383,49 +398,38 @@ mod tests {
 
         // Grid Logic (Force use by calling directly)
         let grid = UniformGrid::new(&lines);
-        let splits_grid = grid.find_splits(&lines, &noder);
+        let mut splits_grid = grid.find_splits(&lines, &noder);
 
         // SIMD Logic
-        let splits_simd = noder.find_splits_simd(&lines);
+        let mut splits_simd = noder.find_splits_simd(&lines);
+
+        // Sort both to compare
+        splits_grid.sort_by(|a, b| {
+            a.0.cmp(&b.0)
+                .then_with(|| (a.1.x, a.1.y).partial_cmp(&(b.1.x, b.1.y)).unwrap())
+        });
+        splits_simd.sort_by(|a, b| {
+            a.0.cmp(&b.0)
+                .then_with(|| (a.1.x, a.1.y).partial_cmp(&(b.1.x, b.1.y)).unwrap())
+        });
+
+        splits_grid.dedup();
+        splits_simd.dedup();
 
         assert_eq!(
             splits_grid.len(),
             splits_simd.len(),
-            "Different vector lengths"
+            "Different event counts"
         );
 
-        for (idx, points_grid) in splits_grid.iter().enumerate() {
-            let points_simd = &splits_simd[idx];
-
-            if points_grid.is_empty() && points_simd.is_empty() {
-                continue;
-            }
-
-            // Sort points to ensure order independence
-            let mut p_grid = points_grid.clone();
-            p_grid.sort_by(|a, b| (a.x, a.y).partial_cmp(&(b.x, b.y)).unwrap());
-            p_grid.dedup();
-
-            let mut p_simd = points_simd.clone();
-            p_simd.sort_by(|a, b| (a.x, a.y).partial_cmp(&(b.x, b.y)).unwrap());
-            p_simd.dedup();
-
-            assert_eq!(
-                p_grid.len(),
-                p_simd.len(),
-                "Mismatch point count at index {}",
-                idx
+        for (e1, e2) in splits_grid.iter().zip(splits_simd.iter()) {
+            assert_eq!(e1.0, e2.0, "Mismatch index");
+            assert!(
+                (e1.1.x - e2.1.x).abs() < 1e-10 && (e1.1.y - e2.1.y).abs() < 1e-10,
+                "Point mismatch: {:?} vs {:?}",
+                e1.1,
+                e2.1
             );
-
-            for (p_g, p_s) in p_grid.iter().zip(p_simd.iter()) {
-                assert!(
-                    (p_g.x - p_s.x).abs() < 1e-10 && (p_g.y - p_s.y).abs() < 1e-10,
-                    "Point mismatch at index {}: {:?} vs {:?}",
-                    idx,
-                    p_g,
-                    p_s
-                );
-            }
         }
     }
 
@@ -470,15 +474,18 @@ mod tests {
         let l1 = Line::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 10.0, y: 10.0 });
         let l2 = Line::new(Coord { x: 0.0, y: 10.0 }, Coord { x: 10.0, y: 0.0 });
         let lines = vec![l1, l2];
-        let mut splits = vec![Vec::new(); 2];
+        let mut splits = Vec::new();
 
         let noder = SnapNoder::new(0.0);
         noder.check_intersection(&lines, 0, 1, &mut splits);
 
-        assert!(!splits[0].is_empty());
-        assert!(!splits[1].is_empty());
+        assert!(!splits.is_empty());
+        let count_0 = splits.iter().filter(|(i, _)| *i == 0).count();
+        let count_1 = splits.iter().filter(|(i, _)| *i == 1).count();
+        assert!(count_0 > 0);
+        assert!(count_1 > 0);
 
-        let p = splits[0][0];
+        let p = splits[0].1;
         assert!((p.x - 5.0).abs() < 1e-10);
         assert!((p.y - 5.0).abs() < 1e-10);
     }


### PR DESCRIPTION
This PR optimizes the noding process by flattening the intersection event list structure. Previously, `find_splits` returned a `Vec<Vec<Coord>>` where the outer vector corresponded to input lines. This required allocating a vector for every line, even if no intersections were found. The new implementation returns a single flat `Vec<(usize, Coord)>` containing only actual intersection events.

Key changes:
- `UniformGrid::find_splits` now returns `Vec<(usize, Coord<f64>)>`.
- `SnapNoder::find_splits_simd` now returns `Vec<(usize, Coord<f64>)>`.
- `SnapNoder::node` logic updated to sort the flat event list by line index and iterate through it using a sliding window.
- Updated unit tests in `grid.rs` and `snap.rs` to verify the new return type and structure.
- Added a larger test case (size 100) to `benches/polygonize_bench.rs` to better measure performance improvements on larger datasets.


---
*PR created automatically by Jules for task [7501905850710317653](https://jules.google.com/task/7501905850710317653) started by @graydonpleasants*