### PR TITLE
🧹 refactor(python): remove unused imports in test_wrapper.py

### DIFF
--- a/python/test_wrapper.py
+++ b/python/test_wrapper.py
@@ -152,7 +152,6 @@ def test_odd_length_coordinates():
 def test_import_error_fallback():
     print("\nTesting ImportError fallback in __init__.py...")
     import importlib
-    import builtins
     import geo_polygonize
 
     with patch.dict('sys.modules', {'geo_polygonize.geo_polygonize_core': None, 'geo_polygonize_core': None}):
@@ -180,11 +179,8 @@ def test_return_polygons_without_shapely():
     offsets = np.array([0, 2, 4, 6, 8], dtype=np.uint32)
 
     # Mock shapely.geometry not being available
-    import sys
-    import builtins
-    import unittest.mock
 
-    with unittest.mock.patch.dict('sys.modules', {'shapely': None, 'shapely.geometry': None}):
+    with patch.dict('sys.modules', {'shapely': None, 'shapely.geometry': None}):
         try:
             polygonize(coords, offsets, return_polygons=True)
             assert False, "Should have raised ImportError"
@@ -201,7 +197,6 @@ def test_library_not_found(mock_glob, mock_exists):
     mock_exists.return_value = False
     mock_glob.return_value = []
 
-    import sys
     if 'geo_polygonize.cffi_wrapper' in sys.modules:
         del sys.modules['geo_polygonize.cffi_wrapper']
 


### PR DESCRIPTION
🎯 **What:** Removed unused and redundant local imports in `python/test_wrapper.py`. Specifically, I removed local imports of `sys`, `builtins`, and `unittest.mock` that were either already imported at the top level or not used at all. I also simplified the usage of `patch.dict` in `test_return_polygons_without_shapely`.

💡 **Why:** This improves maintainability and readability by reducing boilerplate and noise in the test file. Using top-level imports consistently makes the code easier to follow.

✅ **Verification:**
- Verified the file's syntax using `python3 -m py_compile python/test_wrapper.py`.
- Conducted a manual review to ensure that all removed local imports were indeed redundant due to existing top-level imports (like `from unittest.mock import patch` and `import sys`).
- Full test suite execution was attempted but skipped due to network-restricted environment preventing dependency installation.

✨ **Result:** A cleaner and more standard-compliant test file for the Python bindings.

---
*PR created automatically by Jules for task [5792225083090256155](https://jules.google.com/task/5792225083090256155) started by @graydonpleasants*