### PR TITLE
fix(core): prevent panic amplification at FFI boundary

### DIFF
--- a/crates/geo-polygonize-core/src/ffi.rs
+++ b/crates/geo-polygonize-core/src/ffi.rs
@@ -67,7 +67,7 @@ impl SchemaExporter for MockSchemaExporter {
 /// - `input_array` and `input_schema` must be valid, non-null pointers to valid Arrow C Data Interface structures.
 /// - `output_array` and `output_schema` must be valid, non-null pointers to allocated but uninitialized or safe-to-overwrite Arrow C Data Interface structures.
 /// - `options` must be a valid, non-null pointer to a `PolygonizerOptions` struct.
-/// - We use `std::panic::catch_unwind` inside `polygonize_ffi_internal` to ensure panics don't cross the FFI boundary, returning a defined error code instead.
+/// - We use `std::panic::catch_unwind` at this boundary to ensure panics don't cross the FFI boundary, returning a defined error code (99) instead.
 #[no_mangle]
 pub unsafe extern "C" fn polygonize_ffi(
     input_array: *mut FFI_ArrowArray,
@@ -76,31 +76,36 @@ pub unsafe extern "C" fn polygonize_ffi(
     output_schema: *mut FFI_ArrowSchema,
     options: *const PolygonizerOptions,
 ) -> i32 {
-    if options.is_null() {
-        return 1;
-    }
-    let opts = &*options;
-    let mut arrow_opts = crate::options::PolygonizerOptions {
-        node_input: opts.node_input != 0,
-        snap_grid_size: opts.snap_grid_size,
-        extract_only_polygonal: opts.extract_only_polygonal != 0,
-        ..Default::default()
-    };
-    arrow_opts.diagnostics.enabled = opts.report_mode != 0;
-    arrow_opts.diagnostics.report_mode = opts.report_mode != 0;
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
+        if options.is_null() {
+            return 1;
+        }
+        let opts = &*options;
+        let mut arrow_opts = crate::options::PolygonizerOptions {
+            node_input: opts.node_input != 0,
+            snap_grid_size: opts.snap_grid_size,
+            extract_only_polygonal: opts.extract_only_polygonal != 0,
+            ..Default::default()
+        };
+        arrow_opts.diagnostics.enabled = opts.report_mode != 0;
+        arrow_opts.diagnostics.report_mode = opts.report_mode != 0;
 
-    polygonize_ffi_internal(
-        input_array,
-        input_schema,
-        output_array,
-        output_schema,
-        arrow_opts,
-    )
+        polygonize_ffi_internal(
+            input_array,
+            input_schema,
+            output_array,
+            output_schema,
+            arrow_opts,
+        )
+    }))
+    .unwrap_or(99)
 }
 
 /// # Safety
 ///
 /// This function is unsafe because it dereferences raw pointers.
+///
+/// We use `std::panic::catch_unwind` at this boundary to ensure panics don't cross the FFI boundary, returning a defined error code (99) instead.
 #[no_mangle]
 pub unsafe extern "C" fn polygonize_with_options_ffi(
     input_array: *mut FFI_ArrowArray,
@@ -110,28 +115,31 @@ pub unsafe extern "C" fn polygonize_with_options_ffi(
     options_json: *const u8,
     options_json_len: usize,
 ) -> i32 {
-    if options_json.is_null() {
-        return 1;
-    }
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
+        if options_json.is_null() {
+            return 1;
+        }
 
-    let slice = std::slice::from_raw_parts(options_json, options_json_len);
-    let options_str = match std::str::from_utf8(slice) {
-        Ok(s) => s,
-        Err(_) => return 1,
-    };
+        let slice = std::slice::from_raw_parts(options_json, options_json_len);
+        let options_str = match std::str::from_utf8(slice) {
+            Ok(s) => s,
+            Err(_) => return 1,
+        };
 
-    let arrow_opts: crate::options::PolygonizerOptions = match serde_json::from_str(options_str) {
-        Ok(o) => o,
-        Err(_) => return 1,
-    };
+        let arrow_opts: crate::options::PolygonizerOptions = match serde_json::from_str(options_str) {
+            Ok(o) => o,
+            Err(_) => return 1,
+        };
 
-    polygonize_ffi_internal(
-        input_array,
-        input_schema,
-        output_array,
-        output_schema,
-        arrow_opts,
-    )
+        polygonize_ffi_internal(
+            input_array,
+            input_schema,
+            output_array,
+            output_schema,
+            arrow_opts,
+        )
+    }))
+    .unwrap_or(99)
 }
 
 unsafe fn polygonize_ffi_internal(
@@ -141,56 +149,53 @@ unsafe fn polygonize_ffi_internal(
     output_schema: *mut FFI_ArrowSchema,
     arrow_opts: crate::options::PolygonizerOptions,
 ) -> i32 {
-    std::panic::catch_unwind(|| {
-        if input_array.is_null()
-            || input_schema.is_null()
-            || output_array.is_null()
-            || output_schema.is_null()
-        {
-            return 1;
+    if input_array.is_null()
+        || input_schema.is_null()
+        || output_array.is_null()
+        || output_schema.is_null()
+    {
+        return 1;
+    }
+
+    let field = match Field::try_from(&*input_schema) {
+        Ok(f) => f,
+        Err(_) => return 2,
+    };
+
+    let array_val = std::ptr::replace(input_array, FFI_ArrowArray::empty());
+    let arrow_data = match from_ffi(array_val, &*input_schema) {
+        Ok(data) => data,
+        Err(_) => return 2,
+    };
+    let array = arrow::array::make_array(arrow_data);
+
+    match polygonize_arrow(array.as_ref(), &field, arrow_opts) {
+        Ok(polygon_array) => {
+            let array_ref = polygon_array.into_array_ref();
+            let data = array_ref.to_data();
+
+            let ffi_array = FFI_ArrowArray::new(&data);
+            std::ptr::write(output_array, ffi_array);
+
+            let ffi_schema = match DefaultSchemaExporter::try_export(data.data_type()) {
+                Ok(s) => s,
+                Err(_) => return 4,
+            };
+            std::ptr::write(output_schema, ffi_schema);
+
+            0
         }
-
-        let field = match Field::try_from(&*input_schema) {
-            Ok(f) => f,
-            Err(_) => return 2,
-        };
-
-        let array_val = std::ptr::replace(input_array, FFI_ArrowArray::empty());
-        let arrow_data = match from_ffi(array_val, &*input_schema) {
-            Ok(data) => data,
-            Err(_) => return 2,
-        };
-        let array = arrow::array::make_array(arrow_data);
-
-        match polygonize_arrow(array.as_ref(), &field, arrow_opts) {
-            Ok(polygon_array) => {
-                let array_ref = polygon_array.into_array_ref();
-                let data = array_ref.to_data();
-
-                let ffi_array = FFI_ArrowArray::new(&data);
-                std::ptr::write(output_array, ffi_array);
-
-                let ffi_schema = match DefaultSchemaExporter::try_export(data.data_type()) {
-                    Ok(s) => s,
-                    Err(_) => return 4,
-                };
-                std::ptr::write(output_schema, ffi_schema);
-
-                0
-            }
-            Err(e) => match e {
-                crate::error::PolygonizeError::InvalidBufferShape { .. } => 5,
-                crate::error::PolygonizeError::InvalidArgumentType { .. } => 6,
-                crate::error::PolygonizeError::InvalidGeometry { .. } => 7,
-                crate::error::PolygonizeError::TopologyFailure { .. } => 8,
-                crate::error::PolygonizeError::UnsupportedOptionCombination { .. } => 9,
-                crate::error::PolygonizeError::InternalInvariantViolation { .. } => 10,
-                crate::error::PolygonizeError::ArrowError(_) => 11,
-                _ => 12,
-            },
-        }
-    })
-    .unwrap_or(99)
+        Err(e) => match e {
+            crate::error::PolygonizeError::InvalidBufferShape { .. } => 5,
+            crate::error::PolygonizeError::InvalidArgumentType { .. } => 6,
+            crate::error::PolygonizeError::InvalidGeometry { .. } => 7,
+            crate::error::PolygonizeError::TopologyFailure { .. } => 8,
+            crate::error::PolygonizeError::UnsupportedOptionCombination { .. } => 9,
+            crate::error::PolygonizeError::InternalInvariantViolation { .. } => 10,
+            crate::error::PolygonizeError::ArrowError(_) => 11,
+            _ => 12,
+        },
+    }
 }
 
 #[cfg(test)]

--- a/crates/geo-polygonize-core/src/ffi.rs
+++ b/crates/geo-polygonize-core/src/ffi.rs
@@ -126,7 +126,8 @@ pub unsafe extern "C" fn polygonize_with_options_ffi(
             Err(_) => return 1,
         };
 
-        let arrow_opts: crate::options::PolygonizerOptions = match serde_json::from_str(options_str) {
+        let arrow_opts: crate::options::PolygonizerOptions = match serde_json::from_str(options_str)
+        {
             Ok(o) => o,
             Err(_) => return 1,
         };


### PR DESCRIPTION
🎯 **What:** Missing panic handlers in FFI entry points `polygonize_ffi` and `polygonize_with_options_ffi`.

⚠️ **Risk:** A panic in the Rust core during FFI execution would cross the language boundary, causing an immediate process abort in the host environment (e.g., Python, C/C++), which could lead to Denial of Service or unstable host states.

🛡️ **Solution:** Wrapped the implementation of `polygonize_ffi` and `polygonize_with_options_ffi` in `std::panic::catch_unwind` blocks using `std::panic::AssertUnwindSafe`. Panics are now caught and translated to error code `99`. Internal `unsafe` blocks were added to the closures to allow dereferencing raw pointers and calling internal unsafe functions. Redundant panic handling in `polygonize_ffi_internal` was removed to centralize protection at the actual FFI boundary.

---
*PR created automatically by Jules for task [10087021016890994112](https://jules.google.com/task/10087021016890994112) started by @graydonpleasants*