### PR TITLE
🧹 Deduplicate parallel logic in PlanarGraph::bulk_load

### DIFF
--- a/src/graph/planar_graph.rs
+++ b/src/graph/planar_graph.rs
@@ -1,3 +1,6 @@
+use crate::utils::parallel::{
+    par_flat_map, par_into_enumerate_map, par_sort_unstable, par_zip_for_each,
+};
 use crate::utils::{compare_angular, z_order_index};
 use geo::Line;
 use geo_types::{Coord, LineString};
@@ -228,18 +231,10 @@ impl PlanarGraph {
             ]
         };
 
-        #[cfg(feature = "parallel")]
-        let mut entries: Vec<NodeEntry> = lines.par_iter().flat_map_iter(to_entries).collect();
-
-        #[cfg(not(feature = "parallel"))]
-        let mut entries: Vec<NodeEntry> = lines.iter().flat_map(to_entries).collect();
+        let mut entries: Vec<NodeEntry> = par_flat_map(&lines, to_entries);
 
         // 2. Sort using precomputed Z-order
-        #[cfg(feature = "parallel")]
-        entries.par_sort_unstable();
-
-        #[cfg(not(feature = "parallel"))]
-        entries.sort_unstable();
+        par_sort_unstable(&mut entries);
 
         // Dedup using exact equality.
         entries.dedup_by(|a, b| {
@@ -310,21 +305,13 @@ impl PlanarGraph {
         }
 
         // Reserve exact capacity
-        #[cfg(feature = "parallel")]
-        self.nodes_outgoing
-            .par_iter_mut()
-            .zip(degrees.par_iter())
-            .for_each(|(adj, &deg)| {
-                adj.reserve(deg);
-            });
-
-        #[cfg(not(feature = "parallel"))]
-        self.nodes_outgoing
-            .iter_mut()
-            .zip(degrees.iter())
-            .for_each(|(adj, &deg)| {
-                adj.reserve(deg);
-            });
+        par_zip_for_each(
+            &mut self.nodes_outgoing,
+            &degrees,
+            |adj: &mut Vec<usize>, deg: &usize| {
+                adj.reserve(*deg);
+            },
+        );
 
         // 5. Build Edges
         self.edges.reserve(valid_edges.len());
@@ -337,15 +324,7 @@ impl PlanarGraph {
             create_edge_components(i, u, v, line, edges_start_len, directed_edges_start_len)
         };
 
-        #[cfg(feature = "parallel")]
-        let new_edges_data: Vec<_> = valid_edges
-            .into_par_iter()
-            .enumerate()
-            .map(mapper)
-            .collect();
-
-        #[cfg(not(feature = "parallel"))]
-        let new_edges_data: Vec<_> = valid_edges.into_iter().enumerate().map(mapper).collect();
+        let new_edges_data: Vec<_> = par_into_enumerate_map(valid_edges, mapper);
 
         for (u, v, de_u_v_idx, de_v_u_idx, de_u_v, de_v_u, edge) in new_edges_data {
             self.directed_edges.push(de_u_v);

--- a/src/utils/parallel.rs
+++ b/src/utils/parallel.rs
@@ -50,3 +50,73 @@ where
         collection.iter_mut().for_each(f);
     }
 }
+
+/// Helper for parallel flat_map
+#[inline]
+pub fn par_flat_map<T, F, U, R>(slice: &[T], f: F) -> Vec<R>
+where
+    T: Sync,
+    F: Fn(&T) -> U + Sync + Send,
+    U: IntoIterator<Item = R>,
+    R: Send,
+{
+    #[cfg(all(feature = "parallel", not(target_arch = "wasm32")))]
+    {
+        slice.par_iter().flat_map_iter(f).collect()
+    }
+    #[cfg(any(not(feature = "parallel"), target_arch = "wasm32"))]
+    {
+        slice.iter().flat_map(f).collect()
+    }
+}
+
+/// Helper for parallel unstable sort
+#[inline]
+pub fn par_sort_unstable<T: Ord + Send>(slice: &mut [T]) {
+    #[cfg(all(feature = "parallel", not(target_arch = "wasm32")))]
+    {
+        slice.par_sort_unstable();
+    }
+    #[cfg(any(not(feature = "parallel"), target_arch = "wasm32"))]
+    {
+        slice.sort_unstable();
+    }
+}
+
+/// Helper for parallel zip and for_each
+#[inline]
+pub fn par_zip_for_each<A, B, F>(a: &mut [A], b: &[B], f: F)
+where
+    A: Send,
+    B: Sync,
+    F: Fn(&mut A, &B) + Sync + Send,
+{
+    #[cfg(all(feature = "parallel", not(target_arch = "wasm32")))]
+    {
+        a.par_iter_mut()
+            .zip(b.par_iter())
+            .for_each(|(x, y)| f(x, y));
+    }
+    #[cfg(any(not(feature = "parallel"), target_arch = "wasm32"))]
+    {
+        a.iter_mut().zip(b.iter()).for_each(|(x, y)| f(x, y));
+    }
+}
+
+/// Helper for parallel consume, enumerate, map and collect
+#[inline]
+pub fn par_into_enumerate_map<T, F, U>(vec: Vec<T>, f: F) -> Vec<U>
+where
+    T: Send,
+    F: Fn((usize, T)) -> U + Sync + Send,
+    U: Send,
+{
+    #[cfg(all(feature = "parallel", not(target_arch = "wasm32")))]
+    {
+        vec.into_par_iter().enumerate().map(f).collect()
+    }
+    #[cfg(any(not(feature = "parallel"), target_arch = "wasm32"))]
+    {
+        vec.into_iter().enumerate().map(f).collect()
+    }
+}


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Refactored `src/graph/planar_graph.rs` to remove duplicated `#[cfg(feature = "parallel")]` blocks in the `bulk_load` method.
Created reusable helper functions in `src/utils/parallel.rs`: `par_flat_map`, `par_sort_unstable`, `par_zip_for_each`, and `par_into_enumerate_map`.

💡 **Why:** How this improves maintainability
The `bulk_load` method contained significant code duplication to handle both parallel (Rayon) and sequential execution paths. This made the function harder to read and maintain. Abstraction into helper functions keeps the core logic of `bulk_load` clean and linear, while centralizing the parallel/sequential switching logic in a dedicated utility module.

✅ **Verification:** How you confirmed the change is safe
- Ran `cargo check` to ensure compilation.
- Ran `cargo test` (default features = parallel) to verify correctness with Rayon enabled.
- Ran `cargo test --no-default-features` to verify correctness with Rayon disabled (scalar mode).
- Verified that `test_bulk_load` in `src/graph/tests.rs` passes in both modes.

✨ **Result:** The improvement achieved
`PlanarGraph::bulk_load` is significantly cleaner and no longer repeats logic blocks. The new helpers in `src/utils/parallel.rs` are available for other parts of the codebase.

---
*PR created automatically by Jules for task [9903729829039686241](https://jules.google.com/task/9903729829039686241) started by @graydonpleasants*