### PR TITLE
test(core): add test for centroid_2d empty exterior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-core"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "approx",
  "arrow",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-wasm"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "arrow",
  "arrow-ipc",

--- a/crates/geo-polygonize-core/src/types.rs
+++ b/crates/geo-polygonize-core/src/types.rs
@@ -365,4 +365,10 @@ mod tests {
         assert!((centroid.x() - expected_x).abs() < 1e-8);
         assert!((centroid.y() - expected_y).abs() < 1e-8);
     }
+
+    #[test]
+    fn test_centroid_empty_exterior() {
+        let poly = Polygon3D::new(vec![], vec![], vec![], vec![]);
+        assert_eq!(poly.centroid_2d(), None);
+    }
 }


### PR DESCRIPTION
🎯 **What:** The `centroid_2d` method in `Polygon3D` correctly handles edge cases, but lacked a specific test to verify that an empty exterior returns `None`.
📊 **Coverage:** Added a test case `test_centroid_empty_exterior` which constructs an empty `Polygon3D` and asserts that `centroid_2d()` evaluates to `None`.
✨ **Result:** Improved test coverage and ensured that the Option return type handles edge cases gracefully without introducing regressions.

---
*PR created automatically by Jules for task [10063897720925357429](https://jules.google.com/task/10063897720925357429) started by @graydonpleasants*