### PR TITLE
fix(wasm): add repository url for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,10 @@
     "./*": "./dist/*"
   },
   "types": "./dist/standard/es/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/graydonpleasants/geo-polygonize"
+  },
   "devDependencies": {
     "@commitlint/cli": "^20.4.3",
     "@commitlint/config-conventional": "^20.4.3",


### PR DESCRIPTION
### Motivation
- Fix npm publish provenance verification failure (`422 Unprocessable Entity`) caused by an empty `repository.url` in `package.json` so the provenance bundle can match the expected GitHub repository.

### Description
- Add a `repository` object to the root `package.json` with `"type": "git"` and `"url": "https://github.com/graydonpleasants/geo-polygonize"` and commit the change to `package.json`.

### Testing
- Ran `node -e "const p=require('./package.json'); console.log(p.repository)"`, `git diff -- package.json`, and `git rev-parse --short HEAD` to verify the `repository` entry is present and the change is committed, and all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abc9c968f4832f8bca48b297952d61)