### PR TITLE
fix(github): track version updates for python and rust crates

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,3 +18,7 @@ jobs:
           token: ${{ secrets.GH_PAT }}
           release-type: node
           package-name: "geo-polygonize"
+          extra-files: |
+            pyproject.toml
+            crates/geo-polygonize-core/Cargo.toml
+            crates/geo-polygonize-wasm/Cargo.toml


### PR DESCRIPTION
This PR updates `.github/workflows/release-please.yml` to instruct `googleapis/release-please-action` to track and update the versions in `pyproject.toml` and our two `Cargo.toml` files when it creates a release pull request. This resolves an issue where the Python package version and Rust crates version were not correctly updated alongside the npm `package.json` package.

---
*PR created automatically by Jules for task [5406513403463614789](https://jules.google.com/task/5406513403463614789) started by @graydonpleasants*