### PR TITLE
feat(wasm): stringify Set and Map in debug output

### DIFF
--- a/pkg-threads/geo_polygonize.js
+++ b/pkg-threads/geo_polygonize.js
@@ -70,6 +70,20 @@ function debugString(val) {
         return `${val.name}: ${val.message}\n${val.stack}`;
     }
     // TODO we could test for more things here, like `Set`s and `Map`s.
+    if (val instanceof Map) {
+        let debug = '[';
+        for (let [k, v] of val) {
+            debug += debugString(k) + ' => ' + debugString(v) + ', ';
+        }
+        return 'Map(' + val.size + ') ' + debug + ']';
+    }
+    if (val instanceof Set) {
+        let debug = '[';
+        for (let v of val) {
+            debug += debugString(v) + ', ';
+        }
+        return 'Set(' + val.size + ') ' + debug + ']';
+    }
     return className;
 }
 

--- a/scripts/build_wasm.sh
+++ b/scripts/build_wasm.sh
@@ -153,6 +153,12 @@ for DIR in pkg-scalar pkg-simd pkg-threads; do
     # 3. Replace original file
     mv "$TEMP_FILE" "$D_TS_FILE"
   fi
+
+  # Patch JS file to stringify Set and Map in debugString
+  JS_FILE="${DIR}/geo_polygonize.js"
+  if [ -f "$JS_FILE" ]; then
+    node scripts/patch_wasm_bindgen_output.cjs
+  fi
 done
 
 # Ensure wrapper exists

--- a/scripts/patch_wasm_bindgen_output.cjs
+++ b/scripts/patch_wasm_bindgen_output.cjs
@@ -1,0 +1,43 @@
+const fs = require('fs');
+const path = require('path');
+
+const dirs = ['pkg-scalar', 'pkg-simd', 'pkg-threads'];
+
+dirs.forEach(dir => {
+    // __dirname is scripts/, so we need to go up one level
+    const filePath = path.join(__dirname, '..', dir, 'geo_polygonize.js');
+    if (fs.existsSync(filePath)) {
+        let content = fs.readFileSync(filePath, 'utf8');
+
+        const targetString = `// TODO we could test for more things here, like \`Set\`s and \`Map\`s.`;
+
+        const replacementString = `// TODO we could test for more things here, like \`Set\`s and \`Map\`s.
+    if (val instanceof Map) {
+        let debug = '[';
+        for (let [k, v] of val) {
+            debug += debugString(k) + ' => ' + debugString(v) + ', ';
+        }
+        return 'Map(' + val.size + ') ' + debug + ']';
+    }
+    if (val instanceof Set) {
+        let debug = '[';
+        for (let v of val) {
+            debug += debugString(v) + ', ';
+        }
+        return 'Set(' + val.size + ') ' + debug + ']';
+    }`;
+
+        // Ensure it hasn't already been patched
+        if (content.includes(targetString) && !content.includes(`if (val instanceof Map)`)) {
+            content = content.replace(targetString, replacementString);
+            fs.writeFileSync(filePath, content, 'utf8');
+            console.log(`Patched ${filePath}`);
+        } else if (content.includes(`if (val instanceof Map)`)) {
+            console.log(`Already patched ${filePath}`);
+        } else {
+            console.log(`Target string not found in ${filePath}`);
+        }
+    } else {
+        console.log(`File not found: ${filePath}`);
+    }
+});


### PR DESCRIPTION
The original `pkg-threads/geo_polygonize.js` (and the others) contained a generic `TODO` generated by `wasm-bindgen` indicating that `Set` and `Map` testing could be implemented for enhanced debugging capabilities within the binding logic. Since editing these files directly gets overwritten on rebuilds, this PR introduces a robust post-build hook `scripts/patch_wasm_bindgen_output.cjs` hooked into `scripts/build_wasm.sh` which replaces the `TODO` block safely on each variant build with logic that properly stringifies `Map(size) [key => val]` and `Set(size) [val]`.

---
*PR created automatically by Jules for task [18344512542120704871](https://jules.google.com/task/18344512542120704871) started by @graydonpleasants*