### PR TITLE
perf(core): index pre-snap reference vertices

### DIFF
--- a/crates/geo-polygonize-core/benches/polygonize_bench.rs
+++ b/crates/geo-polygonize-core/benches/polygonize_bench.rs
@@ -1,5 +1,7 @@
 use criterion::measurement::Measurement;
-use criterion::{criterion_group, criterion_main, BenchmarkGroup, BenchmarkId, Criterion};
+use criterion::{
+    criterion_group, criterion_main, BenchmarkGroup, BenchmarkId, Criterion, Throughput,
+};
 use geo_polygonize_core::noding::snap::{NodingStrategy, SnapNoder};
 use geo_polygonize_core::{Polygonizer, TiledPolygonizer};
 use geo_types::{Coord, LineString, Rect};
@@ -297,6 +299,37 @@ fn make_random_lines(count: usize) -> Vec<Line3D> {
         .collect()
 }
 
+fn make_pre_snap_lines(bands: usize) -> Vec<Line3D> {
+    (0..bands)
+        .flat_map(|i| {
+            let y = i as f64 * 2.0;
+            [
+                Line3D::new(
+                    Coord3D::new(0.0, y, 0.0),
+                    Coord3D::new(100.0, y, 0.0),
+                    (i * 2) as u32,
+                ),
+                Line3D::new(
+                    Coord3D::new(50.0, y + 0.25, 0.0),
+                    Coord3D::new(50.5, y + 0.75, 0.0),
+                    (i * 2 + 1) as u32,
+                ),
+            ]
+        })
+        .collect()
+}
+
+fn bench_pre_snap(c: &mut Criterion) {
+    let lines = make_pre_snap_lines(1_000);
+    let mut group = c.benchmark_group("pre_snap/cfb_style");
+    group.sample_size(10);
+    group.throughput(Throughput::Elements(lines.len() as u64));
+    group.bench_function("2000_segments", |b| {
+        b.iter(|| SnapNoder::pre_snap_to_reference_vertices(criterion::black_box(&lines), 0.5));
+    });
+    group.finish();
+}
+
 fn bench_kernel_grid_build(c: &mut Criterion) {
     let lines = make_random_lines(10_000);
     c.bench_function("kernel_grid_build_10k", |b| {
@@ -327,6 +360,7 @@ criterion_group!(
     kernel_benches,
     bench_kernel_grid_build,
     bench_kernel_find_splits,
-    bench_kernel_node
+    bench_kernel_node,
+    bench_pre_snap
 );
 criterion_main!(benches, kernel_benches);

--- a/crates/geo-polygonize-core/src/diagnostics.rs
+++ b/crates/geo-polygonize-core/src/diagnostics.rs
@@ -75,6 +75,7 @@ pub struct NodingWorkStats {
     pub aabb_rejections: usize,
     pub exact_intersection_calls: usize,
     pub split_events: usize,
+    pub pre_snap_vertex_candidates: usize,
 }
 
 impl NodingWorkStats {
@@ -86,6 +87,7 @@ impl NodingWorkStats {
         self.aabb_rejections += other.aabb_rejections;
         self.exact_intersection_calls += other.exact_intersection_calls;
         self.split_events += other.split_events;
+        self.pre_snap_vertex_candidates += other.pre_snap_vertex_candidates;
     }
 }
 

--- a/crates/geo-polygonize-core/src/noding/snap.rs
+++ b/crates/geo-polygonize-core/src/noding/snap.rs
@@ -1,10 +1,12 @@
 use crate::diagnostics::{NodingIterationStats, NodingWorkStats};
+use crate::index::{IndexedEnvelope, RStarBackend};
 use crate::noding::grid::UniformGrid;
 use crate::options::SnapStrategy;
 use crate::types::{Coord3D, Line3D};
 use crate::utils::soa::SoALines;
 use geo::algorithm::line_intersection::{line_intersection, LineIntersection};
 use geo::Coord;
+use rstar::AABB;
 use wide::f64x4;
 
 #[cfg(feature = "parallel")]
@@ -12,12 +14,11 @@ use rayon::prelude::*;
 
 fn nearest_reference_vertex(
     coord: Coord3D,
-    reference_vertices: &[Coord3D],
+    reference_vertices: impl Iterator<Item = Coord3D>,
     tolerance_sq: f64,
 ) -> Coord3D {
     reference_vertices
-        .iter()
-        .filter_map(|&vertex| {
+        .filter_map(|vertex| {
             let dx = vertex.x - coord.x;
             let dy = vertex.y - coord.y;
             let dist_sq = dx * dx + dy * dy;
@@ -31,6 +32,40 @@ fn nearest_reference_vertex(
         })
         .map(|(_, vertex)| vertex)
         .unwrap_or(coord)
+}
+
+fn nearest_reference_vertex_indexed(
+    coord: Coord3D,
+    reference_vertices: &[Coord3D],
+    index: &RStarBackend,
+    tolerance: f64,
+) -> (Coord3D, usize) {
+    if !coord.x.is_finite() || !coord.y.is_finite() || !tolerance.is_finite() {
+        return (
+            nearest_reference_vertex(
+                coord,
+                reference_vertices.iter().copied(),
+                tolerance * tolerance,
+            ),
+            reference_vertices.len(),
+        );
+    }
+
+    let query = AABB::from_corners(
+        [coord.x - tolerance, coord.y - tolerance],
+        [coord.x + tolerance, coord.y + tolerance],
+    );
+    let tolerance_sq = tolerance * tolerance;
+    let mut candidates = 0;
+    let nearest = nearest_reference_vertex(
+        coord,
+        index.locate_in_envelope_intersecting(&query).map(|idx| {
+            candidates += 1;
+            reference_vertices[idx]
+        }),
+        tolerance_sq,
+    );
+    (nearest, candidates)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -272,8 +307,19 @@ impl SnapNoder {
     }
 
     pub fn pre_snap_to_reference_vertices(lines: &[Line3D], tolerance: f64) -> Vec<Line3D> {
+        Self::pre_snap_impl(lines, tolerance, true).0
+    }
+
+    pub(crate) fn pre_snap_to_reference_vertices_with_stats(
+        lines: &[Line3D],
+        tolerance: f64,
+    ) -> (Vec<Line3D>, usize) {
+        Self::pre_snap_impl(lines, tolerance, true)
+    }
+
+    fn pre_snap_impl(lines: &[Line3D], tolerance: f64, use_index: bool) -> (Vec<Line3D>, usize) {
         if lines.is_empty() || tolerance <= 0.0 {
-            return lines.to_vec();
+            return (lines.to_vec(), 0);
         }
 
         let mut reference_vertices: Vec<Coord3D> = SnapNoder::new(0.0)
@@ -289,14 +335,50 @@ impl SnapNoder {
         });
         reference_vertices.dedup_by(|a, b| a.x == b.x && a.y == b.y);
 
+        let vertex_index = use_index.then(|| {
+            RStarBackend::new(
+                reference_vertices
+                    .iter()
+                    .enumerate()
+                    .map(|(index, vertex)| IndexedEnvelope {
+                        aabb: AABB::from_corners([vertex.x, vertex.y], [vertex.x, vertex.y]),
+                        index,
+                    })
+                    .collect(),
+            )
+        });
+
         let tolerance_sq = tolerance * tolerance;
         let mut snapped = Vec::with_capacity(lines.len());
         let mut points = Vec::new();
+        let mut vertex_candidates = 0;
 
-        // ponytail: O(segments * vertices); add a spatial index if CFB-scale pre-snap profiles hot.
         for &line in lines {
-            let start = nearest_reference_vertex(line.start, &reference_vertices, tolerance_sq);
-            let end = nearest_reference_vertex(line.end, &reference_vertices, tolerance_sq);
+            let (start, start_candidates) = if let Some(index) = vertex_index.as_ref() {
+                nearest_reference_vertex_indexed(line.start, &reference_vertices, index, tolerance)
+            } else {
+                (
+                    nearest_reference_vertex(
+                        line.start,
+                        reference_vertices.iter().copied(),
+                        tolerance_sq,
+                    ),
+                    reference_vertices.len(),
+                )
+            };
+            let (end, end_candidates) = if let Some(index) = vertex_index.as_ref() {
+                nearest_reference_vertex_indexed(line.end, &reference_vertices, index, tolerance)
+            } else {
+                (
+                    nearest_reference_vertex(
+                        line.end,
+                        reference_vertices.iter().copied(),
+                        tolerance_sq,
+                    ),
+                    reference_vertices.len(),
+                )
+            };
+            vertex_candidates += start_candidates + end_candidates;
             let dx = end.x - start.x;
             let dy = end.y - start.y;
             let len_sq = dx * dx + dy * dy;
@@ -308,20 +390,49 @@ impl SnapNoder {
             points.push((0.0, start));
             points.push((1.0, end));
 
-            for &vertex in &reference_vertices {
-                let vx = vertex.x - start.x;
-                let vy = vertex.y - start.y;
-                let t = (vx * dx + vy * dy) / len_sq;
-                if !(0.0..=1.0).contains(&t) {
-                    continue;
-                }
+            {
+                let mut consider_vertex = |vertex: Coord3D| {
+                    vertex_candidates += 1;
+                    let vx = vertex.x - start.x;
+                    let vy = vertex.y - start.y;
+                    let t = (vx * dx + vy * dy) / len_sq;
+                    if !(0.0..=1.0).contains(&t) {
+                        return;
+                    }
 
-                let nearest_x = start.x + t * dx;
-                let nearest_y = start.y + t * dy;
-                let dist_x = vertex.x - nearest_x;
-                let dist_y = vertex.y - nearest_y;
-                if dist_x * dist_x + dist_y * dist_y <= tolerance_sq {
-                    points.push((t, vertex));
+                    let nearest_x = start.x + t * dx;
+                    let nearest_y = start.y + t * dy;
+                    let dist_x = vertex.x - nearest_x;
+                    let dist_y = vertex.y - nearest_y;
+                    if dist_x * dist_x + dist_y * dist_y <= tolerance_sq {
+                        points.push((t, vertex));
+                    }
+                };
+
+                if let Some(index) = vertex_index.as_ref().filter(|_| {
+                    start.x.is_finite()
+                        && start.y.is_finite()
+                        && end.x.is_finite()
+                        && end.y.is_finite()
+                        && tolerance.is_finite()
+                }) {
+                    let query = AABB::from_corners(
+                        [
+                            start.x.min(end.x) - tolerance,
+                            start.y.min(end.y) - tolerance,
+                        ],
+                        [
+                            start.x.max(end.x) + tolerance,
+                            start.y.max(end.y) + tolerance,
+                        ],
+                    );
+                    for idx in index.locate_in_envelope_intersecting(&query) {
+                        consider_vertex(reference_vertices[idx]);
+                    }
+                } else {
+                    for &vertex in &reference_vertices {
+                        consider_vertex(vertex);
+                    }
                 }
             }
 
@@ -345,7 +456,7 @@ impl SnapNoder {
             }
         }
 
-        snapped
+        (snapped, vertex_candidates)
     }
 
     fn normalize_and_dedup(&self, lines: &mut Vec<Line3D>) {
@@ -814,6 +925,31 @@ mod tests {
                 && line.end == Coord3D::new(10.3, 0.02, 0.0))
                 || (line.start == Coord3D::new(10.3, 0.02, 0.0)
                     && line.end == Coord3D::new(10.0, 0.0, 0.0))));
+    }
+
+    #[test]
+    fn indexed_pre_snap_matches_linear_candidate_scan() {
+        let lines: Vec<_> = (0..100)
+            .flat_map(|i| {
+                let y = i as f64 * 2.0;
+                [
+                    make_line(0.0, y, 100.0, y),
+                    make_line(50.0, y + 0.25, 50.5, y + 0.75),
+                ]
+            })
+            .collect();
+
+        let (linear, linear_candidates) = SnapNoder::pre_snap_impl(&lines, 0.5, false);
+        let (indexed, indexed_candidates) = SnapNoder::pre_snap_impl(&lines, 0.5, true);
+
+        assert_eq!(indexed.len(), linear.len());
+        for (actual, expected) in indexed.iter().zip(linear) {
+            assert_eq!(actual.start, expected.start);
+            assert_eq!(actual.end, expected.end);
+            assert_eq!(actual.line_id, expected.line_id);
+        }
+        assert_eq!(linear_candidates, 240_000);
+        assert_eq!(indexed_candidates, 1_100);
     }
 
     #[test]

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -159,11 +159,14 @@ impl Polygonizer {
         let segments;
 
         if self.options.node_input {
+            let mut pre_snap_vertex_candidates = 0;
             if self.options.pre_snap_tolerance > 0.0 {
-                all_segments = SnapNoder::pre_snap_to_reference_vertices(
+                let (snapped, candidates) = SnapNoder::pre_snap_to_reference_vertices_with_stats(
                     &all_segments,
                     self.options.pre_snap_tolerance,
                 );
+                all_segments = snapped;
+                pre_snap_vertex_candidates = candidates;
             }
 
             // Sort by 2D coordinates
@@ -199,7 +202,8 @@ impl Polygonizer {
                     let noder = SnapNoder::new(self.options.snap_grid_size)
                         .with_snap_strategy(self.options.snap_strategy.clone());
                     if let Some(diagnostics) = diagnostics {
-                        let (noded, stats, work_stats) = noder.node_with_stats(all_segments);
+                        let (noded, stats, mut work_stats) = noder.node_with_stats(all_segments);
+                        work_stats.pre_snap_vertex_candidates = pre_snap_vertex_candidates;
                         diagnostics.intersection_stats.interpolated_intersections = stats
                             .iter()
                             .map(|iteration| iteration.intersections_found)
@@ -216,8 +220,9 @@ impl Polygonizer {
                 crate::options::NodingBackend::Advanced => {
                     let noder = AdvancedNoder::new();
                     if let Some(diagnostics) = diagnostics {
-                        let (noded, stats, work_stats) =
+                        let (noded, stats, mut work_stats) =
                             SnapNoder::new(0.0).node_with_stats(all_segments);
+                        work_stats.pre_snap_vertex_candidates = pre_snap_vertex_candidates;
                         diagnostics.intersection_stats.interpolated_intersections = stats
                             .iter()
                             .map(|iteration| iteration.intersections_found)

--- a/crates/geo-polygonize-core/src/polygonizer_tests.rs
+++ b/crates/geo-polygonize-core/src/polygonizer_tests.rs
@@ -674,6 +674,20 @@ mod tests {
     }
 
     #[test]
+    fn diagnostics_report_pre_snap_candidates() {
+        let mut poly = Polygonizer::new();
+        poly.node_input = true;
+        poly.options.pre_snap_tolerance = 0.5;
+        poly.diagnostics_options.enabled = true;
+        poly.add_geometry(LineString::from(vec![(0.0, 0.0), (10.0, 0.0)]).into());
+        poly.add_geometry(LineString::from(vec![(5.0, 0.4), (5.0, 1.0)]).into());
+
+        let diagnostics = poly.polygonize().unwrap().diagnostics.unwrap();
+
+        assert!(diagnostics.noding_work_stats.pre_snap_vertex_candidates > 0);
+    }
+
+    #[test]
     fn diagnostics_report_containment_work() {
         let mut poly = Polygonizer::new();
         poly.diagnostics_options.enabled = true;


### PR DESCRIPTION
## Summary
- reuse the existing `RStarBackend` to index exact-noded reference vertices
- query tolerance-expanded endpoint and segment envelopes before applying the unchanged exact distance and deterministic tie-breaking rules
- report `pre_snap_vertex_candidates` through noding diagnostics
- add linear/indexed parity coverage and a CFB-shaped Criterion workload

Part of #774.

## Evidence

Apple M1 Max, 2,000-segment CFB-shaped pre-snap workload:

| Implementation | Time | Throughput |
|---|---:|---:|
| Quadratic reference scan | 20.53 ms | 97.4 K segments/s |
| Existing R-tree index | 3.29 ms | 607.7 K segments/s |
| Change | **-84.07%** | **+527.9%** |

At test scale, the same geometry reduces examined reference-vertex candidates from 240,000 to 1,100 (99.54%) while producing identical coordinates, segment order, and line IDs.

The CFB fixture test also dropped from about 19.8 s before indexing to about 0.88 s locally in the debug test profile while preserving its expected output.

## Semantics
- nearest endpoint selection keeps the existing `(distance, x, y)` ordering
- expanded AABB queries are conservative; the existing exact distance-to-segment test remains authoritative
- non-finite inputs fall back to the previous linear scan
- no new dependency or index abstraction

## Validation
- `cargo test -p geo-polygonize-core` — passed (116 unit tests plus all integration, CFB, golden, provenance, determinism, and robustness targets)
- `cargo clippy -p geo-polygonize-core --tests --bench polygonize_bench -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed
- Criterion comparison against saved quadratic baseline — passed