### PR TITLE
fix(core): ignore Vitepress dead link for playground

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -3,6 +3,9 @@ import { defineConfig } from 'vitepress'
 export default defineConfig({
   title: "geo-polygonize",
   description: "A native Rust port of the JTS/GEOS polygonization algorithm (Wasm)",
+  ignoreDeadLinks: [
+    /^\/playground\//,
+  ],
   themeConfig: {
     nav: [
       { text: 'Home', link: '/' },


### PR DESCRIPTION
Configured Vitepress in `docs/.vitepress/config.ts` to ignore dead links matching `/^\/playground\//`. The `/playground` link triggered a build failure when `npm run docs:build` was run because the playground is an externally built React application located within the repo, not managed by Vitepress itself.

---
*PR created automatically by Jules for task [5147930089179374076](https://jules.google.com/task/5147930089179374076) started by @graydonpleasants*