### PR TITLE
perf(core): cache prepared ring metadata

### DIFF
--- a/BENCHMARKING.md
+++ b/BENCHMARKING.md
@@ -21,6 +21,24 @@ cargo bench --bench polygonize_bench
 
 This will compile and run the benchmarks defined in `benches/polygonize_bench.rs`. The output will show the average time per iteration for various input sizes.
 
+### Containment Benchmarks
+
+Run the isolated prepared-ring, shell-filtering, hole-assignment, and end-to-end containment matrix with:
+
+```bash
+cargo bench -p geo-polygonize-core --bench hole_sort_bench
+```
+
+To compare a change against a saved Criterion baseline:
+
+```bash
+cargo bench -p geo-polygonize-core --bench hole_sort_bench -- --save-baseline before
+# edit the implementation
+cargo bench -p geo-polygonize-core --bench hole_sort_bench -- --baseline before
+```
+
+Use `--quick` while iterating; omit it for decision-quality results.
+
 ### Comparing with Shapely (Python)
 
 To run a comparison between the Rust implementation and Python's `shapely.ops.polygonize`:

--- a/crates/geo-polygonize-core/benches/hole_sort_bench.rs
+++ b/crates/geo-polygonize-core/benches/hole_sort_bench.rs
@@ -1,67 +1,180 @@
-use criterion::{criterion_group, criterion_main, Criterion};
-use geo_polygonize_core::options::PolygonizerOptions;
-use geo_polygonize_core::{Coord3D, Line3D, Polygonizer};
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use geo_polygonize_core::containment::ContainmentForest;
+use geo_polygonize_core::options::{PolygonizerOptions, TouchPolicy};
+use geo_polygonize_core::{Coord3D, Line3D, Polygon3D, Polygonizer};
 use std::f64::consts::PI;
 
-fn generate_circle_points(
-    center_x: f64,
-    center_y: f64,
-    radius: f64,
-    num_points: usize,
-) -> Vec<Coord3D> {
-    let mut points = Vec::with_capacity(num_points + 1);
-    for i in 0..num_points {
-        let angle = 2.0 * PI * (i as f64) / (num_points as f64);
+fn circle_points(center_x: f64, center_y: f64, radius: f64, edges: usize) -> Vec<Coord3D> {
+    let mut points = Vec::with_capacity(edges + 1);
+    for i in 0..edges {
+        let angle = 2.0 * PI * i as f64 / edges as f64;
         points.push(Coord3D::new(
             center_x + radius * angle.cos(),
             center_y + radius * angle.sin(),
             0.0,
         ));
     }
-    // Close the ring
     points.push(points[0]);
     points
 }
 
-fn generate_hole_sort_scenario(num_holes: usize, points_per_hole: usize) -> Vec<Line3D> {
-    let mut lines = Vec::new();
-
-    // Outer shell: a large circle CCW
-    let shell_points = generate_circle_points(500.0, 500.0, 500.0, 100);
-    for i in 0..shell_points.len() - 1 {
-        lines.push(Line3D::new(shell_points[i], shell_points[i + 1], 0));
-    }
-
-    // Many holes: small circles CW
-    for i in 0..num_holes {
-        let x = (i % 30) as f64 * 30.0 + 50.0;
-        let y = (i / 30) as f64 * 30.0 + 50.0;
-        let mut hole_points = generate_circle_points(x, y, 10.0, points_per_hole);
-        hole_points.reverse(); // Make it CW for hole
-        for j in 0..hole_points.len() - 1 {
-            lines.push(Line3D::new(
-                hole_points[j],
-                hole_points[j + 1],
-                (i + 1) as u32,
-            ));
-        }
-    }
-
-    lines
+fn circle_polygon(center_x: f64, center_y: f64, radius: f64, edges: usize) -> Polygon3D {
+    Polygon3D::new(
+        circle_points(center_x, center_y, radius, edges),
+        vec![],
+        vec![],
+        vec![],
+    )
 }
 
-fn bench_hole_sort(c: &mut Criterion) {
-    let lines = generate_hole_sort_scenario(1000, 100);
-    let options = PolygonizerOptions::default();
+fn disjoint_shells(count: usize, edges: usize) -> Vec<Polygon3D> {
+    (0..count)
+        .map(|i| circle_polygon(i as f64 * 4.0, 0.0, 1.0, edges))
+        .collect()
+}
 
-    c.bench_function("hole_sort_1000_holes_100_points", |b| {
+fn nested_shells(count: usize, edges: usize) -> Vec<Polygon3D> {
+    (0..count)
+        .map(|i| circle_polygon(0.0, 0.0, (count - i) as f64 * 2.0, edges))
+        .collect()
+}
+
+fn overlapping_non_containing_shells(count: usize, edges: usize) -> Vec<Polygon3D> {
+    (0..count)
+        .map(|i| circle_polygon(i as f64 * 0.25, 0.0, 10.0, edges))
+        .collect()
+}
+
+fn holes(count: usize, edges: usize) -> Vec<Polygon3D> {
+    (0..count)
+        .map(|i| {
+            let mut hole = circle_polygon(
+                (i % 32) as f64 * 2.0 - 31.0,
+                (i / 32) as f64 * 2.0 - 31.0,
+                0.75,
+                edges,
+            );
+            hole.exterior.reverse();
+            hole
+        })
+        .collect()
+}
+
+fn polygon_lines(polygon: &Polygon3D, line_id: u32) -> impl Iterator<Item = Line3D> + '_ {
+    polygon
+        .exterior
+        .windows(2)
+        .map(move |pair| Line3D::new(pair[0], pair[1], line_id))
+}
+
+fn bench_preparation(c: &mut Criterion) {
+    let mut group = c.benchmark_group("containment/prepare_ring_edges");
+    for edges in [16, 64, 256, 1_024, 16_384] {
+        let shells = vec![circle_polygon(0.0, 0.0, 100.0, edges)];
+        group.throughput(Throughput::Elements(edges as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(edges), &shells, |b, shells| {
+            b.iter(|| ContainmentForest::new(black_box(shells)));
+        });
+    }
+    group.finish();
+
+    let mut group = c.benchmark_group("containment/prepare_shell_count");
+    for count in [1, 64, 256, 1_000] {
+        let shells = disjoint_shells(count, 64);
+        group.throughput(Throughput::Elements(count as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(count), &shells, |b, shells| {
+            b.iter(|| ContainmentForest::new(black_box(shells)));
+        });
+    }
+    group.finish();
+}
+
+fn bench_filtering(c: &mut Criterion) {
+    let mut group = c.benchmark_group("containment/filter_shells");
+    for (name, shells) in [
+        ("disjoint", disjoint_shells(256, 64)),
+        ("nested", nested_shells(256, 64)),
+        (
+            "overlapping_non_containing",
+            overlapping_non_containing_shells(256, 64),
+        ),
+    ] {
+        let forest = ContainmentForest::new(&shells);
+        group.throughput(Throughput::Elements(shells.len() as u64));
+        group.bench_function(name, |b| {
+            b.iter(|| {
+                forest.filter_polygonal(black_box(&shells), black_box(&TouchPolicy::AllowEdgeShare))
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_hole_assignment(c: &mut Criterion) {
+    let shells = vec![circle_polygon(0.0, 0.0, 100.0, 1_024)];
+    let forest = ContainmentForest::new(&shells);
+    let mut group = c.benchmark_group("containment/assign_holes");
+    for count in [1, 100, 1_000] {
+        let holes = holes(count, 64);
+        group.throughput(Throughput::Elements(count as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(count), &holes, |b, holes| {
+            b.iter(|| {
+                holes
+                    .iter()
+                    .filter_map(|hole| {
+                        forest.assign_hole(
+                            black_box(hole),
+                            black_box(&shells),
+                            black_box(&TouchPolicy::AllowEdgeShare),
+                        )
+                    })
+                    .sum::<usize>()
+            });
+        });
+    }
+    group.finish();
+
+    let shells = nested_shells(256, 64);
+    let forest = ContainmentForest::new(&shells);
+    let hole = circle_polygon(0.0, 0.0, 0.5, 64);
+    c.bench_function("containment/assign_one_hole/256_nested_shells", |b| {
         b.iter(|| {
-            let mut poly = Polygonizer::with_options(options.clone());
-            poly.add_lines(lines.clone());
-            poly.polygonize().unwrap();
+            forest.assign_hole(
+                black_box(&hole),
+                black_box(&shells),
+                black_box(&TouchPolicy::AllowEdgeShare),
+            )
         });
     });
 }
 
-criterion_group!(benches, bench_hole_sort);
+fn bench_end_to_end(c: &mut Criterion) {
+    let shell = circle_polygon(0.0, 0.0, 100.0, 1_024);
+    let holes = holes(1_000, 64);
+    let lines: Vec<_> = polygon_lines(&shell, 0)
+        .chain(
+            holes
+                .iter()
+                .enumerate()
+                .flat_map(|(i, hole)| polygon_lines(hole, (i + 1) as u32)),
+        )
+        .collect();
+    let options = PolygonizerOptions::default();
+
+    c.bench_function("containment/end_to_end/1000_holes", |b| {
+        b.iter(|| {
+            let mut polygonizer = Polygonizer::with_options(options.clone());
+            polygonizer.add_lines(lines.clone());
+            polygonizer.polygonize().unwrap()
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_preparation,
+    bench_filtering,
+    bench_hole_assignment,
+    bench_end_to_end
+);
 criterion_main!(benches);

--- a/crates/geo-polygonize-core/src/containment.rs
+++ b/crates/geo-polygonize-core/src/containment.rs
@@ -2,59 +2,97 @@ use crate::diagnostics::ContainmentStats;
 use crate::index::{IndexedEnvelope, RStarBackend};
 use crate::options::TouchPolicy;
 use crate::polygonizer::{
-    bounding_rect_3d, guaranteed_interior_probe, rings_share_edge, rings_touch_at_vertex,
+    bounding_rect_3d, guaranteed_interior_probe_prepared, rings_share_edge, rings_touch_at_vertex,
 };
 use crate::types::Polygon3D;
 use crate::utils::simd::SimdRing;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 use rstar::AABB;
+use std::sync::OnceLock;
+
+struct PreparedRing {
+    signed_area: f64,
+    aabb: Option<AABB<[f64; 2]>>,
+    diagonal: f64,
+    probe: OnceLock<Option<geo_types::Point<f64>>>,
+}
+
+impl PreparedRing {
+    fn new(polygon: &Polygon3D) -> Self {
+        let signed_area = Polygon3D::ring_signed_area_2d(&polygon.exterior);
+        let bbox = bounding_rect_3d(&polygon.exterior);
+        let diagonal = bbox
+            .as_ref()
+            .map(|bbox| {
+                let dx = bbox.max().x - bbox.min().x;
+                let dy = bbox.max().y - bbox.min().y;
+                (dx * dx + dy * dy).sqrt()
+            })
+            .unwrap_or(1.0);
+        let aabb = bbox.map(|bbox| {
+            AABB::from_corners([bbox.min().x, bbox.min().y], [bbox.max().x, bbox.max().y])
+        });
+
+        Self {
+            signed_area,
+            aabb,
+            diagonal,
+            probe: OnceLock::new(),
+        }
+    }
+
+    fn probe(&self, polygon: &Polygon3D, locator: &SimdRing) -> Option<geo_types::Point<f64>> {
+        *self.probe.get_or_init(|| {
+            guaranteed_interior_probe_prepared(
+                &polygon.exterior,
+                self.signed_area,
+                self.diagonal,
+                locator,
+            )
+        })
+    }
+}
 
 pub struct ContainmentForest {
     pub tree: RStarBackend,
     pub simd_shells: Vec<Option<SimdRing>>,
     // Cache exterior areas to avoid O(N) recalculations of `exterior_unsigned_area_2d()` inside the tree intersection loops.
     pub shell_areas: Vec<Option<f64>>,
+    prepared_shells: Vec<PreparedRing>,
 }
 
 impl ContainmentForest {
     pub fn new(shells: &[Polygon3D]) -> Self {
-        let mut simd_shells: Vec<Option<SimdRing>> = Vec::with_capacity(shells.len());
-        let mut shell_areas: Vec<Option<f64>> = Vec::with_capacity(shells.len());
         #[cfg(feature = "parallel")]
-        {
-            let (shells_p, areas_p): (Vec<_>, Vec<_>) = shells
-                .par_iter()
-                .map(|s| {
-                    (
-                        Some(SimdRing::new_3d(&s.exterior)),
-                        Some(s.exterior_unsigned_area_2d()),
-                    )
-                })
-                .unzip();
-            simd_shells.extend(shells_p);
-            shell_areas.extend(areas_p);
-        }
+        let prepared_and_locators: Vec<_> = shells
+            .par_iter()
+            .map(|shell| {
+                let locator = SimdRing::new_3d(&shell.exterior);
+                (PreparedRing::new(shell), locator)
+            })
+            .collect();
         #[cfg(not(feature = "parallel"))]
-        {
-            let (shells_p, areas_p): (Vec<_>, Vec<_>) = shells
-                .iter()
-                .map(|s| {
-                    (
-                        Some(SimdRing::new_3d(&s.exterior)),
-                        Some(s.exterior_unsigned_area_2d()),
-                    )
-                })
-                .unzip();
-            simd_shells.extend(shells_p);
-            shell_areas.extend(areas_p);
+        let prepared_and_locators: Vec<_> = shells
+            .iter()
+            .map(|shell| {
+                let locator = SimdRing::new_3d(&shell.exterior);
+                (PreparedRing::new(shell), locator)
+            })
+            .collect();
+
+        let mut prepared_shells = Vec::with_capacity(shells.len());
+        let mut simd_shells = Vec::with_capacity(shells.len());
+        let mut shell_areas = Vec::with_capacity(shells.len());
+        for (prepared, locator) in prepared_and_locators {
+            shell_areas.push(Some(prepared.signed_area.abs()));
+            prepared_shells.push(prepared);
+            simd_shells.push(Some(locator));
         }
 
         let mut indexed_shells = Vec::with_capacity(shells.len());
-        for (i, shell) in shells.iter().enumerate() {
-            if let Some(bbox) = bounding_rect_3d(&shell.exterior) {
-                let aabb: AABB<[f64; 2]> =
-                    AABB::from_corners([bbox.min().x, bbox.min().y], [bbox.max().x, bbox.max().y]);
+        for (i, prepared) in prepared_shells.iter().enumerate() {
+            if let Some(aabb) = prepared.aabb {
                 indexed_shells.push(IndexedEnvelope { aabb, index: i });
             }
         }
@@ -64,6 +102,7 @@ impl ContainmentForest {
             tree,
             simd_shells,
             shell_areas,
+            prepared_shells,
         }
     }
 
@@ -90,28 +129,19 @@ impl ContainmentForest {
         let mut keep_mask = vec![true; shells.len()];
         let mut container_counts = vec![0; shells.len()];
 
-        let probe_points: Vec<Option<geo_types::Point<f64>>> = shells
-            .iter()
-            .map(|s| guaranteed_interior_probe(&s.exterior))
-            .collect();
-
         for (i, shell) in shells.iter().enumerate() {
-            let bbox: geo::Rect<f64> = match bounding_rect_3d(&shell.exterior) {
-                Some(b) => b,
+            let prepared = &self.prepared_shells[i];
+            let aabb = match prepared.aabb.as_ref() {
+                Some(aabb) => aabb,
                 None => {
                     keep_mask[i] = false;
                     continue;
                 }
             };
-            let aabb: AABB<[f64; 2]> =
-                AABB::from_corners([bbox.min().x, bbox.min().y], [bbox.max().x, bbox.max().y]);
 
-            let candidates = self.tree.locate_containing_envelope(&aabb);
-            let probe = probe_points[i];
-            let Some(area_i) = self.shell_areas[i] else {
-                keep_mask[i] = false;
-                continue;
-            };
+            let candidates = self.tree.locate_containing_envelope(aabb);
+            let probe = prepared.probe(shell, self.simd_shells[i].as_ref().unwrap());
+            let area_i = prepared.signed_area.abs();
 
             if let Some(probe_pt) = probe {
                 for j in candidates {
@@ -122,9 +152,7 @@ impl ContainmentForest {
                         continue;
                     }
 
-                    let Some(area_j) = self.shell_areas[j] else {
-                        continue;
-                    };
+                    let area_j = self.prepared_shells[j].signed_area.abs();
                     if !(area_j > area_i || ((area_j - area_i).abs() < 1e-9 && j < i)) {
                         if let Some(stats) = stats.as_deref_mut() {
                             stats.area_rejections += 1;
@@ -211,25 +239,23 @@ impl ContainmentForest {
         touch_policy: &TouchPolicy,
         mut stats: Option<&mut ContainmentStats>,
     ) -> Option<usize> {
-        let bbox = bounding_rect_3d(&hole_3d.exterior)?;
-        let hole_aabb: AABB<[f64; 2]> =
-            AABB::from_corners([bbox.min().x, bbox.min().y], [bbox.max().x, bbox.max().y]);
+        let hole_locator = SimdRing::new_3d(&hole_3d.exterior);
+        let prepared_hole = PreparedRing::new(hole_3d);
+        let hole_aabb = prepared_hole.aabb.as_ref()?;
 
-        let candidates = self.tree.locate_containing_envelope(&hole_aabb);
+        let candidates = self.tree.locate_containing_envelope(hole_aabb);
 
         let mut best_shell_idx = None;
         let mut min_area = f64::MAX;
 
-        let probe_point = guaranteed_interior_probe(&hole_3d.exterior)?;
-        let hole_area = hole_3d.exterior_unsigned_area_2d();
+        let probe_point = prepared_hole.probe(hole_3d, &hole_locator)?;
+        let hole_area = prepared_hole.signed_area.abs();
 
         for idx in candidates {
             if let Some(stats) = stats.as_deref_mut() {
                 stats.envelope_candidates += 1;
             }
-            let Some(area) = self.shell_areas[idx] else {
-                continue;
-            };
+            let area = self.prepared_shells[idx].signed_area.abs();
             if area <= hole_area + 1e-6 || area >= min_area {
                 if let Some(stats) = stats.as_deref_mut() {
                     stats.area_rejections += 1;
@@ -277,5 +303,33 @@ impl ContainmentForest {
         }
 
         best_shell_idx
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::Coord3D;
+
+    #[test]
+    fn prepared_ring_retains_containment_metadata() {
+        let polygon = Polygon3D::new(
+            vec![
+                Coord3D::new(0.0, 0.0, 0.0),
+                Coord3D::new(10.0, 0.0, 0.0),
+                Coord3D::new(10.0, 10.0, 0.0),
+                Coord3D::new(0.0, 10.0, 0.0),
+                Coord3D::new(0.0, 0.0, 0.0),
+            ],
+            vec![],
+            vec![],
+            vec![],
+        );
+        let locator = SimdRing::new_3d(&polygon.exterior);
+        let prepared = PreparedRing::new(&polygon);
+
+        assert_eq!(prepared.signed_area, 100.0);
+        assert_eq!(prepared.aabb.unwrap().lower(), [0.0, 0.0]);
+        assert!(locator.contains(prepared.probe(&polygon, &locator).unwrap().0));
     }
 }

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -938,15 +938,34 @@ pub fn guaranteed_interior_probe(coords: &[Coord3D]) -> Option<geo_types::Point<
         return None;
     }
 
-    let hole_simd = SimdRing::new_3d(coords);
-    let diag = bounding_rect_3d(coords)
-        .map(|b| {
-            let dx = b.max().x - b.min().x;
-            let dy = b.max().y - b.min().y;
+    let locator = SimdRing::new_3d(coords);
+    let bbox = bounding_rect_3d(coords);
+    let diagonal = bbox
+        .map(|bbox| {
+            let dx = bbox.max().x - bbox.min().x;
+            let dy = bbox.max().y - bbox.min().y;
             (dx * dx + dy * dy).sqrt()
         })
         .unwrap_or(1.0);
-    let eps = (diag * 1e-9).max(1e-10);
+    guaranteed_interior_probe_prepared(coords, area, diagonal, &locator)
+}
+
+pub(crate) fn guaranteed_interior_probe_prepared(
+    coords: &[Coord3D],
+    signed_area: f64,
+    diagonal: f64,
+    locator: &SimdRing,
+) -> Option<geo_types::Point<f64>> {
+    if coords.len() < 4 || !signed_area.is_finite() || signed_area.abs() < 1e-12 {
+        return None;
+    }
+
+    let unique_n = coords.len().saturating_sub(1);
+    if unique_n < 3 {
+        return None;
+    }
+
+    let eps = (diagonal * 1e-9).max(1e-10);
 
     for i in 0..unique_n {
         let prev = coords[(i + unique_n - 1) % unique_n];
@@ -969,7 +988,7 @@ pub fn guaranteed_interior_probe(coords: &[Coord3D]) -> Option<geo_types::Point<
         }
 
         let turn = in_edge.x * out_edge.y - in_edge.y * out_edge.x;
-        let convex = if area > 0.0 {
+        let convex = if signed_area > 0.0 {
             turn > 1e-12
         } else {
             turn < -1e-12
@@ -1006,7 +1025,7 @@ pub fn guaranteed_interior_probe(coords: &[Coord3D]) -> Option<geo_types::Point<
                 x: curr.x + sign * bisector_unit.x * eps,
                 y: curr.y + sign * bisector_unit.y * eps,
             };
-            if hole_simd.contains(candidate) {
+            if locator.contains(candidate) {
                 return Some(geo_types::Point(candidate));
             }
         }


### PR DESCRIPTION
## Summary
- cache signed area, bounding boxes, and lazily computed probe data in an internal prepared-ring structure
- reuse prepared metadata in shell filtering and hole assignment
- split out a prepared probe helper and add coverage for retained containment metadata
- expand the containment Criterion matrix and document saved-baseline comparisons

Part of #774.

## Benchmark results

Full Criterion runs on Apple M1 Max with `rustc 1.96.1`, comparing the same benchmark harness against `origin/main`. Values below are median wall-time deltas; negative is faster.

| Workload | Delta |
|---|---:|
| Filter 256 disjoint shells | -70.4% |
| Filter 256 overlapping, non-containing shells | -70.5% |
| Filter 256 nested shells | -3.8% |
| Assign 1 hole | -11.5% |
| Assign 100 holes | -10.9% |
| Assign 1,000 holes | -10.9% |
| End-to-end 1,000 holes | -4.5% |

Prepared-ring construction was broadly neutral: seven of nine cases were between -5.1% and +4.0%; the 1,024-edge case was +8.2%, and 16,384 edges was -0.7%. This keeps the preparation tradeoff visible rather than claiming a setup win.

Run the suite with:

```bash
cargo bench -p geo-polygonize-core --bench hole_sort_bench
```

## Testing
- `cargo test -p geo-polygonize-core` — passed (111 unit tests plus all integration, fixture, and doc-test targets)
- `cargo clippy -p geo-polygonize-core --tests --bench hole_sort_bench -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- full `hole_sort_bench` Criterion baseline comparison — passed
