### PR TITLE
chore(core): replace unwrap with expect in ffi test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-core"
-version = "0.22.1"
+version = "0.23.0"
 dependencies = [
  "approx",
  "arrow",
@@ -784,7 +784,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-wasm"
-version = "0.22.1"
+version = "0.23.0"
 dependencies = [
  "arrow",
  "arrow-ipc",

--- a/crates/geo-polygonize-core/src/ffi.rs
+++ b/crates/geo-polygonize-core/src/ffi.rs
@@ -246,7 +246,8 @@ mod tests {
         let input_arrow_array = builder.finish();
 
         let array_ref = input_arrow_array.into_array_ref();
-        let (input_array, input_schema) = arrow::ffi::to_ffi(&array_ref.to_data()).unwrap();
+        let (input_array, input_schema) = arrow::ffi::to_ffi(&array_ref.to_data())
+            .expect("Failed to convert arrow array to FFI structs");
         let mut input_array_ffi = std::mem::ManuallyDrop::new(input_array);
         let mut input_schema_ffi = std::mem::ManuallyDrop::new(input_schema);
 


### PR DESCRIPTION
🎯 **What:** Replaced `.unwrap()` with `.expect("Failed to convert arrow array to FFI structs")` in `crates/geo-polygonize-core/src/ffi.rs`.
💡 **Why:** To improve code health by providing a descriptive panic message rather than a generic one in the test, addressing the "unused unwrap" code health issue.
✅ **Verification:** Ran `cargo test` in `crates/geo-polygonize-core`, and all tests passed successfully, ensuring no regressions.
✨ **Result:** Better error reporting in tests and improved code readability.

---
*PR created automatically by Jules for task [3832332942254383653](https://jules.google.com/task/3832332942254383653) started by @graydonpleasants*