### PR TITLE
fix(core): remove unused CachePadded struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-core"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "approx",
  "arrow",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-wasm"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "arrow",
  "arrow-ipc",

--- a/crates/geo-polygonize-core/src/noding/grid.rs
+++ b/crates/geo-polygonize-core/src/noding/grid.rs
@@ -8,12 +8,6 @@ use wide::f64x4;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
-#[cfg(feature = "parallel")]
-#[repr(align(64))]
-#[derive(Clone)]
-#[allow(dead_code)]
-struct CachePadded<T>(pub T);
-
 pub struct UniformGrid {
     /// Compressed Sparse Row (CSR) storage
     /// cell_offsets[i]..cell_offsets[i+1] gives the range in cell_items for cell i


### PR DESCRIPTION
🎯 **What:** Removed the unused `CachePadded` struct and its associated `#allow(dead_code)` and `#[cfg(feature = "parallel")]` attributes from `crates/geo-polygonize-core/src/noding/grid.rs`.
💡 **Why:** The struct was unused and explicitly tagged with `#[allow(dead_code)]`. Removing it improves code health, hygiene, readability, and removes unnecessary compiler annotations, leaving a cleaner and more maintainable codebase.
✅ **Verification:** Verified that `cargo clippy --workspace --all-targets` and `cargo fmt --all` pass without error, and `cargo test --workspace` passes all tests.
✨ **Result:** A slightly cleaner, better-maintained codebase with no dangling dead code.

---
*PR created automatically by Jules for task [10111085817359134815](https://jules.google.com/task/10111085817359134815) started by @graydonpleasants*