### PR TITLE
test(core): Improve Coord3D Arithmetic tests

### DIFF
--- a/crates/geo-polygonize-core/src/types.rs
+++ b/crates/geo-polygonize-core/src/types.rs
@@ -265,26 +265,49 @@ mod tests {
     }
 
     #[test]
-    fn test_coord3d_arithmetic() {
+    fn test_coord3d_add() {
         let c1 = Coord3D::new(1.0, 2.0, 3.0);
         let c2 = Coord3D::new(4.0, 5.0, 6.0);
+        assert_eq!(c1 + c2, Coord3D::new(5.0, 7.0, 9.0));
 
-        // Add
-        let sum = c1 + c2;
-        assert_eq!(sum, Coord3D::new(5.0, 7.0, 9.0));
+        let c3 = Coord3D::new(-1.0, 0.0, -3.0);
+        assert_eq!(c1 + c3, Coord3D::new(0.0, 2.0, 0.0));
+    }
 
-        // Sub
-        let diff = c2 - c1;
-        assert_eq!(diff, Coord3D::new(3.0, 3.0, 3.0));
+    #[test]
+    fn test_coord3d_sub() {
+        let c1 = Coord3D::new(1.0, 2.0, 3.0);
+        let c2 = Coord3D::new(4.0, 5.0, 6.0);
+        assert_eq!(c2 - c1, Coord3D::new(3.0, 3.0, 3.0));
 
-        // Mul
-        let scaled = c1 * 2.0;
-        assert_eq!(scaled, Coord3D::new(2.0, 4.0, 6.0));
+        let c3 = Coord3D::new(1.0, 2.0, 3.0);
+        assert_eq!(c1 - c3, Coord3D::new(0.0, 0.0, 0.0));
+    }
 
-        // Negative and zero
-        let c3 = Coord3D::new(-1.0, 0.0, 1.0);
-        assert_eq!(c1 + c3, Coord3D::new(0.0, 2.0, 4.0));
-        assert_eq!(c3 * -1.0, Coord3D::new(1.0, 0.0, -1.0));
+    #[test]
+    fn test_coord3d_mul() {
+        let c1 = Coord3D::new(1.0, 2.0, 3.0);
+
+        // Positive scalar
+        assert_eq!(c1 * 2.0, Coord3D::new(2.0, 4.0, 6.0));
+
+        // Negative scalar
+        assert_eq!(c1 * -1.5, Coord3D::new(-1.5, -3.0, -4.5));
+
+        // Zero scalar
+        assert_eq!(c1 * 0.0, Coord3D::new(0.0, 0.0, 0.0));
+    }
+
+    #[test]
+    fn test_coord3d_arithmetic_chain() {
+        let c1 = Coord3D::new(1.0, 2.0, 3.0);
+        let c2 = Coord3D::new(3.0, 2.0, 1.0);
+        let c3 = Coord3D::new(1.0, 1.0, 1.0);
+
+        // (c1 + c2) * 0.5 - c3
+        // (4, 4, 4) * 0.5 - (1, 1, 1) = (2, 2, 2) - (1, 1, 1) = (1, 1, 1)
+        let result = (c1 + c2) * 0.5 - c3;
+        assert_eq!(result, Coord3D::new(1.0, 1.0, 1.0));
     }
 
     #[test]


### PR DESCRIPTION
🎯 What: The testing gap addressed
The single basic arithmetic test for `Coord3D` operations (add, sub, mul) was replaced with targeted and isolated unit tests to ensure all edge cases for mathematical operations function correctly.

📊 Coverage: What scenarios are now tested
- Add (`test_coord3d_add`): Tested positive, negative, and zero addition values.
- Sub (`test_coord3d_sub`): Tested regular subtraction and subtracting a coordinate from itself to yield zero.
- Mul (`test_coord3d_mul`): Tested scalar multiplication with positive, negative, and zero values.
- Chain (`test_coord3d_arithmetic_chain`): Tested chaining multiple operations together `(c1 + c2) * 0.5 - c3`.

✨ Result: The improvement in test coverage
Replaced the single `test_coord3d_arithmetic` with 4 isolated tests. Test isolation was greatly improved, providing fine-grained verification and robust testing over `Coord3D` operations while correctly increasing edge cases.

---
*PR created automatically by Jules for task [6844261102626121258](https://jules.google.com/task/6844261102626121258) started by @graydonpleasants*