### PR TITLE
test: Add edge case tests for empty Polygonizer input

### DIFF
--- a/src/polygonizer_tests.rs
+++ b/src/polygonizer_tests.rs
@@ -183,4 +183,38 @@ mod tests {
             .expect("Polygonization should not fail on Point input");
         assert_eq!(polygons.len(), 0);
     }
+
+    #[test]
+    fn test_polygonize_empty_input_with_noding() {
+        let mut poly = Polygonizer::new();
+        poly.node_input = true;
+        let polygons = poly
+            .polygonize()
+            .expect("Polygonization should not fail on empty input with noding");
+        assert_eq!(polygons.len(), 0);
+    }
+
+    #[test]
+    fn test_polygonize_empty_linestring_with_noding() {
+        let mut poly = Polygonizer::new();
+        poly.node_input = true;
+        poly.add_geometry(geo_types::Geometry::LineString(geo_types::LineString::new(
+            vec![],
+        )));
+        let polygons = poly
+            .polygonize()
+            .expect("Polygonization should not fail on empty LineString with noding");
+        assert_eq!(polygons.len(), 0);
+    }
+
+    #[test]
+    fn test_polygonize_point_with_noding() {
+        let mut poly = Polygonizer::new();
+        poly.node_input = true;
+        poly.add_geometry(geo_types::Geometry::Point(geo_types::Point::new(0.0, 0.0)));
+        let polygons = poly
+            .polygonize()
+            .expect("Polygonization should not fail on Point input with noding");
+        assert_eq!(polygons.len(), 0);
+    }
 }


### PR DESCRIPTION
This PR adds comprehensive unit tests to ensure `Polygonizer` robustness when handling empty inputs, specifically when `node_input` is enabled.

**Changes:**
- Added `test_polygonize_empty_input_with_noding`: Verifies `polygonize()` returns empty result for fresh `Polygonizer` with `node_input=true`.
- Added `test_polygonize_empty_linestring_with_noding`: Verifies handling of empty `LineString` input with noding.
- Added `test_polygonize_point_with_noding`: Verifies handling of ignored `Point` input with noding.

These tests confirm that the noding pipeline (including `UniformGrid` and SIMD noder) gracefully handles empty or effectively empty datasets without panicking.

---
*PR created automatically by Jules for task [7125288567304072158](https://jules.google.com/task/7125288567304072158) started by @graydonpleasants*