### PR TITLE
fix(github): support release-please component tags in publish workflows

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+      - "geo-polygonize-v*"
 
 jobs:
   publish-npm:

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+      - "geo-polygonize-v*"
 
 jobs:
   build-wheels:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+      - "geo-polygonize-v*"
 
 jobs:
   publish:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "packages": {
     ".": {
       "release-type": "node",
+      "include-component-in-tag": false,
       "changelog-sections": [
         {"type": "feat", "section": "Features"},
         {"type": "fix", "section": "Bug Fixes"},


### PR DESCRIPTION
### Motivation
- Publishing workflows stopped triggering because release-please produced component-prefixed tags (`geo-polygonize-v*`) while workflows only listened for `v*` tags.
- Future releases should use plain `v*` tags while preserving compatibility with existing prefixed tags.

### Description
- Disable component prefix in generated tags by setting `"include-component-in-tag": false` in `release-please-config.json` so future tags are `v*`.
- Add `"geo-polygonize-v*"` to the `on.push.tags` trigger in `.github/workflows/publish.yml` to support legacy prefixed crate tags.
- Add `"geo-polygonize-v*"` to the `on.push.tags` trigger in `.github/workflows/publish-python.yml` to support legacy prefixed PyPI tags.
- Add `"geo-polygonize-v*"` to the `on.push.tags` trigger in `.github/workflows/publish-npm.yml` to support legacy prefixed npm tags.

### Testing
- Loaded `release-please-config.json` with `python` and the file parsed successfully indicating valid JSON.
- Parsed the updated workflow YAML files with `ruby` (`YAML.load_file`) and each file loaded successfully indicating valid YAML and workflow syntax.
- Performed a local diff and verified the three workflow files and `release-please-config.json` contain the intended changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab140bbc68832fb1039ff9b33e338d)