### PR TITLE
perf(core): use graph identity for touch checks

### DIFF
--- a/crates/geo-polygonize-core/benches/hole_sort_bench.rs
+++ b/crates/geo-polygonize-core/benches/hole_sort_bench.rs
@@ -241,14 +241,29 @@ fn bench_hole_assignment(c: &mut Criterion) {
             )
         });
     });
+
+    let shells = vec![circle_polygon(0.0, 0.0, 100.0, 1_024)];
+    let forest = ContainmentForest::new(&shells);
+    let hole = circle_polygon(0.0, 0.0, 0.75, 64);
+    let mut group = c.benchmark_group("containment/touch_policy/1024x64");
+    for policy in [
+        TouchPolicy::AllowEdgeShare,
+        TouchPolicy::AllowPointTouchDisallowEdgeShare,
+        TouchPolicy::TreatAnyTouchAsDisjoint,
+    ] {
+        group.bench_with_input(format!("{policy:?}"), &policy, |b, policy| {
+            b.iter(|| forest.assign_hole(black_box(&hole), black_box(&shells), black_box(policy)));
+        });
+    }
+    group.finish();
 }
 
 fn bench_end_to_end(c: &mut Criterion) {
     let shell = circle_polygon(0.0, 0.0, 100.0, 1_024);
-    let holes = holes(1_000, 64);
+    let holes_1000 = holes(1_000, 64);
     let lines: Vec<_> = polygon_lines(&shell, 0)
         .chain(
-            holes
+            holes_1000
                 .iter()
                 .enumerate()
                 .flat_map(|(i, hole)| polygon_lines(hole, (i + 1) as u32)),
@@ -268,6 +283,9 @@ fn bench_end_to_end(c: &mut Criterion) {
         .containment_stats;
     assert_eq!(stats.max_point_in_ring_calls_per_shell, 1_000);
     assert_eq!(stats.shells_with_64_plus_point_in_ring_calls, 1);
+    assert_eq!(stats.shared_edge_checks, 1_000);
+    assert_eq!(stats.shared_edge_pair_checks, 65_536_000);
+    assert_eq!(stats.graph_edge_key_checks, 0);
 
     c.bench_function("containment/end_to_end/1000_holes", |b| {
         b.iter(|| {
@@ -276,6 +294,43 @@ fn bench_end_to_end(c: &mut Criterion) {
             polygonizer.polygonize().unwrap()
         });
     });
+
+    let holes = holes(100, 64);
+    let lines: Vec<_> = polygon_lines(&shell, 0)
+        .chain(
+            holes
+                .iter()
+                .enumerate()
+                .flat_map(|(i, hole)| polygon_lines(hole, (i + 1) as u32)),
+        )
+        .collect();
+    let prepare = |node_input| {
+        let options = PolygonizerOptions {
+            node_input,
+            ..Default::default()
+        };
+        let mut polygonizer = Polygonizer::with_options(options);
+        polygonizer.add_lines(lines.clone());
+        let result = polygonizer.polygonize().unwrap();
+        let area: f64 = result
+            .polygons
+            .iter()
+            .map(Polygon3D::unsigned_area_2d)
+            .sum();
+        (polygonizer, result.polygons.len(), area)
+    };
+    let (geometry, geometry_count, geometry_area) = prepare(false);
+    let (graph, graph_count, graph_area) = prepare(true);
+    assert_eq!(geometry_count, graph_count);
+    assert!((geometry_area - graph_area).abs() < 1e-6);
+
+    let mut group = c.benchmark_group("containment/reused_graph/100_holes");
+    for (name, mut polygonizer) in [("geometry_fallback", geometry), ("graph_identity", graph)] {
+        group.bench_function(name, |b| {
+            b.iter(|| black_box(polygonizer.polygonize().unwrap()));
+        });
+    }
+    group.finish();
 }
 
 criterion_group!(

--- a/crates/geo-polygonize-core/src/containment.rs
+++ b/crates/geo-polygonize-core/src/containment.rs
@@ -2,9 +2,10 @@ use crate::diagnostics::ContainmentStats;
 use crate::index::{IndexedEnvelope, RStarBackend};
 use crate::options::TouchPolicy;
 use crate::polygonizer::{
-    bounding_rect_3d, guaranteed_interior_probe_prepared, rings_share_edge, rings_touch_at_vertex,
+    bounding_rect_3d, guaranteed_interior_probe_prepared, rings_share_edge_with_count,
+    rings_touch_at_vertex_with_count,
 };
-use crate::types::Polygon3D;
+use crate::types::{Polygon3D, RingGraphIdentity};
 use crate::utils::simd::SimdRing;
 use geo::algorithm::indexed::IntervalTreeMultiPolygon;
 use geo::{Contains, MultiPolygon};
@@ -17,6 +18,83 @@ use std::sync::OnceLock;
 const LOCATOR_INDEX_QUERY_THRESHOLD: usize = 64;
 const LOCATOR_INDEX_MIN_COORDS: usize = 65;
 
+fn touch_allowed(
+    shell: &Polygon3D,
+    shell_identity: Option<&RingGraphIdentity>,
+    ring: &Polygon3D,
+    ring_identity: Option<&RingGraphIdentity>,
+    touch_policy: &TouchPolicy,
+    mut stats: Option<&mut ContainmentStats>,
+) -> bool {
+    match touch_policy {
+        TouchPolicy::AllowPointTouchDisallowEdgeShare | TouchPolicy::TreatAnyTouchAsDisjoint => {
+            let (shares_edge, pair_checks, used_graph_ids) = if let (
+                Some(shell_identity),
+                Some(ring_identity),
+            ) = (shell_identity, ring_identity)
+            {
+                let (shares_edge, pair_checks) =
+                    sorted_intersects(&shell_identity.edge_keys, &ring_identity.edge_keys);
+                (shares_edge, pair_checks, true)
+            } else {
+                let (shares_edge, pair_checks) =
+                    rings_share_edge_with_count(&shell.exterior, &ring.exterior, 1e-10);
+                (shares_edge, pair_checks, false)
+            };
+            if let Some(stats) = stats.as_deref_mut() {
+                stats.shared_edge_checks += 1;
+                if used_graph_ids {
+                    stats.graph_edge_key_checks += pair_checks;
+                } else {
+                    stats.shared_edge_pair_checks += pair_checks;
+                }
+            }
+            if shares_edge || matches!(touch_policy, TouchPolicy::AllowPointTouchDisallowEdgeShare)
+            {
+                return !shares_edge;
+            }
+
+            let (touches_vertex, pair_checks, used_graph_ids) = if let (
+                Some(shell_identity),
+                Some(ring_identity),
+            ) =
+                (shell_identity, ring_identity)
+            {
+                let (touches_vertex, pair_checks) =
+                    sorted_intersects(&shell_identity.node_ids, &ring_identity.node_ids);
+                (touches_vertex, pair_checks, true)
+            } else {
+                let (touches_vertex, pair_checks) =
+                    rings_touch_at_vertex_with_count(&shell.exterior, &ring.exterior, 1e-10);
+                (touches_vertex, pair_checks, false)
+            };
+            if let Some(stats) = stats {
+                stats.shared_vertex_checks += 1;
+                if used_graph_ids {
+                    stats.graph_vertex_id_checks += pair_checks;
+                } else {
+                    stats.shared_vertex_pair_checks += pair_checks;
+                }
+            }
+            !touches_vertex
+        }
+        TouchPolicy::AllowEdgeShare => true,
+    }
+}
+
+fn sorted_intersects<T: Ord>(left: &[T], right: &[T]) -> (bool, usize) {
+    let (mut i, mut j, mut checks) = (0, 0, 0);
+    while i < left.len() && j < right.len() {
+        checks += 1;
+        match left[i].cmp(&right[j]) {
+            std::cmp::Ordering::Less => i += 1,
+            std::cmp::Ordering::Greater => j += 1,
+            std::cmp::Ordering::Equal => return (true, checks),
+        }
+    }
+    (false, checks)
+}
+
 struct PreparedRing {
     signed_area: f64,
     aabb: Option<AABB<[f64; 2]>>,
@@ -24,10 +102,11 @@ struct PreparedRing {
     probe: OnceLock<Option<geo_types::Point<f64>>>,
     locator_queries: AtomicUsize,
     interval_locator: OnceLock<IntervalTreeMultiPolygon<f64>>,
+    graph_identity: Option<RingGraphIdentity>,
 }
 
 impl PreparedRing {
-    fn new(polygon: &Polygon3D) -> Self {
+    fn new(polygon: &Polygon3D, graph_identity: Option<RingGraphIdentity>) -> Self {
         let signed_area = Polygon3D::ring_signed_area_2d(&polygon.exterior);
         let bbox = bounding_rect_3d(&polygon.exterior);
         let diagonal = bbox
@@ -49,6 +128,7 @@ impl PreparedRing {
             probe: OnceLock::new(),
             locator_queries: AtomicUsize::new(0),
             interval_locator: OnceLock::new(),
+            graph_identity,
         }
     }
 
@@ -94,20 +174,40 @@ pub struct ContainmentForest {
 
 impl ContainmentForest {
     pub fn new(shells: &[Polygon3D]) -> Self {
+        Self::new_impl(shells, None)
+    }
+
+    pub(crate) fn new_with_graph_ids(
+        shells: &[Polygon3D],
+        graph_ids: &[Option<RingGraphIdentity>],
+    ) -> Self {
+        Self::new_impl(shells, Some(graph_ids))
+    }
+
+    fn new_impl(shells: &[Polygon3D], graph_ids: Option<&[Option<RingGraphIdentity>]>) -> Self {
+        debug_assert!(graph_ids.is_none_or(|ids| ids.len() == shells.len()));
         #[cfg(feature = "parallel")]
         let prepared_and_locators: Vec<_> = shells
             .par_iter()
-            .map(|shell| {
+            .enumerate()
+            .map(|(i, shell)| {
                 let locator = SimdRing::new_3d(&shell.exterior);
-                (PreparedRing::new(shell), locator)
+                (
+                    PreparedRing::new(shell, graph_ids.and_then(|ids| ids[i].clone())),
+                    locator,
+                )
             })
             .collect();
         #[cfg(not(feature = "parallel"))]
         let prepared_and_locators: Vec<_> = shells
             .iter()
-            .map(|shell| {
+            .enumerate()
+            .map(|(i, shell)| {
                 let locator = SimdRing::new_3d(&shell.exterior);
-                (PreparedRing::new(shell), locator)
+                (
+                    PreparedRing::new(shell, graph_ids.and_then(|ids| ids[i].clone())),
+                    locator,
+                )
             })
             .collect();
 
@@ -208,34 +308,14 @@ impl ContainmentForest {
                             stats.point_in_ring_calls += 1;
                         }
                         if self.prepared_shells[j].contains(&shells[j], simd_shell, probe_pt.0) {
-                            let touch_ok = match touch_policy {
-                                TouchPolicy::AllowPointTouchDisallowEdgeShare => {
-                                    if let Some(stats) = stats.as_deref_mut() {
-                                        stats.shared_edge_checks += 1;
-                                    }
-                                    !rings_share_edge(&shells[j].exterior, &shell.exterior, 1e-10)
-                                }
-                                TouchPolicy::TreatAnyTouchAsDisjoint => {
-                                    if let Some(stats) = stats.as_deref_mut() {
-                                        stats.shared_edge_checks += 1;
-                                    }
-                                    let shares_edge = rings_share_edge(
-                                        &shells[j].exterior,
-                                        &shell.exterior,
-                                        1e-10,
-                                    );
-                                    if let Some(stats) = stats.as_deref_mut() {
-                                        stats.shared_vertex_checks += usize::from(!shares_edge);
-                                    }
-                                    !shares_edge
-                                        && !rings_touch_at_vertex(
-                                            &shells[j].exterior,
-                                            &shell.exterior,
-                                            1e-10,
-                                        )
-                                }
-                                TouchPolicy::AllowEdgeShare => true,
-                            };
+                            let touch_ok = touch_allowed(
+                                &shells[j],
+                                self.prepared_shells[j].graph_identity.as_ref(),
+                                shell,
+                                prepared.graph_identity.as_ref(),
+                                touch_policy,
+                                stats.as_deref_mut(),
+                            );
 
                             container_counts[i] += usize::from(touch_ok);
                         }
@@ -261,29 +341,47 @@ impl ContainmentForest {
         shells: &[Polygon3D],
         touch_policy: &TouchPolicy,
     ) -> Option<usize> {
-        self.assign_hole_impl(hole_3d, shells, touch_policy, None)
+        self.assign_hole_impl(hole_3d, None, shells, touch_policy, None)
     }
 
-    pub(crate) fn assign_hole_with_stats(
+    pub(crate) fn assign_hole_with_graph_ids(
         &self,
         hole_3d: &Polygon3D,
+        hole_graph_ids: Option<&RingGraphIdentity>,
+        shells: &[Polygon3D],
+        touch_policy: &TouchPolicy,
+    ) -> Option<usize> {
+        self.assign_hole_impl(hole_3d, hole_graph_ids, shells, touch_policy, None)
+    }
+
+    pub(crate) fn assign_hole_with_graph_ids_and_stats(
+        &self,
+        hole_3d: &Polygon3D,
+        hole_graph_ids: Option<&RingGraphIdentity>,
         shells: &[Polygon3D],
         touch_policy: &TouchPolicy,
     ) -> (Option<usize>, ContainmentStats) {
         let mut stats = ContainmentStats::default();
-        let best_shell_idx = self.assign_hole_impl(hole_3d, shells, touch_policy, Some(&mut stats));
+        let best_shell_idx = self.assign_hole_impl(
+            hole_3d,
+            hole_graph_ids,
+            shells,
+            touch_policy,
+            Some(&mut stats),
+        );
         (best_shell_idx, stats)
     }
 
     fn assign_hole_impl(
         &self,
         hole_3d: &Polygon3D,
+        hole_graph_ids: Option<&RingGraphIdentity>,
         shells: &[Polygon3D],
         touch_policy: &TouchPolicy,
         mut stats: Option<&mut ContainmentStats>,
     ) -> Option<usize> {
         let hole_locator = SimdRing::new_3d(&hole_3d.exterior);
-        let prepared_hole = PreparedRing::new(hole_3d);
+        let prepared_hole = PreparedRing::new(hole_3d, hole_graph_ids.cloned());
         let hole_aabb = prepared_hole.aabb.as_ref()?;
 
         let candidates = self.tree.locate_containing_envelope(hole_aabb);
@@ -311,31 +409,14 @@ impl ContainmentForest {
                     stats.point_in_ring_calls += 1;
                 }
                 if self.prepared_shells[idx].contains(&shells[idx], simd_shell, probe_point.0) {
-                    let touch_ok = match touch_policy {
-                        TouchPolicy::AllowPointTouchDisallowEdgeShare => {
-                            if let Some(stats) = stats.as_deref_mut() {
-                                stats.shared_edge_checks += 1;
-                            }
-                            !rings_share_edge(&shells[idx].exterior, &hole_3d.exterior, 1e-10)
-                        }
-                        TouchPolicy::TreatAnyTouchAsDisjoint => {
-                            if let Some(stats) = stats.as_deref_mut() {
-                                stats.shared_edge_checks += 1;
-                            }
-                            let shares_edge =
-                                rings_share_edge(&shells[idx].exterior, &hole_3d.exterior, 1e-10);
-                            if let Some(stats) = stats.as_deref_mut() {
-                                stats.shared_vertex_checks += usize::from(!shares_edge);
-                            }
-                            !shares_edge
-                                && !rings_touch_at_vertex(
-                                    &shells[idx].exterior,
-                                    &hole_3d.exterior,
-                                    1e-10,
-                                )
-                        }
-                        TouchPolicy::AllowEdgeShare => true,
-                    };
+                    let touch_ok = touch_allowed(
+                        &shells[idx],
+                        self.prepared_shells[idx].graph_identity.as_ref(),
+                        hole_3d,
+                        prepared_hole.graph_identity.as_ref(),
+                        touch_policy,
+                        stats.as_deref_mut(),
+                    );
 
                     if touch_ok {
                         min_area = area;
@@ -371,11 +452,40 @@ mod tests {
             vec![],
         );
         let locator = SimdRing::new_3d(&polygon.exterior);
-        let prepared = PreparedRing::new(&polygon);
+        let prepared = PreparedRing::new(&polygon, None);
 
         assert_eq!(prepared.signed_area, 100.0);
         assert_eq!(prepared.aabb.unwrap().lower(), [0.0, 0.0]);
         assert!(locator.contains(prepared.probe(&polygon, &locator).unwrap().0));
+    }
+
+    #[test]
+    fn graph_identity_distinguishes_point_and_edge_touch() {
+        let polygon = Polygon3D::new(vec![], vec![], vec![], vec![]);
+        let shell_ids = RingGraphIdentity::new(vec![(0, 1)], vec![0, 1]);
+        let ring_ids = RingGraphIdentity::new(vec![(1, 2)], vec![1, 2]);
+        let mut stats = ContainmentStats::default();
+
+        assert!(touch_allowed(
+            &polygon,
+            Some(&shell_ids),
+            &polygon,
+            Some(&ring_ids),
+            &TouchPolicy::AllowPointTouchDisallowEdgeShare,
+            Some(&mut stats),
+        ));
+        assert!(!touch_allowed(
+            &polygon,
+            Some(&shell_ids),
+            &polygon,
+            Some(&ring_ids),
+            &TouchPolicy::TreatAnyTouchAsDisjoint,
+            Some(&mut stats),
+        ));
+        assert_eq!(stats.shared_edge_pair_checks, 0);
+        assert_eq!(stats.shared_vertex_pair_checks, 0);
+        assert!(stats.graph_edge_key_checks > 0);
+        assert!(stats.graph_vertex_id_checks > 0);
     }
 
     #[test]
@@ -422,7 +532,7 @@ mod tests {
         exterior.push(exterior[0]);
         let polygon = Polygon3D::new(exterior, vec![], vec![], vec![]);
         let simd = SimdRing::new_3d(&polygon.exterior);
-        let prepared = PreparedRing::new(&polygon);
+        let prepared = PreparedRing::new(&polygon, None);
         let boundary = Coord { x: 0.0, y: -10.0 };
 
         assert!(simd.contains(boundary));

--- a/crates/geo-polygonize-core/src/diagnostics.rs
+++ b/crates/geo-polygonize-core/src/diagnostics.rs
@@ -39,7 +39,11 @@ pub struct ContainmentStats {
     pub max_point_in_ring_calls_per_shell: usize,
     pub shells_with_64_plus_point_in_ring_calls: usize,
     pub shared_edge_checks: usize,
+    pub shared_edge_pair_checks: usize,
+    pub graph_edge_key_checks: usize,
     pub shared_vertex_checks: usize,
+    pub shared_vertex_pair_checks: usize,
+    pub graph_vertex_id_checks: usize,
 }
 
 impl ContainmentStats {
@@ -54,7 +58,11 @@ impl ContainmentStats {
         self.shells_with_64_plus_point_in_ring_calls +=
             other.shells_with_64_plus_point_in_ring_calls;
         self.shared_edge_checks += other.shared_edge_checks;
+        self.shared_edge_pair_checks += other.shared_edge_pair_checks;
+        self.graph_edge_key_checks += other.graph_edge_key_checks;
         self.shared_vertex_checks += other.shared_vertex_checks;
+        self.shared_vertex_pair_checks += other.shared_vertex_pair_checks;
+        self.graph_vertex_id_checks += other.graph_vertex_id_checks;
     }
 }
 

--- a/crates/geo-polygonize-core/src/graph/mod.rs
+++ b/crates/geo-polygonize-core/src/graph/mod.rs
@@ -1,4 +1,5 @@
 pub mod planar_graph;
+pub(crate) use planar_graph::ExtractedRing;
 pub use planar_graph::{DirEdgeId, EdgeId, NodeId, PlanarGraph};
 
 #[cfg(test)]

--- a/crates/geo-polygonize-core/src/graph/planar_graph.rs
+++ b/crates/geo-polygonize-core/src/graph/planar_graph.rs
@@ -21,6 +21,13 @@ pub type EdgeId = usize;
 /// Index of a directed half-edge in the graph.
 pub type DirEdgeId = usize;
 
+pub(crate) struct ExtractedRing {
+    pub coords: Vec<Coord3D>,
+    pub line_ids: Vec<u32>,
+    pub edge_keys: Vec<(NodeId, NodeId)>,
+    pub node_ids: Vec<NodeId>,
+}
+
 /// An undirected edge in the planar graph.
 #[derive(Clone, Debug)]
 pub struct Edge {
@@ -651,6 +658,16 @@ impl PlanarGraph {
 
     /// Extracts rings from the graph following the GEOS flow.
     pub fn get_edge_rings(&mut self) -> Vec<(Vec<Coord3D>, Vec<u32>)> {
+        self.get_edge_rings_with_graph_ids(false)
+            .into_iter()
+            .map(|ring| (ring.coords, ring.line_ids))
+            .collect()
+    }
+
+    pub(crate) fn get_edge_rings_with_graph_ids(
+        &mut self,
+        include_graph_ids: bool,
+    ) -> Vec<ExtractedRing> {
         NEXT_POINTERS.with(|cell| {
             let mut next_pointers = cell.borrow_mut();
             next_pointers.clear();
@@ -673,7 +690,7 @@ impl PlanarGraph {
             );
 
             // Extract the minimal rings from the graph.
-            self.extract_valid_rings(&next_pointers)
+            self.extract_valid_rings(&next_pointers, include_graph_ids)
         })
     }
 
@@ -818,7 +835,11 @@ impl PlanarGraph {
     }
 
     /// Extracts valid rings by following `next_pointers`.
-    fn extract_valid_rings(&mut self, next_pointers: &[usize]) -> Vec<(Vec<Coord3D>, Vec<u32>)> {
+    fn extract_valid_rings(
+        &mut self,
+        next_pointers: &[usize],
+        include_graph_ids: bool,
+    ) -> Vec<ExtractedRing> {
         for de in &mut self.directed_edges {
             de.is_visited = false;
         }
@@ -869,6 +890,16 @@ impl PlanarGraph {
             if is_valid_ring && !ring_edges.is_empty() {
                 let mut coords = Vec::with_capacity(ring_edges.len() + 1);
                 let mut ids = Vec::with_capacity(ring_edges.len());
+                let mut edge_keys = if include_graph_ids {
+                    Vec::with_capacity(ring_edges.len())
+                } else {
+                    Vec::new()
+                };
+                let mut node_ids = if include_graph_ids {
+                    Vec::with_capacity(ring_edges.len())
+                } else {
+                    Vec::new()
+                };
                 let start_node_idx = self.directed_edges[ring_edges[0]].src;
                 coords.push(Coord3D {
                     x: self.nodes_x[start_node_idx],
@@ -880,6 +911,14 @@ impl PlanarGraph {
                     let de = &self.directed_edges[de_idx];
                     let edge_idx = de.edge_idx;
                     ids.push(self.edges[edge_idx].line.line_id);
+                    if include_graph_ids {
+                        edge_keys.push(if de.src < de.dst {
+                            (de.src, de.dst)
+                        } else {
+                            (de.dst, de.src)
+                        });
+                        node_ids.push(de.src);
+                    }
 
                     let dst_idx = de.dst;
                     coords.push(Coord3D {
@@ -889,7 +928,12 @@ impl PlanarGraph {
                     });
                 }
 
-                rings.push((coords, ids));
+                rings.push(ExtractedRing {
+                    coords,
+                    line_ids: ids,
+                    edge_keys,
+                    node_ids,
+                });
             }
         }
         rings

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -1,12 +1,12 @@
 use crate::containment::ContainmentForest;
 use crate::diagnostics::{ContainmentStats, PolygonizerDiagnostics};
 use crate::error::Result;
-use crate::graph::PlanarGraph;
+use crate::graph::{ExtractedRing, PlanarGraph};
 use crate::noding::advanced::AdvancedNoder;
 use crate::noding::snap::SnapNoder;
 use crate::options::DiagnosticsOptions;
 use crate::options::{DeterminismOptions, PolygonizerOptions};
-use crate::types::{Coord3D, Line3D, Polygon3D};
+use crate::types::{Coord3D, Line3D, Polygon3D, RingGraphIdentity};
 use crate::utils::simd::SimdRing;
 use crate::utils::z_order_index;
 use geo::Contains;
@@ -280,7 +280,9 @@ impl Polygonizer {
         let mut dangles = self.graph.prune_dangles();
 
         // 3. Find rings (3D)
-        let rings_with_ids = self.graph.get_edge_rings();
+        let rings_with_ids = self
+            .graph
+            .get_edge_rings_with_graph_ids(self.options.node_input);
 
         // 3b. Find cut edges
         let mut cut_edges = self.graph.get_cut_edges();
@@ -294,7 +296,8 @@ impl Polygonizer {
 
         // 4. Classify Rings (Shell vs Hole)
         let t_ring_extraction_start = get_time();
-        let (shells, holes, invalid_rings_candidates) = extract_and_classify_rings(rings_with_ids);
+        let (shells, holes, invalid_rings_candidates) =
+            extract_and_classify_rings(rings_with_ids, self.options.node_input);
 
         if let Some(ref mut d) = diag {
             d.phase_times.ring_extraction = get_elapsed(t_ring_extraction_start);
@@ -405,15 +408,18 @@ pub(crate) fn canonicalize_open_line(line: &mut [Coord3D]) {
     }
 }
 
+type ClassifiedRing = (Polygon3D, Option<RingGraphIdentity>);
+
 pub(crate) fn extract_and_classify_rings(
-    rings_with_ids: Vec<(Vec<Coord3D>, Vec<u32>)>,
-) -> (Vec<Polygon3D>, Vec<Polygon3D>, Vec<Polygon3D>) {
+    rings_with_ids: Vec<ExtractedRing>,
+    include_graph_ids: bool,
+) -> (Vec<ClassifiedRing>, Vec<ClassifiedRing>, Vec<Polygon3D>) {
     let mut shells = Vec::with_capacity(rings_with_ids.len() / 2);
     let mut holes = Vec::with_capacity(rings_with_ids.len() / 2);
     let mut invalid_rings_candidates = Vec::new();
 
-    for (ring_coords, ring_ids) in rings_with_ids {
-        let poly3d = Polygon3D::new(ring_coords, vec![], ring_ids, vec![]);
+    for ring in rings_with_ids {
+        let poly3d = Polygon3D::new(ring.coords, vec![], ring.line_ids, vec![]);
         let area = poly3d.signed_area_2d();
 
         if !area.is_finite() || area.abs() < 1e-9 {
@@ -421,10 +427,14 @@ pub(crate) fn extract_and_classify_rings(
             continue;
         }
 
+        let ring = (
+            poly3d,
+            include_graph_ids.then(|| RingGraphIdentity::new(ring.edge_keys, ring.node_ids)),
+        );
         if area > 0.0 {
-            shells.push(poly3d);
+            shells.push(ring);
         } else {
-            holes.push(poly3d);
+            holes.push(ring);
         }
     }
 
@@ -433,8 +443,8 @@ pub(crate) fn extract_and_classify_rings(
 
 #[allow(clippy::type_complexity)]
 fn establish_topology(
-    mut shells: Vec<Polygon3D>,
-    holes: Vec<Polygon3D>,
+    shells: Vec<ClassifiedRing>,
+    holes: Vec<ClassifiedRing>,
     options: &PolygonizerOptions,
 ) -> (
     Vec<Polygon3D>,
@@ -444,12 +454,13 @@ fn establish_topology(
     f64,
     ContainmentStats,
 ) {
+    let (mut shells, mut shell_graph_ids): (Vec<_>, Vec<_>) = shells.into_iter().unzip();
     let collect_stats = options.diagnostics.enabled;
     let mut containment_stats = ContainmentStats::default();
     if collect_stats {
         containment_stats.prepared_shells = shells.len();
     }
-    let mut forest = ContainmentForest::new(&shells);
+    let mut forest = ContainmentForest::new_with_graph_ids(&shells, &shell_graph_ids);
 
     if options.extract_only_polygonal {
         let keep_mask = if collect_stats {
@@ -467,27 +478,44 @@ fn establish_topology(
                 forest.record_locator_reuse(&mut containment_stats);
             }
             let mut new_shells = Vec::new();
+            let mut new_shell_graph_ids = Vec::new();
 
-            for (keep, s) in keep_mask.into_iter().zip(shells) {
+            for ((keep, shell), graph_ids) in keep_mask.into_iter().zip(shells).zip(shell_graph_ids)
+            {
                 if keep {
-                    new_shells.push(s);
+                    new_shells.push(shell);
+                    new_shell_graph_ids.push(graph_ids);
                 }
             }
             shells = new_shells;
+            shell_graph_ids = new_shell_graph_ids;
             if collect_stats {
                 containment_stats.prepared_shells += shells.len();
             }
-            forest = ContainmentForest::new(&shells);
+            forest = ContainmentForest::new_with_graph_ids(&shells, &shell_graph_ids);
         }
     }
 
-    let process_hole_assignment =
-        |hole_3d: Polygon3D| -> (Option<usize>, Polygon3D, ContainmentStats) {
+    let process_hole_assignment = |(hole_3d, graph_ids): (
+        Polygon3D,
+        Option<RingGraphIdentity>,
+    )|
+     -> (Option<usize>, Polygon3D, ContainmentStats) {
             let (best_shell_idx, stats) = if collect_stats {
-                forest.assign_hole_with_stats(&hole_3d, &shells, &options.containment.touch_policy)
+                forest.assign_hole_with_graph_ids_and_stats(
+                    &hole_3d,
+                    graph_ids.as_ref(),
+                    &shells,
+                    &options.containment.touch_policy,
+                )
             } else {
                 (
-                    forest.assign_hole(&hole_3d, &shells, &options.containment.touch_policy),
+                    forest.assign_hole_with_graph_ids(
+                        &hole_3d,
+                        graph_ids.as_ref(),
+                        &shells,
+                        &options.containment.touch_policy,
+                    ),
                     ContainmentStats::default(),
                 )
             };
@@ -664,7 +692,7 @@ mod topology_tests {
         );
 
         let (_, _, _, unassigned_count, unassigned_area, _) =
-            establish_topology(vec![], vec![hole], &PolygonizerOptions::default());
+            establish_topology(vec![], vec![(hole, None)], &PolygonizerOptions::default());
 
         assert_eq!(unassigned_count, 1);
         assert!((unassigned_area - 100.0).abs() < 1e-9);
@@ -1041,39 +1069,59 @@ pub(crate) fn guaranteed_interior_probe_prepared(
 }
 
 pub fn rings_share_edge(shell: &[Coord3D], hole: &[Coord3D], eps: f64) -> bool {
+    rings_share_edge_with_count(shell, hole, eps).0
+}
+
+pub(crate) fn rings_share_edge_with_count(
+    shell: &[Coord3D],
+    hole: &[Coord3D],
+    eps: f64,
+) -> (bool, usize) {
     if shell.len() < 2 || hole.len() < 2 {
-        return false;
+        return (false, 0);
     }
 
+    let mut pair_checks = 0;
     // Bolt optimization: using .windows(2) is faster than loop indexing
     // because it eliminates O(N*M) array bounds checks in this hot inner loop.
     for shell_edge in shell.windows(2) {
         let a1 = shell_edge[0].to_coord_2d();
         let a2 = shell_edge[1].to_coord_2d();
         for hole_edge in hole.windows(2) {
+            pair_checks += 1;
             let b1 = hole_edge[0].to_coord_2d();
             let b2 = hole_edge[1].to_coord_2d();
             if segments_overlap_with_length(a1, a2, b1, b2, eps) {
-                return true;
+                return (true, pair_checks);
             }
         }
     }
 
-    false
+    (false, pair_checks)
 }
 
 pub fn rings_touch_at_vertex(shell: &[Coord3D], hole: &[Coord3D], eps: f64) -> bool {
+    rings_touch_at_vertex_with_count(shell, hole, eps).0
+}
+
+pub(crate) fn rings_touch_at_vertex_with_count(
+    shell: &[Coord3D],
+    hole: &[Coord3D],
+    eps: f64,
+) -> (bool, usize) {
     let eps_sq = eps * eps;
+    let mut pair_checks = 0;
     for s_pt in shell {
         for h_pt in hole {
+            pair_checks += 1;
             let dx = s_pt.x - h_pt.x;
             let dy = s_pt.y - h_pt.y;
             if dx * dx + dy * dy <= eps_sq {
-                return true;
+                return (true, pair_checks);
             }
         }
     }
-    false
+    (false, pair_checks)
 }
 
 fn segments_overlap_with_length(

--- a/crates/geo-polygonize-core/src/types.rs
+++ b/crates/geo-polygonize-core/src/types.rs
@@ -87,6 +87,25 @@ pub struct PolygonProvenance {
     pub input_profile_id: Option<String>,
 }
 
+#[derive(Clone, Debug)]
+pub(crate) struct RingGraphIdentity {
+    pub edge_keys: std::sync::Arc<[(usize, usize)]>,
+    pub node_ids: std::sync::Arc<[usize]>,
+}
+
+impl RingGraphIdentity {
+    pub(crate) fn new(mut edge_keys: Vec<(usize, usize)>, mut node_ids: Vec<usize>) -> Self {
+        edge_keys.sort_unstable();
+        edge_keys.dedup();
+        node_ids.sort_unstable();
+        node_ids.dedup();
+        Self {
+            edge_keys: edge_keys.into(),
+            node_ids: node_ids.into(),
+        }
+    }
+}
+
 #[derive(Clone, Debug, serde::Serialize)]
 pub struct Polygon3D {
     pub exterior: Vec<Coord3D>,


### PR DESCRIPTION
## Summary
- count exact shared-edge/shared-vertex geometry pair work and graph-identity comparisons
- retain canonical graph node-pair edge keys and node membership on rings extracted from noded input
- use sorted identity intersection for touch policies after noding, while preserving the epsilon geometry fallback for unnoded input
- add focused touch-policy and reused-graph Criterion coverage

Part of #774.

## Evidence

Apple M1 Max, Criterion medians/point estimates:

| Workload | Result |
|---|---:|
| 1,024×64 ring pair, touch scan skipped | ~0.315 µs |
| `AllowPointTouchDisallowEdgeShare` geometry scan | ~89.9 µs (≈286× skipped) |
| `TreatAnyTouchAsDisjoint` geometry scans | ~122.5 µs (≈390× skipped) |
| Reused clean graph, 100 holes, geometry fallback | ~2.48 ms |
| Reused clean graph, 100 holes, graph identity | ~1.27 ms (≈49% faster) |
| Default unnoded 1,000-hole end-to-end | no statistically significant change |

The production-shaped unnoded fixture records 65,536,000 exact edge-pair checks. Graph identity is enabled only when `node_input` has produced noded segments; otherwise the existing geometry fallback remains authoritative. Canonical `(NodeId, NodeId)` edge keys are used instead of raw `EdgeId`, because duplicate noded edges can have distinct arena IDs while representing the same boundary segment.

Sorted vectors were selected as the minimum implementation that works. Bitsets would scale with global arena size and hash sets add allocation/hash traffic; neither is justified after the measured end-to-end containment win.

## Validation
- `cargo test -p geo-polygonize-core` — passed (114 unit tests plus all integration, CFB, golden, provenance, determinism, and robustness targets)
- `cargo clippy -p geo-polygonize-core --tests --bench hole_sort_bench -- -D warnings` — passed
- focused Criterion touch-policy, reused-graph, and default 1,000-hole comparisons — passed
- benchmark setup verifies noded and fallback outputs match in polygon count and total area
- `cargo fmt --all -- --check` / `git diff --check` — passed