### PR TITLE
ci(github): remove registry-url from npm publish workflow

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -21,7 +21,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "22"
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
### Motivation
- Prevent `npm publish` from trying to use legacy `NODE_AUTH_TOKEN`-style auth by allowing OIDC trusted publishing to handle end-to-end authentication, which avoids spurious `E404` errors during package upload.

### Description
- Removed the `registry-url: 'https://registry.npmjs.org'` line from ` .github/workflows/publish-npm.yml` so `actions/setup-node` will not generate a temporary `.npmrc` that expects a token.

### Testing
- Verified with `rg -n "NODE_AUTH_TOKEN|registry-url" .github/workflows/publish-npm.yml -S` that no `registry-url` or `NODE_AUTH_TOKEN` references remain, and inspected the workflow file with `nl -ba .github/workflows/publish-npm.yml` to confirm the `Set up Node.js` step no longer sets `registry-url` (checks succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab74be712c832fac723c3cb9d1366f)