### PR TITLE
test(python): test NULL result in python wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "approx",
  "arrow",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-wasm"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "arrow",
  "arrow-ipc",

--- a/python/test_wrapper.py
+++ b/python/test_wrapper.py
@@ -210,6 +210,25 @@ def test_invalid_input_status(mock_lib):
     print("Invalid input status test passed!")
 
 @patch('geo_polygonize.cffi_wrapper.lib', create=True)
+def test_null_result_pointer(mock_lib):
+    print("\nTesting null result pointer...")
+    import geo_polygonize.cffi_wrapper as cw
+
+    # Mock the return values
+    mock_lib.polygonize_ffi.return_value = cw.ffi.NULL
+
+    coords = np.array([0.0, 0.0, 1.0, 1.0], dtype=np.float64)
+    offsets = np.array([0, 2], dtype=np.uint32)
+
+    try:
+        cw.polygonize(coords, offsets)
+        assert False, "Should have raised RuntimeError"
+    except RuntimeError as e:
+        print(f"Caught expected error: {e}")
+        assert "Polygonization failed (returned NULL)" in str(e)
+    print("Null result pointer test passed!")
+
+@patch('geo_polygonize.cffi_wrapper.lib', create=True)
 def test_internal_error_status(mock_lib):
     print("\nTesting internal error status (status == 2)...")
     import geo_polygonize.cffi_wrapper as cw
@@ -241,3 +260,4 @@ if __name__ == "__main__":
     test_library_not_found()
     test_invalid_input_status()
     test_internal_error_status()
+    test_null_result_pointer()


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The error handling logic in `cffi_wrapper.py` for a NULL pointer result from `lib.polygonize_ffi` was missing a test case in `test_wrapper.py`.

📊 **Coverage:** What scenarios are now tested
A new test `test_null_result_pointer` was added to `test_wrapper.py`. This test mocks the FFI return result as `cw.ffi.NULL` to guarantee the expected `RuntimeError("Polygonization failed (returned NULL)")` correctly propagates to the user.

✨ **Result:** The improvement in test coverage
The Python FFI logic now correctly and comprehensively verifies all documented error states: invalid inputs (`status == 1`), internal errors (`status == 2`), and total failure (returning `NULL`).

---
*PR created automatically by Jules for task [15679840678865084972](https://jules.google.com/task/15679840678865084972) started by @graydonpleasants*