### PR TITLE
feat(deps): add cargo fmt pre-commit hook to husky

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+echo "Running cargo fmt..."
+cargo fmt --all
+
+if [ $? -ne 0 ]; then
+  echo "cargo fmt failed"
+  # Exit to abort commit
+  exit 1
+fi
+
+STAGED_RS_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '\.rs$' || true)
+
+if [ -n "$STAGED_RS_FILES" ]; then
+  echo "$STAGED_RS_FILES" | xargs git add
+fi


### PR DESCRIPTION
Adds a pre-commit hook to automatically format Rust code via `cargo fmt` and restage modified `.rs` files. This solves the user's issue by preventing build failures in CI due to unformatted code.

---
*PR created automatically by Jules for task [272159921235107048](https://jules.google.com/task/272159921235107048) started by @graydonpleasants*