### PR TITLE
test(core): Add test for invalid datatype error path in arrow_api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-core"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "approx",
  "arrow",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-wasm"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "arrow",
  "arrow-ipc",

--- a/crates/geo-polygonize-core/tests/arrow_api_tests.rs
+++ b/crates/geo-polygonize-core/tests/arrow_api_tests.rs
@@ -1,0 +1,23 @@
+use arrow::array::Float64Array;
+use arrow::datatypes::{DataType, Field};
+use geo_polygonize_core::arrow_api::{polygonize_arrow, PolygonizerOptions};
+
+#[test]
+fn test_polygonize_arrow_invalid_type_error_path() {
+    let array = Float64Array::from(vec![1.0, 2.0, 3.0]);
+    let field = Field::new("geometry", DataType::Float64, true);
+    let options = PolygonizerOptions {
+        node_input: true,
+        snap_grid_size: 0.0,
+        extract_only_polygonal: false,
+    };
+
+    let result = polygonize_arrow(&array, &field, options);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(
+        err.contains("Failed to convert input array to LineStringArray and fallback failed")
+            && err.contains("DataType: Float64")
+            && err.contains("Field { name: \"geometry\", data_type: Float64, nullable: true")
+    );
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
Added a missing error path test in `crates/geo-polygonize-core/src/arrow_api.rs` which verifies that the `polygonize_arrow` function returns the correct `Err` string when it's passed an invalid arrow data type that it cannot convert to `LineStringArray` or use its fallback strategies on.

📊 **Coverage:** What scenarios are now tested
The specific error block in `arrow_api.rs:73` ("Failed to convert input array to LineStringArray and fallback failed...") is now covered. It tests that passing a simple array (e.g. `Float64Array`) appropriately bubbles up the error containing the details of the invalid `DataType` and `Field`.

✨ **Result:** The improvement in test coverage
Increased robustness of the library by explicitly testing API boundary validations, ensuring that downstream consumers (e.g., FFI, Python, WASM wrappers) receive expected, properly formatted errors when feeding invalid arrow arrays to the core polygonizer.

---
*PR created automatically by Jules for task [9722335196672792616](https://jules.google.com/task/9722335196672792616) started by @graydonpleasants*