### PR TITLE
fix(core): prevent double free and panic unwinding over FFI

### DIFF
--- a/crates/geo-polygonize-core/src/ffi.rs
+++ b/crates/geo-polygonize-core/src/ffi.rs
@@ -63,51 +63,55 @@ pub unsafe extern "C" fn polygonize_ffi(
     output_schema: *mut FFI_ArrowSchema,
     options: *const PolygonizerOptions,
 ) -> i32 {
-    if input_array.is_null()
-        || input_schema.is_null()
-        || output_array.is_null()
-        || output_schema.is_null()
-        || options.is_null()
-    {
-        return 1;
-    }
-
-    let field = match Field::try_from(&*input_schema) {
-        Ok(f) => f,
-        Err(_) => return 2,
-    };
-
-    let arrow_data = match from_ffi(std::ptr::read(input_array), &*input_schema) {
-        Ok(data) => data,
-        Err(_) => return 2,
-    };
-    let array = arrow::array::make_array(arrow_data);
-
-    let opts = &*options;
-    let arrow_opts = ArrowOptions {
-        node_input: opts.node_input != 0,
-        snap_grid_size: opts.snap_grid_size,
-        extract_only_polygonal: opts.extract_only_polygonal != 0,
-    };
-
-    match polygonize_arrow(array.as_ref(), &field, arrow_opts) {
-        Ok(polygon_array) => {
-            let array_ref = polygon_array.into_array_ref();
-            let data = array_ref.to_data();
-
-            let ffi_array = FFI_ArrowArray::new(&data);
-            std::ptr::write(output_array, ffi_array);
-
-            let ffi_schema = match DefaultSchemaExporter::try_export(data.data_type()) {
-                Ok(s) => s,
-                Err(_) => return 4,
-            };
-            std::ptr::write(output_schema, ffi_schema);
-
-            0
+    std::panic::catch_unwind(|| {
+        if input_array.is_null()
+            || input_schema.is_null()
+            || output_array.is_null()
+            || output_schema.is_null()
+            || options.is_null()
+        {
+            return 1;
         }
-        Err(_) => 5,
-    }
+
+        let field = match Field::try_from(&*input_schema) {
+            Ok(f) => f,
+            Err(_) => return 2,
+        };
+
+        let array_val = std::ptr::replace(input_array, FFI_ArrowArray::empty());
+        let arrow_data = match from_ffi(array_val, &*input_schema) {
+            Ok(data) => data,
+            Err(_) => return 2,
+        };
+        let array = arrow::array::make_array(arrow_data);
+
+        let opts = &*options;
+        let arrow_opts = ArrowOptions {
+            node_input: opts.node_input != 0,
+            snap_grid_size: opts.snap_grid_size,
+            extract_only_polygonal: opts.extract_only_polygonal != 0,
+        };
+
+        match polygonize_arrow(array.as_ref(), &field, arrow_opts) {
+            Ok(polygon_array) => {
+                let array_ref = polygon_array.into_array_ref();
+                let data = array_ref.to_data();
+
+                let ffi_array = FFI_ArrowArray::new(&data);
+                std::ptr::write(output_array, ffi_array);
+
+                let ffi_schema = match DefaultSchemaExporter::try_export(data.data_type()) {
+                    Ok(s) => s,
+                    Err(_) => return 4,
+                };
+                std::ptr::write(output_schema, ffi_schema);
+
+                0
+            }
+            Err(_) => 5,
+        }
+    })
+    .unwrap_or(99)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The `polygonize_ffi` function was found to have two severe security vulnerabilities:
1. Double-Free: `std::ptr::read(input_array)` was used to consume the input array. Because `read` merely copies the memory without zeroing or clearing the original pointer, the C caller still had a reference to the array with its `release` callback intact. When Rust dropped its copy, and the caller dropped its copy, the array was freed twice.
2. Panic Unwinding: The FFI exposed function (`extern "C"`) was not guarded against Rust panics. Unwinding panics across C FFI boundaries causes Undefined Behavior.

This PR fixes these issues by safely consuming the FFI array using `std::ptr::replace(input_array, FFI_ArrowArray::empty())` and wrapping the entire function body within `std::panic::catch_unwind`, catching panics and mapping them to a safe error code (`99`).

---
*PR created automatically by Jules for task [912665248167317822](https://jules.google.com/task/912665248167317822) started by @graydonpleasants*