### PR TITLE
fix(github): ensure playground artifacts are not deleted by Vitepress build

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -72,14 +72,14 @@ jobs:
         env:
           SKIP_SIMD: ${{ github.event_name == 'pull_request' && '1' || '0' }}
 
+      - name: Build Docs Site
+        run: npx vitepress build docs
+
       - name: Build Playground
         run: |
           cd playground
           npm install
           npm run build
-
-      - name: Build Docs Site
-        run: npx vitepress build docs
 
       - name: Upload artifact
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'


### PR DESCRIPTION
Fixes a CI/CD bug where the deployed GitHub Pages site returned a 404 for the playground. This was caused by `npx vitepress build docs` cleaning its `docs/.vitepress/dist` output directory, erasing the already-built playground assets. This PR ensures the Vitepress docs are built *before* the playground is compiled into the `dist` folder.

---
*PR created automatically by Jules for task [2926694916615108202](https://jules.google.com/task/2926694916615108202) started by @graydonpleasants*