### PR TITLE
feat(core): add FlatGeobuf file polygonization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,7 +266,7 @@ dependencies = [
  "arrow-data",
  "arrow-schema",
  "arrow-select",
- "flatbuffers",
+ "flatbuffers 25.12.19",
 ]
 
 [[package]]
@@ -325,7 +325,7 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c872d36b7bf2a6a6a2b40de9156265f0242910791db366a2c17476ba8330d68"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -435,6 +435,12 @@ checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -845,6 +851,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "fearless_simd"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -858,11 +886,21 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flatbuffers"
+version = "24.12.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f1baf0dbf96932ec9a3038d57900329c015b0bfb7b63d904f3bc27e2b02a096"
+dependencies = [
+ "bitflags 1.3.2",
+ "rustc_version",
+]
+
+[[package]]
+name = "flatbuffers"
 version = "25.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "rustc_version",
 ]
 
@@ -874,6 +912,21 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "miniz_oxide",
  "zlib-rs",
+]
+
+[[package]]
+name = "flatgeobuf"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "440aaa920020917f3d52b61d82f871d945d9707cbec6c33a5c55a2d85b385121"
+dependencies = [
+ "byteorder",
+ "fallible-streaming-iterator",
+ "flatbuffers 24.12.23",
+ "geo-traits",
+ "geozero",
+ "log",
+ "tempfile",
 ]
 
 [[package]]
@@ -970,6 +1023,7 @@ dependencies = [
  "criterion",
  "dhat",
  "fearless_simd",
+ "flatgeobuf",
  "float_next_after",
  "geo",
  "geo-traits",
@@ -977,6 +1031,7 @@ dependencies = [
  "geoarrow",
  "geojson",
  "geoparquet",
+ "geozero",
  "getrandom 0.2.17",
  "humantime-serde",
  "iai-callgrind",
@@ -1127,6 +1182,18 @@ dependencies = [
  "serde_json",
  "serde_with",
  "wkt",
+]
+
+[[package]]
+name = "geozero"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5eda63aa99ac06160fd53328ed75c34f14e3196d3f56a3649e247ed796e54b"
+dependencies = [
+ "geo-types",
+ "log",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1564,6 +1631,12 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lock_api"
@@ -2099,7 +2172,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -2243,6 +2316,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2499,6 +2585,19 @@ name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
 
 [[package]]
 name = "termcolor"

--- a/crates/geo-polygonize-core/Cargo.toml
+++ b/crates/geo-polygonize-core/Cargo.toml
@@ -30,6 +30,8 @@ serde_json = "1.0"
 humantime-serde = "1.1.1"
 ts-rs = "12.0.1"
 geoparquet = { version = "0.7.0", optional = true }
+flatgeobuf = { version = "6.0.1", optional = true, default-features = false }
+geozero = { version = "0.15.1", optional = true, default-features = false, features = ["with-geo"] }
 parquet = "57.3.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
@@ -51,6 +53,7 @@ dhat = "0.3.3"
 [features]
 default = ["parallel"]
 geoparquet = ["dep:geoparquet"]
+flatgeobuf = ["dep:flatgeobuf", "dep:geozero"]
 parallel = ["dep:rayon"]
 python = ["dep:pyo3", "dep:numpy"]
 

--- a/crates/geo-polygonize-core/src/flatgeobuf_api.rs
+++ b/crates/geo-polygonize-core/src/flatgeobuf_api.rs
@@ -1,0 +1,135 @@
+use crate::error::PolygonizeError;
+use crate::options::PolygonizerOptions;
+use crate::polygonizer::polygonize_with_options;
+use crate::types::{Coord3D, Line3D, Polygon3D};
+use flatgeobuf::{
+    FallibleStreamingIterator, FgbCrs, FgbReader, FgbWriter, FgbWriterOptions, GeometryType,
+};
+use geo_traits::to_geo::ToGeoGeometry;
+use std::fs::File;
+use std::io::{BufReader, BufWriter};
+
+pub fn polygonize_flatgeobuf_file(
+    input_path: &str,
+    output_path: &str,
+    options: PolygonizerOptions,
+) -> Result<(), PolygonizeError> {
+    let reader = FgbReader::open(BufReader::new(
+        File::open(input_path).map_err(invalid_geometry)?,
+    ))
+    .map_err(invalid_geometry)?;
+    let header = reader.header();
+    if header.has_z() || header.has_m() || header.has_t() || header.has_tm() {
+        return Err(PolygonizeError::UnsupportedOptionCombination {
+            reason: "FlatGeobuf polygonization currently supports XY geometry only".to_string(),
+        });
+    }
+
+    let crs = header.crs();
+    let crs_org = crs.and_then(|value| value.org()).map(str::to_owned);
+    let crs_name = crs.and_then(|value| value.name()).map(str::to_owned);
+    let crs_description = crs.and_then(|value| value.description()).map(str::to_owned);
+    let crs_wkt = crs.and_then(|value| value.wkt()).map(str::to_owned);
+    let crs_code_string = crs.and_then(|value| value.code_string()).map(str::to_owned);
+    let crs_code = crs.map(|value| value.code()).unwrap_or_default();
+
+    let mut features = reader.select_all().map_err(invalid_geometry)?;
+    let mut lines = Vec::new();
+    let mut source_id = 0_u32;
+    while let Some(feature) = features.next().map_err(invalid_geometry)? {
+        let id = source_id;
+        source_id = source_id
+            .checked_add(1)
+            .ok_or_else(|| PolygonizeError::InvalidGeometry {
+                reason: "FlatGeobuf contains more than u32::MAX features".to_string(),
+            })?;
+        let Some(geometry) = feature.geometry_trait().map_err(invalid_geometry)? else {
+            continue;
+        };
+        let Some(geometry) = geometry.try_to_geometry() else {
+            continue;
+        };
+        match geometry {
+            geo::Geometry::LineString(line) => add_line_string(&line, id, &mut lines)?,
+            geo::Geometry::MultiLineString(multi) => {
+                for line in &multi.0 {
+                    add_line_string(line, id, &mut lines)?;
+                }
+            }
+            other => {
+                return Err(PolygonizeError::InvalidGeometry {
+                    reason: format!(
+                        "FlatGeobuf input must contain LineString or MultiLineString geometry, got {other:?}"
+                    ),
+                });
+            }
+        }
+    }
+
+    let result = polygonize_with_options(&lines, &options)?;
+    let writer_options = FgbWriterOptions {
+        crs: FgbCrs {
+            org: crs_org.as_deref(),
+            code: crs_code,
+            name: crs_name.as_deref(),
+            description: crs_description.as_deref(),
+            wkt: crs_wkt.as_deref(),
+            code_string: crs_code_string.as_deref(),
+        },
+        ..Default::default()
+    };
+    let mut writer =
+        FgbWriter::create_with_options("polygons", GeometryType::Polygon, writer_options)
+            .map_err(invalid_geometry)?;
+    for polygon in result.polygons {
+        writer
+            .add_feature_geom(geo::Geometry::Polygon(to_geo_polygon(polygon)), |_| {})
+            .map_err(invalid_geometry)?;
+    }
+    writer
+        .write(BufWriter::new(
+            File::create(output_path).map_err(invalid_geometry)?,
+        ))
+        .map_err(invalid_geometry)
+}
+
+fn add_line_string(
+    line: &geo::LineString,
+    source_id: u32,
+    lines: &mut Vec<Line3D>,
+) -> Result<(), PolygonizeError> {
+    for segment in line.lines() {
+        if !segment.start.x.is_finite()
+            || !segment.start.y.is_finite()
+            || !segment.end.x.is_finite()
+            || !segment.end.y.is_finite()
+        {
+            return Err(PolygonizeError::InvalidGeometry {
+                reason: "FlatGeobuf contains NaN or infinite coordinates".to_string(),
+            });
+        }
+        lines.push(Line3D::new(
+            Coord3D::new(segment.start.x, segment.start.y, 0.0),
+            Coord3D::new(segment.end.x, segment.end.y, 0.0),
+            source_id,
+        ));
+    }
+    Ok(())
+}
+
+fn to_geo_polygon(polygon: Polygon3D) -> geo::Polygon {
+    geo::Polygon::new(
+        to_geo_ring(polygon.exterior),
+        polygon.interiors.into_iter().map(to_geo_ring).collect(),
+    )
+}
+
+fn to_geo_ring(ring: Vec<Coord3D>) -> geo::LineString {
+    ring.into_iter().map(|coord| (coord.x, coord.y)).collect()
+}
+
+fn invalid_geometry(error: impl ToString) -> PolygonizeError {
+    PolygonizeError::InvalidGeometry {
+        reason: error.to_string(),
+    }
+}

--- a/crates/geo-polygonize-core/src/lib.rs
+++ b/crates/geo-polygonize-core/src/lib.rs
@@ -34,3 +34,6 @@ pub use types::{Coord3D, Line3D, Polygon3D};
 
 #[cfg(feature = "geoparquet")]
 pub mod geoparquet_api;
+
+#[cfg(feature = "flatgeobuf")]
+pub mod flatgeobuf_api;

--- a/crates/geo-polygonize-core/tests/flatgeobuf_integration.rs
+++ b/crates/geo-polygonize-core/tests/flatgeobuf_integration.rs
@@ -1,0 +1,77 @@
+#![cfg(feature = "flatgeobuf")]
+
+use flatgeobuf::{
+    FallibleStreamingIterator, FgbCrs, FgbReader, FgbWriter, FgbWriterOptions, GeometryType,
+};
+use geo::Area;
+use geo_polygonize_core::flatgeobuf_api::polygonize_flatgeobuf_file;
+use geo_polygonize_core::options::PolygonizerOptions;
+use geo_traits::to_geo::ToGeoGeometry;
+use std::fs::{self, File};
+use std::io::{BufReader, BufWriter};
+
+#[test]
+fn polygonizes_a_flatgeobuf_file() {
+    let input_path =
+        std::env::temp_dir().join(format!("geo-polygonize-{}-input.fgb", std::process::id()));
+    let output_path =
+        std::env::temp_dir().join(format!("geo-polygonize-{}-output.fgb", std::process::id()));
+    write_square(&input_path);
+
+    polygonize_flatgeobuf_file(
+        input_path.to_str().unwrap(),
+        output_path.to_str().unwrap(),
+        PolygonizerOptions::default(),
+    )
+    .unwrap();
+
+    let reader = FgbReader::open(BufReader::new(File::open(&output_path).unwrap())).unwrap();
+    assert_eq!(reader.header().geometry_type(), GeometryType::Polygon);
+    assert_eq!(reader.header().crs().unwrap().code(), 4326);
+    let mut features = reader.select_all().unwrap();
+    let feature = features.next().unwrap().unwrap();
+    let geometry = feature
+        .geometry_trait()
+        .unwrap()
+        .unwrap()
+        .try_to_geometry()
+        .unwrap();
+    let geo::Geometry::Polygon(polygon) = geometry else {
+        panic!("expected polygon output");
+    };
+    assert_eq!(polygon.unsigned_area(), 100.0);
+    assert!(features.next().unwrap().is_none());
+
+    fs::remove_file(input_path).unwrap();
+    fs::remove_file(output_path).unwrap();
+}
+
+fn write_square(path: &std::path::Path) {
+    let options = FgbWriterOptions {
+        crs: FgbCrs {
+            code: 4326,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let mut writer =
+        FgbWriter::create_with_options("lines", GeometryType::LineString, options).unwrap();
+    let points = [
+        geo::coord! { x: 0.0, y: 0.0 },
+        geo::coord! { x: 10.0, y: 0.0 },
+        geo::coord! { x: 10.0, y: 10.0 },
+        geo::coord! { x: 0.0, y: 10.0 },
+        geo::coord! { x: 0.0, y: 0.0 },
+    ];
+    for pair in points.windows(2) {
+        writer
+            .add_feature_geom(
+                geo::Geometry::LineString(geo::LineString::new(pair.to_vec())),
+                |_| {},
+            )
+            .unwrap();
+    }
+    writer
+        .write(BufWriter::new(File::create(path).unwrap()))
+        .unwrap();
+}


### PR DESCRIPTION
## What changed

- add an optional `flatgeobuf` core feature without the crate's HTTP/TLS dependency stack
- add `polygonize_flatgeobuf_file` for verified local FlatGeobuf LineString/MultiLineString input and Polygon output
- preserve input CRS metadata and source-feature IDs through the existing polygonizer
- reject non-XY dimensions, unsupported geometry types, and non-finite coordinates explicitly
- add one end-to-end FlatGeobuf round-trip test

## Scope

Polygonization is dataset-wide, so this first adapter emits geometry-only polygon features rather than inventing a property aggregation policy. HTTP range reading and 3D/M/T output are also deferred until callers define concrete requirements.

## Validation

- `cargo test -p geo-polygonize-core --features 'flatgeobuf geoparquet'`
- `cargo clippy -p geo-polygonize-core --features 'flatgeobuf geoparquet' --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #748