### PR TITLE
ci(python): checkout before publish sbom

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -59,6 +59,8 @@ jobs:
     permissions:
       id-token: write
     steps:
+      - uses: actions/checkout@v4
+
       - name: Download wheels
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- checkout the repository in the Python publish job before generating the SBOM
- keeps the post-upload SBOM step from failing on missing python/requirements.txt

## Verification
- git diff --check