### PR TITLE
perf(core): avoid cloning holes and pre-allocate result vector in polygonize loop

### DIFF
--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -391,12 +391,14 @@ impl Polygonizer {
         }
 
         // 6. Construct Final Polygons
-        let mut result = Vec::new();
-        for (i, shell) in shells.into_iter().enumerate() {
+        let mut result = Vec::with_capacity(shells.len());
+        for ((shell, holes), holes_ids) in shells
+            .into_iter()
+            .zip(shell_holes.into_iter())
+            .zip(shell_holes_ids.into_iter())
+        {
             let exterior = shell.exterior;
             let exterior_ids = shell.exterior_ids;
-            let holes = shell_holes[i].clone();
-            let holes_ids = shell_holes_ids[i].clone();
 
             let p = Polygon3D::new(exterior, holes, exterior_ids, holes_ids);
 


### PR DESCRIPTION
This PR implements a performance optimization in the `polygonize` method of `geo-polygonize-core`. 

Previously, the code was cloning `shell_holes[i]` and `shell_holes_ids[i]` for every shell in the loop. By refactoring the loop to use `into_iter()` and `zip()`, we now transfer ownership of these vectors directly into the `Polygon3D` constructor, eliminating the need for expensive deep clones. Additionally, the `result` vector is now pre-allocated with the correct capacity, further reducing memory allocation overhead.

While environment-specific issues prevented running the full benchmark suite, this change adheres to documented codebase performance patterns and provides a clear theoretical improvement in both CPU and memory efficiency.

---
*PR created automatically by Jules for task [11578602484238620531](https://jules.google.com/task/11578602484238620531) started by @graydonpleasants*