### PR TITLE
chore(core): add readme metadata for published packages

### DIFF
--- a/crates/geo-polygonize-core/Cargo.toml
+++ b/crates/geo-polygonize-core/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.4.1"
 edition = "2021"
 description = "A native Rust port of the JTS/GEOS polygonization algorithm. Reconstruct valid polygons from a set of lines."
 license = "MIT OR Apache-2.0"
+readme = "../../README.md"
 
 [lib]
 crate-type = ["rlib", "cdylib"]

--- a/crates/geo-polygonize-wasm/Cargo.toml
+++ b/crates/geo-polygonize-wasm/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.4.1"
 edition = "2021"
 description = "WebAssembly bindings for geo-polygonize-core, a native Rust port of the JTS/GEOS polygonization algorithm."
 license = "MIT OR Apache-2.0"
+readme = "../../README.md"
 
 [lib]
 crate-type = ["cdylib"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "geo-polygonize-py"
 version = "0.4.1"
 requires-python = ">=3.7"
 description = "Python bindings for geo-polygonize-core, a native Rust port of the JTS/GEOS polygonization algorithm."
+readme = "README.md"
 license = {text = "MIT OR Apache-2.0"}
 classifiers = [
     "Programming Language :: Rust",


### PR DESCRIPTION
### Motivation
- Ensure published package pages include the repository README so crates.io, PyPI wheels/sdists, and other registries show a proper project description.
- The workspace crates and Python package previously lacked explicit `readme` metadata, so README content could be omitted when publishing.

### Description
- Add `readme = "../../README.md"` to `crates/geo-polygonize-core/Cargo.toml` so the core crate uses the repository README for published metadata.
- Add `readme = "../../README.md"` to `crates/geo-polygonize-wasm/Cargo.toml` so the wasm crate uses the repository README for published metadata.
- Add `readme = "README.md"` to `pyproject.toml` so the Python package metadata references the repository README when building/publishing.

### Testing
- Ran `cargo metadata --no-deps --format-version 1` and validated `pyproject.toml` with Python `tomllib` to assert `project.readme` is `README.md`, and both checks succeeded.
- Verified the three files were updated and committed (`crates/geo-polygonize-core/Cargo.toml`, `crates/geo-polygonize-wasm/Cargo.toml`, `pyproject.toml`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab26f896e4832fab25d2cf5319c1c1)