### PR TITLE
fix: use custom token for release-please to allow PR creation

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,5 +15,6 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
+          token: ${{ secrets.GH_PAT }}
           release-type: node
           package-name: "geo-polygonize"


### PR DESCRIPTION
Fixes an issue where `release-please` fails to create its release Pull Request due to insufficient permissions. 
It replaces the default `GITHUB_TOKEN` with a custom token `secrets.GH_PAT`. 

Using a PAT is also required by GitHub Actions so that when `release-please` pushes a git tag (like `v1.2.3`), the push event correctly triggers downstream workflows (like `publish-npm.yml` and `publish-python.yml`).

Please make sure you create a new **Repository Secret** named `GH_PAT` containing a Personal Access Token with `repo` scopes before merging this.

---
*PR created automatically by Jules for task [12746554020330918725](https://jules.google.com/task/12746554020330918725) started by @graydonpleasants*