### PR TITLE
fix(core): Fix potential out-of-bounds read in polygonize_with_options_ffi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-core"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "approx",
  "arrow",
@@ -994,7 +994,7 @@ dependencies = [
 
 [[package]]
 name = "geo-polygonize-wasm"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "arrow",
  "arrow-ipc",

--- a/crates/geo-polygonize-core/src/ffi.rs
+++ b/crates/geo-polygonize-core/src/ffi.rs
@@ -107,14 +107,15 @@ pub unsafe extern "C" fn polygonize_with_options_ffi(
     input_schema: *mut FFI_ArrowSchema,
     output_array: *mut FFI_ArrowArray,
     output_schema: *mut FFI_ArrowSchema,
-    options_json: *const std::os::raw::c_char,
+    options_json: *const u8,
+    options_json_len: usize,
 ) -> i32 {
     if options_json.is_null() {
         return 1;
     }
 
-    let c_str = std::ffi::CStr::from_ptr(options_json);
-    let options_str = match c_str.to_str() {
+    let slice = std::slice::from_raw_parts(options_json, options_json_len);
+    let options_str = match std::str::from_utf8(slice) {
         Ok(s) => s,
         Err(_) => return 1,
     };


### PR DESCRIPTION
🎯 **What:** Fixed a potential Out-of-Bounds Read vulnerability in the `polygonize_with_options_ffi` FFI function located in `crates/geo-polygonize-core/src/ffi.rs`.
⚠️ **Risk:** The previous implementation relied on `CStr::from_ptr`, which scanned memory for a null terminator. If a caller provided a pointer to a string that wasn't properly null-terminated, it could lead to an unbounded memory read, potentially crashing the application or leaking sensitive information from adjacent memory blocks.
🛡️ **Solution:** Modified the FFI signature to accept an explicit length (`options_json_len: usize`). Replaced the vulnerable `CStr::from_ptr` with `std::slice::from_raw_parts` and `std::str::from_utf8` to enforce safe, bounded memory reads.

---
*PR created automatically by Jules for task [9576805456342839934](https://jules.google.com/task/9576805456342839934) started by @graydonpleasants*