### PR TITLE
feat(python): add import probe helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,15 @@ use geo_polygonize_core::arrow_api::{polygonize_arrow, PolygonizerOptions};
 
 ### Python
 
-The library provides native Python bindings via PyO3, packaged as `geo-polygonize`.
+The Python package is published as `geo-polygonize-py` and imported as `geo_polygonize`.
+
+```bash
+pip install geo-polygonize-py
+```
 
 ```python
 import numpy as np
-from geo_polygonize import polygonize
+from geo_polygonize import polygonize, import_probe
 
 # 1. Using Shapely LineStrings or coordinate lists directly
 lines = [
@@ -116,8 +120,54 @@ coords = np.array([
 # The final closing offset is computed implicitly.
 offsets = np.array([0, 5], dtype=np.uint32)
 
-# Returns a dictionary with 'flat_coords', 'ring_offsets', 'polygon_offsets', etc.
+# Returns a stable dictionary with 'polygons', diagnostics, and provenance.
 result_dict = polygonize(coords=coords, offsets=offsets)
+
+# Native-extension probes are cheap and safe for optional integrations.
+ok, error = import_probe()
+```
+
+CFB/autograder integrations should use the versioned production profile rather
+than assembling caller-side knobs or using legacy `polygonize(..., node=True,
+snap=0.5)` calls:
+
+```python
+from geo_polygonize import cfb_robust_options, polygonize_with_options
+
+result = polygonize_with_options(
+    coords=coords,
+    offsets=offsets,
+    options=cfb_robust_options(),
+)
+```
+
+The default return shape is a stable dictionary with `polygons` as
+`SimplePolygon` values. Use `return_polygons=True` only when you want Shapely
+`Polygon` objects.
+
+For Shapely parity checks, compare report-mode outputs with the built-in
+mismatch helper:
+
+```python
+from geo_polygonize import explain_mismatch, polygonize_with_options
+
+options = cfb_robust_options()
+result_a = polygonize_with_options(coords=coords_a, offsets=offsets_a, options=options)
+result_b = polygonize_with_options(coords=coords_b, offsets=offsets_b, options=options)
+result_a["options"] = options
+result_b["options"] = options
+
+mismatch = explain_mismatch(result_a, result_b)
+```
+
+For a minimal Shapely smoke comparison, use area signatures:
+
+```python
+from shapely.ops import polygonize as shapely_polygonize
+
+rust_polys = polygonize_with_options(lines=lines, options=cfb_robust_options(), return_polygons=True)
+rust_areas = sorted(round(poly.area, 6) for poly in rust_polys)
+shapely_areas = sorted(round(poly.area, 6) for poly in shapely_polygonize(lines))
 ```
 
 ### WebAssembly (WASM)

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -11,3 +11,9 @@ This library provides high-performance polygonization of lines and rings. It is 
 ## Installation
 
 See the respective integration guides for details.
+
+Python users install `geo-polygonize-py` and import `geo_polygonize`:
+
+```bash
+pip install geo-polygonize-py
+```

--- a/python/geo_polygonize/__init__.py
+++ b/python/geo_polygonize/__init__.py
@@ -3,6 +3,10 @@ import numpy as np
 
 import json
 
+_IMPORT_OK = True
+_IMPORT_ERROR = None
+_polygonize_with_options_impl = None
+
 try:
     from .geo_polygonize_core import (
         polygonize as _polygonize_impl,
@@ -12,11 +16,14 @@ try:
         PolygonizeOptionsError,
         PolygonizeTopologyError
     )
-except ImportError:
+except Exception:
     try:
         from .cffi_wrapper import polygonize as _polygonize_impl
-    except Exception as import_error:
-        def _polygonize_impl(*args, _import_error=import_error, **kwargs):
+    except Exception as fallback_import_error:
+        _IMPORT_OK = False
+        _IMPORT_ERROR = fallback_import_error
+
+        def _polygonize_impl(*args, _import_error=fallback_import_error, **kwargs):
             raise ImportError("geo_polygonize native extension is not available") from _import_error
 
     # Fallback exception classes if C extension is missing
@@ -31,6 +38,14 @@ except ImportError:
 
     class PolygonizeTopologyError(ValueError):
         pass
+
+def import_probe():
+    """Return (ok, error) for geo_polygonize runtime availability."""
+    return _IMPORT_OK, None if _IMPORT_ERROR is None else str(_IMPORT_ERROR)
+
+def is_available():
+    """Return True when a geo_polygonize runtime backend is importable."""
+    return import_probe()[0]
 
 def polygonize_with_options(lines=None, coords=None, offsets=None, options=None, stride=None, line_ids=None, return_polygons=False):
     """
@@ -105,9 +120,9 @@ def polygonize_with_options(lines=None, coords=None, offsets=None, options=None,
 
     options_json = None if options is None else json.dumps(options)
 
-    try:
+    if _polygonize_with_options_impl is not None:
         result = _polygonize_with_options_impl(coords, offsets, stride=stride, options_json=options_json, line_ids=line_ids)
-    except NameError:
+    else:
         # Fallback for CFFI which does not support options mapping fully yet
         result = _polygonize_impl(coords, offsets, node=options_dict.get("node_input", False), snap=options_dict.get("snap_grid_size", 1e-10), extract_only_polygonal=options_dict.get("extract_only_polygonal", False), stride=stride, line_ids=line_ids)
 

--- a/python/test_wrapper.py
+++ b/python/test_wrapper.py
@@ -9,6 +9,14 @@ sys.path.append(os.path.join(os.path.dirname(__file__)))
 
 from geo_polygonize import polygonize
 
+def test_import_probe():
+    import geo_polygonize
+
+    ok, error = geo_polygonize.import_probe()
+    assert isinstance(ok, bool)
+    assert error is None or isinstance(error, str)
+    assert geo_polygonize.is_available() is ok
+
 def test_square():
     print("Testing square polygonization...")
     coords = np.array([
@@ -160,6 +168,7 @@ def test_import_error_fallback():
 
         import geo_polygonize.cffi_wrapper as cffi_wrapper
         assert geo_polygonize._polygonize_impl is cffi_wrapper.polygonize
+        assert geo_polygonize.import_probe() == (True, None)
         print("ImportError fallback test passed!")
 
     # Reload again to restore the module state for other tests
@@ -433,6 +442,7 @@ def test_extract_only_polygonal():
 
 if __name__ == "__main__":
     test_square()
+    test_import_probe()
     test_two_squares()
     test_square_with_hole()
     test_3d_coordinates()

--- a/tests/test_report_mismatches.py
+++ b/tests/test_report_mismatches.py
@@ -17,6 +17,24 @@ def generate_winding_chaos():
     return lines
 
 class TestReportMismatches(unittest.TestCase):
+    def test_cfb_robust_report_mode_matches_itself(self):
+        coords = np.array([
+            0.0, 0.0, 10.0, 0.0,
+            10.0, 0.0, 10.0, 10.0,
+            10.0, 10.0, 0.0, 10.0,
+            0.0, 10.0, 0.0, 0.0
+        ], dtype=np.float64)
+        offsets = np.array([0, 2, 4, 6], dtype=np.uint32)
+        options = geo_polygonize.cfb_robust_options()
+
+        result_a = geo_polygonize.polygonize_with_options(coords=coords, offsets=offsets, options=options)
+        result_b = geo_polygonize.polygonize_with_options(coords=coords, offsets=offsets, options=options)
+        result_a["options"] = options
+        result_b["options"] = options
+
+        mismatch_info = geo_polygonize.explain_mismatch(result_a, result_b)
+        self.assertTrue(mismatch_info["is_match"], mismatch_info["mismatches"])
+
     def test_options_mismatch(self):
         coords = np.array([
             0.0, 0.0, 10.0, 0.0, 10.0, 10.0, 0.0, 10.0, 0.0, 0.0,


### PR DESCRIPTION
## Summary

- add `import_probe()` and `is_available()` so optional Python integrations can check runtime availability without crashing their fallback path
- make `polygonize_with_options()` use the existing CFFI fallback explicitly when the native options binding is unavailable
- document the PyPI package/import-name mismatch, `cfb_robust_options()` production profile, stable Python return shape, and minimal Shapely parity checks
- add a CFB report-mode regression for `explain_mismatch()`

## Validation

- `python3 -m pytest python/test_wrapper.py tests/test_report_mismatches.py tests/test_cfb_fixtures.py`
- `python3 -m pytest tests python/test_wrapper.py test_python.py`
- `git diff --check`