### PR TITLE
fix(github): fix maintenance workflow infinite loop on automated pr merge

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -20,6 +20,7 @@ concurrency:
 
 jobs:
   maintenance:
+    if: "!startsWith(github.event.head_commit.message, 'chore(github): Update benchmarks and llms.txt')"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Fixes an issue where the `maintenance.yml` workflow gets stuck in an infinite loop after an automated benchmark update PR is merged. 

When the PR titled "chore(github): Update benchmarks and llms.txt" is automerged, it triggers a `push` event with a commit message that *starts with* the PR title but may contain additional merge data (like PR numbers or body). The previous exact match condition failed to catch this, allowing the workflow to run again and create another PR.

This commit updates the condition to use `!startsWith(github.event.head_commit.message, ...)` to reliably exclude these merge commits, breaking the loop.

---
*PR created automatically by Jules for task [8389333865968187243](https://jules.google.com/task/8389333865968187243) started by @graydonpleasants*