### PR TITLE
fix(python): rename python package to geo-polygonize-py

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -22,6 +22,5 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           command: publish
-          args: --release
         env:
           MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["maturin>=1.4,<2.0"]
 build-backend = "maturin"
 
 [project]
-name = "geo_polygonize"
+name = "geo-polygonize-py"
 version = "0.1.0"
 requires-python = ">=3.7"
 classifiers = [


### PR DESCRIPTION
Changes the python project name in `pyproject.toml` to `geo-polygonize-py` to fix the PyPI name collision 400 error during `maturin publish`.

---
*PR created automatically by Jules for task [17708243276514188562](https://jules.google.com/task/17708243276514188562) started by @graydonpleasants*