### PR TITLE
test(core): add unit tests for rings_touch_at_vertex

### DIFF
--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -1183,4 +1183,64 @@ mod tests {
         let p5 = Polygon::new(LineString::from(coords5_2d), vec![]);
         assert!(p5.contains(&probe5));
     }
+
+    #[test]
+    fn test_rings_touch_at_vertex() {
+        let shell = vec![
+            Coord3D::new(0.0, 0.0, 0.0),
+            Coord3D::new(10.0, 0.0, 0.0),
+            Coord3D::new(10.0, 10.0, 0.0),
+            Coord3D::new(0.0, 10.0, 0.0),
+            Coord3D::new(0.0, 0.0, 0.0),
+        ];
+
+        // 1. Exact touch at one vertex (0,0)
+        let hole1 = vec![
+            Coord3D::new(0.0, 0.0, 0.0),
+            Coord3D::new(-1.0, -1.0, 0.0),
+            Coord3D::new(1.0, -1.0, 0.0),
+            Coord3D::new(0.0, 0.0, 0.0),
+        ];
+        assert!(rings_touch_at_vertex(&shell, &hole1, 1e-10));
+
+        // 2. Touch within epsilon of vertex (10,10)
+        let hole2 = vec![
+            Coord3D::new(10.0 + 1e-11, 10.0, 0.0),
+            Coord3D::new(11.0, 11.0, 0.0),
+            Coord3D::new(11.0, 10.0, 0.0),
+            Coord3D::new(10.0 + 1e-11, 10.0, 0.0),
+        ];
+        assert!(rings_touch_at_vertex(&shell, &hole2, 1e-10));
+
+        // 3. No touch (just outside epsilon of vertex 10,10)
+        let hole3 = vec![
+            Coord3D::new(10.0 + 1e-9, 10.0, 0.0),
+            Coord3D::new(11.0, 11.0, 0.0),
+            Coord3D::new(11.0, 10.0, 0.0),
+            Coord3D::new(10.0 + 1e-9, 10.0, 0.0),
+        ];
+        assert!(!rings_touch_at_vertex(&shell, &hole3, 1e-10));
+
+        // 4. Touch at multiple vertices
+        let hole4 = vec![
+            Coord3D::new(0.0, 0.0, 0.0),
+            Coord3D::new(10.0, 0.0, 0.0),
+            Coord3D::new(5.0, -5.0, 0.0),
+            Coord3D::new(0.0, 0.0, 0.0),
+        ];
+        assert!(rings_touch_at_vertex(&shell, &hole4, 1e-10));
+
+        // 5. Disjoint
+        let hole5 = vec![
+            Coord3D::new(20.0, 20.0, 0.0),
+            Coord3D::new(21.0, 20.0, 0.0),
+            Coord3D::new(21.0, 21.0, 0.0),
+            Coord3D::new(20.0, 20.0, 0.0),
+        ];
+        assert!(!rings_touch_at_vertex(&shell, &hole5, 1e-10));
+
+        // 6. Empty rings
+        assert!(!rings_touch_at_vertex(&[], &hole1, 1e-10));
+        assert!(!rings_touch_at_vertex(&shell, &[], 1e-10));
+    }
 }


### PR DESCRIPTION
### 🎯 **What:** The testing gap addressed
The `rings_touch_at_vertex` function in `crates/geo-polygonize-core/src/polygonizer.rs` lacked unit tests. This function is critical for determining how rings (shells and holes) interact during polygon construction.

### 📊 **Coverage:** What scenarios are now tested
- **Exact Match:** Verified that rings touching at the exact same vertex coordinate return `true`.
- **Epsilon Proximity:** Verified that rings within the specified tolerance return `true`.
- **Epsilon Exclusion:** Verified that rings just outside the specified tolerance return `false`.
- **Multiple Touches:** Verified that the function handles cases where multiple vertices between rings are close.
- **Disjoint Rings:** Verified that rings with no close vertices return `false`.
- **Edge Cases:** Verified that empty rings are handled gracefully (returning `false`).

### ✨ **Result:** The improvement in test coverage
This addition provides direct verification for a core utility function, ensuring its reliability for future refactors and preventing regressions in ring-interaction logic.

---
*PR created automatically by Jules for task [5265669479021540269](https://jules.google.com/task/5265669479021540269) started by @graydonpleasants*