### PR TITLE
fix(github): Fix cargo publish timeout when waiting for dependent crates

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,8 +17,17 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Publish to crates.io
-        run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - name: Publish geo-polygonize-core to crates.io
+        run: cargo publish -p geo-polygonize-core --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Publish geo-polygonize-wasm to crates.io
+        run: |
+          for i in 1 2 3 4 5 6; do
+            cargo publish -p geo-polygonize-wasm --token ${{ secrets.CARGO_REGISTRY_TOKEN }} && exit 0
+            echo "Publish failed, waiting before retrying..."
+            sleep 30
+          done
+          exit 1
 
       - name: Install cargo-cyclonedx
         uses: taiki-e/install-action@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-core"
-version = "0.26.0"
+version = "0.28.0"
 dependencies = [
  "approx",
  "arrow",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-wasm"
-version = "0.26.0"
+version = "0.28.0"
 dependencies = [
  "arrow",
  "arrow-ipc",


### PR DESCRIPTION
This fixes a recurring CI failure where `cargo publish` times out and fails the workflow when publishing a workspace because the registry index update for the first crate (`geo-polygonize-core`) takes longer than the default Cargo timeout (60 seconds). Since `geo-polygonize-wasm` depends on the core crate, we solve this by splitting the single `cargo publish` command into two sequential commands and using a robust `bash` retry loop with backoff sleep to give `crates.io` ample time to update the index before timing out.

---
*PR created automatically by Jules for task [3532137103116175248](https://jules.google.com/task/3532137103116175248) started by @graydonpleasants*