### PR TITLE
fix(github): update CycloneDX Node.js SBOM generation action

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -40,7 +40,10 @@ jobs:
         run: npm publish --access public --provenance
 
       - name: Generate SBOM
-        uses: CycloneDX/gh-node-module-sbom-action@v1
+        uses: CycloneDX/gh-node-module-generatebom@v1
+        with:
+          path: './'
+          output: './bom.json'
 
       - name: Upload SBOM
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
The npm publish workflow was failing because the previously used `CycloneDX/gh-node-module-sbom-action` could not be resolved. This updates the `.github/workflows/publish-npm.yml` to use the supported `CycloneDX/gh-node-module-generatebom@v1` and adds the necessary inputs `path` and `output` to ensure the `bom.json` file is correctly generated for the subsequent upload step.

---
*PR created automatically by Jules for task [16604795860863377563](https://jules.google.com/task/16604795860863377563) started by @graydonpleasants*