### PR TITLE
fix(python): Python SBOM generation in GitHub Actions publish workflow

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -71,10 +71,11 @@ jobs:
         with:
           packages-dir: dist
 
+      - name: Install SBOM Tool
+        run: pip install cyclonedx-bom
+
       - name: Generate SBOM
-        uses: CycloneDX/gh-python-sbom-action@v1
-        with:
-          args: --directory python
+        run: cyclonedx-py requirements python/requirements.txt -o bom.json
 
       - name: Upload SBOM
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
This PR replaces the usage of the deprecated `CycloneDX/gh-python-sbom-action` in the `.github/workflows/publish-python.yml` workflow with direct CLI commands using the `cyclonedx-bom` package. 

The previous GitHub Action was removed from the GitHub Marketplace, causing the workflow to fail with "Unable to resolve action , repository not found". Following the official recommendations, the SBOM generation step now installs the tool via `pip install cyclonedx-bom` and runs `cyclonedx-py requirements python/requirements.txt -o bom.json`.

---
*PR created automatically by Jules for task [17613916952174726517](https://jules.google.com/task/17613916952174726517) started by @graydonpleasants*