### PR TITLE
Add DeepWiki guidance configuration

### DIFF
--- a/.devin/wiki.json
+++ b/.devin/wiki.json
@@ -1,0 +1,65 @@
+{
+  "repo_notes": [
+    {
+      "content": "This repository is a Rust port of the JTS/GEOS polygonization algorithm, designed for high performance and robustness. It includes support for WebAssembly (WASM) and SIMD acceleration. The core components are the Polygonizer (orchestrator), PlanarGraph (topology data structure using arena allocation/SoA), and the Noding module (Iterated Snap Rounding for handling dirty inputs).",
+      "author": "DeepWiki Guide"
+    }
+  ],
+  "pages": [
+    {
+      "title": "Home",
+      "purpose": "High-level overview of the project, its goals, and key features (Robust Noding, SIMD, WASM).",
+      "parent": null
+    },
+    {
+      "title": "Core Logic",
+      "purpose": "Explain the central components of the polygonization process.",
+      "parent": "Home"
+    },
+    {
+      "title": "Polygonizer",
+      "purpose": "Deep dive into `src/polygonizer.rs`, explaining how it orchestrates the noding, graph building, and polygon extraction phases.",
+      "parent": "Core Logic"
+    },
+    {
+      "title": "PlanarGraph",
+      "purpose": "Explain the `PlanarGraph` data structure in `src/graph/planar_graph.rs`. Highlight the use of arena allocation (index-based graph) and Structure of Arrays (SoA) for performance.",
+      "parent": "Core Logic"
+    },
+    {
+      "title": "Robustness & Noding",
+      "purpose": "Detail how the library handles dirty inputs and ensures topological correctness.",
+      "parent": "Home"
+    },
+    {
+      "title": "Iterated Snap Rounding",
+      "purpose": "Explain the ISR algorithm implemented in `src/noding/snap.rs`, including how it resolves self-intersections and overlaps.",
+      "parent": "Robustness & Noding"
+    },
+    {
+      "title": "Grid Indexing",
+      "purpose": "Describe the spatial grid used in `src/noding/grid.rs` to accelerate intersection detection during noding.",
+      "parent": "Robustness & Noding"
+    },
+    {
+      "title": "Optimizations",
+      "purpose": "Cover the performance optimizations used throughout the library.",
+      "parent": "Home"
+    },
+    {
+      "title": "SIMD Acceleration",
+      "purpose": "Explain how SIMD is used in `src/utils/simd.rs` for geometric predicates like Point-in-Polygon checks.",
+      "parent": "Optimizations"
+    },
+    {
+      "title": "Memory Layout",
+      "purpose": "Detail the memory layout strategies, such as SoA in `src/utils/soa.rs` and the use of the `talc` allocator for WASM.",
+      "parent": "Optimizations"
+    },
+    {
+      "title": "WASM & Integration",
+      "purpose": "Explain how the library is compiled to WebAssembly and exposed to JavaScript via `src/wasm.rs`.",
+      "parent": "Home"
+    }
+  ]
+}


### PR DESCRIPTION
Added `.devin/wiki.json` to provide guidance for DeepWiki generation, including `repo_notes` and a structured `pages` hierarchy covering core logic, robustness, and optimizations.

---
*PR created automatically by Jules for task [6532997738782910315](https://jules.google.com/task/6532997738782910315) started by @graydonpleasants*