### PR TITLE
chore(python): remove unused shapely import in test wrapper

### DIFF
--- a/python/test_wrapper.py
+++ b/python/test_wrapper.py
@@ -2,8 +2,6 @@ import pytest
 import sys
 import os
 import numpy as np
-import shapely
-from shapely.geometry import shape
 from unittest.mock import patch
 
 # Add python directory to path


### PR DESCRIPTION
🎯 **What:** Removed unused `import shapely` and `from shapely.geometry import shape` in `python/test_wrapper.py`.

💡 **Why:** These imports were unused, causing namespace clutter. Removing them improves the codebase's health, readability, and maintainability.

✅ **Verification:** Ran `python3 -m py_compile python/test_wrapper.py` to ensure there are no syntax errors and reviewed code dependencies to confirm no behavior modifications were introduced.

✨ **Result:** Cleaned up unused variables safely.

---
*PR created automatically by Jules for task [14647736347454998380](https://jules.google.com/task/14647736347454998380) started by @graydonpleasants*