### PR TITLE
perf(core): Optimize dangle tie-break sorting with Schwartzian Transform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-core"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "approx",
  "arrow",
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-wasm"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "arrow",
  "arrow-ipc",

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -608,21 +608,31 @@ fn apply_determinism(
         }
 
         if use_stable_tie_breaks {
-            dangles.sort_by(|l1, l2| {
-                let b1 = bounding_rect_3d(l1).unwrap_or(geo::Rect::new(
-                    geo::Coord { x: 0.0, y: 0.0 },
-                    geo::Coord { x: 0.0, y: 0.0 },
-                ));
-                let b2 = bounding_rect_3d(l2).unwrap_or(geo::Rect::new(
-                    geo::Coord { x: 0.0, y: 0.0 },
-                    geo::Coord { x: 0.0, y: 0.0 },
-                ));
+            // Bolt optimization: Schwartzian Transform for dangles.
+            // Caches the bounding boxes of the open lines to avoid redundant
+            // O(N) evaluations of `bounding_rect_3d` during the O(K log K) sort closure.
+            let mut dangles_with_cache: Vec<_> = dangles
+                .iter_mut()
+                .map(|l| {
+                    let b = bounding_rect_3d(l).unwrap_or(geo::Rect::new(
+                        geo::Coord { x: 0.0, y: 0.0 },
+                        geo::Coord { x: 0.0, y: 0.0 },
+                    ));
+                    (std::mem::take(l), b)
+                })
+                .collect();
+
+            dangles_with_cache.sort_by(|(l1, b1), (l2, b2)| {
                 b1.min()
                     .x
                     .total_cmp(&b2.min().x)
                     .then(b1.min().y.total_cmp(&b2.min().y))
                     .then(l1.len().cmp(&l2.len()))
             });
+
+            for (i, (l, _)) in dangles_with_cache.into_iter().enumerate() {
+                dangles[i] = l;
+            }
         }
 
         let mut combined_invalid: Vec<_> = invalid_rings


### PR DESCRIPTION
💡 What: Applied a Schwartzian Transform to cache the bounding box property calculations of dangles prior to the `sort_by` sorting algorithm inside `apply_determinism`. 
🎯 Why: The original logic called `bounding_rect_3d` inside the closure for every comparison, evaluating the entire line coordinates repeatedly resulting in an O(N * K log K) algorithm.
📊 Impact: Expected performance improvement in scenarios with high levels of dangles and stable tie-breaking determinism, dropping the sort complexity from O(N * K log K) to O(N + K log K).
🔬 Measurement: Can be verified using criterion benchmarks over dense dangle networks. 


---
*PR created automatically by Jules for task [2348344375893116437](https://jules.google.com/task/2348344375893116437) started by @graydonpleasants*