### PR TITLE
test(core): Add test for bounding_rect_3d with empty slice

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-core"
-version = "0.22.1"
+version = "0.23.0"
 dependencies = [
  "approx",
  "arrow",
@@ -784,7 +784,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-wasm"
-version = "0.22.1"
+version = "0.23.0"
 dependencies = [
  "arrow",
  "arrow-ipc",

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -970,6 +970,11 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_bounding_rect_3d_empty() {
+        assert_eq!(bounding_rect_3d(&[]), None);
+    }
+
+    #[test]
     fn test_with_snap_grid() {
         let polygonizer = Polygonizer::new().with_snap_grid(0.123);
         assert_eq!(polygonizer.snap_grid_size, 0.123);


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of test coverage for the `bounding_rect_3d` function when called with an empty slice.
📊 **Coverage:** The empty slice edge case scenario is now tested.
✨ **Result:** The improvement in test coverage guarantees that `bounding_rect_3d` returns `None` for empty inputs, increasing codebase reliability.

---
*PR created automatically by Jules for task [15441034285825428550](https://jules.google.com/task/15441034285825428550) started by @graydonpleasants*