### PR TITLE
build(wasm): update geo-polygonize-core version in Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-core"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "approx",
  "arrow",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-wasm"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "arrow",
  "arrow-ipc",

--- a/crates/geo-polygonize-wasm/Cargo.toml
+++ b/crates/geo-polygonize-wasm/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-geo-polygonize-core = { version = "0.1.0", path = "../geo-polygonize-core", default-features = false }
+geo-polygonize-core = { version = "0.3.0", path = "../geo-polygonize-core", default-features = false }
 wasm-bindgen = "0.2"
 console_error_panic_hook = { version = "0.1.7", optional = true }
 js-sys = "0.3"


### PR DESCRIPTION
The user reported a CI failure where `geo-polygonize-wasm` requires `geo-polygonize-core = "^0.1.0"`, but the available version is `0.3.0`. I updated the `geo-polygonize-core` dependency version requirement in `crates/geo-polygonize-wasm/Cargo.toml` from `0.1.0` to `0.3.0` to align the required version with the local path package. This fixes the CI failure. I also addressed their question about the CI workflows: both are necessary as they serve different purposes (`ci.yml` is for rapid validation while `maintenance.yml` runs long benchmarks). I also ensured the commit message uses a correct scope (`wasm`) as defined in the repository's `AGENTS.md`.

---
*PR created automatically by Jules for task [17141847151880495508](https://jules.google.com/task/17141847151880495508) started by @graydonpleasants*