### PR TITLE
fix(github): upgrade npm before trusted npm publish

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -22,6 +22,9 @@ jobs:
         with:
           node-version: "22"
 
+      - name: Upgrade npm to support Trusted Publishing
+        run: npm install -g npm@latest
+
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
         with:


### PR DESCRIPTION
### Motivation
- Ensure the GitHub Actions runner uses an npm version that supports OIDC Trusted Publishing to avoid ENEEDAUTH fallback when publishing to npm.

### Description
- Add a step after `actions/setup-node` in `.github/workflows/publish-npm.yml` to run `npm install -g npm@latest` so the runner upgrades npm before installing dependencies and publishing.

### Testing
- Verified the workflow change with `git diff -- .github/workflows/publish-npm.yml` and inspected the updated file with `nl -ba .github/workflows/publish-npm.yml`, both commands completed successfully and no unit tests were modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abc00c7524832f815e424962a18101)