### PR TITLE
perf(core): eliminate unnecessary clone of hole coordinates in assignment

### DIFF
--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -329,53 +329,52 @@ impl Polygonizer {
         }
 
         // Process hole assignment
-        let process_hole_assignment = |i: usize| -> Option<(usize, Vec<Coord3D>, Vec<u32>)> {
-            let hole_3d = &holes[i];
+        let process_hole_assignment =
+            |hole_3d: Polygon3D| -> Option<(usize, Vec<Coord3D>, Vec<u32>)> {
+                let bbox = bounding_rect_3d(&hole_3d.exterior)?;
+                let hole_aabb =
+                    AABB::from_corners([bbox.min().x, bbox.min().y], [bbox.max().x, bbox.max().y]);
 
-            let bbox = bounding_rect_3d(&hole_3d.exterior)?;
-            let hole_aabb =
-                AABB::from_corners([bbox.min().x, bbox.min().y], [bbox.max().x, bbox.max().y]);
+                let candidates = tree.locate_in_envelope_intersecting(&hole_aabb);
 
-            let candidates = tree.locate_in_envelope_intersecting(&hole_aabb);
+                let mut best_shell_idx = None;
+                let mut min_area = f64::MAX;
 
-            let mut best_shell_idx = None;
-            let mut min_area = f64::MAX;
+                let probe_point = guaranteed_interior_probe(&hole_3d.exterior)?;
 
-            let probe_point = guaranteed_interior_probe(&hole_3d.exterior)?;
+                for cand in candidates {
+                    let idx = cand.index;
+                    let simd_shell = &simd_shells[idx];
 
-            for cand in candidates {
-                let idx = cand.index;
-                let simd_shell = &simd_shells[idx];
+                    if simd_shell.contains(probe_point.0) {
+                        if rings_share_edge(&shells[idx].exterior, &hole_3d.exterior, 1e-10) {
+                            continue;
+                        }
 
-                if simd_shell.contains(probe_point.0) {
-                    if rings_share_edge(&shells[idx].exterior, &hole_3d.exterior, 1e-10) {
-                        continue;
-                    }
+                        let area = shells[idx].unsigned_area_2d();
+                        let hole_area = hole_3d.unsigned_area_2d();
 
-                    let area = shells[idx].unsigned_area_2d();
-                    let hole_area = hole_3d.unsigned_area_2d();
-
-                    if area > hole_area + 1e-6 && area < min_area {
-                        min_area = area;
-                        best_shell_idx = Some(idx);
+                        if area > hole_area + 1e-6 && area < min_area {
+                            min_area = area;
+                            best_shell_idx = Some(idx);
+                        }
                     }
                 }
-            }
 
-            best_shell_idx.map(|idx| (idx, hole_3d.exterior.clone(), hole_3d.exterior_ids.clone()))
-        };
+                best_shell_idx.map(|idx| (idx, hole_3d.exterior, hole_3d.exterior_ids))
+            };
 
         let assignments: Vec<_>;
         #[cfg(feature = "parallel")]
         {
-            assignments = (0..holes.len())
+            assignments = holes
                 .into_par_iter()
                 .filter_map(process_hole_assignment)
                 .collect();
         }
         #[cfg(not(feature = "parallel"))]
         {
-            assignments = (0..holes.len())
+            assignments = holes
                 .into_iter()
                 .filter_map(process_hole_assignment)
                 .collect();


### PR DESCRIPTION
💡 **What:** Refactored the hole assignment loop in `crates/geo-polygonize-core/src/polygonizer.rs` to consume the `holes` vector entirely using `into_iter()` and `into_par_iter()`. This allowed changing the signature of the mapping closure `process_hole_assignment` to take ownership of `Polygon3D` structs instead of an index. It yields `exterior` and `exterior_ids` fields by value instead of cloning them, and the `&holes[i]` lookup was removed.

🎯 **Why:** The previous code performed unnecessary deep `.clone()`s of `Vec<Coord3D>` and `Vec<u32>` coordinate vectors and ID arrays inside a tight mapping loop. Since the mapping happens at the end of the `holes` lifecycle during assignment, these clones are completely redundant. By destructing and yielding the vectors, memory allocations and CPU overhead during polygonizer construction are eliminated.

📊 **Measured Improvement:** Re-running the standard Criterion suite `polygonize_bench` on my local setup timed out (exceeding 400 seconds limit in this environment), obscuring raw elapsed time measurements. However, the elimination of `.clone()` on large nested `Vec` types per mapped hole deterministically saves exact allocations proportional to `O(holes * vertices per hole)`. Based on Rust memory behavior and the provided tests passing successfully across serial and parallel modes (`rayon`), this represents a strict net theoretical memory efficiency and instruction reduction win at no cost.

---
*PR created automatically by Jules for task [16532749517190893551](https://jules.google.com/task/16532749517190893551) started by @graydonpleasants*