### PR TITLE
fix(github): bump internal workspace dependencies during release-please sync

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -30,6 +30,11 @@
           "type": "toml",
           "path": "crates/geo-polygonize-wasm/Cargo.toml",
           "jsonpath": "$.package.version"
+        },
+        {
+          "type": "toml",
+          "path": "crates/geo-polygonize-wasm/Cargo.toml",
+          "jsonpath": "$.dependencies.geo-polygonize-core.version"
         }
       ]
     }


### PR DESCRIPTION
Update release-please-config.json extra-files to also bump the `geo-polygonize-core` dependency version inside `geo-polygonize-wasm/Cargo.toml`. This ensures the Cargo resolution graph matches the newly created releases during `release-please` pull requests, fixing CI verification failures.

---
*PR created automatically by Jules for task [7196855191151644267](https://jules.google.com/task/7196855191151644267) started by @graydonpleasants*