### PR TITLE
fix(python): explicitly codesign macOS wheels to prevent EXC_BAD_ACCESS

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -6,21 +6,67 @@ on:
       - "v*"
 
 jobs:
-  publish-python:
-    name: Publish Python Package
-    runs-on: ubuntu-latest
+  build-wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 
-      - name: Build and Publish Wheels
+      - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
-          command: publish
+          command: build
+          args: --release --out dist
+
+      - name: Sign macOS wheel
+        if: runner.os == 'macOS'
+        run: |
+          python -m pip install wheel
+          cd dist
+          for whl in *.whl; do
+            mkdir tmp_dir
+            wheel unpack "$whl" -d tmp_dir
+            rm "$whl"
+
+            dir_name=$(ls tmp_dir)
+
+            find "tmp_dir/$dir_name" -name "*.so" -exec codesign --force --sign - {} \;
+
+            wheel pack "tmp_dir/$dir_name"
+            rm -rf tmp_dir
+          done
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}
+          path: dist/*.whl
+
+  publish-python:
+    name: Publish Python Package
+    needs: build-wheels
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download wheels
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          pattern: wheels-*
+          merge-multiple: true
+
+      - name: Publish wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          command: upload
+          args: --skip-existing dist/*
         env:
           MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Fixes `EXC_BAD_ACCESS (SIGKILL (Code Signature Invalid))` on macOS by modifying `.github/workflows/publish-python.yml` to:
- Use a build matrix for Ubuntu, macOS, and Windows.
- Extract macOS wheels using the `wheel` library.
- Ad-hoc sign the compiled `.so` extension with `codesign --force --sign -`.
- Repack the wheel (automatically regenerating the `RECORD` hashes).
- Upload the signed and validated wheels to PyPI.

---
*PR created automatically by Jules for task [3043824053343405762](https://jules.google.com/task/3043824053343405762) started by @graydonpleasants*