### PR TITLE
Refactor bulk_load to use parallel helper functions

### DIFF
--- a/src/graph/planar_graph.rs
+++ b/src/graph/planar_graph.rs
@@ -1,3 +1,4 @@
+use crate::utils::parallel::{flat_map, into_map_enumerate, sort_unstable, zip_for_each};
 use crate::utils::{compare_angular, z_order_index};
 use geo::Line;
 use geo_types::{Coord, LineString};
@@ -215,7 +216,7 @@ impl PlanarGraph {
         }
 
         // 1. Collect all coordinates and precompute Z-order
-        let to_entries = |line: &Line<f64>| {
+        let mut entries: Vec<NodeEntry> = flat_map(&lines, |line| {
             [
                 NodeEntry {
                     z: z_order_index(line.start),
@@ -226,20 +227,10 @@ impl PlanarGraph {
                     c: line.end,
                 },
             ]
-        };
-
-        #[cfg(feature = "parallel")]
-        let mut entries: Vec<NodeEntry> = lines.par_iter().flat_map_iter(to_entries).collect();
-
-        #[cfg(not(feature = "parallel"))]
-        let mut entries: Vec<NodeEntry> = lines.iter().flat_map(to_entries).collect();
+        });
 
         // 2. Sort using precomputed Z-order
-        #[cfg(feature = "parallel")]
-        entries.par_sort_unstable();
-
-        #[cfg(not(feature = "parallel"))]
-        entries.sort_unstable();
+        sort_unstable(&mut entries);
 
         // Dedup using exact equality.
         entries.dedup_by(|a, b| {
@@ -310,21 +301,9 @@ impl PlanarGraph {
         }
 
         // Reserve exact capacity
-        #[cfg(feature = "parallel")]
-        self.nodes_outgoing
-            .par_iter_mut()
-            .zip(degrees.par_iter())
-            .for_each(|(adj, &deg)| {
-                adj.reserve(deg);
-            });
-
-        #[cfg(not(feature = "parallel"))]
-        self.nodes_outgoing
-            .iter_mut()
-            .zip(degrees.iter())
-            .for_each(|(adj, &deg)| {
-                adj.reserve(deg);
-            });
+        zip_for_each(&mut self.nodes_outgoing, &degrees, |(adj, &deg)| {
+            adj.reserve(deg);
+        });
 
         // 5. Build Edges
         self.edges.reserve(valid_edges.len());
@@ -333,19 +312,9 @@ impl PlanarGraph {
         let edges_start_len = self.edges.len();
         let directed_edges_start_len = self.directed_edges.len();
 
-        let mapper = |(i, (u, v, line)): (usize, (NodeId, NodeId, Line<f64>))| {
+        let new_edges_data: Vec<_> = into_map_enumerate(valid_edges, |(i, (u, v, line))| {
             create_edge_components(i, u, v, line, edges_start_len, directed_edges_start_len)
-        };
-
-        #[cfg(feature = "parallel")]
-        let new_edges_data: Vec<_> = valid_edges
-            .into_par_iter()
-            .enumerate()
-            .map(mapper)
-            .collect();
-
-        #[cfg(not(feature = "parallel"))]
-        let new_edges_data: Vec<_> = valid_edges.into_iter().enumerate().map(mapper).collect();
+        });
 
         for (u, v, de_u_v_idx, de_v_u_idx, de_u_v, de_v_u, edge) in new_edges_data {
             self.directed_edges.push(de_u_v);

--- a/src/utils/parallel.rs
+++ b/src/utils/parallel.rs
@@ -50,3 +50,93 @@ where
         collection.iter_mut().for_each(f);
     }
 }
+
+/// Helper for sorting a slice, using unstable sort.
+#[inline]
+pub fn sort_unstable<T>(collection: &mut [T])
+where
+    T: Ord + Send,
+{
+    #[cfg(all(feature = "parallel", not(target_arch = "wasm32")))]
+    {
+        if collection.len() > 1000 {
+            collection.par_sort_unstable();
+        } else {
+            collection.sort_unstable();
+        }
+    }
+    #[cfg(any(not(feature = "parallel"), target_arch = "wasm32"))]
+    {
+        collection.sort_unstable();
+    }
+}
+
+/// Helper for flat_map + collect.
+#[inline]
+pub fn flat_map<T, U, I, F>(collection: &[T], f: F) -> Vec<U>
+where
+    T: Sync,
+    U: Send,
+    I: IntoIterator<Item = U>,
+    F: Fn(&T) -> I + Sync + Send,
+{
+    #[cfg(all(feature = "parallel", not(target_arch = "wasm32")))]
+    {
+        if collection.len() > 1000 {
+            collection.par_iter().flat_map_iter(f).collect()
+        } else {
+            collection.iter().flat_map(f).collect()
+        }
+    }
+    #[cfg(any(not(feature = "parallel"), target_arch = "wasm32"))]
+    {
+        collection.iter().flat_map(f).collect()
+    }
+}
+
+/// Helper for zip + for_each on two slices (one mutable, one immutable).
+#[inline]
+pub fn zip_for_each<T, U, F>(collection1: &mut [T], collection2: &[U], f: F)
+where
+    T: Send,
+    U: Sync,
+    F: Fn((&mut T, &U)) + Sync + Send,
+{
+    #[cfg(all(feature = "parallel", not(target_arch = "wasm32")))]
+    {
+        if collection1.len() > 1000 {
+            collection1
+                .par_iter_mut()
+                .zip(collection2.par_iter())
+                .for_each(f);
+        } else {
+            collection1.iter_mut().zip(collection2.iter()).for_each(f);
+        }
+    }
+    #[cfg(any(not(feature = "parallel"), target_arch = "wasm32"))]
+    {
+        collection1.iter_mut().zip(collection2.iter()).for_each(f);
+    }
+}
+
+/// Helper for into_iter + enumerate + map + collect on a Vec.
+#[inline]
+pub fn into_map_enumerate<T, U, F>(collection: Vec<T>, f: F) -> Vec<U>
+where
+    T: Send,
+    U: Send,
+    F: Fn((usize, T)) -> U + Sync + Send,
+{
+    #[cfg(all(feature = "parallel", not(target_arch = "wasm32")))]
+    {
+        if collection.len() > 1000 {
+            collection.into_par_iter().enumerate().map(f).collect()
+        } else {
+            collection.into_iter().enumerate().map(f).collect()
+        }
+    }
+    #[cfg(any(not(feature = "parallel"), target_arch = "wasm32"))]
+    {
+        collection.into_iter().enumerate().map(f).collect()
+    }
+}


### PR DESCRIPTION
Refactor `PlanarGraph::bulk_load` to improve code health by removing duplicated conditional compilation blocks.

## Changes

-   **`src/utils/parallel.rs`**: Added generic helper functions (`sort_unstable`, `flat_map`, `zip_for_each`, `into_map_enumerate`) that abstract away the `#[cfg(feature = "parallel")]` checks. These helpers also enforce a heuristic (collection size > 1000) to conditionally enable parallelism, optimizing for small datasets.
-   **`src/graph/planar_graph.rs`**: Refactored `bulk_load` to use these helpers instead of repeating `if/else` blocks for parallel vs sequential execution.

## Verification

-   Run `cargo test` (default features = parallel): All tests passed.
-   Run `cargo test --no-default-features` (sequential): All tests passed.
-   Confirmed that `bulk_load` logic remains functionally equivalent (verified via existing `test_bulk_load`).


---
*PR created automatically by Jules for task [1824154473424732996](https://jules.google.com/task/1824154473424732996) started by @graydonpleasants*