### PR TITLE
feat(github): setup deploy to github pages

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -14,6 +14,18 @@ on:
       - 'scripts/docs/**'
       - 'xtask/**'
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 jobs:
   build_docs:
     name: Build Docs
@@ -31,6 +43,9 @@ jobs:
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
 
       - name: Install Node
         uses: actions/setup-node@v4
@@ -57,3 +72,22 @@ jobs:
 
       - name: Build Docs Site
         run: npx vitepress build docs
+
+      - name: Upload artifact
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/.vitepress/dist
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build_docs
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-core"
-version = "0.29.0"
+version = "0.29.2"
 dependencies = [
  "approx",
  "arrow",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-wasm"
-version = "0.29.0"
+version = "0.29.2"
 dependencies = [
  "arrow",
  "arrow-ipc",


### PR DESCRIPTION
Updated `.github/workflows/docs-pages.yml` to include steps for uploading the built VitePress site artifact and deploying it to GitHub Pages. Added necessary permissions (`pages: write`, `id-token: write`) and concurrency controls to prevent conflicting deployments.

---
*PR created automatically by Jules for task [10321387648247738554](https://jules.google.com/task/10321387648247738554) started by @graydonpleasants*