### PR TITLE
fix(core): apply ring rotation independently and add full dangle tie-breaker

### DIFF
--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -451,6 +451,20 @@ impl Polygonizer {
             }
         };
 
+        let cmp_coord = |a: &Coord3D, b: &Coord3D| {
+            a.x.total_cmp(&b.x)
+                .then(a.y.total_cmp(&b.y))
+                .then(a.z.total_cmp(&b.z))
+        };
+
+        let cmp_coord_chain = |a: &[Coord3D], b: &[Coord3D]| {
+            a.iter()
+                .zip(b.iter())
+                .map(|(ca, cb)| cmp_coord(ca, cb))
+                .find(|o| *o != std::cmp::Ordering::Equal)
+                .unwrap_or_else(|| a.len().cmp(&b.len()))
+        };
+
         // 6. Construct Final Polygons
         // Ensure we don't crash on NaNs during processing
         let mut invalid_rings = if invalid_rings_candidates.is_empty() {
@@ -517,6 +531,15 @@ impl Polygonizer {
             }
         }
 
+        if self.determinism.canonical_ring_rotation {
+            for d in dangles.iter_mut() {
+                canonicalize_open_line(d);
+            }
+            for ir in invalid_rings.iter_mut() {
+                canonicalize_ring(ir, None);
+            }
+        }
+
         if self.determinism.canonical_sort {
             let use_stable_tie_breaks = self.determinism.stable_tie_breaks;
             result.sort_by(|p1, p2| {
@@ -543,15 +566,6 @@ impl Polygonizer {
                 })
             });
 
-            if self.determinism.canonical_ring_rotation {
-                for d in dangles.iter_mut() {
-                    canonicalize_open_line(d);
-                }
-                for ir in invalid_rings.iter_mut() {
-                    canonicalize_ring(ir, None);
-                }
-            }
-
             if use_stable_tie_breaks {
                 dangles.sort_by(|l1, l2| {
                     let b1 = bounding_rect_3d(l1).unwrap_or(geo::Rect::new(
@@ -567,6 +581,7 @@ impl Polygonizer {
                         .total_cmp(&b2.min().x)
                         .then(b1.min().y.total_cmp(&b2.min().y))
                         .then(l1.len().cmp(&l2.len()))
+                        .then_with(|| cmp_coord_chain(l1, l2))
                 });
             }
 

--- a/crates/geo-polygonize-core/tests/determinism.rs
+++ b/crates/geo-polygonize-core/tests/determinism.rs
@@ -89,3 +89,51 @@ fn test_determinism_canonical_sort_and_rotation() {
         }
     }
 }
+
+#[test]
+fn test_canonical_ring_rotation_applies_without_canonical_sort() {
+    let mut poly = Polygonizer::new();
+    poly.node_input = true;
+    poly.determinism = DeterminismOptions {
+        canonical_sort: false,
+        canonical_ring_rotation: true,
+        stable_tie_breaks: false,
+    };
+
+    poly.add_lines(vec![Line3D::new(
+        Coord3D::new(5.0, 0.0, 0.0),
+        Coord3D::new(0.0, 0.0, 0.0),
+        0,
+    )]);
+
+    let res = poly.polygonize().unwrap();
+    assert_eq!(res.dangles.len(), 1);
+    assert_eq!(res.dangles[0][0], Coord3D::new(0.0, 0.0, 0.0));
+    assert_eq!(res.dangles[0][1], Coord3D::new(5.0, 0.0, 0.0));
+}
+
+#[test]
+fn test_stable_tie_breaks_fully_order_dangles() {
+    let build = |lines: Vec<Line3D>| {
+        let mut poly = Polygonizer::new();
+        poly.node_input = false;
+        poly.determinism = DeterminismOptions {
+            canonical_sort: true,
+            canonical_ring_rotation: true,
+            stable_tie_breaks: true,
+        };
+        poly.add_lines(lines);
+        poly.polygonize().unwrap()
+    };
+
+    let d1 = Line3D::new(Coord3D::new(0.0, 0.0, 0.0), Coord3D::new(1.0, 1.0, 0.0), 0);
+    let d2 = Line3D::new(Coord3D::new(0.0, 1.0, 0.0), Coord3D::new(1.0, 0.0, 1.0), 0);
+
+    let r1 = build(vec![d1, d2]);
+    let r2 = build(vec![d2, d1]);
+
+    assert_eq!(r1.dangles, r2.dangles);
+    assert_eq!(r1.dangles.len(), 2);
+    assert_eq!(r1.dangles[0][0], Coord3D::new(0.0, 0.0, 0.0));
+    assert_eq!(r1.dangles[1][0], Coord3D::new(0.0, 1.0, 0.0));
+}


### PR DESCRIPTION
### Motivation
- `canonical_ring_rotation` was only applied inside the `canonical_sort` branch, making the toggle ineffective when sorting was disabled. 
- Dangle tie-breaking stopped at bbox origin and length which left some geometries comparing equal and allowed nondeterministic outputs. 
- Deterministic output guarantees require independent ring rotation and a complete tie-breaker to produce byte-identical serialized results across input permutations.

### Description
- Apply `canonical_ring_rotation` to `dangles` and `invalid_rings` unconditionally so the option takes effect even when `canonical_sort` is false. 
- Add `cmp_coord` and `cmp_coord_chain` helpers and use `cmp_coord_chain` as an additional `.then_with()` tie-breaker when sorting `dangles`, providing a full lexicographic coordinate-chain comparison after bbox/length ties. 
- Add two regression tests in `crates/geo-polygonize-core/tests/determinism.rs` to validate ring rotation without canonical sort and to assert stable ordering of dangles across input permutations. 
- Keep existing stable tie-break behavior for polygons/holes and only extend the dangle ordering to guarantee deterministic sequences.

### Testing
- Ran `cargo fmt --all --check` which succeeded. 
- Ran `cargo test -p geo-polygonize-core --test determinism` which executed the determinism test file and passed. 
- Ran `cargo test -p geo-polygonize-core determinism` (package-level tests) and the determinism-related tests passed (all determinism tests OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae2c8973c4832f93bc3e8f566d6a6f)