### PR TITLE
🧹 Add debug string support for Set and Map

### DIFF
--- a/pkg-threads/geo_polygonize.js
+++ b/pkg-threads/geo_polygonize.js
@@ -661,7 +661,32 @@ function debugString(val) {
     if (val instanceof Error) {
         return `${val.name}: ${val.message}\n${val.stack}`;
     }
-    // TODO we could test for more things here, like `Set`s and `Map`s.
+    if (val instanceof Map) {
+        let debug = 'Map(' + val.size + ') {';
+        let first = true;
+        for (const [key, value] of val.entries()) {
+            if (!first) {
+                debug += ', ';
+            }
+            debug += debugString(key) + ' => ' + debugString(value);
+            first = false;
+        }
+        debug += '}';
+        return debug;
+    }
+    if (val instanceof Set) {
+        let debug = 'Set(' + val.size + ') {';
+        let first = true;
+        for (const value of val.values()) {
+            if (!first) {
+                debug += ', ';
+            }
+            debug += debugString(value);
+            first = false;
+        }
+        debug += '}';
+        return debug;
+    }
     return className;
 }
 

--- a/scripts/build_wasm.sh
+++ b/scripts/build_wasm.sh
@@ -74,6 +74,9 @@ build_variant() {
 
     # Remove .gitignore if generated
     rm -f $OUT_DIR/.gitignore
+
+    # Patch debugString
+    node scripts/patch_debug.cjs "$OUT_DIR/geo_polygonize.js"
 }
 
 # Build Scalar
@@ -130,6 +133,9 @@ build_variant_threads() {
     fi
 
     rm -f $OUT_DIR/.gitignore
+
+    # Patch debugString
+    node scripts/patch_debug.cjs "$OUT_DIR/geo_polygonize.js"
 }
 
 build_variant_threads &

--- a/scripts/build_wasm_site.sh
+++ b/scripts/build_wasm_site.sh
@@ -47,6 +47,9 @@ build_variant() {
 
     # Remove .gitignore if generated
     rm -f $OUT_DIR/.gitignore
+
+    # Patch debugString
+    node scripts/patch_debug.cjs "$OUT_DIR/geo_polygonize.js"
 }
 
 # Build Scalar

--- a/scripts/patch_debug.cjs
+++ b/scripts/patch_debug.cjs
@@ -1,0 +1,50 @@
+const fs = require('fs');
+const path = require('path');
+
+const filePath = process.argv[2];
+if (!filePath) {
+    console.error('Usage: node patch_debug.cjs <file-path>');
+    process.exit(1);
+}
+
+let content = fs.readFileSync(filePath, 'utf8');
+
+const patch = `    if (val instanceof Map) {
+        let debug = 'Map(' + val.size + ') {';
+        let first = true;
+        for (const [key, value] of val.entries()) {
+            if (!first) {
+                debug += ', ';
+            }
+            debug += debugString(key) + ' => ' + debugString(value);
+            first = false;
+        }
+        debug += '}';
+        return debug;
+    }
+    if (val instanceof Set) {
+        let debug = 'Set(' + val.size + ') {';
+        let first = true;
+        for (const value of val.values()) {
+            if (!first) {
+                debug += ', ';
+            }
+            debug += debugString(value);
+            first = false;
+        }
+        debug += '}';
+        return debug;
+    }`;
+
+const todoComment = '    // TODO we could test for more things here, like `Set`s and `Map`s.';
+
+if (content.includes(todoComment)) {
+    content = content.replace(todoComment, patch);
+    fs.writeFileSync(filePath, content);
+    console.log('Successfully patched ' + filePath);
+} else if (content.includes('Set(') && content.includes('Map(')) {
+    console.log('File ' + filePath + ' already appears to be patched.');
+} else {
+    console.error('Could not find TODO comment in ' + filePath + '. Patch failed.');
+    process.exit(1);
+}


### PR DESCRIPTION
### 🎯 What
Enhanced the `debugString` function in the JavaScript Wasm bindings to support `Set` and `Map` objects. Added a post-processing script `scripts/patch_debug.cjs` and integrated it into the build pipeline (`scripts/build_wasm.sh` and `scripts/build_wasm_site.sh`) to ensure the enhancement persists across builds.

### 💡 Why
The existing `debugString` implementation only handled primitives and arrays, returning a generic class name for `Set` and `Map`. Providing descriptive output for these collections improves the debugging experience when inspecting Wasm-related errors or state.

### ✅ Verification
Created a standalone test suite `scripts/test_debug_patch.js` (verified and then removed) covering primitives, arrays, maps, sets, and nested collections. Manually verified the patched output in `pkg-threads/geo_polygonize.js`.

### ✨ Result
`debugString` now provides detailed representations:
- `Map(2) {"key" => value, ...}`
- `Set(2) {value1, value2, ...}`
This is automatically applied to all Wasm build variants.

---
*PR created automatically by Jules for task [13187707150415772747](https://jules.google.com/task/13187707150415772747) started by @graydonpleasants*