### PR TITLE
chore(fleet): add issue creation instruction to task-picker prompt

### DIFF
--- a/scripts/fleet/task-picker.ts
+++ b/scripts/fleet/task-picker.ts
@@ -30,6 +30,9 @@ const issuesMarkdown = await getIssuesAsMarkdown()
 
 const prompt = `Analyze the ROADMAP.md and issue list to pick the next target task. Be ambitious and thorough.
 
+**Important Instructions:**
+As your very first step, you must use the \`gh\` CLI to create a new GitHub issue for the task you select. Add an "in progress" label to it, and include a link to your Jules session so subsequent runs know this task is currently being worked on.
+
 ## ROADMAP.md
 \`\`\`markdown
 ${roadmapText}


### PR DESCRIPTION
This PR modifies the `task-picker.ts` script used by the fleet workflow. It updates the prompt sent to Jules, explicitly instructing it to use the `gh` CLI to create an issue, add an "in progress" label, and link its session as its very first action. This effectively reserves the task and prevents duplicate work by concurrent workflow runs.

---
*PR created automatically by Jules for task [8576831335962169965](https://jules.google.com/task/8576831335962169965) started by @graydonpleasants*