### PR TITLE
test(core): add unit test for `with_snap_grid`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "approx",
  "arrow",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-wasm"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "arrow",
  "arrow-ipc",

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -688,3 +688,14 @@ fn extract_segments(geom: &Geometry<f64>, out: &mut Vec<Line3D>) {
         _ => {}
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_with_snap_grid() {
+        let polygonizer = Polygonizer::new().with_snap_grid(0.123);
+        assert_eq!(polygonizer.snap_grid_size, 0.123);
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing test for `with_snap_grid` in `Polygonizer` (issue #79).
📊 **Coverage:** A unit test `test_with_snap_grid` was added to `crates/geo-polygonize-core/src/polygonizer.rs` to verify that `with_snap_grid` correctly updates the `snap_grid_size` field on the `Polygonizer` instance.
✨ **Result:** Improved test coverage for the `Polygonizer` API, specifically for the builder pattern method `with_snap_grid`.

---
*PR created automatically by Jules for task [12360556234186794707](https://jules.google.com/task/12360556234186794707) started by @graydonpleasants*