### PR TITLE
perf(core): benchmark adaptive point locators

### DIFF
--- a/crates/geo-polygonize-core/benches/hole_sort_bench.rs
+++ b/crates/geo-polygonize-core/benches/hole_sort_bench.rs
@@ -1,6 +1,9 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use geo::algorithm::indexed::IntervalTreeMultiPolygon;
+use geo::{Contains, Coord, MultiPolygon};
 use geo_polygonize_core::containment::ContainmentForest;
 use geo_polygonize_core::options::{PolygonizerOptions, TouchPolicy};
+use geo_polygonize_core::utils::simd::SimdRing;
 use geo_polygonize_core::{Coord3D, Line3D, Polygon3D, Polygonizer};
 use std::f64::consts::PI;
 
@@ -65,6 +68,98 @@ fn polygon_lines(polygon: &Polygon3D, line_id: u32) -> impl Iterator<Item = Line
         .exterior
         .windows(2)
         .map(move |pair| Line3D::new(pair[0], pair[1], line_id))
+}
+
+fn locator_query_points(count: usize) -> Vec<Coord<f64>> {
+    (0..count)
+        .map(|i| {
+            let angle = 2.0 * PI * i as f64 / count as f64;
+            let radius = if i % 2 == 0 { 50.0 } else { 150.0 };
+            Coord {
+                x: radius * angle.cos(),
+                y: radius * angle.sin(),
+            }
+        })
+        .collect()
+}
+
+fn bench_point_locators(c: &mut Criterion) {
+    for edges in [16, 64, 256, 1_024, 16_384] {
+        let ring = circle_polygon(0.0, 0.0, 100.0, edges);
+        let polygon = ring.to_polygon_2d();
+        let multipolygon = MultiPolygon(vec![polygon.clone()]);
+        let simd = SimdRing::new_3d(&ring.exterior);
+        let interval = IntervalTreeMultiPolygon::new(&multipolygon);
+        let points = locator_query_points(1_024);
+
+        let scalar_count = points
+            .iter()
+            .filter(|point| polygon.contains(*point))
+            .count();
+        assert_eq!(
+            scalar_count,
+            points.iter().filter(|point| simd.contains(**point)).count()
+        );
+        assert_eq!(
+            scalar_count,
+            points
+                .iter()
+                .filter(|point| interval.contains(*point))
+                .count()
+        );
+
+        let mut group = c.benchmark_group("point_locator/prepare");
+        group.throughput(Throughput::Elements(edges as u64));
+        group.bench_function(BenchmarkId::new("simd", edges), |b| {
+            b.iter(|| SimdRing::new_3d(black_box(&ring.exterior)));
+        });
+        group.bench_function(BenchmarkId::new("scalar", edges), |b| {
+            b.iter(|| black_box(&ring).to_polygon_2d());
+        });
+        group.bench_function(BenchmarkId::new("interval", edges), |b| {
+            b.iter(|| {
+                let polygon = black_box(&ring).to_polygon_2d();
+                IntervalTreeMultiPolygon::new(&MultiPolygon(vec![polygon]))
+            });
+        });
+        group.finish();
+
+        for query_count in [1, 16, 64, 1_024] {
+            let points = &points[..query_count];
+            let mut group =
+                c.benchmark_group(format!("point_locator/amortized_{query_count}_queries"));
+            group.throughput(Throughput::Elements(query_count as u64));
+            group.bench_function(BenchmarkId::new("simd", edges), |b| {
+                b.iter(|| {
+                    let locator = SimdRing::new_3d(&ring.exterior);
+                    black_box(points)
+                        .iter()
+                        .filter(|point| locator.contains(**point))
+                        .count()
+                });
+            });
+            group.bench_function(BenchmarkId::new("scalar", edges), |b| {
+                b.iter(|| {
+                    let locator = ring.to_polygon_2d();
+                    black_box(points)
+                        .iter()
+                        .filter(|point| locator.contains(*point))
+                        .count()
+                });
+            });
+            group.bench_function(BenchmarkId::new("interval", edges), |b| {
+                b.iter(|| {
+                    let polygon = ring.to_polygon_2d();
+                    let locator = IntervalTreeMultiPolygon::new(&MultiPolygon(vec![polygon]));
+                    black_box(points)
+                        .iter()
+                        .filter(|point| locator.contains(*point))
+                        .count()
+                });
+            });
+            group.finish();
+        }
+    }
 }
 
 fn bench_preparation(c: &mut Criterion) {
@@ -172,6 +267,7 @@ fn bench_end_to_end(c: &mut Criterion) {
 
 criterion_group!(
     benches,
+    bench_point_locators,
     bench_preparation,
     bench_filtering,
     bench_hole_assignment,


### PR DESCRIPTION
## Summary
- add a 75-case Criterion matrix comparing the existing SIMD ray cast, `geo`'s robust scalar polygon locator, and `IntervalTreeMultiPolygon`
- measure locator preparation separately from amortized build-and-query workloads
- cover 16, 64, 256, 1,024, and 16,384-edge rings with 1, 16, 64, and 1,024 queries
- assert all three locators agree on the generated interior/exterior query corpus before benchmarking

Part of #774.

## Results

Full 100-sample Criterion run on Apple M1 Max with `rustc 1.96.1`:

- **1 query:** scalar won at every ring size.
- **16 queries:** scalar won from 64 through 16,384 edges; SIMD won the 16-edge case.
- **64 queries:** the interval tree won from 64 through 16,384 edges. SIMD narrowly won the 16-edge case (1.02 µs vs 1.05 µs).
- **1,024 queries:** the interval tree won every ring size, from 10.38 µs at 16 edges to 670 µs at 16,384 edges.
- At 1,024 edges × 1,024 queries, interval indexing took 48.69 µs vs 705.72 µs scalar and 956.88 µs SIMD.
- At 16,384 edges × 1,024 queries, interval indexing took 670 µs vs 10.68 ms scalar and 15.04 ms SIMD.

The evidence supports scalar location for low reuse and interval indexing around 64 queries for non-trivial rings. It does **not** support adding an adaptive runtime locator yet: actual per-ring reuse and boundary/topology parity must be measured before changing containment semantics.

Run the matrix with:

```bash
cargo bench -p geo-polygonize-core --bench hole_sort_bench -- point_locator
```

## Validation
- `cargo test -p geo-polygonize-core` — passed
- `cargo fmt --all -- --check` — passed
- `cargo clippy -p geo-polygonize-core --bench hole_sort_bench -- -D warnings` — passed
- full 100-sample point-locator Criterion matrix — passed
