### PR TITLE
fix(python): remove invalid `--release` argument from maturin publish command

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -22,6 +22,5 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           command: publish
-          args: --release
         env:
           MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Removes the invalid `args: --release` from the `maturin-action` step in `.github/workflows/publish-python.yml` to fix the python package build action.

---
*PR created automatically by Jules for task [17708243276514188562](https://jules.google.com/task/17708243276514188562) started by @graydonpleasants*