### PR TITLE
fix(core): remove debug print in polygonizer.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-core"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "approx",
  "arrow",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-wasm"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "arrow",
  "arrow-ipc",

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -337,7 +337,6 @@ impl Polygonizer {
                     if area > hole_area + 1e-6 && area < min_area {
                         min_area = area;
                         best_shell_idx = Some(idx);
-                        println!("Hole {} assigned to shell {}", i, idx);
                     }
                 }
             }


### PR DESCRIPTION
🎯 **What:** Removed a debug `println!` statement in `crates/geo-polygonize-core/src/polygonizer.rs` that logged `"Hole {} assigned to shell {}"`.

💡 **Why:** To improve code health, clean up output from the core library, and avoid polluting standard output with unnecessary debug information in production environments.

✅ **Verification:** Verified by running `cargo fmt --all` (passed), `cargo clippy --workspace --all-targets` (passed with no new warnings), and `cargo test -p geo-polygonize-core` (all 59 tests passed).

✨ **Result:** The codebase is cleaner and no longer prints debug statements when polygonizing geometries with holes.

---
*PR created automatically by Jules for task [6513484195488488256](https://jules.google.com/task/6513484195488488256) started by @graydonpleasants*