### PR TITLE
fix(core): secure offset conversion in arrow api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-core"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "approx",
  "arrow",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-wasm"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "arrow",
  "arrow-ipc",

--- a/crates/geo-polygonize-core/src/arrow_api.rs
+++ b/crates/geo-polygonize-core/src/arrow_api.rs
@@ -178,11 +178,19 @@ fn process_list_array<O: arrow::array::OffsetSizeTrait>(
         if list_arr.is_null(i) {
             continue;
         }
-        let start = list_arr.value_offsets()[i].to_usize().unwrap();
-        let end = list_arr.value_offsets()[i + 1].to_usize().unwrap();
+        let start = list_arr.value_offsets()[i]
+            .to_usize()
+            .ok_or("Invalid start offset: cannot convert to usize")?;
+        let end = list_arr.value_offsets()[i + 1]
+            .to_usize()
+            .ok_or("Invalid end offset: cannot convert to usize")?;
 
         if end <= start {
             continue;
+        }
+
+        if end > x_vals.len() || end > y_vals.len() {
+            return Err("Offset out of bounds for x/y coordinate arrays".to_string());
         }
 
         // Iterate points in the linestring


### PR DESCRIPTION
### 🎯 What
Fixed an unsafe `unwrap()` call on `to_usize()` conversions for offset values in the Arrow `GenericListArray` processing within `arrow_api.rs`.

### ⚠️ Risk
If the Arrow array contained corrupted, negative, or maliciously crafted offsets, the `unwrap()` would panic, potentially leading to a Denial of Service (DoS) vulnerability. Additionally, if the converted offsets were technically valid `usize` values but exceeded the bounds of the underlying coordinate arrays (`x_vals`, `y_vals`), it would cause an out-of-bounds panic.

### 🛡️ Solution
Replaced the `unwrap()` calls with `.ok_or("Invalid start/end offset: cannot convert to usize")?` to safely bubble up an error. Furthermore, an explicit bounds check was added to verify that the `end` offset does not exceed the lengths of the `x_vals` or `y_vals` arrays, completely avoiding out-of-bounds access.

---
*PR created automatically by Jules for task [13946767600122574187](https://jules.google.com/task/13946767600122574187) started by @graydonpleasants*