### PR TITLE
ci(github): use OIDC-only npm publishing in workflow

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -36,5 +36,3 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### Motivation
- Remove reliance on a long-lived `NPM_TOKEN` for npm publish and instead rely on GitHub OIDC Trusted Publishers to avoid `ENEEDAUTH` failures. 
- Ensure the publish job uses the required `id-token: write` permission so GitHub can mint OIDC tokens for npm. 
- Keep secure provenance information attached to published packages by using `npm publish --provenance`.

### Description
- Removed the `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` environment from the `Publish to npm` step in `.github/workflows/publish-npm.yml` so publishing relies on OIDC. 
- Preserved the `permissions` block including `id-token: write` and `contents: read` for the `publish-npm` job to enable OIDC issuance and repository checkout. 
- Left the `npm publish --access public --provenance` invocation in place to attach provenance metadata to the published package.

### Testing
- Ran `git diff -- .github/workflows/publish-npm.yml` to verify the environment removal change and it showed the expected diff. 
- Ran `git status --short` and `git diff --check` to ensure the workspace is clean and there are no whitespace or merge issues, and these checks succeeded. 
- Committed the change with the Conventional Commit title and validated the workflow file content via `sed`/`nl` inspection to confirm the `id-token: write` permission and publish command are correct.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab217b0ef0832fb72f81c4f3e45da5)