### PR TITLE
test(core): populate noded segment diagnostics

### DIFF
--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -242,6 +242,7 @@ impl Polygonizer {
         self.build_graph()?;
         if let Some(ref mut d) = diag {
             d.phase_times.ingest_and_node = get_elapsed(t_ingest_start);
+            d.noded_segment_count = self.graph.edges.len();
         }
 
         let t_graph_build_start = get_time();

--- a/crates/geo-polygonize-core/src/polygonizer_tests.rs
+++ b/crates/geo-polygonize-core/src/polygonizer_tests.rs
@@ -642,10 +642,14 @@ mod tests {
         );
 
         let first = poly.polygonize().expect("First polygonization failed");
-        assert_eq!(first.diagnostics.unwrap().input_segment_count, 4);
+        let first_diagnostics = first.diagnostics.unwrap();
+        assert_eq!(first_diagnostics.input_segment_count, 4);
+        assert_eq!(first_diagnostics.noded_segment_count, 4);
 
         let second = poly.polygonize().expect("Second polygonization failed");
-        assert_eq!(second.diagnostics.unwrap().input_segment_count, 4);
+        let second_diagnostics = second.diagnostics.unwrap();
+        assert_eq!(second_diagnostics.input_segment_count, 4);
+        assert_eq!(second_diagnostics.noded_segment_count, 4);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- populate the existing `noded_segment_count` diagnostics field after graph build
- assert the field in the repeated polygonize diagnostics regression test

## Context

While investigating the merged CFB `rw` xfail, local probes showed the Shapely-only diff does not overlap any Rust graph ring or unassigned negative ring. That rules out the broad bounded-negative-ring promotion idea for this fixture: the missing area has already diverged before ring classification.

This PR keeps the durable part of that investigation: `noded_segment_count` already exists in the diagnostics struct, but it was always reported as zero. Filling it makes future CFB parity reports more useful when deciding whether a gap is in noding/pre-snap or later topology assembly.

## Validation

- `cargo fmt --check`
- `cargo test -p geo-polygonize-core test_repeated_polygonize_preserves_input_segments_when_node_input_disabled -- --nocapture`
- `cargo test -p geo-polygonize-core --test cfb_fixtures -- --nocapture`
- `cargo test -p geo-polygonize-core`
