### PR TITLE
chore(python): refactor complex mock_import in python tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-core"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "approx",
  "arrow",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-wasm"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "arrow",
  "arrow-ipc",

--- a/python/test_wrapper.py
+++ b/python/test_wrapper.py
@@ -157,14 +157,7 @@ def test_import_error_fallback():
     import builtins
     import geo_polygonize
 
-    real_import = builtins.__import__
-
-    def mock_import(name, globals=None, locals=None, fromlist=(), level=0):
-        if 'geo_polygonize_core' in name or (fromlist and 'geo_polygonize_core' in fromlist):
-            raise ImportError("Mocked ImportError for testing")
-        return real_import(name, globals, locals, fromlist, level)
-
-    with patch('builtins.__import__', side_effect=mock_import):
+    with patch.dict('sys.modules', {'geo_polygonize.geo_polygonize_core': None, 'geo_polygonize_core': None}):
         importlib.reload(geo_polygonize)
 
         import geo_polygonize.cffi_wrapper as cffi_wrapper
@@ -190,13 +183,7 @@ def test_return_polygons_without_shapely():
     import builtins
     import unittest.mock
 
-    real_import = builtins.__import__
-    def mock_import(name, globals=None, locals=None, fromlist=(), level=0):
-        if name == 'shapely.geometry' or name == 'shapely':
-            raise ImportError("Mocked ImportError")
-        return real_import(name, globals, locals, fromlist, level)
-
-    with unittest.mock.patch('builtins.__import__', side_effect=mock_import):
+    with unittest.mock.patch.dict('sys.modules', {'shapely': None, 'shapely.geometry': None}):
         try:
             polygonize(coords, offsets, return_polygons=True)
             assert False, "Should have raised ImportError"


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed the custom, unused (or unnecessarily complex) `mock_import` functions located in `python/test_wrapper.py` and replaced them with standard `patch.dict` usage for simulating missing modules via `sys.modules`.

💡 **Why:** How this improves maintainability
Mocking the global `builtins.__import__` function can lead to confusing and brittle tests. Replacing this custom logic with the standard `unittest.mock.patch.dict('sys.modules', {'module_name': None})` approach is a more idiomatic Pythonic way to trigger an `ImportError` when specific modules are imported during a fallback test, making the code much easier to read and maintain.

✅ **Verification:** How you confirmed the change is safe
Ran the python test suite via `pytest python/test_wrapper.py`. Verified that the tests `test_import_error_fallback` and `test_return_polygons_without_shapely` continued to behave properly and threw the expected errors without regressions. Extraneous dummy files were deleted and state cleaned via code review feedback.

✨ **Result:** The improvement achieved
A cleaner and more standard Python test suite that eliminates unnecessarily complex mocking of `__import__` while maintaining complete code coverage.

---
*PR created automatically by Jules for task [16505038004755637197](https://jules.google.com/task/16505038004755637197) started by @graydonpleasants*