### PR TITLE
fix(python): upgrade pyo3 for advisory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       uses: taiki-e/install-action@cargo-audit
 
     - name: Run cargo audit
-      run: cargo audit --ignore RUSTSEC-2025-0020 --ignore RUSTSEC-2026-0173 --ignore RUSTSEC-2026-0177
+      run: cargo audit --ignore RUSTSEC-2025-0020 --ignore RUSTSEC-2026-0173
 
     - name: Set up Node.js
       uses: actions/setup-node@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,7 +578,7 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn",
@@ -810,7 +810,7 @@ dependencies = [
  "lazy_static",
  "mintex",
  "parking_lot",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "serde",
  "serde_json",
  "thousands",
@@ -1253,12 +1253,6 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -1421,15 +1415,6 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
-]
-
-[[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
 ]
 
 [[package]]
@@ -1615,15 +1600,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "minicov"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1761,9 +1737,9 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.21.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec170733ca37175f5d75a5bea5911d6ff45d2cd52849ce98b685394e4f2f37f4"
+checksum = "6a5b15d63a5ff39e378daed0e1340d3a5964703ea9712eb09a0dc66fade996f4"
 dependencies = [
  "libc",
  "ndarray",
@@ -1771,7 +1747,8 @@ dependencies = [
  "num-integer",
  "num-traits",
  "pyo3",
- "rustc-hash",
+ "pyo3-build-config",
+ "rustc-hash 2.1.3",
 ]
 
 [[package]]
@@ -1982,37 +1959,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.21.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e00b96a521718e08e03b1a622f01c8a8deb50719335de3f60b3b3950f069d8"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
- "cfg-if",
- "indoc",
  "libc",
- "memoffset",
- "parking_lot",
+ "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.21.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7883df5835fafdad87c0d888b266c8ec0f4c9ca48a5bed6bbb592e8dedee1b50"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.21.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01be5843dc60b916ab4dad1dca6d20b9b4e6ddc8e15f50c47fe6d85f1fb97403"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2020,9 +1992,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.21.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77b34069fc0682e11b31dbd10321cbf94808394c56fd996796ce45217dfac53c"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2032,13 +2004,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.21.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08260721f32db5e1a5beae69a55553f56b99bd0e1c3e6e0a5e8851a9d0f5a85c"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]
@@ -2252,6 +2223,12 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -2522,9 +2499,9 @@ checksum = "c1bbb9f3c5c463a01705937a24fdabc5047929ac764b2d5b9cf681c1f5041ed5"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "termcolor"
@@ -2711,12 +2688,6 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "utf8parse"

--- a/crates/geo-polygonize-core/Cargo.toml
+++ b/crates/geo-polygonize-core/Cargo.toml
@@ -21,8 +21,8 @@ log = "0.4"
 thiserror = "1.0"
 float_next_after = "1.0"
 smallvec = "1.11"
-pyo3 = { version = "0.21", features = ["extension-module", "abi3-py37"], optional = true }
-numpy = { version = "0.21", optional = true }
+pyo3 = { version = "0.29", features = ["extension-module", "abi3-py38"], optional = true }
+numpy = { version = "0.29", optional = true }
 arrow = { version = "57", features = ["ffi"] }
 geoarrow = "0.7.0"
 geo-traits = "0.3.0"

--- a/crates/geo-polygonize-core/src/python.rs
+++ b/crates/geo-polygonize-core/src/python.rs
@@ -64,7 +64,7 @@ fn polygonize_with_options<'py>(
     stride: u8,
     options_json: Option<&str>,
     line_ids: Option<PyReadonlyArray1<'py, u32>>,
-) -> PyResult<PyObject> {
+) -> PyResult<Py<PyAny>> {
     let options: crate::options::PolygonizerOptions = if let Some(json) = options_json {
         serde_json::from_str(json)
             .map_err(|e| PolygonizeOptionsError::new_err(format!("Invalid options json: {}", e)))?
@@ -88,7 +88,7 @@ fn polygonize<'py>(
     stride: u8,
     line_ids: Option<PyReadonlyArray1<'py, u32>>,
     report_mode: bool,
-) -> PyResult<PyObject> {
+) -> PyResult<Py<PyAny>> {
     let mut options = crate::options::PolygonizerOptions::default();
     options.diagnostics.enabled = report_mode;
     options.diagnostics.report_mode = report_mode;
@@ -106,7 +106,7 @@ fn polygonize_internal<'py>(
     stride: u8,
     options: crate::options::PolygonizerOptions,
     line_ids: Option<PyReadonlyArray1<'py, u32>>,
-) -> PyResult<PyObject> {
+) -> PyResult<Py<PyAny>> {
     let coords_slice = coords.as_slice()?;
     let offsets_slice = offsets.as_slice()?;
 
@@ -276,49 +276,49 @@ fn polygonize_internal<'py>(
     // We will build Python polygons via the SimplePolygon class from geo_polygonize.types.
     // If geo_polygonize.types isn't available, we fallback to a simple dict representation?
     // The issue asks to "construct and return SimplePolygon objects directly".
-    let py_polygons = PyList::empty_bound(py);
+    let py_polygons = PyList::empty(py);
 
     // Attempt to import the Python class `SimplePolygon`
     let simple_polygon_cls = py
-        .import_bound("geo_polygonize.types")?
+        .import("geo_polygonize.types")?
         .getattr("SimplePolygon")?;
 
     for poly in &result.polygons {
         // Construct exterior tuples
-        let exterior_pts = PyList::empty_bound(py);
+        let exterior_pts = PyList::empty(py);
         for c in &poly.exterior {
             if stride == 3 {
-                exterior_pts.append(PyTuple::new_bound(py, [c.x, c.y, c.z]))?;
+                exterior_pts.append(PyTuple::new(py, [c.x, c.y, c.z])?)?;
             } else {
-                exterior_pts.append(PyTuple::new_bound(py, [c.x, c.y]))?;
+                exterior_pts.append(PyTuple::new(py, [c.x, c.y])?)?;
             }
         }
-        let shell = PyTuple::new_bound(py, exterior_pts);
+        let shell = PyTuple::new(py, exterior_pts)?;
 
-        let shell_ids = PyTuple::new_bound(py, &poly.exterior_ids);
+        let shell_ids = PyTuple::new(py, &poly.exterior_ids)?;
 
         // Construct interiors
-        let holes = PyList::empty_bound(py);
-        let holes_ids = PyList::empty_bound(py);
+        let holes = PyList::empty(py);
+        let holes_ids = PyList::empty(py);
 
         for (h_idx, ring) in poly.interiors.iter().enumerate() {
-            let ring_pts = PyList::empty_bound(py);
+            let ring_pts = PyList::empty(py);
             for c in ring {
                 if stride == 3 {
-                    ring_pts.append(PyTuple::new_bound(py, [c.x, c.y, c.z]))?;
+                    ring_pts.append(PyTuple::new(py, [c.x, c.y, c.z])?)?;
                 } else {
-                    ring_pts.append(PyTuple::new_bound(py, [c.x, c.y]))?;
+                    ring_pts.append(PyTuple::new(py, [c.x, c.y])?)?;
                 }
             }
-            holes.append(PyTuple::new_bound(py, ring_pts))?;
+            holes.append(PyTuple::new(py, ring_pts)?)?;
 
-            let r_ids = PyTuple::new_bound(py, &poly.interiors_ids[h_idx]);
+            let r_ids = PyTuple::new(py, &poly.interiors_ids[h_idx])?;
             holes_ids.append(r_ids)?;
         }
 
         let py_provenance = if let Some(ref prov) = poly.provenance {
-            let prov_dict = PyDict::new_bound(py);
-            let b_ids = PyTuple::new_bound(py, &prov.boundary_line_ids);
+            let prov_dict = PyDict::new(py);
+            let b_ids = PyTuple::new(py, &prov.boundary_line_ids)?;
             prov_dict.set_item("boundary_line_ids", b_ids)?;
             if let Some(ref prof_id) = prov.input_profile_id {
                 prov_dict.set_item("input_profile_id", prof_id)?;
@@ -336,55 +336,52 @@ fn polygonize_internal<'py>(
     }
 
     // Construct dangles
-    let py_dangles = PyList::empty_bound(py);
+    let py_dangles = PyList::empty(py);
     for dangle in &result.dangles {
-        let dangle_pts = PyList::empty_bound(py);
+        let dangle_pts = PyList::empty(py);
         for c in dangle {
             if stride == 3 {
-                dangle_pts.append(PyTuple::new_bound(py, [c.x, c.y, c.z]))?;
+                dangle_pts.append(PyTuple::new(py, [c.x, c.y, c.z])?)?;
             } else {
-                dangle_pts.append(PyTuple::new_bound(py, [c.x, c.y]))?;
+                dangle_pts.append(PyTuple::new(py, [c.x, c.y])?)?;
             }
         }
-        py_dangles.append(PyTuple::new_bound(py, dangle_pts))?;
+        py_dangles.append(PyTuple::new(py, dangle_pts)?)?;
     }
 
     // Construct cut edges
-    let py_cut_edges = PyList::empty_bound(py);
+    let py_cut_edges = PyList::empty(py);
     for cut_edge in &result.cut_edges {
-        let cut_edge_pts = PyList::empty_bound(py);
+        let cut_edge_pts = PyList::empty(py);
         for c in cut_edge {
             if stride == 3 {
-                cut_edge_pts.append(PyTuple::new_bound(py, [c.x, c.y, c.z]))?;
+                cut_edge_pts.append(PyTuple::new(py, [c.x, c.y, c.z])?)?;
             } else {
-                cut_edge_pts.append(PyTuple::new_bound(py, [c.x, c.y]))?;
+                cut_edge_pts.append(PyTuple::new(py, [c.x, c.y])?)?;
             }
         }
-        py_cut_edges.append(PyTuple::new_bound(py, cut_edge_pts))?;
+        py_cut_edges.append(PyTuple::new(py, cut_edge_pts)?)?;
     }
 
     // Construct invalid rings
-    let py_invalid_rings = PyList::empty_bound(py);
+    let py_invalid_rings = PyList::empty(py);
     for invalid_ring in &result.invalid_rings {
-        let invalid_pts = PyList::empty_bound(py);
+        let invalid_pts = PyList::empty(py);
         for c in invalid_ring {
             if stride == 3 {
-                invalid_pts.append(PyTuple::new_bound(py, [c.x, c.y, c.z]))?;
+                invalid_pts.append(PyTuple::new(py, [c.x, c.y, c.z])?)?;
             } else {
-                invalid_pts.append(PyTuple::new_bound(py, [c.x, c.y]))?;
+                invalid_pts.append(PyTuple::new(py, [c.x, c.y])?)?;
             }
         }
-        py_invalid_rings.append(PyTuple::new_bound(py, invalid_pts))?;
+        py_invalid_rings.append(PyTuple::new(py, invalid_pts)?)?;
     }
 
-    let dict = PyDict::new_bound(py);
-    dict.set_item("flat_coords", PyArray1::from_vec_bound(py, flat_coords))?;
-    dict.set_item("ring_offsets", PyArray1::from_vec_bound(py, ring_offsets))?;
-    dict.set_item(
-        "polygon_offsets",
-        PyArray1::from_vec_bound(py, polygon_offsets),
-    )?;
-    dict.set_item("flat_line_ids", PyArray1::from_vec_bound(py, flat_line_ids))?;
+    let dict = PyDict::new(py);
+    dict.set_item("flat_coords", PyArray1::from_vec(py, flat_coords))?;
+    dict.set_item("ring_offsets", PyArray1::from_vec(py, ring_offsets))?;
+    dict.set_item("polygon_offsets", PyArray1::from_vec(py, polygon_offsets))?;
+    dict.set_item("flat_line_ids", PyArray1::from_vec(py, flat_line_ids))?;
     dict.set_item("stride", stride)?;
 
     dict.set_item("polygons", py_polygons)?;
@@ -395,7 +392,7 @@ fn polygonize_internal<'py>(
     if let Some(ref diag) = result.diagnostics {
         // Map diagnostics using serde to a Python dict
         if let Ok(diag_json) = serde_json::to_string(diag) {
-            let json_module = py.import_bound("json")?;
+            let json_module = py.import("json")?;
             let loads_func = json_module.getattr("loads")?;
             let py_diag = loads_func.call1((diag_json,))?;
             dict.set_item("diagnostics", py_diag)?;
@@ -407,21 +404,18 @@ fn polygonize_internal<'py>(
 
 #[pymodule]
 fn geo_polygonize_core(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add(
-        "PolygonizeTypeError",
-        py.get_type_bound::<PolygonizeTypeError>(),
-    )?;
+    m.add("PolygonizeTypeError", py.get_type::<PolygonizeTypeError>())?;
     m.add(
         "PolygonizeGeometryError",
-        py.get_type_bound::<PolygonizeGeometryError>(),
+        py.get_type::<PolygonizeGeometryError>(),
     )?;
     m.add(
         "PolygonizeOptionsError",
-        py.get_type_bound::<PolygonizeOptionsError>(),
+        py.get_type::<PolygonizeOptionsError>(),
     )?;
     m.add(
         "PolygonizeTopologyError",
-        py.get_type_bound::<PolygonizeTopologyError>(),
+        py.get_type::<PolygonizeTopologyError>(),
     )?;
     m.add_function(wrap_pyfunction!(polygonize, m)?)?;
     m.add_function(wrap_pyfunction!(polygonize_with_options, m)?)?;

--- a/deny.toml
+++ b/deny.toml
@@ -74,8 +74,6 @@ ignore = [
     "RUSTSEC-2024-0436",
     # iai-callgrind 0.16.1 pulls this through its benchmark macro dependency.
     "RUSTSEC-2026-0173",
-    # pyo3 0.29 needs a Python binding migration; this code does not use PyCFunction::new_closure.
-    "RUSTSEC-2026-0177",
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "geo-polygonize-py"
 version = "0.33.0"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 description = "Python bindings for geo-polygonize-core, a native Rust port of the JTS/GEOS polygonization algorithm."
 readme = "README.md"
 license = {text = "MIT OR Apache-2.0"}


### PR DESCRIPTION
## Summary
- upgrade pyo3/numpy to 0.29 and move Python ABI support to cp38+
- migrate the native Python wrapper API calls for PyO3 0.29
- remove the RUSTSEC-2026-0177 ignore from deny/audit config

## Verification
- `PATH="$HOME/.rustup/toolchains/stable-aarch64-apple-darwin/bin:$PATH" cargo check -p geo-polygonize-core --features python`
- `PATH="$HOME/.rustup/toolchains/stable-aarch64-apple-darwin/bin:$PATH" cargo test --workspace --quiet`
- `python3 -m pip install -e .`
- `python3 -m pytest tests python/test_wrapper.py test_python.py`

Note: local `cargo fmt`, `cargo audit`, and `cargo deny` are not installed in this shell. `cargo test -p geo-polygonize-core --features python` links against Python differently than maturin on this macOS shell and fails with unresolved Python symbols; the maturin editable build and pytest path pass.
