### PR TITLE
refactor(core): replace unwrap with option handling in planar graph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-core"
-version = "0.22.1"
+version = "0.23.0"
 dependencies = [
  "approx",
  "arrow",
@@ -784,7 +784,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-wasm"
-version = "0.22.1"
+version = "0.23.0"
 dependencies = [
  "arrow",
  "arrow-ipc",

--- a/crates/geo-polygonize-core/src/graph/planar_graph.rs
+++ b/crates/geo-polygonize-core/src/graph/planar_graph.rs
@@ -568,14 +568,12 @@ impl PlanarGraph {
                         .filter(|&idx| !self.directed_edges[idx].is_marked),
                 );
 
-                if valid_edges.is_empty() {
-                    continue;
-                }
-
-                let mut next = *valid_edges.last().unwrap();
-                for &curr in &valid_edges {
-                    next_pointers[curr] = next;
-                    next = curr;
+                if let Some(&last) = valid_edges.last() {
+                    let mut next = last;
+                    for &curr in &valid_edges {
+                        next_pointers[curr] = next;
+                        next = curr;
+                    }
                 }
             }
 


### PR DESCRIPTION
🎯 **What:** Replaced an unsafe-looking `unwrap()` in `get_edge_rings` with safe idiomatic `if let Some(...)` syntax.
💡 **Why:** This avoids a runtime panic path entirely and simplifies the control flow (removes the `is_empty()` check and `continue`), leading to more idiomatic, readable, and robust Rust code.
✅ **Verification:** Ran `cargo test -p geo-polygonize-core` and verified all tests pass without introducing any regressions.
✨ **Result:** A safer, more robust inner loop within the planar graph logic.

---
*PR created automatically by Jules for task [9285436690874514294](https://jules.google.com/task/9285436690874514294) started by @graydonpleasants*