### PR TITLE
fix(wasm): ship generated declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,8 @@ This library supports WebAssembly with an ergonomic dual-build configuration tha
 npm install geo-polygonize
 ```
 
-**Standard Usage (Bundlers / Browser):**
-The default entry point automatically handles feature detection (SIMD) and lazy-loading of the Wasm binary. The Wasm is inlined as a Base64 Data URI, so no extra bundler configuration is needed.
+**Standard Usage (Quick Demos):**
+The default entry point automatically handles feature detection (SIMD) and lazy-loading of the Wasm binary. The Wasm is inlined as a Base64 Data URI, so no extra bundler configuration is needed. For app builds, prefer the slim entry point below so your bundler keeps the Wasm assets out of the JavaScript chunk.
 
 ```javascript
 import init, { polygonize, polygonize_geoarrow } from "geo-polygonize";
@@ -210,24 +210,24 @@ async function run() {
 }
 ```
 
-**Slim Usage (Manual Loading):**
-If you prefer to manage the Wasm binary yourself (e.g., to reduce bundle size or load from a CDN), import from `geo-polygonize/slim`.
+**Slim Usage (Apps / Manual Loading):**
+For Vite and other app bundlers, import from `geo-polygonize/slim` and pass explicit Wasm asset URLs.
 
 ```javascript
-import { initBest, polygonize } from "geo-polygonize/slim";
+import { cfbRobustOptions, initBest } from "geo-polygonize/slim";
+import scalarUrl from "geo-polygonize/geo_polygonize.wasm?url";
+import simdUrl from "geo-polygonize/geo_polygonize_simd.wasm?url";
 
 async function run() {
-    // You must provide the compiled WebAssembly.Module or URL
-    // You can choose to load the SIMD or Scalar version based on your own detection or availability
-    const response = await fetch("geo_polygonize.wasm");
-    const buffer = await response.arrayBuffer();
-    const module = await WebAssembly.compile(buffer);
+    const wasm = await initBest(
+        { module_or_path: scalarUrl },
+        { module_or_path: simdUrl },
+    );
 
-    // Helper to initialize the best available implementation
-    // Pass the module to both arguments if you only have one version
-    await initBest(module, module);
-
-    // ... use polygonize
+    const result = wasm.polygonizeWithOptions(
+        JSON.stringify(geojson),
+        cfbRobustOptions,
+    );
 }
 ```
 

--- a/crates/geo-polygonize-wasm/tests/wasm.test.js
+++ b/crates/geo-polygonize-wasm/tests/wasm.test.js
@@ -1,9 +1,39 @@
 import { describe, it, expect } from 'vitest';
-import { readFileSync, readdirSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import init, { polygonize, cfbRobustOptions } from '../../../dist/standard/es/index.js';
 
 describe('WASM Polygonizer', () => {
+    it('should publish declaration paths referenced by wrapper types', () => {
+        expect(existsSync(resolve('dist/standard/pkg-scalar/geo_polygonize.d.ts'))).toBe(true);
+        expect(existsSync(resolve('dist/slim/pkg-scalar/geo_polygonize.d.ts'))).toBe(true);
+        expect(existsSync(resolve('dist/threads/pkg-threads/geo_polygonize.d.ts'))).toBe(true);
+    });
+
+    it('should initialize slim with module alias options', async () => {
+        const { cfbRobustOptions, initBest } = await import('../../../dist/slim/es/index_slim.js');
+        const wasm = await initBest(
+            { module: await WebAssembly.compile(readFileSync(resolve('dist/geo_polygonize.wasm'))) },
+            { module: await WebAssembly.compile(readFileSync(resolve('dist/geo_polygonize_simd.wasm'))) },
+        );
+
+        const input = {
+            type: "FeatureCollection",
+            features: [
+                {
+                    type: "Feature",
+                    geometry: {
+                        type: "LineString",
+                        coordinates: [[0, 0], [10, 0], [10, 10], [0, 10], [0, 0]]
+                    }
+                }
+            ]
+        };
+
+        const result = JSON.parse(wasm.polygonizeWithOptions(JSON.stringify(input), cfbRobustOptions));
+        expect(result.features).toHaveLength(1);
+    });
+
     it('should polygonize a simple square', async () => {
         await init();
 

--- a/docs/WASM_API.md
+++ b/docs/WASM_API.md
@@ -16,7 +16,7 @@ Polygonizes linework provided as a GeoJSON FeatureCollection, Feature, or Geomet
 **Example:**
 
 ```javascript
-import { polygonize } from "geo-polygonize";
+import init, { polygonize } from "geo-polygonize";
 
 const geojson = {
     type: "FeatureCollection",
@@ -31,9 +31,30 @@ const geojson = {
     ]
 };
 
+await init();
+
 // With explicit parameters to match backend configurations
 const resultStr = polygonize(JSON.stringify(geojson), true, 0.5);
 const result = JSON.parse(resultStr);
+```
+
+For production app bundles, prefer `geo-polygonize/slim` with explicit Wasm
+asset URLs and the versioned CFB profile:
+
+```ts
+import { cfbRobustOptions, initBest } from "geo-polygonize/slim";
+import scalarUrl from "geo-polygonize/geo_polygonize.wasm?url";
+import simdUrl from "geo-polygonize/geo_polygonize_simd.wasm?url";
+
+const wasm = await initBest(
+  { module_or_path: scalarUrl },
+  { module_or_path: simdUrl },
+);
+
+const resultStr = wasm.polygonizeWithOptions(
+  JSON.stringify(geojson),
+  cfbRobustOptions,
+);
 ```
 
 ### `polygonize_buffers(coords, offsets, stride, node_input, snap_grid_size)`

--- a/docs/guide/wasm.md
+++ b/docs/guide/wasm.md
@@ -7,3 +7,27 @@ The `geo-polygonize` WebAssembly package can be used in the browser or in Node.j
 ```bash
 npm install geo-polygonize
 ```
+
+## Browser Apps
+
+Use the slim entry point in Vite or similar app builds so the Wasm binaries stay
+as assets instead of being inlined into the JavaScript chunk.
+
+```ts
+import { cfbRobustOptions, initBest } from "geo-polygonize/slim";
+import scalarUrl from "geo-polygonize/geo_polygonize.wasm?url";
+import simdUrl from "geo-polygonize/geo_polygonize_simd.wasm?url";
+
+const wasm = await initBest(
+  { module_or_path: scalarUrl },
+  { module_or_path: simdUrl },
+);
+
+const result = wasm.polygonizeWithOptions(
+  JSON.stringify(geojson),
+  cfbRobustOptions,
+);
+```
+
+The default `geo-polygonize` import is convenient for quick demos, but it
+inlines the Wasm builds into the importing chunk.

--- a/pkg-wrapper/index_slim.ts
+++ b/pkg-wrapper/index_slim.ts
@@ -1,5 +1,4 @@
 import initScalar, * as scalarExports from "../pkg-scalar/geo_polygonize.js";
-import initSimd, * as simdExports from "../pkg-simd/geo_polygonize.js";
 
 // We re-export everything. The user is responsible for calling init with the correct module/url.
 export * from "../pkg-scalar/geo_polygonize.js";
@@ -27,7 +26,14 @@ export * from "./cfb";
 let isSimdSupported: boolean | undefined;
 const SIMD_TEST_BYTES = new Uint8Array([0,97,115,109,1,0,0,0,1,5,1,96,0,1,123,3,2,1,0,10,10,1,8,0,65,0,253,15,253,98,11]);
 
-export async function initBest(scalarModule: any, simdModule: any) {
+function normalizeInitInput(input: any) {
+    if (input && typeof input === "object" && "module" in input && !("module_or_path" in input)) {
+        return { ...input, module_or_path: input.module };
+    }
+    return input;
+}
+
+export async function initBest(scalarModule: any, simdModule?: any) {
     if (isSimdSupported === undefined) {
         try {
             isSimdSupported = WebAssembly.validate(SIMD_TEST_BYTES);
@@ -36,11 +42,6 @@ export async function initBest(scalarModule: any, simdModule: any) {
         }
     }
 
-    if (isSimdSupported && simdModule) {
-        await initSimd(simdModule);
-        return simdExports;
-    } else {
-        await initScalar(scalarModule);
-        return scalarExports;
-    }
+    await initScalar(normalizeInitInput(isSimdSupported && simdModule ? simdModule : scalarModule));
+    return scalarExports;
 }

--- a/scripts/build_wasm.sh
+++ b/scripts/build_wasm.sh
@@ -147,6 +147,15 @@ for WORKER_HELPERS in $(find pkg-threads/snippets -name "workerHelpers.js" 2>/de
     mv "$TEMP_FILE" "$WORKER_HELPERS"
 done
 
+echo "Patching wasm-bindgen fallback URLs for Vite..."
+for BINDGEN_JS in pkg-scalar/geo_polygonize.js pkg-simd/geo_polygonize.js pkg-threads/geo_polygonize.js; do
+    if [ -f "$BINDGEN_JS" ]; then
+        TEMP_FILE=$(mktemp)
+        sed -e "s/new URL('geo_polygonize_bg.wasm', import.meta.url)/new URL(\/\\* @vite-ignore \\*\/ 'geo_polygonize_bg.wasm', import.meta.url)/g" "$BINDGEN_JS" > "$TEMP_FILE"
+        mv "$TEMP_FILE" "$BINDGEN_JS"
+    fi
+done
+
 # Export the ts-rs bindings so that TS type-checks succeed when imported via pkg-wrapper
 echo "Exporting our TS-RS bindings into wasm-bindgen definitions..."
 export TS_RS_EXPORT_DIR="crates/geo-polygonize-core/bindings"
@@ -170,6 +179,20 @@ for DIR in pkg-scalar pkg-simd pkg-threads; do
   fi
 done
 
+copy_wasm_bindgen_types() {
+    for ENV in standard slim threads; do
+        if [ -d "dist/$ENV/es/bindings" ]; then
+            mkdir -p "dist/$ENV/pkg-wrapper"
+            cp -r "dist/$ENV/es/bindings" "dist/$ENV/pkg-wrapper/"
+        fi
+    done
+
+    mkdir -p dist/standard/pkg-scalar dist/slim/pkg-scalar dist/threads/pkg-threads
+    cp pkg-scalar/*.d.ts dist/standard/pkg-scalar/
+    cp pkg-scalar/*.d.ts dist/slim/pkg-scalar/
+    cp pkg-threads/*.d.ts dist/threads/pkg-threads/
+}
+
 # Ensure wrapper exists
 if [ ! -d "pkg-wrapper" ]; then
     echo "pkg-wrapper directory missing!"
@@ -184,6 +207,7 @@ fi
 # Bundle with Rollup
 echo "Running rollup..."
 npx rollup -c
+copy_wasm_bindgen_types
 
 # Prepare distribution files
 echo "Preparing dist..."

--- a/scripts/build_wasm_site.sh
+++ b/scripts/build_wasm_site.sh
@@ -63,6 +63,15 @@ else
     build_variant "simd" "-C target-feature=+simd128"
 fi
 
+echo "Patching wasm-bindgen fallback URLs for Vite..."
+for BINDGEN_JS in pkg-scalar/geo_polygonize.js pkg-simd/geo_polygonize.js; do
+    if [ -f "$BINDGEN_JS" ]; then
+        TEMP_FILE=$(mktemp)
+        sed -e "s/new URL('geo_polygonize_bg.wasm', import.meta.url)/new URL(\/\\* @vite-ignore \\*\/ 'geo_polygonize_bg.wasm', import.meta.url)/g" "$BINDGEN_JS" > "$TEMP_FILE"
+        mv "$TEMP_FILE" "$BINDGEN_JS"
+    fi
+done
+
 # Export the ts-rs bindings so that TS type-checks succeed when imported via pkg-wrapper
 echo "Exporting our TS-RS bindings into wasm-bindgen definitions..."
 export TS_RS_EXPORT_DIR="crates/geo-polygonize-core/bindings"
@@ -81,6 +90,19 @@ for DIR in pkg-scalar pkg-simd; do
   fi
 done
 
+copy_wasm_bindgen_types() {
+    for ENV in standard slim; do
+        if [ -d "dist/$ENV/es/bindings" ]; then
+            mkdir -p "dist/$ENV/pkg-wrapper"
+            cp -r "dist/$ENV/es/bindings" "dist/$ENV/pkg-wrapper/"
+        fi
+    done
+
+    mkdir -p dist/standard/pkg-scalar dist/slim/pkg-scalar
+    cp pkg-scalar/*.d.ts dist/standard/pkg-scalar/
+    cp pkg-scalar/*.d.ts dist/slim/pkg-scalar/
+}
+
 # We mock threads folder to avoid rollup failure when doing slim build
 mkdir -p pkg-threads
 echo "export const threads = 'mocked for site build';" > pkg-threads/index.js
@@ -96,6 +118,7 @@ fi
 # Bundle with Rollup
 echo "Running rollup..."
 npx rollup -c
+copy_wasm_bindgen_types
 
 # Prepare distribution files
 echo "Preparing dist..."


### PR DESCRIPTION
## Summary

- copy generated wasm-bindgen `.d.ts` files into the `dist/*/pkg-*` paths referenced by bundled wrapper declarations
- simplify `geo-polygonize/slim` so `initBest()` initializes the scalar JS binding with the selected scalar/SIMD Wasm binary, matching the standard wrapper model
- accept `{ module }` as an alias for wasm-bindgen's `{ module_or_path }` in `initBest()`
- patch generated wasm-bindgen fallback URLs with `/* @vite-ignore */` before rollup
- document app usage with `geo-polygonize/slim`, bundler `?url` Wasm assets, `cfbRobustOptions`, and `polygonizeWithOptions()`

## Validation

Local:

- `git diff --check -- README.md docs/WASM_API.md docs/guide/wasm.md pkg-wrapper/index_slim.ts scripts/build_wasm.sh scripts/build_wasm_site.sh crates/geo-polygonize-wasm/tests/wasm.test.js`
- `bash -n scripts/build_wasm.sh`
- `bash -n scripts/build_wasm_site.sh`

Not run locally:

- full `npm run build` / Vitest, because this shell has no `rustup` or `wasm-pack`; CI should validate the generated package surface.