### PR TITLE
refactor(core): remove unused y field from Event struct

### DIFF
--- a/crates/geo-polygonize-core/src/noding/advanced.rs
+++ b/crates/geo-polygonize-core/src/noding/advanced.rs
@@ -40,13 +40,11 @@ impl AdvancedNoder {
 
                 events.push(Event {
                     x: left.x,
-                    y: left.y,
                     segment_idx: i,
                     is_left: true,
                 });
                 events.push(Event {
                     x: right.x,
-                    y: right.y,
                     segment_idx: i,
                     is_left: false,
                 });
@@ -284,8 +282,6 @@ impl AdvancedNoder {
 #[derive(Debug, Clone, Copy)]
 struct Event {
     x: f64,
-    #[allow(dead_code)]
-    y: f64,
     segment_idx: usize,
     is_left: bool,
 }


### PR DESCRIPTION
Remove the unused `y` field from the `Event` struct in `crates/geo-polygonize-core/src/noding/advanced.rs`. The field was marked as dead code and was only used during construction. Removal improves maintainability and slightly reduces memory usage per event in the sweep-line priority queue.

---
*PR created automatically by Jules for task [11784820056268504921](https://jules.google.com/task/11784820056268504921) started by @graydonpleasants*