### PR TITLE
test(python): Add missing edge case test for FileNotFoundError in cffi_wrapper.py

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-core"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "approx",
  "arrow",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-wasm"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "arrow",
  "arrow-ipc",

--- a/python/test_wrapper.py
+++ b/python/test_wrapper.py
@@ -3,6 +3,7 @@ import os
 import numpy as np
 import shapely
 from shapely.geometry import shape
+from unittest.mock import patch
 
 # Add python directory to path
 sys.path.append(os.path.join(os.path.dirname(__file__)))
@@ -136,9 +137,28 @@ def test_odd_length_coordinates():
         assert "Coordinates array length must be multiple of" in str(e)
     print("Odd length coordinates test passed!")
 
+@patch('os.path.exists')
+@patch('glob.glob')
+def test_library_not_found(mock_glob, mock_exists):
+    print("\nTesting missing shared library...")
+    # Mock exists to always return False and glob to return empty list
+    mock_exists.return_value = False
+    mock_glob.return_value = []
+
+    import geo_polygonize.cffi_wrapper as cffi_wrapper
+
+    try:
+        cffi_wrapper.find_library()
+        assert False, "Should have raised FileNotFoundError"
+    except FileNotFoundError as e:
+        print(f"Caught expected error: {e}")
+        assert "Could not find geo_polygonize_core shared library" in str(e)
+    print("Missing library test passed!")
+
 if __name__ == "__main__":
     test_square()
     test_two_squares()
     test_square_with_hole()
     test_3d_coordinates()
     test_odd_length_coordinates()
+    test_library_not_found()


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR adds a missing unit test to `python/test_wrapper.py` that verifies `geo_polygonize.cffi_wrapper.find_library()` throws a `FileNotFoundError` with the correct error message when the underlying shared library (`libgeo_polygonize_core.so`, etc.) cannot be found.

📊 **Coverage:** What scenarios are now tested
The edge case where the CFFI library cannot be found in the current wheel path, the dev target directory, or matching glob patterns is now explicitly covered. The new test `test_library_not_found` mocks both `os.path.exists` and `glob.glob` to return `False` and `[]` respectively.

✨ **Result:** The improvement in test coverage
We ensure the `FileNotFoundError` behaves deterministically and fails fast as expected, adding a safety net to `python/geo_polygonize/cffi_wrapper.py:76`.

---
*PR created automatically by Jules for task [17498150156055695925](https://jules.google.com/task/17498150156055695925) started by @graydonpleasants*