### PR TITLE
fix(core): fail golden harness when snapshots or fixtures are missing

### DIFF
--- a/crates/geo-polygonize-core/tests/golden_fixtures.rs
+++ b/crates/geo-polygonize-core/tests/golden_fixtures.rs
@@ -124,11 +124,21 @@ fn run_golden_test(path: &Path) {
             fixture.name
         );
     } else {
-        // Bootstrap the fixture
-        fixture.expected = Some(actual_result);
-        let output = serde_json::to_string_pretty(&fixture).unwrap();
-        fs::write(path, output).unwrap();
-        println!("Bootstrapped expected output for {}", fixture.name);
+        let bootstrap_enabled = std::env::var("GEO_POLYGONIZE_BOOTSTRAP_GOLDEN")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
+
+        if bootstrap_enabled {
+            fixture.expected = Some(actual_result);
+            let output = serde_json::to_string_pretty(&fixture).unwrap();
+            fs::write(path, output).unwrap();
+            println!("Bootstrapped expected output for {}", fixture.name);
+        } else {
+            panic!(
+                "Fixture {} is missing expected output. Set GEO_POLYGONIZE_BOOTSTRAP_GOLDEN=1 to bootstrap snapshots.",
+                fixture.name
+            );
+        }
     }
 }
 
@@ -137,12 +147,14 @@ fn test_all_fixtures() {
     let base_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("tests")
         .join("fixtures");
-    if !base_dir.exists() {
-        return;
-    }
+    assert!(
+        base_dir.exists(),
+        "Golden fixture directory does not exist: {}",
+        base_dir.display()
+    );
 
     let mut count = 0;
-    for entry in walkdir::WalkDir::new(base_dir)
+    for entry in walkdir::WalkDir::new(&base_dir)
         .into_iter()
         .filter_map(|e| e.ok())
     {
@@ -156,5 +168,10 @@ fn test_all_fixtures() {
             count += 1;
         }
     }
+    assert!(
+        count > 0,
+        "No golden fixture files (*.json) found in {}",
+        base_dir.display()
+    );
     println!("Ran {} golden fixtures", count);
 }


### PR DESCRIPTION
### Motivation
- The golden-test harness could silently pass by bootstrapping missing `expected` snapshots or by returning early when the fixtures directory was absent, which reduces CI signal and allows accidental assertion bypasses.

### Description
- Make the harness fail when a fixture's `expected` is missing unless the explicit opt-in `GEO_POLYGONIZE_BOOTSTRAP_GOLDEN` environment variable is set to `1` or `true`.
- Preserve snapshot-writing behavior only when `GEO_POLYGONIZE_BOOTSTRAP_GOLDEN` is enabled, and otherwise `panic!` with guidance on how to bootstrap.
- Add assertions that the fixtures directory exists (`assert!(base_dir.exists())`) and that at least one `*.json` fixture was executed (`assert!(count > 0)`), preventing silent no-op test runs.
- Fix a borrow/move issue by using `walkdir::WalkDir::new(&base_dir)` so the directory path can be reported in assertion messages.

### Testing
- Ran `cargo test -p geo-polygonize-core --test golden_fixtures`, which compiled and the test finished successfully (`1 passed; 0 failed`).
- Verified the harness behavior: missing `expected` now triggers a failure unless `GEO_POLYGONIZE_BOOTSTRAP_GOLDEN` is set, and the directory/empty-fixture assertions trigger when appropriate.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae62b411bc832fbce9d8bc43dde122)