### PR TITLE
Guaranteed interior probe for concave holes and GEOS shell-touch handling

### DIFF
--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -1,9 +1,8 @@
 use crate::error::Result;
 use crate::graph::PlanarGraph;
-use geo::algorithm::centroid::Centroid;
 use geo::bounding_rect::BoundingRect;
 use geo::Area;
-use geo_types::{Coord, Geometry, Line, LineString, Point, Polygon};
+use geo_types::{Coord, Geometry, Line, LineString, Polygon};
 use rstar::{RTree, RTreeObject, AABB};
 
 use crate::noding::snap::SnapNoder;
@@ -277,11 +276,7 @@ impl Polygonizer {
                 let mut best_shell_idx = None;
                 let mut min_area = f64::MAX;
 
-                // Use centroid for inclusion check to avoid boundary issues
-                let probe_point = hole_poly.centroid().unwrap_or_else(|| {
-                    // Fallback to first point if centroid fails (e.g. degenerate)
-                    Point(hole_poly.exterior().0[0])
-                });
+                let probe_point = guaranteed_interior_probe(&hole_poly)?;
 
                 for cand in candidates {
                     let idx = cand.index;
@@ -290,6 +285,14 @@ impl Polygonizer {
 
                     if simd_shell.contains(probe_point.0) {
                         let shell = &shells[idx];
+
+                        // GEOS topology strictness:
+                        // - Point-touch between hole and shell is valid and kept.
+                        // - Edge-sharing invalidates the hole assignment here and we drop the hole.
+                        if rings_share_edge(shell.exterior(), hole_poly.exterior(), 1e-10) {
+                            continue;
+                        }
+
                         let area = shell.unsigned_area();
                         let hole_area = hole_poly.unsigned_area();
 
@@ -342,6 +345,157 @@ impl Polygonizer {
 
         Ok(result)
     }
+}
+
+fn guaranteed_interior_probe(poly: &Polygon<f64>) -> Option<geo_types::Point<f64>> {
+    let ring = poly.exterior();
+    let coords = &ring.0;
+    if coords.len() < 4 {
+        return None;
+    }
+
+    let unique_n = coords.len().saturating_sub(1);
+    if unique_n < 3 {
+        return None;
+    }
+
+    let area = poly.signed_area();
+    if !area.is_finite() || area.abs() < 1e-12 {
+        return None;
+    }
+
+    let hole_simd = SimdRing::new(coords);
+    let diag = poly
+        .bounding_rect()
+        .map(|b| {
+            let dx = b.max().x - b.min().x;
+            let dy = b.max().y - b.min().y;
+            (dx * dx + dy * dy).sqrt()
+        })
+        .unwrap_or(1.0);
+    let eps = (diag * 1e-9).max(1e-10);
+
+    for i in 0..unique_n {
+        let prev = coords[(i + unique_n - 1) % unique_n];
+        let curr = coords[i];
+        let next = coords[(i + 1) % unique_n];
+
+        let in_edge = Coord {
+            x: curr.x - prev.x,
+            y: curr.y - prev.y,
+        };
+        let out_edge = Coord {
+            x: next.x - curr.x,
+            y: next.y - curr.y,
+        };
+
+        let in_len = (in_edge.x * in_edge.x + in_edge.y * in_edge.y).sqrt();
+        let out_len = (out_edge.x * out_edge.x + out_edge.y * out_edge.y).sqrt();
+        if in_len < 1e-12 || out_len < 1e-12 {
+            continue;
+        }
+
+        let turn = in_edge.x * out_edge.y - in_edge.y * out_edge.x;
+        let convex = if area > 0.0 {
+            turn > 1e-12
+        } else {
+            turn < -1e-12
+        };
+        if !convex {
+            continue;
+        }
+
+        let to_prev = Coord {
+            x: (prev.x - curr.x) / in_len,
+            y: (prev.y - curr.y) / in_len,
+        };
+        let to_next = Coord {
+            x: (next.x - curr.x) / out_len,
+            y: (next.y - curr.y) / out_len,
+        };
+
+        let bisector = Coord {
+            x: to_prev.x + to_next.x,
+            y: to_prev.y + to_next.y,
+        };
+        let bisector_len = (bisector.x * bisector.x + bisector.y * bisector.y).sqrt();
+        if bisector_len < 1e-12 {
+            continue;
+        }
+
+        let bisector_unit = Coord {
+            x: bisector.x / bisector_len,
+            y: bisector.y / bisector_len,
+        };
+
+        for sign in [1.0, -1.0] {
+            let candidate = Coord {
+                x: curr.x + sign * bisector_unit.x * eps,
+                y: curr.y + sign * bisector_unit.y * eps,
+            };
+            if hole_simd.contains(candidate) {
+                return Some(geo_types::Point(candidate));
+            }
+        }
+    }
+
+    Some(geo_types::Point(coords[0]))
+}
+
+fn rings_share_edge(shell: &LineString<f64>, hole: &LineString<f64>, eps: f64) -> bool {
+    if shell.0.len() < 2 || hole.0.len() < 2 {
+        return false;
+    }
+
+    let shell_n = shell.0.len() - 1;
+    let hole_n = hole.0.len() - 1;
+
+    for i in 0..shell_n {
+        let a1 = shell.0[i];
+        let a2 = shell.0[i + 1];
+        for j in 0..hole_n {
+            let b1 = hole.0[j];
+            let b2 = hole.0[j + 1];
+            if segments_overlap_with_length(a1, a2, b1, b2, eps) {
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
+fn segments_overlap_with_length(
+    a1: Coord<f64>,
+    a2: Coord<f64>,
+    b1: Coord<f64>,
+    b2: Coord<f64>,
+    eps: f64,
+) -> bool {
+    let ax = a2.x - a1.x;
+    let ay = a2.y - a1.y;
+    let a_len_sq = ax * ax + ay * ay;
+    if a_len_sq <= eps * eps {
+        return false;
+    }
+
+    // Collinearity checks for segment B endpoints against segment A line
+    let cross_b1 = ax * (b1.y - a1.y) - ay * (b1.x - a1.x);
+    let cross_b2 = ax * (b2.y - a1.y) - ay * (b2.x - a1.x);
+    let tol = eps * a_len_sq.sqrt();
+    if cross_b1.abs() > tol || cross_b2.abs() > tol {
+        return false;
+    }
+
+    let t1 = ((b1.x - a1.x) * ax + (b1.y - a1.y) * ay) / a_len_sq;
+    let t2 = ((b2.x - a1.x) * ax + (b2.y - a1.y) * ay) / a_len_sq;
+
+    let min_t = t1.min(t2);
+    let max_t = t1.max(t2);
+    let overlap_start = 0.0_f64.max(min_t);
+    let overlap_end = 1.0_f64.min(max_t);
+
+    overlap_end - overlap_start > eps
 }
 
 fn extract_lines(geom: &Geometry<f64>, out: &mut Vec<LineString<f64>>) {

--- a/crates/geo-polygonize-core/src/polygonizer_tests.rs
+++ b/crates/geo-polygonize-core/src/polygonizer_tests.rs
@@ -217,4 +217,119 @@ mod tests {
             .expect("Polygonization should not fail on Point input with noding");
         assert_eq!(polygons.len(), 0);
     }
+
+    #[test]
+    fn test_concave_hole_uses_interior_probe_not_centroid() {
+        let mut poly = Polygonizer::new();
+
+        // Outer shell (CCW)
+        poly.add_geometry(
+            LineString::from(vec![
+                (0.0, 0.0),
+                (10.0, 0.0),
+                (10.0, 10.0),
+                (0.0, 10.0),
+                (0.0, 0.0),
+            ])
+            .into(),
+        );
+
+        // Concave C-shaped hole (CW). Its centroid lies outside of the ring.
+        poly.add_geometry(
+            LineString::from(vec![
+                (3.0, 3.0),
+                (3.0, 9.0),
+                (9.0, 9.0),
+                (9.0, 7.0),
+                (5.0, 7.0),
+                (5.0, 5.0),
+                (9.0, 5.0),
+                (9.0, 3.0),
+                (3.0, 3.0),
+            ])
+            .into(),
+        );
+
+        let polygons = poly.polygonize().expect("Polygonization failed");
+
+        let shell_with_hole = polygons
+            .iter()
+            .find(|p| (p.unsigned_area() - 72.0).abs() < 1.0);
+        assert!(
+            shell_with_hole.is_some(),
+            "Expected outer shell area near 72 with assigned concave hole"
+        );
+        assert_eq!(shell_with_hole.unwrap().interiors().len(), 1);
+    }
+
+    #[test]
+    fn test_point_touch_hole_is_kept() {
+        let mut poly = Polygonizer::new();
+
+        poly.add_geometry(
+            LineString::from(vec![
+                (0.0, 0.0),
+                (10.0, 0.0),
+                (10.0, 10.0),
+                (0.0, 10.0),
+                (0.0, 0.0),
+            ])
+            .into(),
+        );
+
+        // CW hole touching shell at one vertex (5,0)
+        poly.add_geometry(
+            LineString::from(vec![(5.0, 0.0), (4.0, 2.0), (6.0, 2.0), (5.0, 0.0)]).into(),
+        );
+
+        let polygons = poly.polygonize().expect("Polygonization failed");
+
+        let shell_with_hole = polygons
+            .iter()
+            .find(|p| (p.unsigned_area() - 98.0).abs() < 1.0);
+        assert!(
+            shell_with_hole.is_some(),
+            "Point-touch hole should be retained on parent shell"
+        );
+        assert_eq!(shell_with_hole.unwrap().interiors().len(), 1);
+    }
+
+    #[test]
+    fn test_edge_touch_hole_is_dropped() {
+        let mut poly = Polygonizer::new();
+
+        poly.add_geometry(
+            LineString::from(vec![
+                (0.0, 0.0),
+                (10.0, 0.0),
+                (10.0, 10.0),
+                (0.0, 10.0),
+                (0.0, 0.0),
+            ])
+            .into(),
+        );
+
+        // CW hole sharing an entire edge segment with the shell boundary.
+        poly.add_geometry(
+            LineString::from(vec![
+                (2.0, 0.0),
+                (2.0, 2.0),
+                (4.0, 2.0),
+                (4.0, 0.0),
+                (2.0, 0.0),
+            ])
+            .into(),
+        );
+
+        let polygons = poly.polygonize().expect("Polygonization failed");
+
+        let outer = polygons
+            .iter()
+            .find(|p| (p.unsigned_area() - 100.0).abs() < 1.0);
+        assert!(
+            outer.is_some(),
+            "Edge-touch hole should not be assigned to the parent shell"
+        );
+        assert_eq!(outer.unwrap().interiors().len(), 0);
+    }
 }


### PR DESCRIPTION
### Motivation
- Centroid-based probe points can fall outside highly concave rings, causing valid holes to become orphaned. 
- The GEOS specification treats vertex-only touching differently from full edge-sharing, so hole assignment must detect and resolve edge-touch topologies explicitly.

### Description
- Replace the centroid probe in `Polygonizer::polygonize` with `guaranteed_interior_probe`, which picks a real ring vertex, computes the angle bisector of its adjacent edges, and nudges a probe point inward by an epsilon until it verifies it lies inside the ring via `SimdRing`.
- Add topology checks to hole assignment: call `rings_share_edge(shell.exterior(), hole.exterior(), eps)` and skip assignment when a positive-length collinear overlap (edge-touch) is detected while allowing vertex-only (point-touch) cases.
- Implement helper routines `guaranteed_interior_probe`, `rings_share_edge`, and `segments_overlap_with_length` in `crates/geo-polygonize-core/src/polygonizer.rs`, and remove the centroid import that is no longer used.
- Add regression tests in `crates/geo-polygonize-core/src/polygonizer_tests.rs` covering a concave hole whose centroid lies outside, retention of point-touch holes, and rejection of edge-touch holes.

### Testing
- Ran `cargo fmt` successfully to format changes.
- Ran focused unit tests and they passed: `cargo test -p geo-polygonize-core polygonizer_tests::tests::test_concave_hole_uses_interior_probe_not_centroid` (ok), `cargo test -p geo-polygonize-core point_touch_hole_is_kept` (ok), and `cargo test -p geo-polygonize-core edge_touch_hole_is_dropped` (ok).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f4a4627b4832fa77eb166778858a1)