### PR TITLE
build(github): unhide build commits in release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,19 @@
   "packages": {
     ".": {
       "release-type": "node",
+      "changelog-sections": [
+        {"type": "feat", "section": "Features"},
+        {"type": "fix", "section": "Bug Fixes"},
+        {"type": "perf", "section": "Performance Improvements"},
+        {"type": "revert", "section": "Reverts"},
+        {"type": "docs", "section": "Documentation", "hidden": true},
+        {"type": "style", "section": "Styles", "hidden": true},
+        {"type": "chore", "section": "Miscellaneous Chores", "hidden": true},
+        {"type": "refactor", "section": "Code Refactoring", "hidden": true},
+        {"type": "test", "section": "Tests", "hidden": true},
+        {"type": "build", "section": "Build System", "hidden": false},
+        {"type": "ci", "section": "Continuous Integration", "hidden": true}
+      ],
       "extra-files": [
         {
           "type": "toml",


### PR DESCRIPTION
Fixes an issue where `release-please` would skip generating a release pull request after a `build` commit landed. By explicitly configuring the `changelog-sections` array in `release-please-config.json` to include `"type": "build"` with `"hidden": false`, `release-please` will now recognize these commits as user-facing and proceed to build the release PR.

---
*PR created automatically by Jules for task [9194449315565451274](https://jules.google.com/task/9194449315565451274) started by @graydonpleasants*