### PR TITLE
feat(github): Add manual `workflow_dispatch` release with version input to release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,6 +2,12 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (e.g. 0.4.2)"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -13,6 +19,15 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - name: Run release-please on push
+        if: github.event_name == 'push'
+        uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.GH_PAT }}
+
+      - name: Run release-please with manual version
+        if: github.event_name == 'workflow_dispatch'
+        uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ secrets.GH_PAT }}
+          release-as: ${{ inputs.version }}


### PR DESCRIPTION
### Motivation

- Enable manually-triggered releases that allow specifying an explicit version when automated push-based releases are not desired.
- Distinguish behavior between automatic `push` events and manual dispatches to pass a user-provided `release-as` value.

### Description

- Add `workflow_dispatch` trigger with a `version` input to the `release-please` workflow so a release can be started manually with a version string.
- Split the action into two conditional steps using `if: github.event_name == 'push'` and `if: github.event_name == 'workflow_dispatch'` so each event type runs appropriate logic and has a descriptive step name.
- When dispatched manually, pass `release-as: ${{ inputs.version }}` to `googleapis/release-please-action@v4` and continue using `token: ${{ secrets.GH_PAT }}` for authentication.

### Testing

- No automated tests were run for this workflow change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab283dc624832f9691e625edd65df6)