### PR TITLE
test(python): add invalid shape mismatch test for polygonize_with_options

### DIFF
--- a/python/test_wrapper.py
+++ b/python/test_wrapper.py
@@ -296,6 +296,19 @@ def test_internal_error_status(mock_lib):
     print("Internal error status test passed!")
 
 
+def test_polygonize_with_options_invalid_shape_mismatch():
+    print("\nTesting polygonize_with_options invalid shape mismatch...")
+    from geo_polygonize import polygonize_with_options
+
+    # 2D coords with shape (1, 4) but stride=2
+    coords = np.array([[0.0, 0.0, 1.0, 1.0]], dtype=np.float64)
+    offsets = np.array([0], dtype=np.uint32)
+
+    with pytest.raises(ValueError, match=r"Input shape \(1, 4\) does not match stride 2"):
+        polygonize_with_options(coords=coords, offsets=offsets, stride=2)
+    print("Invalid shape mismatch for polygonize_with_options test passed!")
+
+
 def test_polygonize_with_options():
     print("\nTesting polygonize_with_options API...")
     from geo_polygonize import polygonize_with_options
@@ -444,6 +457,7 @@ if __name__ == "__main__":
     test_internal_error_status()
     test_null_result_pointer()
     test_3d_to_2d_slicing()
+    test_polygonize_with_options_invalid_shape_mismatch()
     test_polygonize_with_options()
     test_rust_typed_errors()
     test_extract_only_polygonal()


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR addresses the lack of testing around error propagation for `polygonize_with_options` when it encounters structurally invalid input shapes (e.g., when the shape dimension conflicts with the specified stride). 

📊 **Coverage:** What scenarios are now tested
A new test (`test_polygonize_with_options_invalid_shape_mismatch`) has been added to `python/test_wrapper.py` that mocks a 2D array and passes it to `polygonize_with_options` with an incompatible stride, asserting that `ValueError` is raised with the correct message. 

✨ **Result:** The improvement in test coverage
Error reporting mechanisms and exception conditions for `polygonize_with_options` invalid shapes are now fully tested, preventing regressions to Python bindings.

---
*PR created automatically by Jules for task [16504198522991649960](https://jules.google.com/task/16504198522991649960) started by @graydonpleasants*