### PR TITLE
fix(core): remove unused coordinate comparator closures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-core"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "approx",
  "arrow",
@@ -770,7 +770,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-wasm"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "arrow",
  "arrow-ipc",

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -451,20 +451,6 @@ impl Polygonizer {
             }
         };
 
-        let cmp_coord = |a: &Coord3D, b: &Coord3D| {
-            a.x.total_cmp(&b.x)
-                .then(a.y.total_cmp(&b.y))
-                .then(a.z.total_cmp(&b.z))
-        };
-
-        let cmp_coord_chain = |a: &[Coord3D], b: &[Coord3D]| {
-            a.iter()
-                .zip(b.iter())
-                .map(|(ca, cb)| cmp_coord(ca, cb))
-                .find(|o| *o != std::cmp::Ordering::Equal)
-                .unwrap_or_else(|| a.len().cmp(&b.len()))
-        };
-
         // 6. Construct Final Polygons
         // Ensure we don't crash on NaNs during processing
         let mut invalid_rings = if invalid_rings_candidates.is_empty() {


### PR DESCRIPTION
### Motivation
- Fix a `clippy` `unused variable` error caused by unused comparator closures in `Polygonizer` so the project can pass `-D warnings` CI checks.

### Description
- Remove the unused `cmp_coord` and `cmp_coord_chain` closures from `crates/geo-polygonize-core/src/polygonizer.rs` and update `Cargo.lock` entries for `geo-polygonize-core` and `geo-polygonize-wasm` to `0.8.0`; this does not change canonicalization or sorting behavior.

### Testing
- Ran `cargo clippy -- -D warnings`, which completed successfully with no warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af03693ea0832f88a09e89166aabd6)