### PR TITLE
perf(github): Optimize CI build pipeline for faster WASM compilation and Rust caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
 
     - name: Cache Rust
       uses: Swatinem/rust-cache@v2
+      with:
+        workspaces: |
+          . -> target
 
     - name: Check formatting
       run: cargo fmt -- --check
@@ -58,6 +61,9 @@ jobs:
 
     - name: Install NPM dependencies
       run: npm install
+
+    - name: Install cargo-binstall
+      uses: cargo-bins/cargo-binstall@main
 
     - name: Build WASM
       run: npm run build

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -43,6 +43,9 @@ jobs:
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            . -> target
 
       - name: Setup Pages
         uses: actions/configure-pages@v4
@@ -61,8 +64,13 @@ jobs:
       - name: Verify Clean Generated Output
         run: git diff --exit-code docs/reference/generated/
 
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@main
+
       - name: Build Site Wasm Library
         run: npm run build:site-lib
+        env:
+          SKIP_SIMD: ${{ github.event_name == 'pull_request' && '1' || '0' }}
 
       - name: Build Playground
         run: |

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -30,8 +30,17 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
 
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            . -> target
+
       - name: Install dependencies
         run: npm ci
+
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@main
 
       - name: Build WebAssembly and TypeScript
         run: npm run build

--- a/crates/geo-polygonize-core/src/bin/export_bindings.rs
+++ b/crates/geo-polygonize-core/src/bin/export_bindings.rs
@@ -1,0 +1,25 @@
+use geo_polygonize_core::options::*;
+use ts_rs::TS;
+
+fn main() {
+    let config = ts_rs::Config::from_env();
+
+    // We export each root type with export_all so it writes out that type and its dependencies.
+    let _ = PolygonizerOptions::export_all(&config);
+    let _ = TargetProfile::export_all(&config);
+    let _ = SnapStrategy::export_all(&config);
+    let _ = SnapMode::export_all(&config);
+    let _ = ZPolicy::export_all(&config);
+    let _ = TouchPolicy::export_all(&config);
+    let _ = TileOwnershipPolicy::export_all(&config);
+    let _ = NodingBackend::export_all(&config);
+    let _ = IndexBackend::export_all(&config);
+    let _ = NodingOptions::export_all(&config);
+    let _ = ContainmentOptions::export_all(&config);
+    let _ = DeterminismOptions::export_all(&config);
+    let _ = geo_polygonize_core::diagnostics::DiagnosticsOptions::export_all(&config);
+    let _ = ProvenanceOptions::export_all(&config);
+    let _ = DedupPolicy::export_all(&config);
+    let _ = TilingOptions::export_all(&config);
+    let _ = ZOptions::export_all(&config);
+}

--- a/scripts/build_wasm.sh
+++ b/scripts/build_wasm.sh
@@ -12,7 +12,11 @@ rustup target add $TARGET
 # Install wasm-bindgen-cli if needed
 if ! command -v wasm-bindgen &> /dev/null || [ "$(wasm-bindgen --version | awk '{print $2}')" != "$WASM_BINDGEN_VERSION" ]; then
     echo "Installing wasm-bindgen-cli $WASM_BINDGEN_VERSION..."
-    cargo install wasm-bindgen-cli --version $WASM_BINDGEN_VERSION
+    if command -v cargo-binstall &> /dev/null; then
+        cargo binstall -y wasm-bindgen-cli --version $WASM_BINDGEN_VERSION
+    else
+        cargo install wasm-bindgen-cli --version $WASM_BINDGEN_VERSION
+    fi
 fi
 
 # Install binaryen (wasm-opt) if needed
@@ -141,8 +145,8 @@ done
 
 # Export the ts-rs bindings so that TS type-checks succeed when imported via pkg-wrapper
 echo "Exporting our TS-RS bindings into wasm-bindgen definitions..."
-export TS_RS_EXPORT_DIR="bindings"
-cargo test -p geo-polygonize-core
+export TS_RS_EXPORT_DIR="crates/geo-polygonize-core/bindings"
+cargo run -p geo-polygonize-core --bin export_bindings --release
 mkdir -p pkg-wrapper/bindings
 cp crates/geo-polygonize-core/bindings/* pkg-wrapper/bindings/
 

--- a/scripts/build_wasm_site.sh
+++ b/scripts/build_wasm_site.sh
@@ -12,7 +12,11 @@ rustup target add $TARGET
 # Install wasm-bindgen-cli if needed
 if ! command -v wasm-bindgen &> /dev/null || [ "$(wasm-bindgen --version | awk '{print $2}')" != "$WASM_BINDGEN_VERSION" ]; then
     echo "Installing wasm-bindgen-cli $WASM_BINDGEN_VERSION..."
-    cargo install wasm-bindgen-cli --version $WASM_BINDGEN_VERSION
+    if command -v cargo-binstall &> /dev/null; then
+        cargo binstall -y wasm-bindgen-cli --version $WASM_BINDGEN_VERSION
+    else
+        cargo install wasm-bindgen-cli --version $WASM_BINDGEN_VERSION
+    fi
 fi
 
 build_variant() {
@@ -46,12 +50,17 @@ build_variant() {
 build_variant "scalar" ""
 
 # Build SIMD
-build_variant "simd" "-C target-feature=+simd128"
+if [ "$SKIP_SIMD" = "1" ]; then
+    echo "Skipping SIMD build as requested. Copying scalar to simd to satisfy dependencies..."
+    cp -r pkg-scalar pkg-simd
+else
+    build_variant "simd" "-C target-feature=+simd128"
+fi
 
 # Export the ts-rs bindings so that TS type-checks succeed when imported via pkg-wrapper
 echo "Exporting our TS-RS bindings into wasm-bindgen definitions..."
-export TS_RS_EXPORT_DIR="bindings"
-cargo test -p geo-polygonize-core
+export TS_RS_EXPORT_DIR="crates/geo-polygonize-core/bindings"
+cargo run -p geo-polygonize-core --bin export_bindings --release
 mkdir -p pkg-wrapper/bindings
 cp crates/geo-polygonize-core/bindings/* pkg-wrapper/bindings/
 


### PR DESCRIPTION
This PR implements multiple performance optimizations to significantly reduce CI and local build times.
- Avoid compiling `wasm-bindgen-cli` from source by utilizing `cargo-binstall`.
- Refactor the `ts-rs` export process into a standalone binary (`export_bindings.rs`) executed via `cargo run --release`, bypassing the compilation of heavy dev-dependencies.
- Conditionally skip the SIMD WASM target generation in standard PRs, providing a scalar fallback for Rollup to consume.
- Apply robust workspace caching via `Swatinem/rust-cache@v2`.

---
*PR created automatically by Jules for task [13508431791379155733](https://jules.google.com/task/13508431791379155733) started by @graydonpleasants*