### PR TITLE
Grid "Supercell" Bucketing for Long Lines

### DIFF
--- a/crates/geo-polygonize-core/src/noding/grid.rs
+++ b/crates/geo-polygonize-core/src/noding/grid.rs
@@ -272,10 +272,9 @@ impl UniformGrid {
 
                             // Deduplicate Global-Global checks
                             // If target is also global, enforce index ordering (only check if g_idx < target_idx)
-                            if global_lines.binary_search(&target_idx).is_ok() {
-                                if target_idx < g_idx {
-                                    continue;
-                                }
+                            if global_lines.binary_search(&target_idx).is_ok() && target_idx < g_idx
+                            {
+                                continue;
                             }
 
                             // Process intersection


### PR DESCRIPTION
This PR implements a "Supercell" or "Global Line" heuristic in `UniformGrid` to prevent memory explosion when processing long lines that span a large number of grid cells.

Changes:
1.  **Grid Construction (`UniformGrid::new`)**:
    *   Calculates the number of cells a line's bounding box touches.
    *   If a line touches more than 50 cells (`MAX_CELLS_PER_LINE`), it is flagged as a "global line".
    *   Global lines are stored in a separate `global_lines` vector and are **not** inserted into the standard CSR grid arrays (`cell_items`, `counts`).

2.  **Intersection Detection (`UniformGrid::find_splits`)**:
    *   The standard grid-based intersection detection remains for local lines.
    *   A new pass processes `global_lines`:
        *   Iterates through each global line.
        *   Checks against **all** other lines in the dataset using `SoALines::intersects_bbox_batch_splatted` for fast SIMD AABB rejection.
        *   Performs exact intersection checks for candidates.
        *   Includes logic to deduplicate checks between two global lines (enforcing index ordering).

3.  **Tests**:
    *   Updated `test_boundary_handling` to assert that long lines are correctly identified as global and excluded from grid cells.
    *   Added `test_global_line_intersection` to verify that global lines correctly intersect with both local lines and other global lines.

This optimization ensures that pathological inputs (e.g., a diagonal line across a 1000x1000 grid) do not result in inserting the line into 1,000+ cells, significantly reducing memory usage and potential OOM errors for such cases.

---
*PR created automatically by Jules for task [9440733068966303540](https://jules.google.com/task/9440733068966303540) started by @graydonpleasants*