### PR TITLE
fix(github): restore JavaScript CI and npm publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
             changed="$(git diff --name-only "$base" "${{ github.sha }}")"
           fi
 
-          if echo "$changed" | grep -Eq '^(crates/|pkg-wrapper/|scripts/build_wasm\.sh|package(-lock)?\.json|rollup\.config\.mjs|tsconfig\.json|\.github/workflows/ci\.yml)$'; then
+          if echo "$changed" | grep -Eq '^(crates/|fixtures/cfb/|pkg-wrapper/|scripts/build_wasm\.sh$|package(-lock)?\.json$|rollup\.config\.mjs$|tsconfig\.json$|\.github/workflows/ci\.yml$)'; then
             echo "wasm=true" >> "$GITHUB_OUTPUT"
           else
             echo "wasm=false" >> "$GITHUB_OUTPUT"

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -317,7 +317,6 @@ impl Polygonizer {
             d.phase_times.ring_extraction = get_elapsed(t_ring_extraction_start);
             d.shell_count = shells.len();
             d.hole_count = holes.len();
-            d.invalid_ring_count = invalid_rings_candidates.len();
         }
 
         let t_containment_start = get_time();
@@ -356,6 +355,7 @@ impl Polygonizer {
             d.unassigned_hole_count = unassigned_hole_count;
             d.unassigned_hole_area = unassigned_hole_area;
             d.containment_stats = containment_stats;
+            d.invalid_ring_count = invalid_rings.len();
             // output_flatten time could be measured here if we had a separate pass, but we'll leave it 0 or record what we have
         }
         Ok(PolygonizerResult {

--- a/crates/geo-polygonize-core/tests/common/cfb_fixture.rs
+++ b/crates/geo-polygonize-core/tests/common/cfb_fixture.rs
@@ -118,6 +118,12 @@ pub fn run_cfb_fixture(fixture: &CfbFixture) {
             "{} invalid-ring count",
             fixture.case_id
         );
+        assert_eq!(
+            result.diagnostics.as_ref().unwrap().invalid_ring_count,
+            fixture.expected.invalid_ring_count,
+            "{} diagnostic invalid-ring count",
+            fixture.case_id
+        );
 
         if !fixture.expected.boundary_line_ids.is_empty() {
             let mut actual: Vec<u64> = result

--- a/scripts/build_wasm.sh
+++ b/scripts/build_wasm.sh
@@ -50,7 +50,7 @@ setup_wasm_tools() {
 
     if [ "$SITE_BUILD" != "1" ] && ! command -v wasm-opt &> /dev/null; then
         echo "wasm-opt not found. Attempting to install via npm..."
-        npm install -g wasm-opt
+        npm install -g --allow-scripts=wasm-opt wasm-opt
         if ! command -v wasm-opt &> /dev/null; then
             echo "Warning: wasm-opt could not be installed. Build will proceed without optimization."
         else


### PR DESCRIPTION
## What changed

- match files beneath `crates/`, `fixtures/cfb/`, and `pkg-wrapper/` when deciding whether to run WASM/JS CI
- explicitly approve `wasm-opt`'s reviewed global install script for current npm
- report the final filtered invalid-ring count in diagnostics
- assert that audited CFB diagnostics agree with the returned invalid rings

## Root cause

The CI regex anchored directory alternatives as exact paths, so most core and fixture changes skipped WASM/JS validation. Release commits changed `package.json` and exposed a latent diagnostics mismatch: the returned result contained the audited 43 invalid rings, while diagnostics counted 44 pre-filter candidates. Separately, current npm blocked `wasm-opt`'s postinstall, leaving an unusable command shim and aborting npm releases.

Scalar and SIMD artifacts from the failing run produced identical geometry and diagnostics, confirming there is no backend-specific geometry change.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p geo-polygonize-core`
- `cargo clippy -p geo-polygonize-core -- -D warnings`
- `actionlint .github/workflows/ci.yml .github/workflows/publish-npm.yml`
- `bash -n scripts/build_wasm.sh`
- npm 12 isolated global install: `npm install -g --allow-scripts=wasm-opt wasm-opt`
- scalar/SIMD comparison using retained artifacts from failing run 29656133618