### PR TITLE
perf(core): Optimize bounds-checking with zipped iterators in filter_polygonal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-core"
-version = "0.29.2"
+version = "0.30.1"
 dependencies = [
  "approx",
  "arrow",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-wasm"
-version = "0.29.2"
+version = "0.30.1"
 dependencies = [
  "arrow",
  "arrow-ipc",

--- a/crates/geo-polygonize-core/src/containment.rs
+++ b/crates/geo-polygonize-core/src/containment.rs
@@ -126,9 +126,11 @@ impl ContainmentForest {
             }
         }
 
-        for i in 0..shells.len() {
-            if keep_mask[i] && container_counts[i] % 2 != 0 {
-                keep_mask[i] = false;
+        // ⚡ Bolt: Iterator Array Optimization
+        // Using iterators avoids O(N) array bounds-checking overhead compared to explicit index looping
+        for (keep, count) in keep_mask.iter_mut().zip(container_counts.iter()) {
+            if *keep && *count % 2 != 0 {
+                *keep = false;
             }
         }
 


### PR DESCRIPTION
💡 What: Replaced an explicit index-based `for i in 0..shells.len()` loop with `.iter_mut().zip(...)` in the `filter_polygonal` function.
🎯 Why: Explicit indexing requires the Rust compiler to insert bounds checks on every iteration. Using a zipped iterator guarantees safe memory access and allows the compiler to completely eliminate this O(N) overhead in this hot loop path.
📊 Impact: Eliminates redundant bounds checking, marginally reducing CPU instructions in dense spatial queries and improving idiomatic codebase health.
🔬 Measurement: Verify that all tests pass cleanly (`cargo test --workspace`) and that the performance benchmarks do not regress.

---
*PR created automatically by Jules for task [12184233732557067487](https://jules.google.com/task/12184233732557067487) started by @graydonpleasants*