### PR TITLE
feat(core): add CFB adoption hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       uses: taiki-e/install-action@cargo-audit
 
     - name: Run cargo audit
-      run: cargo audit --ignore RUSTSEC-2025-0020
+      run: cargo audit --ignore RUSTSEC-2025-0020 --ignore RUSTSEC-2026-0173 --ignore RUSTSEC-2026-0177
 
     - name: Set up Node.js
       uses: actions/setup-node@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"
@@ -695,9 +695,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2060,9 +2060,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",

--- a/crates/geo-polygonize-core/src/ffi.rs
+++ b/crates/geo-polygonize-core/src/ffi.rs
@@ -67,7 +67,7 @@ impl SchemaExporter for MockSchemaExporter {
 /// - `input_array` and `input_schema` must be valid, non-null pointers to valid Arrow C Data Interface structures.
 /// - `output_array` and `output_schema` must be valid, non-null pointers to allocated but uninitialized or safe-to-overwrite Arrow C Data Interface structures.
 /// - `options` must be a valid, non-null pointer to a `PolygonizerOptions` struct.
-/// - We use `std::panic::catch_unwind` inside `polygonize_ffi_internal` to ensure panics don't cross the FFI boundary, returning a defined error code instead.
+/// - We use `std::panic::catch_unwind` at this boundary to ensure panics don't cross the FFI boundary, returning a defined error code (99) instead.
 #[no_mangle]
 pub unsafe extern "C" fn polygonize_ffi(
     input_array: *mut FFI_ArrowArray,
@@ -76,31 +76,36 @@ pub unsafe extern "C" fn polygonize_ffi(
     output_schema: *mut FFI_ArrowSchema,
     options: *const PolygonizerOptions,
 ) -> i32 {
-    if options.is_null() {
-        return 1;
-    }
-    let opts = &*options;
-    let mut arrow_opts = crate::options::PolygonizerOptions {
-        node_input: opts.node_input != 0,
-        snap_grid_size: opts.snap_grid_size,
-        extract_only_polygonal: opts.extract_only_polygonal != 0,
-        ..Default::default()
-    };
-    arrow_opts.diagnostics.enabled = opts.report_mode != 0;
-    arrow_opts.diagnostics.report_mode = opts.report_mode != 0;
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
+        if options.is_null() {
+            return 1;
+        }
+        let opts = &*options;
+        let mut arrow_opts = crate::options::PolygonizerOptions {
+            node_input: opts.node_input != 0,
+            snap_grid_size: opts.snap_grid_size,
+            extract_only_polygonal: opts.extract_only_polygonal != 0,
+            ..Default::default()
+        };
+        arrow_opts.diagnostics.enabled = opts.report_mode != 0;
+        arrow_opts.diagnostics.report_mode = opts.report_mode != 0;
 
-    polygonize_ffi_internal(
-        input_array,
-        input_schema,
-        output_array,
-        output_schema,
-        arrow_opts,
-    )
+        polygonize_ffi_internal(
+            input_array,
+            input_schema,
+            output_array,
+            output_schema,
+            arrow_opts,
+        )
+    }))
+    .unwrap_or(99)
 }
 
 /// # Safety
 ///
 /// This function is unsafe because it dereferences raw pointers.
+///
+/// We use `std::panic::catch_unwind` at this boundary to ensure panics don't cross the FFI boundary, returning a defined error code (99) instead.
 #[no_mangle]
 pub unsafe extern "C" fn polygonize_with_options_ffi(
     input_array: *mut FFI_ArrowArray,
@@ -110,28 +115,32 @@ pub unsafe extern "C" fn polygonize_with_options_ffi(
     options_json: *const u8,
     options_json_len: usize,
 ) -> i32 {
-    if options_json.is_null() {
-        return 1;
-    }
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
+        if options_json.is_null() {
+            return 1;
+        }
 
-    let slice = std::slice::from_raw_parts(options_json, options_json_len);
-    let options_str = match std::str::from_utf8(slice) {
-        Ok(s) => s,
-        Err(_) => return 1,
-    };
+        let slice = std::slice::from_raw_parts(options_json, options_json_len);
+        let options_str = match std::str::from_utf8(slice) {
+            Ok(s) => s,
+            Err(_) => return 1,
+        };
 
-    let arrow_opts: crate::options::PolygonizerOptions = match serde_json::from_str(options_str) {
-        Ok(o) => o,
-        Err(_) => return 1,
-    };
+        let arrow_opts: crate::options::PolygonizerOptions = match serde_json::from_str(options_str)
+        {
+            Ok(o) => o,
+            Err(_) => return 1,
+        };
 
-    polygonize_ffi_internal(
-        input_array,
-        input_schema,
-        output_array,
-        output_schema,
-        arrow_opts,
-    )
+        polygonize_ffi_internal(
+            input_array,
+            input_schema,
+            output_array,
+            output_schema,
+            arrow_opts,
+        )
+    }))
+    .unwrap_or(99)
 }
 
 unsafe fn polygonize_ffi_internal(
@@ -141,56 +150,53 @@ unsafe fn polygonize_ffi_internal(
     output_schema: *mut FFI_ArrowSchema,
     arrow_opts: crate::options::PolygonizerOptions,
 ) -> i32 {
-    std::panic::catch_unwind(|| {
-        if input_array.is_null()
-            || input_schema.is_null()
-            || output_array.is_null()
-            || output_schema.is_null()
-        {
-            return 1;
+    if input_array.is_null()
+        || input_schema.is_null()
+        || output_array.is_null()
+        || output_schema.is_null()
+    {
+        return 1;
+    }
+
+    let field = match Field::try_from(&*input_schema) {
+        Ok(f) => f,
+        Err(_) => return 2,
+    };
+
+    let array_val = std::ptr::replace(input_array, FFI_ArrowArray::empty());
+    let arrow_data = match from_ffi(array_val, &*input_schema) {
+        Ok(data) => data,
+        Err(_) => return 2,
+    };
+    let array = arrow::array::make_array(arrow_data);
+
+    match polygonize_arrow(array.as_ref(), &field, arrow_opts) {
+        Ok(polygon_array) => {
+            let array_ref = polygon_array.into_array_ref();
+            let data = array_ref.to_data();
+
+            let ffi_array = FFI_ArrowArray::new(&data);
+            std::ptr::write(output_array, ffi_array);
+
+            let ffi_schema = match DefaultSchemaExporter::try_export(data.data_type()) {
+                Ok(s) => s,
+                Err(_) => return 4,
+            };
+            std::ptr::write(output_schema, ffi_schema);
+
+            0
         }
-
-        let field = match Field::try_from(&*input_schema) {
-            Ok(f) => f,
-            Err(_) => return 2,
-        };
-
-        let array_val = std::ptr::replace(input_array, FFI_ArrowArray::empty());
-        let arrow_data = match from_ffi(array_val, &*input_schema) {
-            Ok(data) => data,
-            Err(_) => return 2,
-        };
-        let array = arrow::array::make_array(arrow_data);
-
-        match polygonize_arrow(array.as_ref(), &field, arrow_opts) {
-            Ok(polygon_array) => {
-                let array_ref = polygon_array.into_array_ref();
-                let data = array_ref.to_data();
-
-                let ffi_array = FFI_ArrowArray::new(&data);
-                std::ptr::write(output_array, ffi_array);
-
-                let ffi_schema = match DefaultSchemaExporter::try_export(data.data_type()) {
-                    Ok(s) => s,
-                    Err(_) => return 4,
-                };
-                std::ptr::write(output_schema, ffi_schema);
-
-                0
-            }
-            Err(e) => match e {
-                crate::error::PolygonizeError::InvalidBufferShape { .. } => 5,
-                crate::error::PolygonizeError::InvalidArgumentType { .. } => 6,
-                crate::error::PolygonizeError::InvalidGeometry { .. } => 7,
-                crate::error::PolygonizeError::TopologyFailure { .. } => 8,
-                crate::error::PolygonizeError::UnsupportedOptionCombination { .. } => 9,
-                crate::error::PolygonizeError::InternalInvariantViolation { .. } => 10,
-                crate::error::PolygonizeError::ArrowError(_) => 11,
-                _ => 12,
-            },
-        }
-    })
-    .unwrap_or(99)
+        Err(e) => match e {
+            crate::error::PolygonizeError::InvalidBufferShape { .. } => 5,
+            crate::error::PolygonizeError::InvalidArgumentType { .. } => 6,
+            crate::error::PolygonizeError::InvalidGeometry { .. } => 7,
+            crate::error::PolygonizeError::TopologyFailure { .. } => 8,
+            crate::error::PolygonizeError::UnsupportedOptionCombination { .. } => 9,
+            crate::error::PolygonizeError::InternalInvariantViolation { .. } => 10,
+            crate::error::PolygonizeError::ArrowError(_) => 11,
+            _ => 12,
+        },
+    }
 }
 
 #[cfg(test)]

--- a/crates/geo-polygonize-core/src/options.rs
+++ b/crates/geo-polygonize-core/src/options.rs
@@ -93,6 +93,44 @@ impl Default for PolygonizerOptions {
     }
 }
 
+impl PolygonizerOptions {
+    pub fn cfb_robust_v1() -> Self {
+        Self {
+            target: TargetProfile::Native,
+            node_input: true,
+            snap_grid_size: 0.5,
+            extract_only_polygonal: false,
+            snap_strategy: SnapStrategy::GeosCompat,
+            noding: NodingOptions {
+                backend: NodingBackend::Snap,
+                snap_mode: SnapMode::FloatEpsilonDedup,
+            },
+            containment: ContainmentOptions {
+                touch_policy: TouchPolicy::AllowPointTouchDisallowEdgeShare,
+                index_backend: IndexBackend::RStar,
+            },
+            tiling: None,
+            z: ZOptions {
+                policy: ZPolicy::InterpolateAlongEdge,
+            },
+            determinism: DeterminismOptions {
+                canonical_sort: true,
+                canonical_ring_rotation: true,
+                stable_tie_breaks: true,
+            },
+            diagnostics: DiagnosticsOptions {
+                enabled: true,
+                report_mode: true,
+            },
+            provenance: ProvenanceOptions {
+                enabled: true,
+                include_boundary_line_ids: true,
+            },
+            input_profile_id: Some("cfb_robust_v1".to_string()),
+        }
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, TS)]
 #[ts(export)]
 pub enum TargetProfile {

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -61,6 +61,7 @@ pub struct Polygonizer {
 pub struct PolygonizerResult {
     pub polygons: Vec<Polygon3D>,
     pub dangles: Vec<Vec<Coord3D>>,
+    pub cut_edges: Vec<Vec<Coord3D>>,
     pub invalid_rings: Vec<Vec<Coord3D>>,
     pub diagnostics: Option<PolygonizerDiagnostics>,
 }
@@ -253,11 +254,8 @@ impl Polygonizer {
             d.phase_times.graph_build = get_elapsed(t_graph_build_start);
             d.ring_count = rings_with_ids.len();
             d.cut_edge_count = cut_edges.len();
-            // Note: dangles length here does not include cut_edges yet
-            d.dangle_count = dangles.len() + cut_edges.len();
+            d.dangle_count = dangles.len();
         }
-
-        dangles.append(&mut cut_edges);
 
         // 4. Classify Rings (Shell vs Hole)
         let t_ring_extraction_start = get_time();
@@ -287,7 +285,13 @@ impl Polygonizer {
         let mut result =
             construct_final_polygons(shells, shell_holes, shell_holes_ids, &self.options);
 
-        result = apply_determinism(result, &mut dangles, &mut invalid_rings, &self.options);
+        result = apply_determinism(
+            result,
+            &mut dangles,
+            &mut cut_edges,
+            &mut invalid_rings,
+            &self.options,
+        );
 
         if let Some(ref mut d) = diag {
             d.phase_times.containment = get_elapsed(t_containment_start);
@@ -296,6 +300,7 @@ impl Polygonizer {
         Ok(PolygonizerResult {
             polygons: result,
             dangles,
+            cut_edges,
             invalid_rings,
             diagnostics: diag,
         })
@@ -326,18 +331,16 @@ pub(crate) fn canonicalize_ring(ring: &mut Vec<Coord3D>, mut ids: Option<&mut Ve
         .unwrap_or(0);
 
     if min_idx > 0 {
-        let mut new_ring = Vec::with_capacity(ring.len());
-        new_ring.extend_from_slice(&ring[min_idx..n]);
-        new_ring.extend_from_slice(&ring[0..min_idx]);
-        new_ring.push(new_ring[0]);
-        *ring = new_ring;
+        ring[..n].rotate_left(min_idx);
+        if n < ring.len() {
+            ring[n] = ring[0];
+        } else {
+            ring.push(ring[0]);
+        }
 
         if let Some(ref mut ids_vec) = ids {
             if !ids_vec.is_empty() {
-                let mut new_ids = Vec::with_capacity(ids_vec.len());
-                new_ids.extend_from_slice(&ids_vec[min_idx..]);
-                new_ids.extend_from_slice(&ids_vec[0..min_idx]);
-                **ids_vec = new_ids;
+                ids_vec.rotate_left(min_idx);
             }
         }
     }
@@ -449,10 +452,8 @@ pub(crate) fn construct_final_polygons(
     options: &PolygonizerOptions,
 ) -> Vec<Polygon3D> {
     let mut result = Vec::with_capacity(shells.len());
-    for ((shell, mut holes), mut holes_ids) in shells
-        .into_iter()
-        .zip(shell_holes.into_iter())
-        .zip(shell_holes_ids.into_iter())
+    for ((shell, mut holes), mut holes_ids) in
+        shells.into_iter().zip(shell_holes).zip(shell_holes_ids)
     {
         let mut exterior = shell.exterior;
         let mut exterior_ids = shell.exterior_ids;
@@ -558,6 +559,7 @@ pub(crate) fn construct_final_polygons(
 pub(crate) fn apply_determinism(
     mut result: Vec<Polygon3D>,
     dangles: &mut [Vec<Coord3D>],
+    cut_edges: &mut [Vec<Coord3D>],
     invalid_rings: &mut Vec<Vec<Coord3D>>,
     options: &PolygonizerOptions,
 ) -> Vec<Polygon3D> {
@@ -605,6 +607,9 @@ pub(crate) fn apply_determinism(
             for d in dangles.iter_mut() {
                 canonicalize_open_line(d);
             }
+            for edge in cut_edges.iter_mut() {
+                canonicalize_open_line(edge);
+            }
             for ir in invalid_rings.iter_mut() {
                 canonicalize_ring(ir, None);
             }
@@ -636,6 +641,7 @@ pub(crate) fn apply_determinism(
             for (i, (l, _)) in dangles_with_cache.into_iter().enumerate() {
                 dangles[i] = l;
             }
+            sort_open_lines(cut_edges);
         }
 
         let mut combined_invalid: Vec<_> = invalid_rings
@@ -674,6 +680,31 @@ pub(crate) fn apply_determinism(
         }
     }
     result
+}
+
+fn sort_open_lines(lines: &mut [Vec<Coord3D>]) {
+    let mut with_cache: Vec<_> = lines
+        .iter_mut()
+        .map(|l| {
+            let b = bounding_rect_3d(l).unwrap_or(geo::Rect::new(
+                geo::Coord { x: 0.0, y: 0.0 },
+                geo::Coord { x: 0.0, y: 0.0 },
+            ));
+            (std::mem::take(l), b)
+        })
+        .collect();
+
+    with_cache.sort_unstable_by(|(l1, b1), (l2, b2)| {
+        b1.min()
+            .x
+            .total_cmp(&b2.min().x)
+            .then(b1.min().y.total_cmp(&b2.min().y))
+            .then(l1.len().cmp(&l2.len()))
+    });
+
+    for (i, (line, _)) in with_cache.into_iter().enumerate() {
+        lines[i] = line;
+    }
 }
 
 pub(crate) fn process_invalid_rings(

--- a/crates/geo-polygonize-core/src/python.rs
+++ b/crates/geo-polygonize-core/src/python.rs
@@ -349,6 +349,20 @@ fn polygonize_internal<'py>(
         py_dangles.append(PyTuple::new_bound(py, dangle_pts))?;
     }
 
+    // Construct cut edges
+    let py_cut_edges = PyList::empty_bound(py);
+    for cut_edge in &result.cut_edges {
+        let cut_edge_pts = PyList::empty_bound(py);
+        for c in cut_edge {
+            if stride == 3 {
+                cut_edge_pts.append(PyTuple::new_bound(py, [c.x, c.y, c.z]))?;
+            } else {
+                cut_edge_pts.append(PyTuple::new_bound(py, [c.x, c.y]))?;
+            }
+        }
+        py_cut_edges.append(PyTuple::new_bound(py, cut_edge_pts))?;
+    }
+
     // Construct invalid rings
     let py_invalid_rings = PyList::empty_bound(py);
     for invalid_ring in &result.invalid_rings {
@@ -375,6 +389,7 @@ fn polygonize_internal<'py>(
 
     dict.set_item("polygons", py_polygons)?;
     dict.set_item("dangles", py_dangles)?;
+    dict.set_item("cut_edges", py_cut_edges)?;
     dict.set_item("invalid_rings", py_invalid_rings)?;
 
     if let Some(ref diag) = result.diagnostics {

--- a/crates/geo-polygonize-core/src/stateful.rs
+++ b/crates/geo-polygonize-core/src/stateful.rs
@@ -52,7 +52,6 @@ impl StatefulPolygonizer {
 
         // Find cut edges
         let mut cut_edges = self.graph.get_cut_edges();
-        dangles.append(&mut cut_edges);
 
         // Classify Rings
         let (shells, holes, invalid_rings_candidates) = extract_and_classify_rings(rings_with_ids);
@@ -109,7 +108,13 @@ impl StatefulPolygonizer {
             process_invalid_rings(invalid_rings_candidates, &shells_2d)
         };
 
-        result = apply_determinism(result, &mut dangles, &mut invalid_rings, &self.options);
+        result = apply_determinism(
+            result,
+            &mut dangles,
+            &mut cut_edges,
+            &mut invalid_rings,
+            &self.options,
+        );
 
         // Compute Delta
         let new_polygons = result;

--- a/crates/geo-polygonize-core/tests/cfb_fixtures.rs
+++ b/crates/geo-polygonize-core/tests/cfb_fixtures.rs
@@ -1,0 +1,16 @@
+mod common {
+    pub mod cfb_fixture;
+}
+
+use common::cfb_fixture::{cfb_fixture_paths, read_cfb_fixture, run_cfb_fixture};
+
+#[test]
+fn cfb_fixtures_match_expected_output() {
+    let paths = cfb_fixture_paths();
+    assert!(!paths.is_empty(), "expected at least one CFB fixture");
+
+    for path in paths {
+        let fixture = read_cfb_fixture(&path);
+        run_cfb_fixture(&fixture);
+    }
+}

--- a/crates/geo-polygonize-core/tests/common/cfb_fixture.rs
+++ b/crates/geo-polygonize-core/tests/common/cfb_fixture.rs
@@ -1,0 +1,187 @@
+use geo_polygonize_core::options::PolygonizerOptions;
+use geo_polygonize_core::polygonizer::polygonize_with_options;
+use geo_polygonize_core::types::{Coord3D, Line3D, Polygon3D};
+use serde::Deserialize;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CfbFixture {
+    pub case_id: String,
+    pub options_profile: String,
+    pub stride: u8,
+    #[serde(default = "pass_status")]
+    pub expected_status: String,
+    pub lines: Vec<CfbLine>,
+    pub expected: CfbExpected,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CfbLine {
+    pub id: u32,
+    pub coords: Vec<Vec<f64>>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CfbExpected {
+    pub polygon_count: usize,
+    pub total_area: f64,
+    #[serde(default = "default_area_tolerance")]
+    pub area_tolerance: f64,
+    #[serde(default)]
+    pub canonical_ring_hashes: Vec<String>,
+    pub dangle_count: usize,
+    pub cut_edge_count: usize,
+    pub invalid_ring_count: usize,
+    #[serde(default)]
+    pub boundary_line_ids: Vec<u64>,
+}
+
+fn pass_status() -> String {
+    "pass".to_string()
+}
+
+fn default_area_tolerance() -> f64 {
+    1e-6
+}
+
+pub fn cfb_fixture_paths() -> Vec<PathBuf> {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("fixtures")
+        .join("cfb")
+        .join("cases");
+
+    let mut paths: Vec<_> = fs::read_dir(root)
+        .expect("CFB fixture directory should exist")
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().is_some_and(|ext| ext == "json"))
+        .collect();
+    paths.sort();
+    paths
+}
+
+pub fn read_cfb_fixture(path: &Path) -> CfbFixture {
+    let content = fs::read_to_string(path).expect("failed to read CFB fixture");
+    serde_json::from_str(&content).expect("failed to parse CFB fixture")
+}
+
+pub fn run_cfb_fixture(fixture: &CfbFixture) {
+    let options = match fixture.options_profile.as_str() {
+        "cfb_robust_v1" => PolygonizerOptions::cfb_robust_v1(),
+        other => panic!("unsupported CFB options profile {other}"),
+    };
+    let lines = fixture_lines(fixture);
+
+    let result = polygonize_with_options(&lines, &options)
+        .unwrap_or_else(|err| panic!("{} failed: {err}", fixture.case_id));
+
+    let check = || {
+        assert_eq!(
+            result.polygons.len(),
+            fixture.expected.polygon_count,
+            "{} polygon count",
+            fixture.case_id
+        );
+
+        let total_area: f64 = result
+            .polygons
+            .iter()
+            .map(Polygon3D::unsigned_area_2d)
+            .sum();
+        assert!(
+            (total_area - fixture.expected.total_area).abs() <= fixture.expected.area_tolerance,
+            "{} total area: expected {}, got {}",
+            fixture.case_id,
+            fixture.expected.total_area,
+            total_area
+        );
+
+        assert_eq!(
+            result.dangles.len(),
+            fixture.expected.dangle_count,
+            "{} dangle count",
+            fixture.case_id
+        );
+        assert_eq!(
+            result.cut_edges.len(),
+            fixture.expected.cut_edge_count,
+            "{} cut-edge count",
+            fixture.case_id
+        );
+        assert_eq!(
+            result.invalid_rings.len(),
+            fixture.expected.invalid_ring_count,
+            "{} invalid-ring count",
+            fixture.case_id
+        );
+
+        if !fixture.expected.boundary_line_ids.is_empty() {
+            let mut actual: Vec<u64> = result
+                .polygons
+                .iter()
+                .filter_map(|poly| poly.provenance.as_ref())
+                .flat_map(|prov| prov.boundary_line_ids.iter().copied())
+                .collect();
+            actual.sort_unstable();
+            actual.dedup();
+
+            assert_eq!(
+                actual, fixture.expected.boundary_line_ids,
+                "{} boundary line IDs",
+                fixture.case_id
+            );
+        }
+
+        if !fixture.expected.canonical_ring_hashes.is_empty() {
+            let actual: Vec<String> = result
+                .polygons
+                .iter()
+                .map(|poly| canonical_ring_hash(&poly.exterior))
+                .collect();
+            assert_eq!(
+                actual, fixture.expected.canonical_ring_hashes,
+                "{} canonical ring hashes",
+                fixture.case_id
+            );
+        }
+    };
+
+    if fixture.expected_status == "xfail" {
+        let failed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(check)).is_err();
+        assert!(failed, "{} unexpectedly passed", fixture.case_id);
+    } else {
+        check();
+    }
+}
+
+fn fixture_lines(fixture: &CfbFixture) -> Vec<Line3D> {
+    fixture
+        .lines
+        .iter()
+        .flat_map(|line| {
+            line.coords.windows(2).map(|pair| {
+                Line3D::new(
+                    coord(&pair[0], fixture.stride),
+                    coord(&pair[1], fixture.stride),
+                    line.id,
+                )
+            })
+        })
+        .collect()
+}
+
+fn coord(raw: &[f64], stride: u8) -> Coord3D {
+    let z = if stride == 3 { raw[2] } else { 0.0 };
+    Coord3D::new(raw[0], raw[1], z)
+}
+
+fn canonical_ring_hash(ring: &[Coord3D]) -> String {
+    ring.iter()
+        .map(|c| format!("{:.6},{:.6},{:.6}", c.x, c.y, c.z))
+        .collect::<Vec<_>>()
+        .join("|")
+}

--- a/crates/geo-polygonize-wasm/src/lib.rs
+++ b/crates/geo-polygonize-wasm/src/lib.rs
@@ -219,6 +219,9 @@ pub struct WasmPolygonResult {
     flat_line_ids: Vec<u32>,
     stride: u8,
     provenance: JsValue,
+    dangles: JsValue,
+    cut_edges: JsValue,
+    invalid_rings: JsValue,
     diagnostics: JsValue,
 }
 
@@ -258,6 +261,21 @@ impl WasmPolygonResult {
     #[wasm_bindgen(getter)]
     pub fn provenance(&self) -> JsValue {
         self.provenance.clone()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn dangles(&self) -> JsValue {
+        self.dangles.clone()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn cut_edges(&self) -> JsValue {
+        self.cut_edges.clone()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn invalid_rings(&self) -> JsValue {
+        self.invalid_rings.clone()
     }
 
     #[wasm_bindgen(getter)]
@@ -613,6 +631,11 @@ fn polygonize_and_flatten(
     let mut flat_line_ids = Vec::new();
     let mut provenances = Vec::new();
 
+    let js_dangles = serde_wasm_bindgen::to_value(&result.dangles).unwrap_or(JsValue::NULL);
+    let js_cut_edges = serde_wasm_bindgen::to_value(&result.cut_edges).unwrap_or(JsValue::NULL);
+    let js_invalid_rings =
+        serde_wasm_bindgen::to_value(&result.invalid_rings).unwrap_or(JsValue::NULL);
+
     for poly in result.polygons {
         provenances.push(poly.provenance);
         polygon_offsets.push(ring_offsets.len() as u32);
@@ -670,6 +693,9 @@ fn polygonize_and_flatten(
         flat_line_ids,
         stride,
         provenance: js_provenance,
+        dangles: js_dangles,
+        cut_edges: js_cut_edges,
+        invalid_rings: js_invalid_rings,
         diagnostics: js_diagnostics,
     })
 }

--- a/crates/geo-polygonize-wasm/tests/wasm.test.js
+++ b/crates/geo-polygonize-wasm/tests/wasm.test.js
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import init, { polygonize } from '../../../dist/standard/es/index.js';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import init, { polygonize, cfbRobustOptions } from '../../../dist/standard/es/index.js';
 
 describe('WASM Polygonizer', () => {
     it('should polygonize a simple square', async () => {
@@ -179,6 +181,77 @@ describe('WASM Polygonizer', () => {
         } catch (e) {
             expect(e.name).toBe("InvalidBufferShape");
             expect(e.message).toMatch(/line_ids length 2 does not match line count 1/);
+        }
+    });
+
+    it('should throw error when stride is invalid in polygonize_buffers', async () => {
+        expect.assertions(2);
+        await init();
+        const { polygonize_buffers } = await import('../../../dist/standard/es/index.js');
+
+        const coords = new Float64Array([0, 0, 10, 0, 10, 10, 0, 10, 0, 0]);
+        const offsets = new Uint32Array([0]);
+
+        try {
+            polygonize_buffers(coords, offsets, 4, false, 1e-10);
+        } catch (e) {
+            expect(e.name).toBe("InvalidArgumentType");
+            expect(e.message).toBe("stride must be 2 or 3");
+        }
+    });
+
+    it('should throw error when stride is invalid in polygonizeWithOptionsBuffer', async () => {
+        expect.assertions(2);
+        await init();
+        const { polygonizeWithOptionsBuffer } = await import('../../../dist/standard/es/index.js');
+
+        const coords = new Float64Array([0, 0, 10, 0, 10, 10, 0, 10, 0, 0]);
+        const offsets = new Uint32Array([0]);
+        const options = { target: 'WasmSingleThread', node_input: false, snap_grid_size: 1e-10, extract_only_polygonal: false, snap_strategy: 'Grid', noding: { backend: 'Snap', snap_mode: 'FloatEpsilonDedup' }, containment: { touch_policy: 'AllowPointTouchDisallowEdgeShare', index_backend: 'RStar' }, tiling: null, z: { policy: 'Ignore' }, determinism: { canonical_sort: false, canonical_ring_rotation: false, stable_tie_breaks: false }, diagnostics: { enabled: false, report_mode: false }, provenance: { enabled: false, include_boundary_line_ids: false }, input_profile_id: null };
+
+        try {
+            polygonizeWithOptionsBuffer(coords, offsets, 1, options);
+        } catch (e) {
+            expect(e.name).toBe("InvalidArgumentType");
+            expect(e.message).toBe("stride must be 2 or 3");
+        }
+    });
+
+    it('should run CFB fixtures through polygonizeWithOptionsBuffer', async () => {
+        await init();
+        const { polygonizeWithOptionsBuffer } = await import('../../../dist/standard/es/index.js');
+        const fixtureDir = resolve('fixtures/cfb/cases');
+
+        for (const file of readdirSync(fixtureDir).filter((name) => name.endsWith('.json')).sort()) {
+            const fixture = JSON.parse(readFileSync(join(fixtureDir, file), 'utf8'));
+            if (fixture.expectedStatus === 'xfail') continue;
+
+            const coords = [];
+            const offsets = [];
+            const lineIds = [];
+            let offset = 0;
+
+            for (const line of fixture.lines) {
+                offsets.push(offset);
+                lineIds.push(line.id);
+                for (const point of line.coords) {
+                    coords.push(...point.slice(0, fixture.stride));
+                    offset += 1;
+                }
+            }
+
+            const result = polygonizeWithOptionsBuffer(
+                new Float64Array(coords),
+                new Uint32Array(offsets),
+                fixture.stride,
+                cfbRobustOptions,
+                new Uint32Array(lineIds),
+            );
+
+            expect(result.polygon_offsets_len()).toBe(fixture.expected.polygonCount);
+            expect(result.diagnostics.dangle_count).toBe(fixture.expected.dangleCount);
+            expect(result.diagnostics.cut_edge_count).toBe(fixture.expected.cutEdgeCount);
+            expect(result.diagnostics.invalid_ring_count).toBe(fixture.expected.invalidRingCount);
         }
     });
 

--- a/deny.toml
+++ b/deny.toml
@@ -72,6 +72,10 @@ feature-depth = 1
 ignore = [
     "RUSTSEC-2025-0141",
     "RUSTSEC-2024-0436",
+    # iai-callgrind 0.16.1 pulls this through its benchmark macro dependency.
+    "RUSTSEC-2026-0173",
+    # pyo3 0.29 needs a Python binding migration; this code does not use PyCFunction::new_closure.
+    "RUSTSEC-2026-0177",
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.

--- a/fixtures/cfb/cases/simple_square.fixture.json
+++ b/fixtures/cfb/cases/simple_square.fixture.json
@@ -1,0 +1,23 @@
+{
+  "caseId": "simple_square",
+  "description": "Four CAD line segments forming one lot polygon.",
+  "optionsProfile": "cfb_robust_v1",
+  "stride": 2,
+  "expectedStatus": "pass",
+  "blockingForCfb": true,
+  "lines": [
+    { "id": 1, "family": "lot_line", "coords": [[0, 0], [10, 0]] },
+    { "id": 2, "family": "lot_line", "coords": [[10, 0], [10, 10]] },
+    { "id": 3, "family": "lot_line", "coords": [[10, 10], [0, 10]] },
+    { "id": 4, "family": "lot_line", "coords": [[0, 10], [0, 0]] }
+  ],
+  "expected": {
+    "polygonCount": 1,
+    "totalArea": 100,
+    "areaTolerance": 1e-6,
+    "dangleCount": 0,
+    "cutEdgeCount": 0,
+    "invalidRingCount": 0,
+    "boundaryLineIds": [1, 2, 3, 4]
+  }
+}

--- a/fixtures/cfb/schema/v1.fixture.schema.json
+++ b/fixtures/cfb/schema/v1.fixture.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/graydonpleasants/geo-polygonize/fixtures/cfb/schema/v1.fixture.schema.json",
+  "title": "CFB polygonization fixture v1",
+  "type": "object",
+  "required": ["caseId", "optionsProfile", "stride", "lines", "expected"],
+  "properties": {
+    "caseId": { "type": "string" },
+    "description": { "type": "string" },
+    "optionsProfile": { "type": "string" },
+    "stride": { "enum": [2, 3] },
+    "expectedStatus": { "enum": ["pass", "xfail"], "default": "pass" },
+    "reason": { "type": "string" },
+    "blockingForCfb": { "type": "boolean", "default": true },
+    "lines": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "family", "coords"],
+        "properties": {
+          "id": { "type": "integer", "minimum": 0 },
+          "family": { "type": "string" },
+          "coords": {
+            "type": "array",
+            "minItems": 2,
+            "items": {
+              "type": "array",
+              "items": { "type": "number" },
+              "minItems": 2,
+              "maxItems": 3
+            }
+          }
+        }
+      }
+    },
+    "expected": {
+      "type": "object",
+      "required": ["polygonCount", "totalArea", "dangleCount", "cutEdgeCount", "invalidRingCount"],
+      "properties": {
+        "polygonCount": { "type": "integer", "minimum": 0 },
+        "totalArea": { "type": "number" },
+        "areaTolerance": { "type": "number", "default": 1e-6 },
+        "canonicalRingHashes": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "dangleCount": { "type": "integer", "minimum": 0 },
+        "cutEdgeCount": { "type": "integer", "minimum": 0 },
+        "invalidRingCount": { "type": "integer", "minimum": 0 },
+        "boundaryLineIds": {
+          "type": "array",
+          "items": { "type": "integer", "minimum": 0 }
+        }
+      }
+    }
+  }
+}

--- a/pkg-wrapper/cfb.ts
+++ b/pkg-wrapper/cfb.ts
@@ -1,0 +1,34 @@
+import type { PolygonizerOptions } from "./bindings/PolygonizerOptions";
+
+export const cfbRobustOptions: PolygonizerOptions = {
+    target: "Native",
+    node_input: true,
+    snap_grid_size: 0.5,
+    extract_only_polygonal: false,
+    snap_strategy: "GeosCompat",
+    noding: {
+        backend: "Snap",
+        snap_mode: "FloatEpsilonDedup",
+    },
+    containment: {
+        touch_policy: "AllowPointTouchDisallowEdgeShare",
+        index_backend: "RStar",
+    },
+    z: {
+        policy: "InterpolateAlongEdge",
+    },
+    determinism: {
+        canonical_sort: true,
+        canonical_ring_rotation: true,
+        stable_tie_breaks: true,
+    },
+    diagnostics: {
+        enabled: true,
+        report_mode: true,
+    },
+    provenance: {
+        enabled: true,
+        include_boundary_line_ids: true,
+    },
+    input_profile_id: "cfb_robust_v1",
+};

--- a/pkg-wrapper/index.ts
+++ b/pkg-wrapper/index.ts
@@ -37,6 +37,7 @@ export * from "./bindings/TilingOptions";
 export * from "./bindings/TouchPolicy";
 export * from "./bindings/ZOptions";
 export * from "./bindings/ZPolicy";
+export * from "./cfb";
 
 // Override the init function
 // input is ignored because we are using inlined Wasm

--- a/pkg-wrapper/index_slim.ts
+++ b/pkg-wrapper/index_slim.ts
@@ -21,6 +21,7 @@ export * from "./bindings/TilingOptions";
 export * from "./bindings/TouchPolicy";
 export * from "./bindings/ZOptions";
 export * from "./bindings/ZPolicy";
+export * from "./cfb";
 
 // We provide a helper to choose based on feature detection if the user wants to use it
 let isSimdSupported: boolean | undefined;

--- a/pkg-wrapper/index_threads.ts
+++ b/pkg-wrapper/index_threads.ts
@@ -18,5 +18,6 @@ export * from "./bindings/TilingOptions";
 export * from "./bindings/TouchPolicy";
 export * from "./bindings/ZOptions";
 export * from "./bindings/ZPolicy";
+export * from "./cfb";
 
 export default init;

--- a/python/geo_polygonize/__init__.py
+++ b/python/geo_polygonize/__init__.py
@@ -13,7 +13,11 @@ try:
         PolygonizeTopologyError
     )
 except ImportError:
-    from .cffi_wrapper import polygonize as _polygonize_impl
+    try:
+        from .cffi_wrapper import polygonize as _polygonize_impl
+    except Exception as import_error:
+        def _polygonize_impl(*args, _import_error=import_error, **kwargs):
+            raise ImportError("geo_polygonize native extension is not available") from _import_error
 
     # Fallback exception classes if C extension is missing
     class PolygonizeTypeError(ValueError):
@@ -128,6 +132,41 @@ def polygonize_with_options(lines=None, coords=None, offsets=None, options=None,
 
     return result
 
+def cfb_robust_options():
+    return {
+        "target": "Native",
+        "node_input": True,
+        "snap_grid_size": 0.5,
+        "extract_only_polygonal": False,
+        "snap_strategy": "GeosCompat",
+        "noding": {
+            "backend": "Snap",
+            "snap_mode": "FloatEpsilonDedup",
+        },
+        "containment": {
+            "touch_policy": "AllowPointTouchDisallowEdgeShare",
+            "index_backend": "RStar",
+        },
+        "tiling": None,
+        "z": {
+            "policy": "InterpolateAlongEdge",
+        },
+        "determinism": {
+            "canonical_sort": True,
+            "canonical_ring_rotation": True,
+            "stable_tie_breaks": True,
+        },
+        "diagnostics": {
+            "enabled": True,
+            "report_mode": True,
+        },
+        "provenance": {
+            "enabled": True,
+            "include_boundary_line_ids": True,
+        },
+        "input_profile_id": "cfb_robust_v1",
+    }
+
 def explain_mismatch(result_a, result_b, tolerance=1e-5):
     """
     Compares two report-mode outputs and explains why they differ.
@@ -156,7 +195,7 @@ def explain_mismatch(result_a, result_b, tolerance=1e-5):
     diag_a = result_a.get("diagnostics", {})
     diag_b = result_b.get("diagnostics", {})
 
-    topology_keys = ["ring_count", "shell_count", "hole_count", "dangle_count", "invalid_ring_count"]
+    topology_keys = ["ring_count", "shell_count", "hole_count", "dangle_count", "cut_edge_count", "invalid_ring_count"]
     for key in topology_keys:
         val_a = diag_a.get(key)
         val_b = diag_b.get(key)

--- a/python/geo_polygonize/cffi_wrapper.py
+++ b/python/geo_polygonize/cffi_wrapper.py
@@ -243,6 +243,7 @@ def polygonize(coords_array: np.ndarray, offsets_array: np.ndarray, node: bool =
             'flat_line_ids': flat_line_ids,
             'stride': int(out_stride),
             'dangles': dangles,
+            'cut_edges': [],
             'invalid_rings': invalid_rings
         }
 

--- a/scripts/build_wasm.sh
+++ b/scripts/build_wasm.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+export PATH="${CARGO_HOME:-$HOME/.cargo}/bin:$PATH"
+
 # Configuration
 WASM_BINDGEN_VERSION="0.2.114"
 TARGET="wasm32-unknown-unknown"
@@ -18,6 +20,10 @@ if ! command -v wasm-bindgen &> /dev/null || [ "$(wasm-bindgen --version | awk '
         cargo install wasm-bindgen-cli --version $WASM_BINDGEN_VERSION
     fi
 fi
+if ! command -v wasm-bindgen &> /dev/null; then
+    cargo install --force wasm-bindgen-cli --version $WASM_BINDGEN_VERSION
+fi
+WASM_BINDGEN_BIN="$(command -v wasm-bindgen)"
 
 # Install binaryen (wasm-opt) if needed
 if ! command -v wasm-opt &> /dev/null; then
@@ -63,7 +69,7 @@ build_variant() {
     # The previous script used --out-name "geo_polygonize". We should stick to that if possible
     # to avoid breaking downstream consumers.
 
-    ~/.cargo/bin/wasm-bindgen --target web --out-dir $OUT_DIR --out-name "geo_polygonize" "$WASM_PATH"
+    "$WASM_BINDGEN_BIN" --target web --out-dir $OUT_DIR --out-name "geo_polygonize" "$WASM_PATH"
 
     # 3. Optimization
     if command -v wasm-opt &> /dev/null; then
@@ -77,10 +83,10 @@ build_variant() {
 }
 
 # Build Scalar
-build_variant "scalar" "" &
+build_variant "scalar" ""
 
 # Build SIMD
-build_variant "simd" "-C target-feature=+simd128" &
+build_variant "simd" "-C target-feature=+simd128"
 
 # Build Threads
 build_variant_threads() {
@@ -120,7 +126,7 @@ build_variant_threads() {
 
     rm -rf $OUT_DIR
     # Use --target web to ensure correct loading behavior for threads
-    ~/.cargo/bin/wasm-bindgen --target web --out-dir $OUT_DIR --out-name "geo_polygonize" "$WASM_PATH"
+    "$WASM_BINDGEN_BIN" --target web --out-dir $OUT_DIR --out-name "geo_polygonize" "$WASM_PATH"
 
     # 3. Optimization
     if command -v wasm-opt &> /dev/null; then
@@ -132,9 +138,7 @@ build_variant_threads() {
     rm -f $OUT_DIR/.gitignore
 }
 
-build_variant_threads &
-
-wait
+build_variant_threads
 
 echo "Patching wasm-bindgen-rayon workerHelpers.js..."
 for WORKER_HELPERS in $(find pkg-threads/snippets -name "workerHelpers.js" 2>/dev/null); do

--- a/scripts/build_wasm_site.sh
+++ b/scripts/build_wasm_site.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-export PATH="$HOME/.cargo/bin:$PATH"
+export PATH="${CARGO_HOME:-$HOME/.cargo}/bin:$PATH"
 
 # Configuration
 WASM_BINDGEN_VERSION="0.2.114"
@@ -20,6 +20,10 @@ if ! command -v wasm-bindgen &> /dev/null || [ "$(wasm-bindgen --version | awk '
         cargo install wasm-bindgen-cli --version $WASM_BINDGEN_VERSION
     fi
 fi
+if ! command -v wasm-bindgen &> /dev/null; then
+    cargo install --force wasm-bindgen-cli --version $WASM_BINDGEN_VERSION
+fi
+WASM_BINDGEN_BIN="$(command -v wasm-bindgen)"
 
 build_variant() {
     local VARIANT=$1
@@ -42,8 +46,7 @@ build_variant() {
     fi
 
     rm -rf $OUT_DIR
-    # Use full path to avoid PATH issues in CI environments
-    ~/.cargo/bin/wasm-bindgen --target web --out-dir $OUT_DIR --out-name "geo_polygonize" "$WASM_PATH"
+    "$WASM_BINDGEN_BIN" --target web --out-dir $OUT_DIR --out-name "geo_polygonize" "$WASM_PATH"
 
     # Remove .gitignore if generated
     rm -f $OUT_DIR/.gitignore

--- a/tests/test_cfb_fixtures.py
+++ b/tests/test_cfb_fixtures.py
@@ -1,0 +1,83 @@
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import geo_polygonize
+
+
+FIXTURE_DIR = Path(__file__).resolve().parents[1] / "fixtures" / "cfb" / "cases"
+
+
+def _flatten_fixture(fixture):
+    coords = []
+    offsets = []
+    line_ids = []
+    offset = 0
+
+    for line in fixture["lines"]:
+        offsets.append(offset)
+        line_ids.append(line["id"])
+        for point in line["coords"]:
+            coords.extend(point[: fixture["stride"]])
+            offset += 1
+
+    return (
+        np.asarray(coords, dtype=np.float64),
+        np.asarray(offsets, dtype=np.uint32),
+        np.asarray(line_ids, dtype=np.uint32),
+    )
+
+
+def _run_fixture(path):
+    fixture = json.loads(path.read_text())
+    coords, offsets, line_ids = _flatten_fixture(fixture)
+
+    if fixture["optionsProfile"] != "cfb_robust_v1":
+        pytest.fail(f"unsupported fixture profile {fixture['optionsProfile']}")
+
+    try:
+        result = geo_polygonize.polygonize_with_options(
+            coords=coords,
+            offsets=offsets,
+            stride=fixture["stride"],
+            line_ids=line_ids,
+            options=geo_polygonize.cfb_robust_options(),
+        )
+    except Exception as exc:
+        pytest.skip(f"geo_polygonize native fixture runner unavailable: {exc}")
+
+    expected = fixture["expected"]
+    assert len(result["polygons"]) == expected["polygonCount"]
+    assert len(result["dangles"]) == expected["dangleCount"]
+    assert len(result.get("cut_edges", [])) == expected["cutEdgeCount"]
+    assert len(result["invalid_rings"]) == expected["invalidRingCount"]
+
+    area = 0.0
+    for polygon in result["polygons"]:
+        shell = np.asarray(polygon.shell)
+        x = shell[:, 0]
+        y = shell[:, 1]
+        area += abs(float(np.dot(x, np.roll(y, -1)) - np.dot(y, np.roll(x, -1))) / 2.0)
+
+    assert area == pytest.approx(expected["totalArea"], abs=expected.get("areaTolerance", 1e-6))
+
+    expected_ids = expected.get("boundaryLineIds", [])
+    if expected_ids:
+        actual_ids = sorted({
+            line_id
+            for polygon in result["polygons"]
+            for line_id in polygon.provenance.get("boundary_line_ids", [])
+        })
+        assert actual_ids == expected_ids
+
+
+@pytest.mark.parametrize("path", sorted(FIXTURE_DIR.glob("*.json")))
+def test_cfb_fixture(path):
+    fixture = json.loads(path.read_text())
+    if fixture.get("expectedStatus", "pass") == "xfail":
+        with pytest.raises(AssertionError):
+            _run_fixture(path)
+    else:
+        _run_fixture(path)


### PR DESCRIPTION
## Summary
- consolidate the adoption-relevant PR hardening into one branch
- add `PolygonizerOptions::cfb_robust_v1()`, Python `cfb_robust_options()`, and JS `cfbRobustOptions`
- split `cut_edges` out of `dangles` across Rust, Python, and WASM buffer results
- add shared CFB fixture schema/case plus Rust, Python, and WASM fixture runners
- replace PAT-backed automerge action with guarded `gh pr merge --auto --rebase`

## Verification
- `PATH="$HOME/.rustup/toolchains/stable-aarch64-apple-darwin/bin:$PATH" cargo test --workspace --quiet`
- `python3 -m pytest tests python/test_wrapper.py test_python.py`
- `PATH="$HOME/.rustup/toolchains/stable-aarch64-apple-darwin/bin:$PATH" npm run docs:extract`
- `npx tsc --noEmit --pretty false` currently fails only because generated `pkg-scalar`/`pkg-simd` WASM package files are absent before a WASM build

## Blocked locally
- `cargo fmt` is unavailable because this toolchain has no rustfmt component
- `npm run build:site-lib` is blocked because `rustup` is unavailable and `wasm32-unknown-unknown` is not installed locally
