### PR TITLE
feat: Cache WebAssembly initialization in JS wrapper

### DIFF
--- a/pkg-wrapper/index.ts
+++ b/pkg-wrapper/index.ts
@@ -1,19 +1,18 @@
-import init, * as exports from "../pkg-scalar/geo_polygonize.js";
+import wasmInit, * as exports from "../pkg-scalar/geo_polygonize.js";
 import wasmScalarUrl from "../pkg-scalar/geo_polygonize_bg.wasm";
 import wasmSimdUrl from "../pkg-simd/geo_polygonize_bg.wasm";
 
-let simdSupported: boolean | undefined;
-
-function hasSimd() {
-    if (simdSupported !== undefined) return simdSupported;
+// Perform SIMD detection once at module load time
+const simdSupported = (() => {
     try {
-        // Check if WebAssembly.validate validates a small SIMD module
-        simdSupported = WebAssembly.validate(new Uint8Array([0,97,115,109,1,0,0,0,1,5,1,96,0,1,123,3,2,1,0,10,10,1,8,0,65,0,253,15,253,98,11]));
+        return WebAssembly.validate(new Uint8Array([0,97,115,109,1,0,0,0,1,5,1,96,0,1,123,3,2,1,0,10,10,1,8,0,65,0,253,15,253,98,11]));
     } catch (e) {
-        simdSupported = false;
+        return false;
     }
-    return simdSupported;
-}
+})();
+
+// Cache the initialization promise
+let initPromise: Promise<typeof exports> | undefined;
 
 // We re-export everything from the scalar package.
 // The JS bindings in pkg-scalar/geo_polygonize.js are identical to pkg-simd/geo_polygonize.js
@@ -23,8 +22,16 @@ export * from "../pkg-scalar/geo_polygonize.js";
 
 // Override the init function
 // input is ignored because we are using inlined Wasm
-export default async function(_input?: any) {
-    const url = hasSimd() ? wasmSimdUrl : wasmScalarUrl;
-    await init(url);
-    return exports;
+export default function init(_input?: any): Promise<typeof exports> {
+    if (initPromise) return initPromise;
+
+    const url = simdSupported ? wasmSimdUrl : wasmScalarUrl;
+
+    // Create the promise and cache it
+    initPromise = (async () => {
+        await wasmInit(url);
+        return exports;
+    })();
+
+    return initPromise;
 }


### PR DESCRIPTION
Implemented a singleton initialization cache in the `geo-polygonize-wasm` JavaScript/TypeScript wrapper (`pkg-wrapper/index.ts`).
Previously, the `init()` function would re-evaluate SIMD support and attempt to re-initialize the WebAssembly module on every call.
The new implementation:
1.  Performs WebAssembly SIMD feature detection exactly once when the module loads, using a top-level IIFE.
2.  Caches the initialization promise in a module-level variable (`initPromise`).
3.  Checks this cache in the exported `init()` function, returning the existing promise if initialization has already occurred.
This ensures that subsequent calls to `init()` are instant and do not incur the overhead of feature detection or re-initialization.

Verified with a reproduction test case that confirmed `init()` now returns the same promise instance on repeated calls, and existing tests passed with no regressions.

---
*PR created automatically by Jules for task [8110045474724416339](https://jules.google.com/task/8110045474724416339) started by @graydonpleasants*