### PR TITLE
build(wasm): use trusted publishing for npm

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -9,6 +9,9 @@ jobs:
   publish-npm:
     name: Publish NPM Package
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -31,6 +34,6 @@ jobs:
         run: npm run build
 
       - name: Publish to npm
-        run: npm publish --access public
+        run: npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Updates `.github/workflows/publish-npm.yml` to rely on trusted publishing (OIDC). By requesting `id-token: write` permissions, it automatically signs releases with `--provenance`. Note: This PR replaces the previous one to correctly add the `wasm` scope to the title.

---
*PR created automatically by Jules for task [1196576770610283612](https://jules.google.com/task/1196576770610283612) started by @graydonpleasants*