### PR TITLE
chore(python): Add missing extract_only_polygonal tests in Python API

### DIFF
--- a/python/test_wrapper.py
+++ b/python/test_wrapper.py
@@ -383,24 +383,6 @@ def test_3d_to_2d_slicing():
     print("3D to 2D slicing test passed!")
 
 
-if __name__ == "__main__":
-    test_square()
-    test_two_squares()
-    test_square_with_hole()
-    test_3d_coordinates()
-    test_missing_args()
-    test_odd_length_coordinates()
-    test_import_error_fallback()
-    test_return_polygons_without_shapely()
-    test_library_not_found()
-    test_invalid_shape_mismatch()
-    test_invalid_stride()
-    test_invalid_input_status()
-    test_internal_error_status()
-    test_null_result_pointer()
-    test_3d_to_2d_slicing()
-    test_polygonize_with_options()
-
 def test_rust_typed_errors():
     print("\nTesting Rust typed errors propagation...")
     import geo_polygonize
@@ -424,4 +406,55 @@ def test_rust_typed_errors():
         print(f"Caught expected error from bounds check: {e}")
         assert "Invalid offsets" in str(e) or "Invalid input" in str(e)
 
-    print("Rust typed error bounds propagation test passed!")
+
+def test_extract_only_polygonal():
+    print("\nTesting extract_only_polygonal API...")
+    from geo_polygonize import polygonize
+
+    # Create a square with a hole AND a line segment connecting the hole to the shell.
+    # Outer Square: (0,0)->(10,0)->(10,10)->(0,10)->(0,0)
+    # Inner Hole: (2,2)->(8,2)->(8,8)->(2,8)->(2,2)
+    # Cut edge connecting outer to inner: (0,5)->(2,5)
+    coords = np.array([
+        # Outer
+        0.0, 0.0, 10.0, 0.0,
+        10.0, 0.0, 10.0, 10.0,
+        10.0, 10.0, 0.0, 10.0,
+        0.0, 10.0, 0.0, 0.0,
+        # Hole
+        2.0, 2.0, 8.0, 2.0,
+        8.0, 2.0, 8.0, 8.0,
+        8.0, 8.0, 2.0, 8.0,
+        2.0, 8.0, 2.0, 2.0,
+        # Cut edge connecting them
+        0.0, 5.0, 2.0, 5.0
+    ], dtype=np.float64)
+    offsets = np.array([0, 2, 4, 6, 8, 10, 12, 14, 16], dtype=np.uint32)
+
+    result_regular = polygonize(coords, offsets)
+    assert len(result_regular['polygons']) == 2
+
+    result_only_polygonal = polygonize(coords, offsets, extract_only_polygonal=True)
+    assert len(result_only_polygonal['polygons']) == 1
+
+    print("extract_only_polygonal test passed!")
+
+if __name__ == "__main__":
+    test_square()
+    test_two_squares()
+    test_square_with_hole()
+    test_3d_coordinates()
+    test_missing_args()
+    test_odd_length_coordinates()
+    test_import_error_fallback()
+    test_return_polygons_without_shapely()
+    test_library_not_found()
+    test_invalid_shape_mismatch()
+    test_invalid_stride()
+    test_invalid_input_status()
+    test_internal_error_status()
+    test_null_result_pointer()
+    test_3d_to_2d_slicing()
+    test_polygonize_with_options()
+    test_rust_typed_errors()
+    test_extract_only_polygonal()


### PR DESCRIPTION
🎯 **What:** The `extract_only_polygonal` boolean parameter in the Python API of `geo_polygonize` was completely lacking testing coverage.
📊 **Coverage:** A new test case `test_extract_only_polygonal()` has been added which verifies the API properly reduces the results to only the correct valid output. It uses a custom set of geometric inputs specifically tailored to verify the logic.
✨ **Result:** Improved testing coverage and better reliability for this boolean parameter of the polygonize algorithm.

---
*PR created automatically by Jules for task [1004272872875271000](https://jules.google.com/task/1004272872875271000) started by @graydonpleasants*