### PR TITLE
perf(core): adapt point location for long rings

### DIFF
--- a/crates/geo-polygonize-core/benches/hole_sort_bench.rs
+++ b/crates/geo-polygonize-core/benches/hole_sort_bench.rs
@@ -281,7 +281,7 @@ fn bench_fearless_point_in_ring(c: &mut Criterion) {
                     .count()
             });
         });
-        group.bench_function(BenchmarkId::new("wide_multiversion", edges), |b| {
+        group.bench_function(BenchmarkId::new("production", edges), |b| {
             b.iter(|| {
                 black_box(&points)
                     .iter()

--- a/crates/geo-polygonize-core/src/utils/simd.rs
+++ b/crates/geo-polygonize-core/src/utils/simd.rs
@@ -4,6 +4,8 @@ use multiversion::multiversion;
 use wide::f64x4;
 use wide::CmpGt;
 
+const SCALAR_MIN_COORDS: usize = 257;
+
 pub struct SimdRing {
     pub x: Vec<f64>,
     pub y: Vec<f64>,
@@ -54,8 +56,24 @@ impl SimdRing {
             return false;
         }
 
-        contains_impl(&self.x, &self.y, self.len, point)
+        if self.len >= SCALAR_MIN_COORDS {
+            contains_scalar(&self.x, &self.y, self.len, point)
+        } else {
+            contains_simd(&self.x, &self.y, self.len, point)
+        }
     }
+}
+
+fn contains_scalar(x: &[f64], y: &[f64], len: usize, point: Coord<f64>) -> bool {
+    let mut crossings = 0;
+    for i in 0..len - 1 {
+        if ((y[i] > point.y) != (y[i + 1] > point.y))
+            && point.x < (x[i + 1] - x[i]) * (point.y - y[i]) / (y[i + 1] - y[i]) + x[i]
+        {
+            crossings += 1;
+        }
+    }
+    crossings % 2 != 0
 }
 
 #[cfg_attr(
@@ -70,7 +88,7 @@ impl SimdRing {
         "x86+sse2",
     ))
 )]
-fn contains_impl(x: &[f64], y: &[f64], len: usize, point: Coord<f64>) -> bool {
+fn contains_simd(x: &[f64], y: &[f64], len: usize, point: Coord<f64>) -> bool {
     let px = f64x4::splat(point.x);
     let py = f64x4::splat(point.y);
 
@@ -358,6 +376,36 @@ mod tests {
                     test_point, p1, p2, p3
                 );
             }
+        }
+    }
+
+    #[test]
+    fn adaptive_scalar_matches_simd() {
+        let mut coords: Vec<_> = (0..256)
+            .map(|i| {
+                let angle = std::f64::consts::TAU * i as f64 / 256.0;
+                Coord {
+                    x: angle.cos() * 10.0,
+                    y: angle.sin() * 10.0,
+                }
+            })
+            .collect();
+        coords.push(coords[0]);
+        let ring = SimdRing::new(&coords);
+
+        for point in [
+            Coord { x: 0.0, y: 0.0 },
+            Coord { x: 9.0, y: 0.0 },
+            Coord { x: 11.0, y: 0.0 },
+        ] {
+            assert_eq!(
+                contains_scalar(&ring.x, &ring.y, ring.len, point),
+                contains_simd(&ring.x, &ring.y, ring.len, point)
+            );
+            assert_eq!(
+                ring.contains(point),
+                contains_scalar(&ring.x, &ring.y, ring.len, point)
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

- keep the existing SIMD point-in-ring path for rings below 256 edges
- use the dependency-free scalar ray cast for longer rings
- add direct parity coverage for the adaptive boundary
- rename the benchmark entry to describe the production implementation

Part of #774.

## Measured impact

On Apple M1 Max, against the merged SIMD implementation:

- 256 edges: about 9% faster
- 1,024 edges: about 11% faster
- 16,384 edges: about 16% faster
- 1,000-hole assignment: neutral
- 1,000-hole end-to-end polygonization: about 4.7% faster in a fresh A/B run

The first unconditional scalar replacement regressed the production-shaped fixture, so this PR retains SIMD for short rings.

On an x86-64 AMD EPYC 7763 GitHub runner:

- the host exposed AVX2 but not AVX-512
- the adaptive production implementation was 13–20x faster than both `fearless_simd` point-in-ring prototypes
- disabling `fearless_simd` AVX-512 dispatch left its fixed-width timings within about 0.7–1.6%, as expected on a host without AVX-512
- the benchmark executable was 5,073,520 bytes and contained XMM, YMM, and statically emitted ZMM instructions

## Validation

- SIMD/scalar/adaptive parity assertions in the Criterion harness
- adaptive threshold unit test
- existing randomized and boundary point-in-ring tests
- targeted Criterion A/B runs
- formatting, 117 core unit tests, and benchmark-target Clippy
- explicit Wasm scalar, SIMD, and threads package builds on Ubuntu
