### PR TITLE
perf(core): remove per-batch SoA dispatch

### DIFF
--- a/crates/geo-polygonize-core/benches/hole_sort_bench.rs
+++ b/crates/geo-polygonize-core/benches/hole_sort_bench.rs
@@ -342,7 +342,7 @@ fn bench_fearless_aabb_scan(c: &mut Criterion) {
         group.bench_function(BenchmarkId::new("scalar", count), |b| {
             b.iter(|| scalar_aabb_count(black_box(&lines), query));
         });
-        group.bench_function(BenchmarkId::new("wide_multiversion", count), |b| {
+        group.bench_function(BenchmarkId::new("wide", count), |b| {
             b.iter(|| wide_aabb_count(black_box(&soa), query));
         });
         group.bench_function(BenchmarkId::new("fearless_fixed_f64x4", count), |b| {

--- a/crates/geo-polygonize-core/src/utils/soa.rs
+++ b/crates/geo-polygonize-core/src/utils/soa.rs
@@ -1,6 +1,4 @@
 use crate::types::Line3D;
-#[cfg(not(target_arch = "wasm32"))]
-use multiversion::multiversion;
 use wide::f64x4;
 use wide::CmpGe;
 use wide::CmpLe;
@@ -100,18 +98,6 @@ impl SoALines {
 }
 
 #[allow(clippy::too_many_arguments)]
-#[cfg_attr(
-    not(target_arch = "wasm32"),
-    multiversion(targets(
-        "x86_64+avx512f+avx512dq",
-        "x86_64+avx2",
-        "x86+avx2",
-        "x86_64+avx",
-        "x86+avx",
-        "x86_64+sse2",
-        "x86+sse2",
-    ))
-)]
 fn intersects_bbox_batch_splatted_impl(
     min_x: &[f64],
     min_y: &[f64],


### PR DESCRIPTION
## Summary

- remove runtime multiversion dispatch from the fixed four-lane SoA AABB helper
- keep the existing `wide::f64x4` implementation and call sites unchanged
- rename the benchmark entry from `wide_multiversion` to `wide`

Follow-up to #774.

## Why

The helper is called once per four AABBs. On x86, its runtime feature dispatcher therefore ran inside the scan loop even though the data width stayed fixed at four lanes. Compiling the same helper directly removes that repeated overhead without a dependency or new API.

## Measured impact

Same-host AMD EPYC 7763 Criterion A/B against `main`:

- 256 AABBs: 65.61% faster
- 4,096 AABBs: 64.96% faster
- 65,536 AABBs: 65.34% faster

Apple M1 Max was neutral at 256 AABBs, 3.6% faster at 4,096, and within noise at 65,536.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p geo-polygonize-core --lib` — 117 passed
- `cargo clippy -p geo-polygonize-core --bench hole_sort_bench -- -D warnings`
- existing SoA mask, padding, empty-input, and crossing tests
- [x86 same-host benchmark run](https://github.com/graydonpleasants/geo-polygonize/actions/runs/29630079540)
