### PR TITLE
fix(python): include license files in sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,7 @@ python-source = "python"
 manifest-path = "crates/geo-polygonize-core/Cargo.toml"
 module-name = "geo_polygonize.geo_polygonize_core"
 features = ["python"]
+include = [
+    { path = "LICENSE-APACHE", format = "sdist" },
+    { path = "LICENSE-MIT", format = "sdist" },
+]


### PR DESCRIPTION
## Summary
- Add `LICENSE-APACHE` and `LICENSE-MIT` to the Python source distribution manifest
- Ensure published Python sdists carry the required license files

## Testing
- Not run (not requested)