### PR TITLE
Fix benchmark compilation errors

### DIFF
--- a/crates/geo-polygonize-core/benches/polygonize_bench.rs
+++ b/crates/geo-polygonize-core/benches/polygonize_bench.rs
@@ -124,7 +124,7 @@ fn bench_polygonize(c: &mut Criterion) {
                     let mut input_segments = Vec::new();
                     for ls in &lines {
                         for line in ls.lines() {
-                            input_segments.push(line);
+                            input_segments.push(line.into());
                         }
                     }
                     let noder = SnapNoder::new(1e-10); // Auto
@@ -142,7 +142,7 @@ fn bench_polygonize(c: &mut Criterion) {
                     let mut input_segments = Vec::new();
                     for ls in &lines {
                         for line in ls.lines() {
-                            input_segments.push(line);
+                            input_segments.push(line.into());
                         }
                     }
                     let noder = SnapNoder::new(1e-10).with_strategy(NodingStrategy::Grid);
@@ -162,7 +162,7 @@ fn bench_polygonize(c: &mut Criterion) {
                         let mut input_segments = Vec::new();
                         for ls in &lines {
                             for line in ls.lines() {
-                                input_segments.push(line);
+                                input_segments.push(line.into());
                             }
                         }
                         let noder = SnapNoder::new(1e-10).with_strategy(NodingStrategy::Simd);
@@ -196,7 +196,7 @@ fn bench_polygonize(c: &mut Criterion) {
         let mut input_segments = Vec::new();
         for ls in &lines {
             for line in ls.lines() {
-                input_segments.push(line);
+                input_segments.push(line.into());
             }
         }
         // Clone for setup to avoid overhead in loop?
@@ -248,7 +248,7 @@ fn bench_get_edge_rings_dangles(c: &mut Criterion) {
                 // Pruning dangles will mark some edges, causing nodes to have
                 // valid degree < outgoing.len(), forcing the slow path.
                 loop {
-                    if graph.prune_dangles() == 0 {
+                    if graph.prune_dangles().is_empty() {
                         break;
                     }
                 }


### PR DESCRIPTION
This PR fixes compilation errors in the `polygonize_bench.rs` benchmark file within `crates/geo-polygonize-core`. The errors were due to:
1.  Passing `Vec<geo_types::Line>` to `SnapNoder::node`, which expects `Vec<Line3D>`. This was resolved by converting lines using `.into()`.
2.  Comparing the result of `prune_dangles()`, which returns a `Vec<Vec<Coord3D>>`, directly to an integer (`0`). This was corrected to check `.is_empty()`.

These changes restore the ability to run benchmarks for performance regression testing.

---
*PR created automatically by Jules for task [18039819203601930945](https://jules.google.com/task/18039819203601930945) started by @graydonpleasants*