### PR TITLE
fix(core): snap nearby endpoints during pre-snap

### DIFF
--- a/crates/geo-polygonize-core/src/noding/snap.rs
+++ b/crates/geo-polygonize-core/src/noding/snap.rs
@@ -9,6 +9,29 @@ use wide::f64x4;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
+fn nearest_reference_vertex(
+    coord: Coord3D,
+    reference_vertices: &[Coord3D],
+    tolerance_sq: f64,
+) -> Coord3D {
+    reference_vertices
+        .iter()
+        .filter_map(|&vertex| {
+            let dx = vertex.x - coord.x;
+            let dy = vertex.y - coord.y;
+            let dist_sq = dx * dx + dy * dy;
+            (dist_sq > 0.0 && dist_sq <= tolerance_sq).then_some((dist_sq, vertex))
+        })
+        .min_by(|(dist_a, a), (dist_b, b)| {
+            dist_a
+                .total_cmp(dist_b)
+                .then(a.x.total_cmp(&b.x))
+                .then(a.y.total_cmp(&b.y))
+        })
+        .map(|(_, vertex)| vertex)
+        .unwrap_or(coord)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum NodingStrategy {
     Auto,
@@ -207,27 +230,29 @@ impl SnapNoder {
 
         // ponytail: O(segments * vertices); add a spatial index if CFB-scale pre-snap profiles hot.
         for &line in lines {
-            let dx = line.end.x - line.start.x;
-            let dy = line.end.y - line.start.y;
+            let start = nearest_reference_vertex(line.start, &reference_vertices, tolerance_sq);
+            let end = nearest_reference_vertex(line.end, &reference_vertices, tolerance_sq);
+            let dx = end.x - start.x;
+            let dy = end.y - start.y;
             let len_sq = dx * dx + dy * dy;
             if len_sq == 0.0 {
                 continue;
             }
 
             points.clear();
-            points.push((0.0, line.start));
-            points.push((1.0, line.end));
+            points.push((0.0, start));
+            points.push((1.0, end));
 
             for &vertex in &reference_vertices {
-                let vx = vertex.x - line.start.x;
-                let vy = vertex.y - line.start.y;
+                let vx = vertex.x - start.x;
+                let vy = vertex.y - start.y;
                 let t = (vx * dx + vy * dy) / len_sq;
                 if !(0.0..=1.0).contains(&t) {
                     continue;
                 }
 
-                let nearest_x = line.start.x + t * dx;
-                let nearest_y = line.start.y + t * dy;
+                let nearest_x = start.x + t * dx;
+                let nearest_y = start.y + t * dy;
                 let dist_x = vertex.x - nearest_x;
                 let dist_y = vertex.y - nearest_y;
                 if dist_x * dist_x + dist_y * dist_y <= tolerance_sq {
@@ -682,6 +707,27 @@ mod tests {
             .iter()
             .any(|line| line.start == Coord3D::new(5.0, -0.4, 0.0)
                 || line.end == Coord3D::new(5.0, -0.4, 0.0)));
+    }
+
+    #[test]
+    fn test_pre_snap_moves_nearby_endpoints() {
+        let lines = vec![
+            make_line(0.0, 0.0, 10.0, 0.0),
+            make_line(10.3, 0.02, 20.0, 0.0),
+        ];
+
+        let snapped = SnapNoder::pre_snap_to_reference_vertices(&lines, 0.5);
+
+        assert!(snapped
+            .iter()
+            .any(|line| line.start == Coord3D::new(10.0, 0.0, 0.0)
+                || line.end == Coord3D::new(10.0, 0.0, 0.0)));
+        assert!(snapped
+            .iter()
+            .any(|line| (line.start == Coord3D::new(10.0, 0.0, 0.0)
+                && line.end == Coord3D::new(10.3, 0.02, 0.0))
+                || (line.start == Coord3D::new(10.3, 0.02, 0.0)
+                    && line.end == Coord3D::new(10.0, 0.0, 0.0))));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Move pre-snap segment endpoints onto the nearest reference vertex within tolerance, instead of only inserting reference vertices projected onto the segment interior.
- Keeps the existing O(segments * vertices) CFB pre-snap path and adds a focused unit test for endpoint-gap closure.

## CFB parity note
The reduced large_lot_block_anon_rw_unassigned_hole fixture exposed a Shapely/Rust divergence where two right_of_way endpoints were about 0.31 units apart under the 0.5 CFB pre-snap tolerance. Shapely closes that endpoint gap; Rust previously left the perimeter as an open dangle chain.

On the reduced fixture, this change moves Rust from 114 polygons / about 739,588.82 area to 115 polygons / about 785,795.82 area against the Shapely baseline of 116 polygons / 785,802.57 area. The former about 46k missing perimeter-band gap drops to about 119.63 missing area and 112.88 extra area. The fixture remains xfail because one small residual split/count difference remains.

## Tests
- cargo test -p geo-polygonize-core noding::snap::tests::test_pre_snap_moves_nearby_endpoints -- --nocapture
- cargo test -p geo-polygonize-core --test cfb_fixtures -- --nocapture
- cargo test -p geo-polygonize-core