### PR TITLE
perf(core): avoid cloning geometries in tiling logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "approx",
  "arrow",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-wasm"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "arrow",
  "arrow-ipc",

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -35,9 +35,7 @@ pub struct Polygonizer {
     pub snap_grid_size: f64,
     pub extract_only_polygonal: bool,
 
-    // Buffer for inputs if noding is required
-    inputs: Vec<Geometry<f64>>,
-    // Additional buffer for explicit line segments (3D)
+    // Buffer for explicit line segments (3D)
     input_lines: Vec<Line3D>,
     dirty: bool,
 }
@@ -63,7 +61,6 @@ impl Polygonizer {
             node_input: false,
             snap_grid_size: 1e-10, // Default tolerance
             extract_only_polygonal: false,
-            inputs: Vec::new(),
             input_lines: Vec::new(),
             dirty: false,
         }
@@ -81,7 +78,13 @@ impl Polygonizer {
 
     /// Adds a 2D geometry to the graph (Z=0).
     pub fn add_geometry(&mut self, geom: Geometry<f64>) {
-        self.inputs.push(geom);
+        extract_segments(&geom, &mut self.input_lines);
+        self.dirty = true;
+    }
+
+    /// Adds a 2D geometry to the graph (Z=0) from a reference.
+    pub fn add_borrowed_geometry(&mut self, geom: &Geometry<f64>) {
+        extract_segments(geom, &mut self.input_lines);
         self.dirty = true;
     }
 
@@ -96,12 +99,7 @@ impl Polygonizer {
             return Ok(());
         }
 
-        // Flatten inputs to lineal components and convert to Line3D
-        let mut all_segments: Vec<Line3D> = Vec::new();
-        for geom in &self.inputs {
-            extract_segments(geom, &mut all_segments);
-        }
-        all_segments.extend(self.input_lines.iter().cloned());
+        let mut all_segments: Vec<Line3D> = self.input_lines.clone();
 
         let segments;
 

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -53,7 +53,7 @@ impl TiledPolygonizer {
         let mut relevant_lines = 0;
         for (geom, bbox) in &self.geometries {
             if bbox.map(|b| b.intersects(&buffered_bbox)).unwrap_or(false) {
-                local_poly.add_geometry(geom.clone());
+                local_poly.add_borrowed_geometry(geom);
                 relevant_lines += 1;
             }
         }


### PR DESCRIPTION
💡 **What:** 
- Removed `inputs: Vec<Geometry<f64>>` buffer from the main `Polygonizer`.
- Refactored `add_geometry` to immediately extract segments into `input_lines`.
- Introduced `add_borrowed_geometry(&Geometry<f64>)` to allow insertion without ownership.
- Updated `process_tile` in `TiledPolygonizer` to use `add_borrowed_geometry` instead of `geom.clone()`.

🎯 **Why:** 
Geometries (like large polygons or MultiLineStrings) can span multiple tiles. Previously, the tiling loop cloned the entire `Geometry` object for every intersecting tile before sending it to the local `Polygonizer`. This refactor directly borrows the `Geometry`, extracts the much smaller `Line3D` segments directly into the active buffer, and drops the overhead of cloning large data structures.

📊 **Measured Improvement:**
The benchmark for large tiled grids shows no degradation. The change is functionally identical but systematically prevents large allocations.

```
polygonize/grid_tiled/100
                        time:   [12.283 ms 12.408 ms 12.585 ms]
                        change: [-0.2304% +2.4418% +5.1720%] (p = 0.10 > 0.05)
                        No change in performance detected.
```

---
*PR created automatically by Jules for task [14762993412068501127](https://jules.google.com/task/14762993412068501127) started by @graydonpleasants*