### PR TITLE
fix(github): Trigger publish workflows for `geo-polygonize-v*` tags

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+      - "geo-polygonize-v*"
 
 jobs:
   publish-npm:

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+      - "geo-polygonize-v*"
 
 jobs:
   build-wheels:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+      - "geo-polygonize-v*"
 
 jobs:
   publish:


### PR DESCRIPTION
### Motivation
- Ensure publishing workflows run for release tags following the `geo-polygonize-v*` naming pattern in addition to existing `v*` tags.

### Description
- Added `geo-polygonize-v*` to the `on.push.tags` triggers in `/.github/workflows/publish.yml`, `/.github/workflows/publish-npm.yml`, and `/.github/workflows/publish-python.yml` so those workflows fire on the new tag pattern.

### Testing
- No automated tests were run for this change; the update only modifies workflow triggers and does not change build logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab140bbc68832fb1039ff9b33e338d)