### PR TITLE
style(wasm): apply rustfmt to Rust binding modules

### DIFF
--- a/crates/geo-polygonize-core/src/python.rs
+++ b/crates/geo-polygonize-core/src/python.rs
@@ -1,15 +1,27 @@
+use crate::error::PolygonizerError;
 use crate::types::{Coord3D, Line3D};
 use crate::Polygonizer;
-use crate::error::PolygonizerError;
 use numpy::{PyArray1, PyReadonlyArray1};
+use pyo3::create_exception;
+use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList, PyTuple};
-use pyo3::exceptions::{PyValueError, PyRuntimeError};
-use pyo3::create_exception;
 
-create_exception!(geo_polygonize_core, TopologyError, pyo3::exceptions::PyException);
-create_exception!(geo_polygonize_core, InvalidGeometryError, pyo3::exceptions::PyException);
-create_exception!(geo_polygonize_core, NodingError, pyo3::exceptions::PyException);
+create_exception!(
+    geo_polygonize_core,
+    TopologyError,
+    pyo3::exceptions::PyException
+);
+create_exception!(
+    geo_polygonize_core,
+    InvalidGeometryError,
+    pyo3::exceptions::PyException
+);
+create_exception!(
+    geo_polygonize_core,
+    NodingError,
+    pyo3::exceptions::PyException
+);
 
 impl std::convert::From<PolygonizerError> for PyErr {
     fn from(err: PolygonizerError) -> PyErr {
@@ -263,7 +275,10 @@ fn polygonize<'py>(
 #[pymodule]
 fn geo_polygonize_core(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("TopologyError", py.get_type_bound::<TopologyError>())?;
-    m.add("InvalidGeometryError", py.get_type_bound::<InvalidGeometryError>())?;
+    m.add(
+        "InvalidGeometryError",
+        py.get_type_bound::<InvalidGeometryError>(),
+    )?;
     m.add("NodingError", py.get_type_bound::<NodingError>())?;
     m.add_function(wrap_pyfunction!(polygonize, m)?)?;
     Ok(())

--- a/crates/geo-polygonize-wasm/src/lib.rs
+++ b/crates/geo-polygonize-wasm/src/lib.rs
@@ -46,18 +46,18 @@ pub fn polygonize(
         GeoJson::FeatureCollection(fc) => {
             for feature in fc.features {
                 if let Some(geom) = feature.geometry {
-                    let geo_geom: geo::Geometry<f64> = geom
-                        .try_into()
-                        .map_err(|e| to_js_error("ConversionError", format!("Conversion error: {}", e)))?;
+                    let geo_geom: geo::Geometry<f64> = geom.try_into().map_err(|e| {
+                        to_js_error("ConversionError", format!("Conversion error: {}", e))
+                    })?;
                     polygonizer.add_geometry(geo_geom);
                 }
             }
         }
         GeoJson::Feature(f) => {
             if let Some(geom) = f.geometry {
-                let geo_geom: geo::Geometry<f64> = geom
-                    .try_into()
-                    .map_err(|e| to_js_error("ConversionError", format!("Conversion error: {}", e)))?;
+                let geo_geom: geo::Geometry<f64> = geom.try_into().map_err(|e| {
+                    to_js_error("ConversionError", format!("Conversion error: {}", e))
+                })?;
                 polygonizer.add_geometry(geo_geom);
             }
         }
@@ -69,9 +69,7 @@ pub fn polygonize(
         }
     }
 
-    let result = polygonizer
-        .polygonize()
-        .map_err(from_polygonizer_error)?;
+    let result = polygonizer.polygonize().map_err(from_polygonizer_error)?;
 
     let geometries: Vec<Geometry> = result
         .polygons
@@ -171,10 +169,13 @@ pub fn polygonize_buffers(
         };
 
         if start > end {
-            return Err(to_js_error("InvalidInput", format!(
+            return Err(to_js_error(
+                "InvalidInput",
+                format!(
                 "Invalid offsets: start offset ({}) is greater than end offset ({}) at index {}",
                 start, end, i
-            )));
+            ),
+            ));
         }
         if end * stride as usize > coords.len() {
             return Err(to_js_error("InvalidInput", format!(
@@ -228,15 +229,15 @@ pub fn polygonize_geoarrow(
         }
     }
 
-    let geom_col_idx =
-        geom_col_idx.ok_or_else(|| to_js_error("InvalidInput", "No GeoArrow LineString column found"))?;
+    let geom_col_idx = geom_col_idx
+        .ok_or_else(|| to_js_error("InvalidInput", "No GeoArrow LineString column found"))?;
     let field = schema.field(geom_col_idx).clone();
 
     // Collect batches
     let mut arrays = Vec::new();
     for batch_result in reader {
-        let batch =
-            batch_result.map_err(|e| to_js_error("ArrowError", format!("Failed reading batch: {e}")))?;
+        let batch = batch_result
+            .map_err(|e| to_js_error("ArrowError", format!("Failed reading batch: {e}")))?;
         arrays.push(batch.column(geom_col_idx).clone());
     }
 
@@ -289,9 +290,7 @@ fn polygonize_and_flatten(
     mut polygonizer: Polygonizer,
     stride: u8,
 ) -> Result<WasmPolygonResult, JsValue> {
-    let result = polygonizer
-        .polygonize()
-        .map_err(from_polygonizer_error)?;
+    let result = polygonizer.polygonize().map_err(from_polygonizer_error)?;
 
     let mut flat_coords = Vec::new();
     let mut ring_offsets = Vec::new();


### PR DESCRIPTION
### Motivation
- Ensure repository passes `cargo fmt -- --check` by applying rustfmt formatting to Rust binding code.

### Description
- Reordered and reformatted imports and exception macro invocations in `crates/geo-polygonize-core/src/python.rs` to match rustfmt output.
- Wrapped and reformatted long `m.add(...)` call in the Python bindings for readability and consistency.
- Reformatted chained calls, `map_err` closures, and error construction sites in `crates/geo-polygonize-wasm/src/lib.rs` to satisfy rustfmt style.
- No logical behavior changes were made; edits are whitespace/formatting only.

### Testing
- Ran `cargo fmt -- --check` which succeeded after applying the formatting changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af9215f0e4832f9e600e8eb55aed70)