### PR TITLE
chore(core): Remove test mismatch print statement in snap.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-core"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "approx",
  "arrow",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-wasm"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "arrow",
  "arrow-ipc",

--- a/crates/geo-polygonize-core/src/noding/snap.rs
+++ b/crates/geo-polygonize-core/src/noding/snap.rs
@@ -513,13 +513,7 @@ mod tests {
 
         for (e_g, e_s) in splits_grid.iter().zip(splits_simd.iter()) {
             assert_eq!(e_g.0, e_s.0, "Index mismatch");
-            assert!(
-                (e_g.1.x - e_s.1.x).abs() < 1e-10 && (e_g.1.y - e_s.1.y).abs() < 1e-10,
-                "Point mismatch at index {}: {:?} vs {:?}",
-                e_g.0,
-                e_g.1,
-                e_s.1
-            );
+            assert!((e_g.1.x - e_s.1.x).abs() < 1e-10 && (e_g.1.y - e_s.1.y).abs() < 1e-10);
         }
     }
 


### PR DESCRIPTION
🎯 **What:** Removed the explicit "Point mismatch at index..." print statement from the `assert!` in `crates/geo-polygonize-core/src/noding/snap.rs:516`.
💡 **Why:** To improve codebase maintainability by avoiding unnecessarily verbose error messaging within the test assertions. A simplified `assert!` is cleaner and maintains exact equivalence in test logic.
✅ **Verification:** Ran `cargo test -p geo-polygonize-core` and ensured all tests passed successfully. Ran `cargo clippy` and `cargo fmt` as well.
✨ **Result:** Test code is slightly cleaner and test outputs will be less verbose on assertion failures while conveying the same logical equivalence.

---
*PR created automatically by Jules for task [12680954171126184864](https://jules.google.com/task/12680954171126184864) started by @graydonpleasants*