### PR TITLE
test(core): add test for empty array in bulk_load

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-core"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "approx",
  "arrow",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-wasm"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "arrow",
  "arrow-ipc",

--- a/crates/geo-polygonize-core/src/graph/tests.rs
+++ b/crates/geo-polygonize-core/src/graph/tests.rs
@@ -226,4 +226,18 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn test_bulk_load_empty() {
+        let mut graph = PlanarGraph::new();
+        let lines: Vec<Line3D> = vec![];
+
+        graph.bulk_load(lines);
+
+        assert!(graph.nodes_x.is_empty());
+        assert!(graph.edges.is_empty());
+        assert!(graph.directed_edges.is_empty());
+        assert!(graph.nodes_outgoing.is_empty());
+        assert!(graph.node_map.is_empty());
+    }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR addresses the missing edge case test for the `bulk_load` method in `PlanarGraph` when provided with an empty array of lines.

📊 **Coverage:** What scenarios are now tested
The new `test_bulk_load_empty` test covers the scenario where `bulk_load` is called with an empty vector (`vec![]`). It asserts that all relevant internal data structures (`nodes_x`, `edges`, `directed_edges`, `nodes_outgoing`, and `node_map`) remain correctly initialized and empty.

✨ **Result:** The improvement in test coverage
This adds confidence to the `bulk_load` implementation, explicitly verifying the early return for empty line inputs and ensuring no unintended side effects occur.

---
*PR created automatically by Jules for task [6359788423445243289](https://jules.google.com/task/6359788423445243289) started by @graydonpleasants*