### PR TITLE
fix(fleet): explicitly instruct agents to set PR description tags

### DIFF
--- a/scripts/fleet/roadmap-analyzer.ts
+++ b/scripts/fleet/roadmap-analyzer.ts
@@ -40,7 +40,8 @@ const session = await jules.session({
     github: repoInfo.fullName,
     baseBranch,
   },
-  automationMode: 'AUTO_CREATE_PR'
+  automationMode: 'AUTO_CREATE_PR',
+  requirePlanApproval: false
 })
 
 console.log(`✅ Roadmap Analyzer session started: ${session.id}`)

--- a/scripts/fleet/task-picker.ts
+++ b/scripts/fleet/task-picker.ts
@@ -31,7 +31,7 @@ const issuesMarkdown = await getIssuesAsMarkdown()
 const prompt = `Analyze the ROADMAP.md and issue list to pick the next target task. Be ambitious and thorough.
 
 **Important Instructions:**
-As your very first step, you must use the \`gh\` CLI to create a new GitHub issue for the task you select. Add an "in progress" label to it, and include a link to your Jules session so subsequent runs know this task is currently being worked on. When you submit your changes, ensure your Pull Request description includes "Fixes #<issue_number>" so the issue closes automatically upon merge.
+As your very first step, you must use the \`gh\` CLI to create a new GitHub issue for the task you select. Add an "in progress" label to it, and include a link to your Jules session so subsequent runs know this task is currently being worked on. When you submit your changes using the \`submit\` tool, you **MUST** include "Fixes #<issue_number>" in both the \`commit_message\` and \`description\` parameters so the issue closes automatically upon merge.
 
 ## ROADMAP.md
 \`\`\`markdown
@@ -48,7 +48,8 @@ const session = await jules.session({
     github: repoInfo.fullName,
     baseBranch,
   },
-  automationMode: 'AUTO_CREATE_PR'
+  automationMode: 'AUTO_CREATE_PR',
+  requirePlanApproval: false
 })
 
 console.log(`✅ Task Picker session started: ${session.id}`)


### PR DESCRIPTION
This PR addresses the issue where dynamically created task issues weren't being correctly tagged and closed when the `AUTO_CREATE_PR` agents outputted their PRs.

The solution ensures the `task-picker.ts` agent prompt explicitly dictates that the `submit` tool's `commit_message` and `description` parameters **MUST** contain the "Fixes #<issue_number>" directive.

Additionally, we align `task-picker.ts` and `roadmap-analyzer.ts` with repository guidelines to include `requirePlanApproval: false` to guarantee fully automated execution.

---
*PR created automatically by Jules for task [553664541617646549](https://jules.google.com/task/553664541617646549) started by @graydonpleasants*