### PR TITLE
docs(core): expand README guidance for noding and output semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,32 @@ fn main() {
 }
 ```
 
+### Choosing `node_input` and `snap_grid_size`
+
+Polygonization quality is heavily influenced by input noding strategy.
+
+- **`node_input = false`** (default): Fastest path. Use this when your input linework is already noded (all intersections are explicit vertices).
+- **`node_input = true`**: Enables Iterated Snap Rounding (ISR). Use this for real-world datasets that may contain slight misalignments, overlaps, or self-intersections.
+- **`snap_grid_size`** controls how aggressively coordinates are snapped during robust noding:
+  - Start with `1e-10` for high-precision projected data.
+  - Increase to `1e-8` or `1e-6` when near-duplicate vertices prevent clean topology.
+  - Avoid very large values unless your coordinate units are coarse; oversnapping can collapse narrow features.
+
+Practical workflow:
+1. Run with `node_input = false` first on trusted data.
+2. If you observe missing polygons, sliver artifacts, or unresolved intersections, enable `node_input`.
+3. Tune `snap_grid_size` upward incrementally until topology stabilizes.
+
+### Output semantics
+
+The polygonizer intentionally returns only valid polygonal areas that can be formed from closed cycles:
+
+- **Dangles are removed**: dead-end edges do not appear in output polygons.
+- **Cut edges are excluded**: edges that are connected but cannot bound a face are ignored.
+- **Holes and nested shells are preserved** when enough boundary information is present.
+
+This behavior matches classical JTS/GEOS polygonization semantics and is useful for cleaning linework before area analysis.
+
 ### GeoArrow Integration
 
 The library supports ingesting data directly from Arrow arrays via the `arrow_api` module and `ffi`.


### PR DESCRIPTION
### Motivation

- Clarify how the polygonizer's noding options affect result quality so users can choose the appropriate workflow for real-world vs. pre-noded inputs.  
- Set clear expectations about what the polygonizer will return (how dangles/cut edges and holes are handled) to reduce confusion when cleaning linework for area analysis.

### Description

- Add a new `Choosing `node_input` and `snap_grid_size`` section that documents the default behavior, when to enable Iterated Snap Rounding (`node_input = true`), recommended starting values for `snap_grid_size`, and a short practical tuning workflow.  
- Add a new `Output semantics` section that explains that dangles are removed, cut edges are excluded, and holes/nested shells are preserved when boundary information is sufficient.  
- Update `README.md` and commit the change with the message `docs(core): expand README guidance for noding and output semantics`.

### Testing

- Ran `git diff --check` to validate whitespace and simple formatting issues and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aad32a8178832fbcb0dce86fc41336)