### PR TITLE
fix(wasm): add Cargo bin path for site build

### DIFF
--- a/scripts/build_wasm_site.sh
+++ b/scripts/build_wasm_site.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-export PATH="$HOME/.cargo/bin:$PATH"
+export PATH="${CARGO_HOME:-$HOME/.cargo}/bin:$PATH"
 
 # Configuration
 WASM_BINDGEN_VERSION="0.2.114"

--- a/scripts/build_wasm_site.sh
+++ b/scripts/build_wasm_site.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+export PATH="$HOME/.cargo/bin:$PATH"
+
 # Configuration
 WASM_BINDGEN_VERSION="0.2.114"
 TARGET="wasm32-unknown-unknown"


### PR DESCRIPTION
🎯 **What:** Fixed two CI issues: code formatting in `planar_graph.rs` tests using `cargo fmt` and fixed the `wasm-bindgen: command not found` error in the Build Docs CI job by explicitly adding `$HOME/.cargo/bin` to the script's `$PATH`.

📊 **Coverage:** Ensures tests pass formatting checks and `build_wasm_site.sh` runs reliably in CI.

✨ **Result:** Both the `test` and `Build Docs` CI workflows will pass.

---
*PR created automatically by Jules for task [8793434193958642778](https://jules.google.com/task/8793434193958642778) started by @graydonpleasants*