### PR TITLE
test(python): add missing test for invalid stride exception in polygonize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "approx",
  "arrow",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-wasm"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "arrow",
  "arrow-ipc",

--- a/python/test_wrapper.py
+++ b/python/test_wrapper.py
@@ -219,6 +219,15 @@ def test_invalid_shape_mismatch():
         polygonize(coords, offsets, stride=2)
     print("Invalid shape mismatch test passed!")
 
+def test_invalid_stride():
+    print("\nTesting invalid stride...")
+    coords = np.array([0.0, 0.0, 1.0, 1.0], dtype=np.float64)
+    offsets = np.array([0, 2], dtype=np.uint32)
+
+    with pytest.raises(ValueError, match="stride must be 2 or 3"):
+        polygonize(coords, offsets, stride=4)
+    print("Invalid stride test passed!")
+
 @patch('geo_polygonize.cffi_wrapper.lib', create=True)
 def test_invalid_input_status(mock_lib):
     print("\nTesting invalid input status (status == 1)...")
@@ -292,6 +301,7 @@ if __name__ == "__main__":
     test_return_polygons_without_shapely()
     test_library_not_found()
     test_invalid_shape_mismatch()
+    test_invalid_stride()
     test_invalid_input_status()
     test_internal_error_status()
     test_null_result_pointer()


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing test coverage for invalid stride parameters passed to the `polygonize` Python API wrapper.

📊 **Coverage:** What scenarios are now tested: The edge case where `stride` is passed as a value other than `2` or `3` (e.g., `4`), ensuring the API gracefully raises a `ValueError` as expected in `__init__.py:70`.

✨ **Result:** The improvement in test coverage: Improved safety and validation guarantees for Python clients using the API.

---
*PR created automatically by Jules for task [13244771926214964429](https://jules.google.com/task/13244771926214964429) started by @graydonpleasants*