### PR TITLE
test(python): add missing args test for polygonize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "approx",
  "arrow",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-wasm"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "arrow",
  "arrow-ipc",

--- a/python/test_wrapper.py
+++ b/python/test_wrapper.py
@@ -121,6 +121,22 @@ def test_3d_coordinates():
     assert abs(shapely_poly.area - 100.0) < 1e-6
     print("3D coordinates test passed!")
 
+def test_missing_args():
+    print("\nTesting missing arguments...")
+    coords = np.array([0.0, 0.0, 1.0, 1.0], dtype=np.float64)
+    offsets = np.array([0, 2], dtype=np.uint32)
+
+    with pytest.raises(ValueError, match="Either 'lines' or both 'coords' and 'offsets' must be provided."):
+        polygonize()
+
+    with pytest.raises(ValueError, match="Either 'lines' or both 'coords' and 'offsets' must be provided."):
+        polygonize(coords=coords)
+
+    with pytest.raises(ValueError, match="Either 'lines' or both 'coords' and 'offsets' must be provided."):
+        polygonize(offsets=offsets)
+
+    print("Missing arguments test passed!")
+
 def test_odd_length_coordinates():
     print("\nTesting odd length coordinates...")
     # Flat array with 3 elements (1.5 points)
@@ -287,6 +303,7 @@ if __name__ == "__main__":
     test_two_squares()
     test_square_with_hole()
     test_3d_coordinates()
+    test_missing_args()
     test_odd_length_coordinates()
     test_import_error_fallback()
     test_return_polygons_without_shapely()


### PR DESCRIPTION
🎯 **What:** Added a missing edge case test to `python/test_wrapper.py` for verifying that `polygonize()` gracefully handles missing arguments (`coords=None`, `offsets=None`) and raises the appropriate `ValueError`.

📊 **Coverage:** Specifically tests scenarios where `polygonize()` is called with no arguments, only `coords`, or only `offsets`. This shores up the test suite to match API expectations as dictated by `__init__.py`.

✨ **Result:** Improved test coverage and reliability for error handling in the Python API wrapper. The codebase is now more robust against invalid API utilization.

---
*PR created automatically by Jules for task [8728188458910614868](https://jules.google.com/task/8728188458910614868) started by @graydonpleasants*