### PR TITLE
fix(github): set base path for GitHub Pages deployment

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vitepress'
 
 export default defineConfig({
+  base: '/geo-polygonize/',
   title: "geo-polygonize",
   description: "A native Rust port of the JTS/GEOS polygonization algorithm (Wasm)",
   ignoreDeadLinks: [

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: '/geo-polygonize/playground/',
   plugins: [react()],
   build: {
     outDir: '../docs/.vitepress/dist/playground'


### PR DESCRIPTION
Fixes an issue where CSS and other assets were failing to load on the GitHub Pages documentation site because the base path was not configured correctly for deployment to a subdirectory.

Changes:
- Set `base: '/geo-polygonize/'` in `docs/.vitepress/config.ts`
- Set `base: '/geo-polygonize/playground/'` in `playground/vite.config.ts`

---
*PR created automatically by Jules for task [17174908835266595953](https://jules.google.com/task/17174908835266595953) started by @graydonpleasants*