### PR TITLE
test(core): add unit test for add_lines method in Polygonizer

### DIFF
--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -719,4 +719,21 @@ mod tests {
         let polygonizer = Polygonizer::new().with_snap_grid(0.123);
         assert_eq!(polygonizer.snap_grid_size, 0.123);
     }
+
+    #[test]
+    fn test_add_lines() {
+        let mut polygonizer = Polygonizer::new();
+        assert!(!polygonizer.dirty);
+        assert!(polygonizer.input_lines.is_empty());
+
+        let l1 = Line3D::new(Coord3D::new(0.0, 0.0, 0.0), Coord3D::new(1.0, 0.0, 0.0), 0);
+        let l2 = Line3D::new(Coord3D::new(1.0, 0.0, 0.0), Coord3D::new(1.0, 1.0, 0.0), 1);
+
+        polygonizer.add_lines(vec![l1, l2]);
+
+        assert!(polygonizer.dirty);
+        assert_eq!(polygonizer.input_lines.len(), 2);
+        assert_eq!(polygonizer.input_lines[0].start.x, 0.0);
+        assert_eq!(polygonizer.input_lines[1].end.y, 1.0);
+    }
 }


### PR DESCRIPTION
🎯 **What:** The `add_lines` method in `Polygonizer` was previously missing a unit test to verify that lines were being correctly added to the input buffer.
📊 **Coverage:** This tests the `add_lines` public API, checking that it appropriately pushes `Line3D` instances onto the `input_lines` vector and updates the `dirty` property to signal that a rebuild is required.
✨ **Result:** A new unit test has been added to `crates/geo-polygonize-core/src/polygonizer.rs` filling the testing gap. Overall confidence in the robustness of `Polygonizer` is improved.

---
*PR created automatically by Jules for task [955388583255083892](https://jules.google.com/task/955388583255083892) started by @graydonpleasants*