### PR TITLE
perf(core): Replaced the index-based range iterator (0..n).min_by(...) with ring[..n].iter().enumerate().min_by(...) in the canonicalize_ring function.

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -44,3 +44,7 @@
 ## 2024-05-24 - [Optimize Canonical Sorting]
 **Learning:** In spatial sorts, repeatedly evaluating geometric properties like bounds and areas in `O(N log N)` `sort_by` comparators creates a hidden performance bottleneck.
 **Action:** Always pre-calculate expensive sorting properties using a Schwartzian Transform pattern (mapping to a tuple with the cached data) and use `sort_unstable_by` for operations with deterministic tie-breaks.
+
+## 2024-05-28 - [Eliminate Bounds Checks via Iterator Enumerate]
+**Learning:** An index-based range iterator in Rust, like `(0..n).min_by(|i, j| slice[*i].cmp(&slice[*j]))`, requires the compiler to insert bounds-checking on each iteration because the closure receives raw index values that it uses to index the slice. This hurts performance in hot paths. Using `.iter().enumerate().min_by(...)` provides identical functionality, but eliminates the bounds-checking overhead while preserving the readability of iterator-chain methods, preventing the need to rewrite standard logic into lower-level manual `for` loops.
+**Action:** To safely eliminate array bounds checks in Rust while preserving readability during a sequence scan (like finding the minimum index of a collection using `min_by`), prefer iterating over the slice directly (e.g., `slice.iter().enumerate().min_by(...)`) instead of using an index range `(0..n)` which forces the compiler to insert bounds checks. Never sacrifice readability by converting these to manual `for` loops just for micro-optimizations.

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -312,14 +312,17 @@ pub(crate) fn canonicalize_ring(ring: &mut Vec<Coord3D>, mut ids: Option<&mut Ve
         ring.len()
     };
 
-    let min_idx = (0..n)
-        .min_by(|&i, &j| {
-            ring[i]
-                .x
-                .total_cmp(&ring[j].x)
-                .then(ring[i].y.total_cmp(&ring[j].y))
-                .then(ring[i].z.total_cmp(&ring[j].z))
+    // Bolt optimization: using `ring[..n].iter().enumerate().min_by(...)` instead of `(0..n).min_by(...)`
+    // eliminates bounds-checking overhead while preserving readability.
+    let min_idx = ring[..n]
+        .iter()
+        .enumerate()
+        .min_by(|(_, a), (_, b)| {
+            a.x.total_cmp(&b.x)
+                .then(a.y.total_cmp(&b.y))
+                .then(a.z.total_cmp(&b.z))
         })
+        .map(|(i, _)| i)
         .unwrap_or(0);
 
     if min_idx > 0 {


### PR DESCRIPTION
💡 **What**: Replaced the index-based range iterator `(0..n).min_by(...)` with `ring[..n].iter().enumerate().min_by(...)` in the `canonicalize_ring` function.
🎯 **Why**: The original implementation forced the Rust compiler to insert bounds checks inside the hot loop because it was indexing the `ring` vector using raw integers. Using the `.iter()` abstraction directly passes references to the closure, safely eliminating these bounds checks while preserving the functional, readable style.
📊 **Impact**: This micro-optimization reduces CPU overhead in hot paths involving spatial sorting and determinism, contributing to an overall faster execution time for complex polygons with many rings.
🔬 **Measurement**: Verified by ensuring the workspace tests (`cargo test --workspace`) and Python/Wasm integrations pass successfully, maintaining functional parity with zero regressions. Performance can be measured via the existing `iai-callgrind` suite or standard benchmarks over large datasets.

---
*PR created automatically by Jules for task [15054328781452589859](https://jules.google.com/task/15054328781452589859) started by @graydonpleasants*