### PR TITLE
fix: add missing version to geo-polygonize-core dependency

### DIFF
--- a/crates/geo-polygonize-wasm/Cargo.toml
+++ b/crates/geo-polygonize-wasm/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-geo-polygonize-core = { path = "../geo-polygonize-core", default-features = false }
+geo-polygonize-core = { version = "0.1.0", path = "../geo-polygonize-core", default-features = false }
 wasm-bindgen = "0.2"
 console_error_panic_hook = { version = "0.1.7", optional = true }
 js-sys = "0.3"


### PR DESCRIPTION
Fixes an issue where the `geo-polygonize-wasm` crate fails to publish because its `geo-polygonize-core` dependency is missing a version requirement. This PR simply adds `version = "0.1.0"` to the path dependency declaration in `crates/geo-polygonize-wasm/Cargo.toml`.

---
*PR created automatically by Jules for task [57344639625903470](https://jules.google.com/task/57344639625903470) started by @graydonpleasants*