### PR TITLE
test(python): Add missing edge case test for ValueError with invalid shape

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-core"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "approx",
  "arrow",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-wasm"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "arrow",
  "arrow-ipc",

--- a/python/test_wrapper.py
+++ b/python/test_wrapper.py
@@ -1,3 +1,4 @@
+import pytest
 import sys
 import os
 import numpy as np
@@ -208,6 +209,16 @@ def test_library_not_found(mock_glob, mock_exists):
         assert "Could not find geo_polygonize_core shared library" in str(e)
     print("Missing library test passed!")
 
+def test_invalid_shape_mismatch():
+    print("\nTesting invalid shape mismatch...")
+    # 2D coords with shape (1, 4) but stride=2
+    coords = np.array([[0.0, 0.0, 1.0, 1.0]], dtype=np.float64)
+    offsets = np.array([0], dtype=np.uint32)
+
+    with pytest.raises(ValueError, match=r"Input shape \(1, 4\) does not match stride 2"):
+        polygonize(coords, offsets, stride=2)
+    print("Invalid shape mismatch test passed!")
+
 @patch('geo_polygonize.cffi_wrapper.lib', create=True)
 def test_invalid_input_status(mock_lib):
     print("\nTesting invalid input status (status == 1)...")
@@ -280,6 +291,7 @@ if __name__ == "__main__":
     test_import_error_fallback()
     test_return_polygons_without_shapely()
     test_library_not_found()
+    test_invalid_shape_mismatch()
     test_invalid_input_status()
     test_internal_error_status()
     test_null_result_pointer()


### PR DESCRIPTION
* 🎯 **What:** Added a test for the `ValueError` raised when the input shape of coords does not match the provided stride.
* 📊 **Coverage:** Covered the edge case where `coords.shape[1] != stride` and it's not the `stride == 2` and `coords.shape[1] == 3` case.
* ✨ **Result:** Improved test suite reliability by ensuring proper handling of invalid coordinate dimensions and strides.

---
*PR created automatically by Jules for task [10172826384757148737](https://jules.google.com/task/10172826384757148737) started by @graydonpleasants*