### PR TITLE
Safe handling of 3D coordinates and input validation in Python wrapper

### DIFF
--- a/python/geo_polygonize/__init__.py
+++ b/python/geo_polygonize/__init__.py
@@ -1,6 +1,38 @@
 from .types import SimplePolygon
+import numpy as np
 
 try:
-    from .geo_polygonize_core import polygonize
+    from .geo_polygonize_core import polygonize as _polygonize_impl
 except ImportError:
-    from .cffi_wrapper import polygonize
+    from .cffi_wrapper import polygonize as _polygonize_impl
+
+def polygonize(coords, offsets, node=False, snap=1e-10):
+    """
+    Polygonize a set of lines.
+
+    Args:
+        coords: float64 array of shape (N, 2) or (N, 3) or flattened.
+        offsets: uint32 array of start indices in coords.
+        node: whether to node the input.
+        snap: snap grid size.
+
+    Returns:
+        List of SimplePolygon objects.
+    """
+    # Ensure coords is a numpy array
+    coords = np.ascontiguousarray(coords, dtype=np.float64)
+
+    # Handle (N, 3) case: slice out Z
+    if coords.ndim == 2 and coords.shape[1] == 3:
+        coords = coords[:, :2]
+        coords = np.ascontiguousarray(coords, dtype=np.float64)
+
+    # Flatten if 2D (N, 2)
+    if coords.ndim == 2:
+        coords = coords.ravel()
+
+    # Check for odd length (must be pairs of XY)
+    if coords.size % 2 != 0:
+        raise ValueError("Coordinates array must have an even number of elements (XY pairs).")
+
+    return _polygonize_impl(coords, offsets, node=node, snap=snap)

--- a/python/test_wrapper.py
+++ b/python/test_wrapper.py
@@ -93,7 +93,55 @@ def test_square_with_hole():
     assert abs(areas[1] - 64.0) < 1e-6
     print("Square with hole test passed!")
 
+def test_3d_coordinates():
+    print("\nTesting 3D coordinates (expecting Z to be ignored)...")
+    # A square in 3D: (0,0,100), (10,0,101), (10,10,102), (0,10,103)
+    coords = np.array([
+        [0.0, 0.0, 100.0],
+        [10.0, 0.0, 101.0],
+        [10.0, 10.0, 102.0],
+        [0.0, 10.0, 103.0],
+        [0.0, 0.0, 100.0]  # Closed ring
+    ], dtype=np.float64)
+
+    # Offsets in POINTS (indices into the N rows)
+    # 5 points.
+    # We want one ring.
+    # Note: polygonize usually takes multiple lines.
+    # If we pass a single closed linestring, it should work if it forms a polygon.
+    # We need to include the last point (index 4) to close the loop P3->P4.
+    # Offsets define range [start, end). The loop runs for j in start..end-1.
+    # To get segments P0-P1, P1-P2, P2-P3, P3-P4, we need j=0,1,2,3.
+    # So end-1 = 4 => end = 5.
+    offsets = np.array([0, 5], dtype=np.uint32)
+
+    polys = polygonize(coords, offsets)
+    print(f"Result count: {len(polys)}")
+    assert len(polys) == 1
+
+    poly = polys[0]
+    shapely_poly = shape(poly.__geo_interface__)
+    print(f"Shapely area: {shapely_poly.area}")
+    assert abs(shapely_poly.area - 100.0) < 1e-6
+    print("3D coordinates test passed!")
+
+def test_odd_length_coordinates():
+    print("\nTesting odd length coordinates...")
+    # Flat array with 3 elements (1.5 points)
+    coords = np.array([0.0, 0.0, 1.0], dtype=np.float64)
+    offsets = np.array([0], dtype=np.uint32)
+
+    try:
+        polygonize(coords, offsets)
+        assert False, "Should have raised ValueError"
+    except ValueError as e:
+        print(f"Caught expected error: {e}")
+        assert "Coordinates array must have an even number of elements" in str(e)
+    print("Odd length coordinates test passed!")
+
 if __name__ == "__main__":
     test_square()
     test_two_squares()
     test_square_with_hole()
+    test_3d_coordinates()
+    test_odd_length_coordinates()


### PR DESCRIPTION
This PR enhances the Python FFI wrapper for `geo_polygonize` to improve robustness and safety, specifically addressing potential issues with 3D coordinate inputs and invalid array lengths.

Key changes:
- **3D Coordinate Support:** The wrapper now detects input arrays with shape `(N, 3)` (e.g., from CAD data) and explicitly slices them to `(N, 2)` (XY only) before passing them to the Rust backend. This prevents the backend from interpreting Z coordinates as X or Y values, which would result in malformed geometry.
- **Input Validation:** A check was added to ensure the flattened coordinate array has an even number of elements. If an odd-length array is passed, a descriptive `ValueError` is raised instead of potentially crashing or returning error codes from the C/Rust layer.
- **Contiguity Enforcement:** The wrapper ensures all coordinate inputs are converted to C-contiguous `float64` arrays before processing.
- **Tests:** New test cases were added to `python/test_wrapper.py` to verify:
    - Correct polygonization of a 3D square (ignoring Z).
    - Proper error raising for odd-length coordinate arrays.

This prevents C-level segfaults or undefined behavior when users inadvertently pass 3D data or malformed arrays.

---
*PR created automatically by Jules for task [3304622262700449293](https://jules.google.com/task/3304622262700449293) started by @graydonpleasants*