### PR TITLE
fix(core): decode GeoParquet before polygonizing

### DIFF
--- a/crates/geo-polygonize-core/src/geoparquet_api.rs
+++ b/crates/geo-polygonize-core/src/geoparquet_api.rs
@@ -2,11 +2,11 @@ use crate::arrow_api::polygonize_arrow;
 use crate::error::PolygonizeError;
 use crate::options::PolygonizerOptions;
 use arrow::array::Array;
-use arrow::datatypes::{Field, Schema};
+use arrow::datatypes::Schema;
 use arrow::record_batch::RecordBatch;
 use geoarrow::array::GeoArrowArray;
 use geoarrow::datatypes::CoordType;
-use geoparquet::reader::GeoParquetReaderBuilder;
+use geoparquet::reader::{GeoParquetReaderBuilder, GeoParquetRecordBatchReader};
 use geoparquet::writer::{GeoParquetRecordBatchEncoder, GeoParquetWriterOptions};
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use parquet::arrow::ArrowWriter;
@@ -35,7 +35,7 @@ pub fn polygonize_geoparquet_file(
         }
     })?;
 
-    let _schema = if let Some(meta) = &geo_meta {
+    let schema = if let Some(meta) = &geo_meta {
         // True = convert geometries to geoarrow from wkb, Interleaved
 
         builder
@@ -52,6 +52,11 @@ pub fn polygonize_geoparquet_file(
         .map_err(|e| PolygonizeError::InvalidGeometry {
             reason: e.to_string(),
         })?;
+    let reader = GeoParquetRecordBatchReader::try_new(reader, schema).map_err(|e| {
+        PolygonizeError::InvalidGeometry {
+            reason: e.to_string(),
+        }
+    })?;
 
     let out_file = File::create(output_path).map_err(|e| PolygonizeError::InvalidGeometry {
         reason: e.to_string(),
@@ -74,12 +79,12 @@ pub fn polygonize_geoparquet_file(
 
             if field.name() == geometry_column_name {
                 let polygon_array = polygonize_arrow(col.as_ref(), field, options.clone())?;
+                let new_field = Arc::new(
+                    polygon_array
+                        .data_type()
+                        .to_field(field.name(), field.is_nullable()),
+                );
                 let arr_ref = polygon_array.into_array_ref();
-                let new_field = Arc::new(Field::new(
-                    field.name(),
-                    arr_ref.data_type().clone(),
-                    field.is_nullable(),
-                ));
                 actual_new_fields.push(new_field);
                 new_columns.push(arr_ref);
             } else {

--- a/crates/geo-polygonize-core/tests/geoparquet_integration.rs
+++ b/crates/geo-polygonize-core/tests/geoparquet_integration.rs
@@ -1,0 +1,88 @@
+#![cfg(feature = "geoparquet")]
+
+use arrow::record_batch::RecordBatch;
+use geo_polygonize_core::geoparquet_api::polygonize_geoparquet_file;
+use geo_polygonize_core::options::PolygonizerOptions;
+use geo_traits::{LineStringTrait, PolygonTrait};
+use geoarrow::array::{GeoArrowArray, GeoArrowArrayAccessor, LineStringBuilder, PolygonArray};
+use geoarrow::datatypes::{Dimension, LineStringType};
+use geoparquet::reader::{GeoParquetReaderBuilder, GeoParquetRecordBatchReader};
+use geoparquet::writer::{GeoParquetRecordBatchEncoder, GeoParquetWriterOptions};
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use parquet::arrow::ArrowWriter;
+use std::fs::{self, File};
+use std::sync::Arc;
+
+#[test]
+fn polygonizes_a_geoparquet_file() {
+    let input_path = std::env::temp_dir().join(format!(
+        "geo-polygonize-{}-input.parquet",
+        std::process::id()
+    ));
+    let output_path = std::env::temp_dir().join(format!(
+        "geo-polygonize-{}-output.parquet",
+        std::process::id()
+    ));
+
+    write_square(&input_path);
+    polygonize_geoparquet_file(
+        input_path.to_str().unwrap(),
+        output_path.to_str().unwrap(),
+        "geometry",
+        PolygonizerOptions::default(),
+    )
+    .unwrap();
+
+    let builder =
+        ParquetRecordBatchReaderBuilder::try_new(File::open(&output_path).unwrap()).unwrap();
+    let metadata = builder.geoparquet_metadata().unwrap().unwrap();
+    assert_eq!(metadata.primary_column, "geometry");
+    let schema = builder
+        .geoarrow_schema(&metadata, true, geoarrow::datatypes::CoordType::Interleaved)
+        .unwrap();
+    let reader = builder.build().unwrap();
+    let mut reader = GeoParquetRecordBatchReader::try_new(reader, schema.clone()).unwrap();
+    let batch = reader.next().unwrap().unwrap();
+    assert!(reader.next().is_none());
+
+    let polygons = PolygonArray::try_from((batch.column(0).as_ref(), schema.field(0))).unwrap();
+    assert_eq!(polygons.len(), 1);
+    let polygon = polygons.get(0).unwrap().unwrap();
+    assert_eq!(polygon.exterior().unwrap().num_coords(), 5);
+
+    fs::remove_file(input_path).unwrap();
+    fs::remove_file(output_path).unwrap();
+}
+
+fn write_square(path: &std::path::Path) {
+    let points = [
+        geo::coord! { x: 0.0, y: 0.0 },
+        geo::coord! { x: 10.0, y: 0.0 },
+        geo::coord! { x: 10.0, y: 10.0 },
+        geo::coord! { x: 0.0, y: 10.0 },
+        geo::coord! { x: 0.0, y: 0.0 },
+    ];
+    let typ = LineStringType::new(Dimension::XY, Arc::new(Default::default()));
+    let mut lines = LineStringBuilder::new(typ);
+    for pair in points.windows(2) {
+        lines
+            .push_line_string(Some(&geo::LineString::new(pair.to_vec())))
+            .unwrap();
+    }
+    let lines = lines.finish();
+    let schema = Arc::new(arrow::datatypes::Schema::new(vec![lines
+        .data_type()
+        .to_field("geometry", false)]));
+    let batch = RecordBatch::try_new(schema.clone(), vec![lines.into_array_ref()]).unwrap();
+
+    let mut encoder =
+        GeoParquetRecordBatchEncoder::try_new(&schema, &GeoParquetWriterOptions::default())
+            .unwrap();
+    let mut writer =
+        ArrowWriter::try_new(File::create(path).unwrap(), encoder.target_schema(), None).unwrap();
+    writer
+        .write(&encoder.encode_record_batch(&batch).unwrap())
+        .unwrap();
+    writer.append_key_value_metadata(encoder.into_keyvalue().unwrap());
+    writer.close().unwrap();
+}


### PR DESCRIPTION
## What changed

- decode GeoParquet WKB/native geometry batches through `GeoParquetRecordBatchReader` before calling the Arrow polygonizer
- preserve GeoArrow polygon extension metadata on the output field so the GeoParquet writer recognizes it
- add one end-to-end square test covering GeoParquet write → read/decode → polygonize → write → read

## Root cause

The API inferred a native GeoArrow schema but stored it in an unused variable. The raw Parquet reader therefore passed a binary WKB array to `polygonize_arrow`, which only accepts LineString arrays. After polygonization, the output field also discarded its GeoArrow extension metadata, preventing valid GeoParquet encoding.

## Validation

- `cargo test -p geo-polygonize-core --features geoparquet`
- `cargo clippy -p geo-polygonize-core --features geoparquet --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

All-target clippy still reports the pre-existing `field_reassign_with_default` warning in the #806 regression test; this PR does not touch it.

Closes #794