### PR TITLE
ci(github): add PR title linter and update AGENTS.md

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,0 +1,28 @@
+name: Lint PR Title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Define custom scopes
+          scopes: |
+            core
+            python
+            wasm
+            fleet
+            deps
+
+          # Require a scope to always be present
+          requireScope: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# AI Agent Instructions
+
+## Pull Request and Commit Standards
+
+### PR Titles
+The PR title **must** follow the Conventional Commits specification. This ensures that `release-please` functions correctly and changelogs are generated accurately.
+
+When creating a Pull Request, the title must be in the following format:
+`<type>(<scope>): <short description>`
+
+#### Allowed Scopes
+The scope is **required** for every Pull Request. You must use one of the following scopes depending on what part of the repository you are modifying:
+
+*   `core`: Modifications to the Rust core implementation (`crates/geo-polygonize-core`).
+*   `python`: Modifications to the Python bindings (`python/`, `crates/geo-polygonize-core/src/python.rs`).
+*   `wasm`: Modifications to the WASM bindings (`pkg-threads/`, `pkg-wrapper/`, `crates/geo-polygonize-wasm`).
+*   `fleet`: Modifications to the fleet automation tools (`scripts/fleet/`).
+*   `deps`: Dependency updates or modifications.
+
+If a PR spans multiple areas, try to pick the most significant one or consider if the PR should be split.
+
+#### Allowed Types
+Standard Conventional Commit types apply:
+*   `feat`: A new feature.
+*   `fix`: A bug fix.
+*   `docs`: Documentation only changes.
+*   `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc).
+*   `refactor`: A code change that neither fixes a bug nor adds a feature.
+*   `perf`: A code change that improves performance.
+*   `test`: Adding missing tests or correcting existing tests.
+*   `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm).
+*   `ci`: Changes to our CI configuration files and scripts.
+*   `chore`: Other changes that don't modify src or test files.
+*   `revert`: Reverts a previous commit.
+
+#### Examples
+*   `feat(core): implement SIMD intersection checks`
+*   `fix(python): resolve memory leak in FFI translation`
+*   `docs(wasm): update README for threads package`
+*   `chore(deps): update rayon to 1.10.0`


### PR DESCRIPTION
This PR introduces a GitHub Actions workflow (`.github/workflows/pr-lint.yml`) that lints PR titles to ensure they comply with the Conventional Commits specification. This ensures that the final squashed commits have correct formats, which is crucial for `release-please` to function smoothly.

Additionally, this PR adds an `AGENTS.md` file that documents these standards, explicitly defining the allowed scopes (`core`, `python`, `wasm`, `fleet`, `deps`) and requiring them.

---
*PR created automatically by Jules for task [16774131526518705125](https://jules.google.com/task/16774131526518705125) started by @graydonpleasants*