### PR TITLE
fix(core): preserve GeoArrow metadata semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ A native Rust port of the JTS/GEOS polygonization algorithm. This crate allows y
 - **Robust Polygonization**: Extracts polygons from unstructured linework.
 - **Robust Noding**: Implements **Iterated Snap Rounding (ISR)** to guarantee topological correctness on dirty inputs (self-intersections, overlaps).
 - **Hardware Acceleration**: Uses **SIMD** instructions (via `wide` crate) for critical geometric predicates like Point-in-Polygon checks.
-- **Wasm Optimized**: Tailored for WebAssembly with `talc` allocator and Zero-Copy data support (`geoarrow`).
+- **Wasm Optimized**: Tailored for WebAssembly with `talc` allocator and binary GeoArrow support.
 - **Performance**: Competitive with GEOS/Shapely (C++), outperforming it on random sparse inputs and scaling well on dense grids.
 - **Geo Ecosystem**: Fully integrated with `geo-types` and `geo` crates.
-- **GeoArrow Support**: Zero-copy data transfer via Arrow C Data Interface and Arrow IPC (Wasm).
+- **GeoArrow Support**: Arrow C Data Interface and Arrow IPC integration with GeoArrow metadata.
 
 ## Engineering Roadmap
 
@@ -110,7 +110,7 @@ for p in polygons:
     print(p.area)
 
 # 2. Using High-Performance Flat Arrays
-# Perfect for zero-copy integrations or massive datasets
+# Flat buffers avoid Python object-per-coordinate overhead
 coords = np.array([
     0.0, 0.0, 10.0, 0.0, 10.0, 10.0, 0.0, 10.0, 0.0, 0.0,
     0.0, 0.0, 10.0, 10.0

--- a/crates/geo-polygonize-core/src/arrow_api.rs
+++ b/crates/geo-polygonize-core/src/arrow_api.rs
@@ -5,7 +5,7 @@ use arrow::array::{Array, AsArray, GenericListArray};
 use arrow::datatypes::{DataType, Field, Float64Type};
 use geo_traits::to_geo::ToGeoLineString;
 use geoarrow::array::{GeoArrowArray, GeoArrowArrayAccessor, LineStringArray, PolygonBuilder};
-use geoarrow::datatypes::{Dimension, PolygonType};
+use geoarrow::datatypes::{Dimension, GeoArrowType, Metadata, PolygonType};
 use std::convert::TryFrom;
 use std::sync::Arc;
 
@@ -17,62 +17,60 @@ pub fn polygonize_arrow(
     options: PolygonizerOptions,
 ) -> Result<geoarrow::array::PolygonArray, PolygonizeError> {
     let mut polygonizer = Polygonizer::with_options(options);
+    let metadata = match GeoArrowType::from_extension_field(field)
+        .map_err(|e| PolygonizeError::ArrowError(e.to_string()))?
+    {
+        Some(GeoArrowType::LineString(typ)) => {
+            if typ.dimension() != Dimension::XY {
+                return Err(PolygonizeError::UnsupportedOptionCombination {
+                    reason: format!(
+                        "GeoArrow polygonization currently supports XY coordinates only, got {:?}",
+                        typ.dimension()
+                    ),
+                });
+            }
+            typ.metadata().clone()
+        }
+        Some(other) => {
+            return Err(PolygonizeError::InvalidArgumentType {
+                field: field.name().to_string(),
+                expected: "geoarrow.linestring".to_string(),
+                actual: format!("{other:?}"),
+            });
+        }
+        None => Arc::new(
+            Metadata::try_from(field).map_err(|e| PolygonizeError::ArrowError(e.to_string()))?,
+        ),
+    };
+
+    if let Some(edges) = metadata.edges() {
+        return Err(PolygonizeError::UnsupportedOptionCombination {
+            reason: format!("GeoArrow polygonization supports planar edges only, got {edges:?}"),
+        });
+    }
 
     let mut lines = Vec::new();
 
-    // Attempt 1: Standard try_from
-    if let Ok(arr) = LineStringArray::try_from((array, field)) {
-        process_linestring_array(&arr, &mut lines)?;
-    } else {
-        // Fallback 2: Patch metadata
-        let mut new_metadata = field.metadata().clone();
-        new_metadata.insert(
-            "ARROW:extension:name".to_string(),
-            "ogc.geoarrow.linestring".to_string(),
-        );
-        let new_field = field.clone().with_metadata(new_metadata);
-
-        if let Ok(arr) = LineStringArray::try_from((array, &new_field)) {
-            process_linestring_array(&arr, &mut lines)?;
-        } else {
-            // Fallback 3: Construct field from array DataType
-            match array.data_type() {
-                DataType::List(_) => {
-                    // as_list returns &GenericListArray<O>, NOT Option.
-                    // And it panics if type mismatch in older versions, but `AsArray::as_list` in recent arrow (52+)
-                    // assumes the caller checked the type or it panics?
-                    // Docs: "Downcast this to a GenericListArray. Panics if the array is not a GenericListArray."
-                    // So we must be careful. We checked DataType::List above.
-                    let list_arr = array.as_list::<i32>();
-                    process_list_array(list_arr, &mut lines)?;
-                }
-                DataType::LargeList(_) => {
-                    let list_arr = array.as_list::<i64>();
-                    process_list_array(list_arr, &mut lines)?;
-                }
-                _ => {
-                    let array_type = array.data_type();
-                    let new_field_exact = Field::new("geometry", array_type.clone(), true)
-                        .with_metadata(
-                            [(
-                                "ARROW:extension:name".to_string(),
-                                "ogc.geoarrow.linestring".to_string(),
-                            )]
-                            .into(),
-                        );
-
-                    if let Ok(arr) = LineStringArray::try_from((array, &new_field_exact)) {
-                        process_linestring_array(&arr, &mut lines)?;
-                    } else {
-                        return Err(PolygonizeError::ArrowError(format!(
-                             "Failed to convert input array to LineStringArray and fallback failed. DataType: {:?}, Field: {:?}.",
-                             array.data_type(),
-                             field
-                         )));
-                    }
-                }
-            }
+    match LineStringArray::try_from((array, field)) {
+        Ok(arr) => process_linestring_array(&arr, &mut lines)?,
+        Err(error)
+            if field
+                .extension_type_name()
+                .is_some_and(|name| name != "ogc.geoarrow.linestring") =>
+        {
+            return Err(PolygonizeError::ArrowError(error.to_string()));
         }
+        Err(_) => match array.data_type() {
+            DataType::List(_) => process_list_array(array.as_list::<i32>(), &mut lines)?,
+            DataType::LargeList(_) => process_list_array(array.as_list::<i64>(), &mut lines)?,
+            _ => {
+                return Err(PolygonizeError::ArrowError(format!(
+                    "Failed to convert input array to LineStringArray and fallback failed. DataType: {:?}, Field: {:?}.",
+                    array.data_type(),
+                    field
+                )));
+            }
+        },
     }
 
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -109,10 +107,7 @@ pub fn polygonize_arrow(
         })
         .collect();
 
-    let mut builder = PolygonBuilder::new(PolygonType::new(
-        Dimension::XY,
-        Arc::new(Default::default()),
-    ));
+    let mut builder = PolygonBuilder::new(PolygonType::new(Dimension::XY, metadata));
     for poly in geo_polygons {
         builder
             .push_polygon(Some(&poly))
@@ -159,6 +154,15 @@ fn process_list_array<O: arrow::array::OffsetSizeTrait>(
         .ok_or_else(|| PolygonizeError::InvalidBufferShape {
             reason: "List values must be Struct".to_string(),
         })?;
+
+    if struct_arr.num_columns() != 2 {
+        return Err(PolygonizeError::UnsupportedOptionCombination {
+            reason: format!(
+                "GeoArrow polygonization currently supports XY coordinates only, got {} coordinate columns",
+                struct_arr.num_columns()
+            ),
+        });
+    }
 
     // Get x and y columns
     // We assume field names "x" and "y" or indices 0 and 1

--- a/crates/geo-polygonize-core/src/ffi.rs
+++ b/crates/geo-polygonize-core/src/ffi.rs
@@ -1,5 +1,4 @@
 use crate::arrow_api::polygonize_arrow;
-use arrow::datatypes::DataType;
 use arrow::datatypes::Field;
 use arrow::error::ArrowError;
 use arrow::ffi::{from_ffi, FFI_ArrowArray, FFI_ArrowSchema};
@@ -21,14 +20,14 @@ pub struct PolygonizerOptions {
 pub unsafe extern "C" fn polygonize_result_free() {}
 
 pub trait SchemaExporter {
-    fn try_export(data_type: &DataType) -> Result<FFI_ArrowSchema, ArrowError>;
+    fn try_export(field: &Field) -> Result<FFI_ArrowSchema, ArrowError>;
 }
 
 pub struct RealSchemaExporter;
 
 impl SchemaExporter for RealSchemaExporter {
-    fn try_export(data_type: &DataType) -> Result<FFI_ArrowSchema, ArrowError> {
-        FFI_ArrowSchema::try_from(data_type)
+    fn try_export(field: &Field) -> Result<FFI_ArrowSchema, ArrowError> {
+        FFI_ArrowSchema::try_from(field)
     }
 }
 
@@ -47,14 +46,14 @@ pub struct MockSchemaExporter;
 
 #[cfg(test)]
 impl SchemaExporter for MockSchemaExporter {
-    fn try_export(data_type: &DataType) -> Result<FFI_ArrowSchema, ArrowError> {
+    fn try_export(field: &Field) -> Result<FFI_ArrowSchema, ArrowError> {
         let should_error = MOCK_SCHEMA_ERROR.with(|f| *f.borrow());
         if should_error {
             Err(ArrowError::CDataInterface(
                 "Mocked schema export error".to_string(),
             ))
         } else {
-            FFI_ArrowSchema::try_from(data_type)
+            FFI_ArrowSchema::try_from(field)
         }
     }
 }
@@ -172,13 +171,14 @@ unsafe fn polygonize_ffi_internal(
 
     match polygonize_arrow(array.as_ref(), &field, arrow_opts) {
         Ok(polygon_array) => {
+            let field = polygon_array.data_type().to_field("geometry", true);
             let array_ref = polygon_array.into_array_ref();
             let data = array_ref.to_data();
 
             let ffi_array = FFI_ArrowArray::new(&data);
             std::ptr::write(output_array, ffi_array);
 
-            let ffi_schema = match DefaultSchemaExporter::try_export(data.data_type()) {
+            let ffi_schema = match DefaultSchemaExporter::try_export(&field) {
                 Ok(s) => s,
                 Err(_) => return 4,
             };

--- a/crates/geo-polygonize-core/tests/arrow_api_tests.rs
+++ b/crates/geo-polygonize-core/tests/arrow_api_tests.rs
@@ -3,7 +3,8 @@ use arrow::buffer::OffsetBuffer;
 use arrow::datatypes::{DataType, Field};
 use geo_polygonize_core::arrow_api::{polygonize_arrow, PolygonizerOptions};
 use geo_traits::{LineStringTrait, PolygonTrait};
-use geoarrow::array::{GeoArrowArray, GeoArrowArrayAccessor};
+use geoarrow::array::{GeoArrowArray, GeoArrowArrayAccessor, LineStringBuilder};
+use geoarrow::datatypes::{Crs, Dimension, Edges, LineStringType, Metadata};
 use std::sync::Arc;
 
 #[test]
@@ -68,4 +69,51 @@ fn test_polygonize_arrow_fallback_large_list() {
     } else {
         panic!("Missing polygon");
     }
+}
+
+#[test]
+fn polygonize_arrow_preserves_crs_metadata() {
+    let metadata = Arc::new(Metadata::new(
+        Crs::from_authority_code("EPSG:3857".to_string()),
+        None,
+    ));
+    let typ = LineStringType::new(Dimension::XY, metadata.clone());
+    let mut builder = LineStringBuilder::new(typ);
+    builder
+        .push_line_string(Some(&geo::LineString::from(vec![
+            (0., 0.),
+            (10., 0.),
+            (10., 10.),
+            (0., 10.),
+            (0., 0.),
+        ])))
+        .unwrap();
+    let input = builder.finish();
+    let field = input.data_type().to_field("geometry", true);
+    let array = input.into_array_ref();
+
+    let result = polygonize_arrow(array.as_ref(), &field, PolygonizerOptions::default()).unwrap();
+    let output_field = result.data_type().to_field("geometry", true);
+
+    assert_eq!(output_field.extension_type_name(), Some("geoarrow.polygon"));
+    assert_eq!(
+        output_field.extension_type_metadata(),
+        field.extension_type_metadata()
+    );
+}
+
+#[test]
+fn polygonize_arrow_rejects_non_planar_edges() {
+    let metadata = Arc::new(Metadata::new(Default::default(), Some(Edges::Spherical)));
+    let typ = LineStringType::new(Dimension::XY, metadata);
+    let builder = LineStringBuilder::new(typ);
+    let input = builder.finish();
+    let field = input.data_type().to_field("geometry", true);
+    let array = input.into_array_ref();
+
+    let error = polygonize_arrow(array.as_ref(), &field, PolygonizerOptions::default())
+        .unwrap_err()
+        .to_string();
+
+    assert!(error.contains("supports planar edges only"));
 }

--- a/crates/geo-polygonize-core/tests/arrow_integration.rs
+++ b/crates/geo-polygonize-core/tests/arrow_integration.rs
@@ -63,27 +63,7 @@ fn test_ffi_arrow_integration_square() {
     let output_arrow_array = arrow::array::make_array(output_data);
 
     // 7. Verify Output (PolygonArray)
-    // "Field extension type name mismatch, expected geoarrow.polygon, found ogc.geoarrow.polygon"
-    // `geoarrow-rs` recently switched to standard names? Or expects specific one?
-    // The previous error message `expected geoarrow.polygon, found ogc.geoarrow.polygon` means `PolygonArray::try_from` expected old name `geoarrow.polygon`
-    // but we supplied `ogc.geoarrow.polygon`.
-    // Wait, `Field::new("geometry", ..., true)` doesn't have metadata unless we add it.
-    // Ah, I set it to "ogc.geoarrow.polygon".
-    // Let's check which one `geoarrow` expects.
-    // The error says: expected `geoarrow.polygon`.
-    // So `geoarrow 0.7` expects `geoarrow.polygon` NOT `ogc.geoarrow.polygon`?
-    // That's surprising as 0.7 should support standard.
-    // Maybe we should check the error message closely: `expected geoarrow.polygon`.
-    // So I should use "geoarrow.polygon".
-
-    let mut metadata = std::collections::HashMap::new();
-    metadata.insert(
-        "ARROW:extension:name".to_string(),
-        "geoarrow.polygon".to_string(),
-    );
-
-    let field = Field::new("geometry", output_arrow_array.data_type().clone(), true)
-        .with_metadata(metadata);
+    let field = Field::try_from(&output_schema).expect("Failed to import output field");
 
     let polygon_array = PolygonArray::try_from((output_arrow_array.as_ref(), &field))
         .expect("Failed to convert to PolygonArray");

--- a/crates/geo-polygonize-wasm/src/lib.rs
+++ b/crates/geo-polygonize-wasm/src/lib.rs
@@ -497,7 +497,7 @@ pub fn polygonize_buffers(
 #[wasm_bindgen(js_name = polygonizeGeoArrowWithOptions)]
 /// Polygonizes an Arrow IPC stream containing a GeoArrow LineString array.
 ///
-/// This zero-copy path avoids JSON serialization overhead and returns a binary
+/// This binary path avoids JSON serialization overhead and returns an
 /// Arrow IPC stream containing a GeoArrow Polygon array. Requires the options
 /// to be passed as a parsed JS object.
 pub fn polygonize_geoarrow_with_options_js(
@@ -554,7 +554,10 @@ fn polygonize_geoarrow_internal(
     let mut geom_col_idx = None;
     for (i, field) in schema.fields().iter().enumerate() {
         if let Some(metadata) = field.metadata().get("ARROW:extension:name") {
-            if metadata.starts_with("ogc.geoarrow.linestring") {
+            if matches!(
+                metadata.as_str(),
+                "geoarrow.linestring" | "ogc.geoarrow.linestring"
+            ) {
                 geom_col_idx = Some(i);
                 break;
             }
@@ -587,9 +590,7 @@ fn polygonize_geoarrow_internal(
     // Serialize result to IPC
     let mut output_buffer = Vec::new();
     {
-        // Use data_type().clone().into() to get arrow DataType
-        let field =
-            arrow::datatypes::Field::new("geometry", result_array.data_type().clone().into(), true);
+        let field = result_array.data_type().to_field("geometry", true);
         let schema = Arc::new(arrow::datatypes::Schema::new(vec![field]));
 
         let mut writer = arrow_ipc::writer::StreamWriter::try_new(&mut output_buffer, &schema)
@@ -703,8 +704,7 @@ fn polygonize_and_flatten(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::Array;
-    use arrow::datatypes::{Field, Schema};
+    use arrow::datatypes::Schema;
     use arrow::record_batch::RecordBatch;
     use arrow_ipc::writer::StreamWriter;
     use geoarrow::array::PolygonArray;
@@ -734,16 +734,8 @@ mod tests {
         let input_array = builder.finish();
 
         use geoarrow::array::GeoArrowArray;
+        let field = input_array.data_type().to_field("geometry", true);
         let arrow_array = input_array.into_array_ref();
-
-        let mut field = Field::new("geometry", arrow_array.data_type().clone(), true);
-        field.set_metadata(
-            [(
-                "ARROW:extension:name".to_string(),
-                "ogc.geoarrow.linestring".to_string(),
-            )]
-            .into(),
-        );
 
         let schema = Arc::new(Schema::new(vec![field]));
         let batch = RecordBatch::try_new(schema.clone(), vec![arrow_array]).unwrap();
@@ -788,19 +780,8 @@ mod tests {
         let batch = &batches[0];
         let geom_col = batch.column(0);
 
-        let mut field = geom_field.clone();
-
-        // Ensure the arrow result can be successfully converted to a geoarrow PolygonArray
-        field.set_metadata(
-            [(
-                "ARROW:extension:name".to_string(),
-                "geoarrow.polygon".to_string(),
-            )]
-            .into(),
-        );
-
         use std::convert::TryFrom;
-        let poly_array = PolygonArray::try_from((geom_col.as_ref(), &field)).unwrap();
+        let poly_array = PolygonArray::try_from((geom_col.as_ref(), geom_field)).unwrap();
         assert_eq!(poly_array.len(), 1);
     }
 }


### PR DESCRIPTION
## Summary

- preserve GeoArrow CRS metadata through native Arrow, GeoParquet, C Data Interface, and Wasm IPC output
- emit standard `geoarrow.linestring` / `geoarrow.polygon` extension fields while retaining the existing legacy read path
- reject non-planar edges and non-XY dimensions instead of silently interpreting or dropping them
- remove unmeasured zero-copy claims from public documentation

## Root cause

The shared Arrow path rebuilt polygons with default XY metadata, while FFI and Wasm exported only the physical Arrow data type. This discarded extension metadata. Wasm discovery also only recognized the legacy extension name.

## Impact

Callers retain CRS metadata, receive standard GeoArrow output fields, and get an explicit error for unsupported spherical/geodesic or higher-dimensional inputs instead of silently incorrect geometry.

Closes the correctness-first portion of #710; allocation measurement and copy-elision remain follow-up work.

## Checks

- `cargo test -p geo-polygonize-core`
- `cargo test -p geo-polygonize-core --test arrow_api_tests --test arrow_integration`
- `cargo clippy -p geo-polygonize-core --lib -- -D warnings`
- `cargo clippy -p geo-polygonize-core --test arrow_api_tests --test arrow_integration -- -D warnings`
- `cargo clippy -p geo-polygonize-wasm --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

The local all-feature workspace test remains blocked by the existing macOS PyO3 linker configuration. Direct `wasm32-unknown-unknown` checking remains blocked by the local clang build lacking that target; CI has the configured Wasm toolchain.
