### PR TITLE
test(python): add edge case test for 3D to 2D coordinate slicing

### DIFF
--- a/python/test_wrapper.py
+++ b/python/test_wrapper.py
@@ -307,6 +307,25 @@ def test_internal_error_status(mock_lib):
     print("Internal error status test passed!")
 
 
+def test_3d_to_2d_slicing():
+    print("\nTesting 3D to 2D slicing (stride=2, shape=(N, 3))...")
+    # 2D array with 3 columns, but we want 2D polygonization (XY)
+    coords = np.array([
+        [0.0, 0.0, 100.0],
+        [10.0, 0.0, 101.0],
+        [10.0, 10.0, 102.0],
+        [0.0, 10.0, 103.0],
+        [0.0, 0.0, 100.0]
+    ], dtype=np.float64)
+    offsets = np.array([0, 5], dtype=np.uint32)
+
+    # This should trigger the slicing coords = coords[:, :2]
+    polys = polygonize(coords, offsets, stride=2, return_polygons=True)
+    assert len(polys) == 1
+    assert abs(polys[0].area - 100.0) < 1e-6
+    print("3D to 2D slicing test passed!")
+
+
 if __name__ == "__main__":
     test_square()
     test_two_squares()
@@ -322,6 +341,7 @@ if __name__ == "__main__":
     test_invalid_input_status()
     test_internal_error_status()
     test_null_result_pointer()
+    test_3d_to_2d_slicing()
 
 def test_rust_typed_errors():
     print("\nTesting Rust typed errors propagation...")


### PR DESCRIPTION
### 🎯 What
Addressed the testing gap in `python/geo_polygonize/__init__.py` related to the slicing of coordinate arrays when `stride=2` and the input shape has 3 columns.

### 📊 Coverage
The new test case `test_3d_to_2d_slicing` in `python/test_wrapper.py` covers:
- Input 2D numpy arrays with shape (N, 3).
- Explicit `stride=2` parameter.
- Verification that the Z-dimension is ignored and the correct area is calculated based on XY coordinates.

### ✨ Result
Increased the reliability of the Python input validation logic and ensured that the automatic slicing of 3D-shaped arrays into 2D is correctly handled. Verified the logic using a mock-based script and functional integration tests.

---
*PR created automatically by Jules for task [12161794907138279893](https://jules.google.com/task/12161794907138279893) started by @graydonpleasants*