### PR TITLE
test(python): expand polygonize argument validation testing

### DIFF
--- a/python/test_wrapper.py
+++ b/python/test_wrapper.py
@@ -119,8 +119,38 @@ def test_3d_coordinates():
     assert abs(shapely_poly.area - 100.0) < 1e-6
     print("3D coordinates test passed!")
 
+def test_lines_argument():
+    print("\nTesting lines argument...")
+    from geo_polygonize import polygonize_with_options
+
+    # Create lines representing a square
+    lines = [
+        [(0.0, 0.0), (10.0, 0.0)],
+        [(10.0, 0.0), (10.0, 10.0)],
+        [(10.0, 10.0), (0.0, 10.0)],
+        [(0.0, 10.0), (0.0, 0.0)]
+    ]
+
+    # Test with polygonize
+    polys1 = polygonize(lines=lines, return_polygons=True)
+    assert len(polys1) == 1
+    assert abs(polys1[0].area - 100.0) < 1e-6
+
+    # Test with polygonize_with_options
+    polys2 = polygonize_with_options(lines=lines, return_polygons=True)
+    assert len(polys2) == 1
+    assert abs(polys2[0].area - 100.0) < 1e-6
+
+    # Test with empty lines list
+    res = polygonize(lines=[])
+    assert len(res.get('polygons', [])) == 0
+
+    print("Lines argument test passed!")
+
 def test_missing_args():
     print("\nTesting missing arguments...")
+    from geo_polygonize import polygonize_with_options
+
     coords = np.array([0.0, 0.0, 1.0, 1.0], dtype=np.float64)
     offsets = np.array([0, 2], dtype=np.uint32)
 
@@ -132,6 +162,15 @@ def test_missing_args():
 
     with pytest.raises(ValueError, match="Either 'lines' or both 'coords' and 'offsets' must be provided."):
         polygonize(offsets=offsets)
+
+    with pytest.raises(ValueError, match="Either 'lines' or both 'coords' and 'offsets' must be provided."):
+        polygonize_with_options()
+
+    with pytest.raises(ValueError, match="Either 'lines' or both 'coords' and 'offsets' must be provided."):
+        polygonize_with_options(coords=coords)
+
+    with pytest.raises(ValueError, match="Either 'lines' or both 'coords' and 'offsets' must be provided."):
+        polygonize_with_options(offsets=offsets)
 
     print("Missing arguments test passed!")
 
@@ -163,7 +202,10 @@ def test_import_error_fallback():
         print("ImportError fallback test passed!")
 
     # Reload again to restore the module state for other tests
-    importlib.reload(geo_polygonize.cffi_wrapper)
+    try:
+        importlib.reload(geo_polygonize.cffi_wrapper)
+    except ImportError:
+        pass
     importlib.reload(geo_polygonize)
 
 def test_return_polygons_without_shapely():


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `polygonize` arguments validation was partially tested, missing explicit paths for `polygonize_with_options` argument validation and not verifying the `lines` parameter. 

📊 **Coverage:** What scenarios are now tested
- Added `test_lines_argument()` to ensure both `polygonize` and `polygonize_with_options` process the `lines` argument correctly.
- Added assertions to `test_missing_args()` to ensure `polygonize_with_options` raises ValueErrors when passed missing parameters (e.g. only `coords` or only `offsets`).
- Fixed a buggy test, `test_import_error_fallback`, which crashed on teardown because `geo_polygonize.cffi_wrapper` was occasionally absent from `sys.modules`. 

✨ **Result:** The improvement in test coverage
More robust validation for argument checking across both exposed Python entrypoints, mitigating edge cases where invalid arguments may slip past validation.

---
*PR created automatically by Jules for task [1614598032572148811](https://jules.google.com/task/1614598032572148811) started by @graydonpleasants*