### PR TITLE
fix(github): make release automation use PAT squash merges

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -21,9 +21,9 @@ jobs:
     steps:
       - name: Enable auto-merge
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
           gh pr merge ${{ github.event.pull_request.number }} \
             --repo ${{ github.repository }} \
             --auto \
-            --rebase
+            --squash

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,3 +31,42 @@ jobs:
         with:
           token: ${{ secrets.GH_PAT }}
           release-as: ${{ inputs.version }}
+
+      - name: Detect release PR branch
+        id: release-pr
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          branch="$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --state open \
+            --head release-please--branches--main--components--geo-polygonize \
+            --json headRefName \
+            --jq '.[0].headRefName // empty')"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout release PR branch
+        if: steps.release-pr.outputs.branch != ''
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.release-pr.outputs.branch }}
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Set up Rust
+        if: steps.release-pr.outputs.branch != ''
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Update Cargo.lock
+        if: steps.release-pr.outputs.branch != ''
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          cargo check
+          if git diff --quiet -- Cargo.lock; then
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Cargo.lock
+          git commit -m "chore(main): update Cargo.lock for release"
+          git push


### PR DESCRIPTION
## Summary
- use the repository PAT for auto-merge so merge pushes can trigger downstream workflows
- switch auto-merge from rebase to squash so release-please sees conventional PR titles
- update Cargo.lock automatically on release-please PR branches when manifest version bumps require it

## Checks
- git diff --check
- YAML parsed with Ruby Psych
- actionlint unavailable locally