### PR TITLE
fix(wasm): disable multiversion macro on wasm32 to fix CI native dispatch failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-core"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "approx",
  "arrow",
@@ -994,7 +994,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-wasm"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "arrow",
  "arrow-ipc",

--- a/crates/geo-polygonize-core/Cargo.toml
+++ b/crates/geo-polygonize-core/Cargo.toml
@@ -32,6 +32,8 @@ humantime-serde = "1.1.1"
 ts-rs = "12.0.1"
 geoparquet = { version = "0.7.0", optional = true }
 parquet = "57.3.0"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 multiversion = "0.8.0"
 
 [dev-dependencies]

--- a/crates/geo-polygonize-core/src/utils/simd.rs
+++ b/crates/geo-polygonize-core/src/utils/simd.rs
@@ -1,4 +1,5 @@
 use geo::Coord;
+#[cfg(not(target_arch = "wasm32"))]
 use multiversion::multiversion;
 use wide::f64x4;
 use wide::CmpGt;
@@ -57,15 +58,18 @@ impl SimdRing {
     }
 }
 
-#[multiversion(targets(
-    "x86_64+avx512f+avx512dq",
-    "x86_64+avx2",
-    "x86+avx2",
-    "x86_64+avx",
-    "x86+avx",
-    "x86_64+sse2",
-    "x86+sse2",
-))]
+#[cfg_attr(
+    not(target_arch = "wasm32"),
+    multiversion(targets(
+        "x86_64+avx512f+avx512dq",
+        "x86_64+avx2",
+        "x86+avx2",
+        "x86_64+avx",
+        "x86+avx",
+        "x86_64+sse2",
+        "x86+sse2",
+    ))
+)]
 fn contains_impl(x: &[f64], y: &[f64], len: usize, point: Coord<f64>) -> bool {
     let px = f64x4::splat(point.x);
     let py = f64x4::splat(point.y);

--- a/crates/geo-polygonize-core/src/utils/soa.rs
+++ b/crates/geo-polygonize-core/src/utils/soa.rs
@@ -1,4 +1,5 @@
 use crate::types::Line3D;
+#[cfg(not(target_arch = "wasm32"))]
 use multiversion::multiversion;
 use wide::f64x4;
 use wide::CmpGe;
@@ -99,15 +100,18 @@ impl SoALines {
 }
 
 #[allow(clippy::too_many_arguments)]
-#[multiversion(targets(
-    "x86_64+avx512f+avx512dq",
-    "x86_64+avx2",
-    "x86+avx2",
-    "x86_64+avx",
-    "x86+avx",
-    "x86_64+sse2",
-    "x86+sse2",
-))]
+#[cfg_attr(
+    not(target_arch = "wasm32"),
+    multiversion(targets(
+        "x86_64+avx512f+avx512dq",
+        "x86_64+avx2",
+        "x86+avx2",
+        "x86_64+avx",
+        "x86+avx",
+        "x86_64+sse2",
+        "x86+sse2",
+    ))
+)]
 fn intersects_bbox_batch_splatted_impl(
     min_x: &[f64],
     min_y: &[f64],


### PR DESCRIPTION
This commit conditionally compiles the `multiversion` macro, disabling it for `wasm32` targets. 

Removing `multiversion` for WebAssembly targets prevents CI native dispatch build failures for `wasm32-unknown-unknown`, as it doesn't robustly support runtime feature detection for `wasm32+simd128`. We continue using it on x86 architectures to allow AVX dispatch, while gracefully falling back to a single compiled scalar implementation for Wasm.

---
*PR created automatically by Jules for task [11417015987329601147](https://jules.google.com/task/11417015987329601147) started by @graydonpleasants*