### PR TITLE
test(python): remove unused and broken CFFI test function

### DIFF
--- a/tests/test_dangles.py
+++ b/tests/test_dangles.py
@@ -1,4 +1,3 @@
-import pytest
 from geo_polygonize import polygonize as polygonize_pyo3
 import numpy as np
 
@@ -45,15 +44,3 @@ def test_square_with_tail_pyo3():
     result = polygonize_pyo3(np.array(coords_data), np.array(offsets_data, dtype=np.uint32))
     check_result(result)
 
-def test_square_with_tail_cffi():
-    print("Testing CFFI implementation")
-    try:
-        from geo_polygonize.cffi_wrapper import polygonize as polygonize_cffi
-    except ImportError as e:
-        pytest.skip(f"CFFI wrapper import failed: {e}")
-    except Exception as e:
-        pytest.skip(f"CFFI wrapper initialization failed: {e}")
-
-    pytest.skip("CFFI wrapper currently unimplemented/broken due to Arrow-only migration.")
-    result = polygonize_cffi(np.array(coords_data), np.array(offsets_data, dtype=np.uint32))
-    check_result(result)


### PR DESCRIPTION
🎯 **What:** Removed the `test_square_with_tail_cffi` function and its associated `import pytest` from `tests/test_dangles.py`.
💡 **Why:** The test was explicitly calling `pytest.skip` because the CFFI wrapper it tests is broken and deprecated following the Arrow-only migration. Removing this dead code improves maintainability and reduces noise.
✅ **Verification:** Verified the deletion manually and confirmed the file's syntax using `python3 -m py_compile`. Full test execution was blocked by missing dependencies in the environment, but syntax verification ensures no regressions in the remaining code.
✨ **Result:** Cleaner test suite with no unreachable code or unused imports.

---
*PR created automatically by Jules for task [9579181457221005036](https://jules.google.com/task/9579181457221005036) started by @graydonpleasants*