### PR TITLE
chore(core): remove commented out code in simd tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-core"
-version = "0.22.1"
+version = "0.23.0"
 dependencies = [
  "approx",
  "arrow",
@@ -784,7 +784,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-wasm"
-version = "0.22.1"
+version = "0.23.0"
 dependencies = [
  "arrow",
  "arrow-ipc",

--- a/crates/geo-polygonize-core/src/utils/simd.rs
+++ b/crates/geo-polygonize-core/src/utils/simd.rs
@@ -298,8 +298,6 @@ mod tests {
                 // Geo's contains is strict (false for boundary).
                 // SimdRing is strict-ish (false for most boundary, true for some vertices).
                 // We skip points too close to boundary to avoid flaky tests on undefined behavior.
-                // Convert test_point to Point for distance check
-                // let point_geo = geo::Point(test_point);
                 // Check distance to boundary
                 let boundary = poly.exterior();
 


### PR DESCRIPTION
🎯 **What:** Removed commented out code (`// let point_geo = geo::Point(test_point);`) in `crates/geo-polygonize-core/src/utils/simd.rs`.
💡 **Why:** Removing dead code improves readability and maintainability of the codebase.
✅ **Verification:** Ran `cargo test` in `crates/geo-polygonize-core` and verified all tests pass without issues.
✨ **Result:** A cleaner test file with no stale commented out code.

---
*PR created automatically by Jules for task [8857437949922195450](https://jules.google.com/task/8857437949922195450) started by @graydonpleasants*