### PR TITLE
test(core): add GeoArrow conformance baselines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1029,6 +1029,7 @@ dependencies = [
  "geo-traits",
  "geo-types",
  "geoarrow",
+ "geoarrow-test",
  "geojson",
  "geoparquet",
  "geozero",
@@ -1064,6 +1065,7 @@ dependencies = [
  "geo-polygonize-core",
  "geo-traits",
  "geoarrow",
+ "geoarrow-test",
  "geojson",
  "getrandom 0.2.17",
  "js-sys",
@@ -1137,6 +1139,15 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "geoarrow-test"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fa523608cbc42f1238eaf7ea44a3009426513fe8109f8aada918720be01d10b"
+dependencies = [
+ "wkt",
 ]
 
 [[package]]

--- a/crates/geo-polygonize-core/Cargo.toml
+++ b/crates/geo-polygonize-core/Cargo.toml
@@ -45,6 +45,7 @@ fearless_simd = "=0.6.0"
 rand = "0.8"
 clap = { version = "4.5", features = ["derive"] }
 geojson = "0.24"
+geoarrow-test = "0.7.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 walkdir = "2.5.0"

--- a/crates/geo-polygonize-core/benches/allocation_bench.rs
+++ b/crates/geo-polygonize-core/benches/allocation_bench.rs
@@ -1,34 +1,205 @@
 #[global_allocator]
 static ALLOC: dhat::Alloc = dhat::Alloc;
 
+use arrow::array::make_array;
+use arrow::datatypes::Field;
+use arrow::ffi::{from_ffi, FFI_ArrowArray, FFI_ArrowSchema};
+use geo_polygonize_core::arrow_api::polygonize_arrow;
+use geo_polygonize_core::ffi::{polygonize_ffi, PolygonizerOptions as FfiOptions};
 use geo_polygonize_core::options::PolygonizerOptions;
 use geo_polygonize_core::Polygonizer;
 use geo_types::{Coord, LineString};
+use geoarrow::array::{GeoArrowArray, PolygonArray};
+use geoarrow::datatypes::Metadata;
 use rand::{rngs::StdRng, Rng, SeedableRng};
+use std::convert::TryFrom;
+use std::hint::black_box;
+use std::sync::Arc;
+
+#[allow(dead_code)]
+mod geoarrow_reference {
+    include!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../fixtures/geoarrow/reference.rs"
+    ));
+}
+
+fn measure(name: &str, runs: u64, warm_up: bool, mut run: impl FnMut() -> u64) {
+    if warm_up {
+        black_box(run());
+    }
+    let before = dhat::HeapStats::get();
+    let minimum_boundary_bytes: u64 = (0..runs).map(|_| run()).sum();
+    let after = dhat::HeapStats::get();
+    println!(
+        "{name},{},{},{minimum_boundary_bytes}",
+        (after.total_blocks - before.total_blocks) / runs,
+        (after.total_bytes - before.total_bytes) / runs,
+        minimum_boundary_bytes = minimum_boundary_bytes / runs,
+    );
+}
 
 fn main() {
-    let profiler = dhat::Profiler::new_heap();
+    let profile_path =
+        std::env::temp_dir().join(format!("geo-polygonize-dhat-{}.json", std::process::id()));
+    let _profiler = dhat::Profiler::builder().file_name(profile_path).build();
+    // This is a lower bound: IPC/file paths must transfer their payload bytes.
+    // A zero here means no serialization boundary, not an allocation-free call.
+    println!("boundary,allocations,allocated_bytes,minimum_boundary_bytes");
 
-    // Create a complex dataset
-    let mut rng = StdRng::seed_from_u64(42);
-    let mut poly = Polygonizer::with_options(PolygonizerOptions {
-        node_input: true,
-        ..Default::default()
+    let input = geoarrow_reference::square(Arc::new(Metadata::default()));
+    let field = input.data_type().to_field("geometry", true);
+    let array = input.into_array_ref();
+    measure("rust_arrow", 10, true, || {
+        let polygons = polygonize_arrow(
+            black_box(array.as_ref()),
+            black_box(&field),
+            PolygonizerOptions::default(),
+        )
+        .unwrap();
+        geoarrow_reference::assert_square(&polygons);
+        0
     });
 
-    for _ in 0..100 {
-        let n_points = rng.gen_range(5..20);
-        let mut coords = Vec::with_capacity(n_points);
-        for _ in 0..n_points {
-            coords.push(Coord {
-                x: rng.gen_range(0.0..100.0),
-                y: rng.gen_range(0.0..100.0),
-            });
+    let input = geoarrow_reference::square(Arc::new(Metadata::default()));
+    let input_field = input.data_type().to_field("geometry", true);
+    let input_array = input.into_array_ref();
+    measure("c_data_interface", 10, true, || {
+        let (mut ffi_input_array, _) = arrow::ffi::to_ffi(&input_array.to_data()).unwrap();
+        let mut ffi_input_schema = FFI_ArrowSchema::try_from(&input_field).unwrap();
+        let mut output_array = FFI_ArrowArray::empty();
+        let mut output_schema = FFI_ArrowSchema::empty();
+        let options = FfiOptions {
+            node_input: 0,
+            snap_grid_size: 1e-10,
+            extract_only_polygonal: 0,
+            report_mode: 0,
+        };
+        let status = unsafe {
+            polygonize_ffi(
+                &mut ffi_input_array,
+                &mut ffi_input_schema,
+                &mut output_array,
+                &mut output_schema,
+                &options,
+            )
+        };
+        assert_eq!(status, 0);
+        let data = unsafe { from_ffi(output_array, &output_schema).unwrap() };
+        let array = make_array(data);
+        let field = Field::try_from(&output_schema).unwrap();
+        let polygons = PolygonArray::try_from((array.as_ref(), &field)).unwrap();
+        geoarrow_reference::assert_square(&polygons);
+        0
+    });
+
+    let ipc = geoarrow_reference::square_ipc(Arc::new(Metadata::default()));
+    measure("wasm_arrow_ipc", 10, true, || {
+        let (array, field) = geoarrow_reference::read_geometry_ipc(&ipc);
+        let polygons =
+            polygonize_arrow(array.as_ref(), &field, PolygonizerOptions::default()).unwrap();
+        let schema = Arc::new(arrow::datatypes::Schema::new(vec![polygons
+            .data_type()
+            .to_field("geometry", true)]));
+        let batch = arrow::record_batch::RecordBatch::try_new(
+            schema.clone(),
+            vec![polygons.into_array_ref()],
+        )
+        .unwrap();
+        let mut output = Vec::new();
+        let mut writer = arrow::ipc::writer::StreamWriter::try_new(&mut output, &schema).unwrap();
+        writer.write(&batch).unwrap();
+        writer.finish().unwrap();
+        drop(writer);
+        black_box(&output);
+        (ipc.len() + output.len()) as u64
+    });
+
+    let official_ipc = geoarrow_reference::official_separated_ipc();
+    measure("official_arrow_ipc", 10, true, || {
+        let (array, field) = geoarrow_reference::read_geometry_ipc(&official_ipc);
+        let polygons =
+            polygonize_arrow(array.as_ref(), &field, PolygonizerOptions::default()).unwrap();
+        assert_eq!(polygons.len(), 0);
+        official_ipc.len() as u64
+    });
+
+    #[cfg(feature = "geoparquet")]
+    measure_geoparquet();
+
+    let mut rng = StdRng::seed_from_u64(42);
+    let lines: Vec<_> = (0..100)
+        .map(|_| {
+            let coords = (0..rng.gen_range(5..20))
+                .map(|_| Coord {
+                    x: rng.gen_range(0.0..100.0),
+                    y: rng.gen_range(0.0..100.0),
+                })
+                .collect();
+            LineString::new(coords)
+        })
+        .collect();
+    measure("core_random_100", 1, false, || {
+        let mut polygonizer = Polygonizer::with_options(PolygonizerOptions {
+            node_input: true,
+            ..Default::default()
+        });
+        for line in &lines {
+            polygonizer.add_geometry(line.clone().into());
         }
-        poly.add_geometry(LineString::new(coords).into());
-    }
+        black_box(polygonizer.polygonize().unwrap());
+        0
+    });
+}
 
-    let _result = poly.polygonize().expect("Polygonization failed");
+#[cfg(feature = "geoparquet")]
+fn measure_geoparquet() {
+    use arrow::record_batch::RecordBatch;
+    use geo_polygonize_core::geoparquet_api::polygonize_geoparquet_file;
+    use geoparquet::writer::{GeoParquetRecordBatchEncoder, GeoParquetWriterOptions};
+    use parquet::arrow::ArrowWriter;
+    use std::fs::{self, File};
 
-    drop(profiler);
+    let input_path = std::env::temp_dir().join(format!(
+        "geo-polygonize-allocation-{}-input.parquet",
+        std::process::id()
+    ));
+    let output_path = std::env::temp_dir().join(format!(
+        "geo-polygonize-allocation-{}-output.parquet",
+        std::process::id()
+    ));
+    let lines = geoarrow_reference::square(Arc::new(Metadata::default()));
+    let schema = Arc::new(arrow::datatypes::Schema::new(vec![lines
+        .data_type()
+        .to_field("geometry", false)]));
+    let batch = RecordBatch::try_new(schema.clone(), vec![lines.into_array_ref()]).unwrap();
+    let mut encoder =
+        GeoParquetRecordBatchEncoder::try_new(&schema, &GeoParquetWriterOptions::default())
+            .unwrap();
+    let mut writer = ArrowWriter::try_new(
+        File::create(&input_path).unwrap(),
+        encoder.target_schema(),
+        None,
+    )
+    .unwrap();
+    writer
+        .write(&encoder.encode_record_batch(&batch).unwrap())
+        .unwrap();
+    writer.append_key_value_metadata(encoder.into_keyvalue().unwrap());
+    writer.close().unwrap();
+
+    let input_bytes = fs::metadata(&input_path).unwrap().len();
+    measure("geoparquet_file", 10, true, || {
+        polygonize_geoparquet_file(
+            input_path.to_str().unwrap(),
+            output_path.to_str().unwrap(),
+            "geometry",
+            PolygonizerOptions::default(),
+        )
+        .unwrap();
+        input_bytes + fs::metadata(&output_path).unwrap().len()
+    });
+
+    fs::remove_file(input_path).unwrap();
+    fs::remove_file(output_path).unwrap();
 }

--- a/crates/geo-polygonize-core/tests/arrow_api_tests.rs
+++ b/crates/geo-polygonize-core/tests/arrow_api_tests.rs
@@ -7,6 +7,14 @@ use geoarrow::array::{GeoArrowArray, GeoArrowArrayAccessor, LineStringBuilder};
 use geoarrow::datatypes::{Crs, Dimension, Edges, LineStringType, Metadata};
 use std::sync::Arc;
 
+#[allow(dead_code)]
+mod geoarrow_reference {
+    include!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../fixtures/geoarrow/reference.rs"
+    ));
+}
+
 #[test]
 fn test_polygonize_arrow_invalid_type_error_path() {
     let array = Float64Array::from(vec![1.0, 2.0, 3.0]);
@@ -73,33 +81,59 @@ fn test_polygonize_arrow_fallback_large_list() {
 
 #[test]
 fn polygonize_arrow_preserves_crs_metadata() {
-    let metadata = Arc::new(Metadata::new(
+    for crs in [
         Crs::from_authority_code("EPSG:3857".to_string()),
-        None,
-    ));
-    let typ = LineStringType::new(Dimension::XY, metadata.clone());
-    let mut builder = LineStringBuilder::new(typ);
-    builder
-        .push_line_string(Some(&geo::LineString::from(vec![
-            (0., 0.),
-            (10., 0.),
-            (10., 10.),
-            (0., 10.),
-            (0., 0.),
-        ])))
-        .unwrap();
-    let input = builder.finish();
-    let field = input.data_type().to_field("geometry", true);
-    let array = input.into_array_ref();
+        Crs::from_wkt2_2019("PROJCRS[\"test\"]".to_string()),
+        Crs::from_unknown_crs_type("opaque-crs".to_string()),
+    ] {
+        let input = geoarrow_reference::square(Arc::new(Metadata::new(crs, None)));
+        let field = input.data_type().to_field("geometry", true);
+        let array = input.into_array_ref();
 
-    let result = polygonize_arrow(array.as_ref(), &field, PolygonizerOptions::default()).unwrap();
-    let output_field = result.data_type().to_field("geometry", true);
+        let result =
+            polygonize_arrow(array.as_ref(), &field, PolygonizerOptions::default()).unwrap();
+        let output_field = result.data_type().to_field("geometry", true);
 
-    assert_eq!(output_field.extension_type_name(), Some("geoarrow.polygon"));
-    assert_eq!(
-        output_field.extension_type_metadata(),
-        field.extension_type_metadata()
-    );
+        assert_eq!(output_field.extension_type_name(), Some("geoarrow.polygon"));
+        assert_eq!(
+            output_field.extension_type_metadata(),
+            field.extension_type_metadata()
+        );
+    }
+}
+
+#[test]
+fn polygonizes_official_geoarrow_reference_layouts() {
+    for bytes in [
+        geoarrow_reference::official_separated_ipc(),
+        geoarrow_reference::official_interleaved_ipc(),
+    ] {
+        let (array, field) = geoarrow_reference::read_geometry_ipc(&bytes);
+        let result =
+            polygonize_arrow(array.as_ref(), &field, PolygonizerOptions::default()).unwrap();
+
+        assert_eq!(field.extension_type_name(), Some("geoarrow.linestring"));
+        assert_eq!(result.len(), 0);
+        assert_eq!(
+            result
+                .data_type()
+                .to_field("geometry", true)
+                .extension_type_name(),
+            Some("geoarrow.polygon")
+        );
+    }
+}
+
+#[test]
+fn rejects_official_non_xy_geoarrow_reference_cases() {
+    for bytes in geoarrow_reference::official_non_xy_ipc() {
+        let (array, field) = geoarrow_reference::read_geometry_ipc(&bytes);
+        let error = polygonize_arrow(array.as_ref(), &field, PolygonizerOptions::default())
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("supports XY coordinates only"));
+    }
 }
 
 #[test]

--- a/crates/geo-polygonize-core/tests/arrow_integration.rs
+++ b/crates/geo-polygonize-core/tests/arrow_integration.rs
@@ -2,32 +2,34 @@ use arrow::array::Array;
 use arrow::datatypes::Field;
 use arrow::ffi::{FFI_ArrowArray, FFI_ArrowSchema};
 use geo_polygonize_core::ffi::{polygonize_ffi, PolygonizerOptions};
-use geo_traits::LineStringTrait;
-use geo_traits::PolygonTrait;
-use geoarrow::array::{GeoArrowArray, GeoArrowArrayAccessor, PolygonArray};
+use geoarrow::array::{GeoArrowArray, PolygonArray};
+use geoarrow::datatypes::{Crs, Metadata};
 use std::convert::TryFrom;
 use std::sync::Arc;
 
+#[allow(dead_code)]
+mod geoarrow_reference {
+    include!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../fixtures/geoarrow/reference.rs"
+    ));
+}
+
 #[test]
 fn test_ffi_arrow_integration_square() {
-    // 1. Create Input Arrow Array (LineStringArray)
-    let coord0 = geo::Coord { x: 0.0, y: 0.0 };
-    let coord1 = geo::Coord { x: 10.0, y: 0.0 };
-    let coord2 = geo::Coord { x: 10.0, y: 10.0 };
-    let coord3 = geo::Coord { x: 0.0, y: 10.0 };
-
-    let line_string = geo::LineString::new(vec![coord0, coord1, coord2, coord3, coord0]);
-
-    use geoarrow::datatypes::{Dimension, LineStringType};
-    let typ = LineStringType::new(Dimension::XY, Arc::new(Default::default()));
-    let mut builder = geoarrow::array::LineStringBuilder::new(typ);
-    builder.push_line_string(Some(&line_string)).unwrap();
-    let input_array = builder.finish();
+    let metadata = Arc::new(Metadata::new(
+        Crs::from_authority_code("EPSG:3857".to_string()),
+        None,
+    ));
+    let input_array = geoarrow_reference::square(metadata);
+    let input_field = input_array.data_type().to_field("geometry", true);
 
     // 2. Export Input to FFI
     let arrow_array = input_array.into_array_ref();
-    let (input_array_ffi, input_schema_ffi) =
+    let (input_array_ffi, _) =
         arrow::ffi::to_ffi(&arrow_array.to_data()).expect("Failed to export input array to FFI");
+    let input_schema_ffi =
+        FFI_ArrowSchema::try_from(&input_field).expect("Failed to export GeoArrow input field");
 
     let mut input_array_ffi = std::mem::ManuallyDrop::new(input_array_ffi);
     let mut input_schema_ffi = std::mem::ManuallyDrop::new(input_schema_ffi);
@@ -68,14 +70,11 @@ fn test_ffi_arrow_integration_square() {
     let polygon_array = PolygonArray::try_from((output_arrow_array.as_ref(), &field))
         .expect("Failed to convert to PolygonArray");
 
-    assert_eq!(polygon_array.len(), 1);
-
-    if let Ok(Some(poly)) = polygon_array.get(0) {
-        let exterior = poly.exterior().expect("Missing exterior");
-        assert_eq!(exterior.num_coords(), 5);
-    } else {
-        panic!("Missing polygon");
-    }
+    geoarrow_reference::assert_square(&polygon_array);
+    assert_eq!(
+        field.extension_type_metadata(),
+        input_field.extension_type_metadata()
+    );
 }
 
 #[test]

--- a/crates/geo-polygonize-core/tests/geoparquet_integration.rs
+++ b/crates/geo-polygonize-core/tests/geoparquet_integration.rs
@@ -3,15 +3,22 @@
 use arrow::record_batch::RecordBatch;
 use geo_polygonize_core::geoparquet_api::polygonize_geoparquet_file;
 use geo_polygonize_core::options::PolygonizerOptions;
-use geo_traits::{LineStringTrait, PolygonTrait};
-use geoarrow::array::{GeoArrowArray, GeoArrowArrayAccessor, LineStringBuilder, PolygonArray};
-use geoarrow::datatypes::{Dimension, LineStringType};
+use geoarrow::array::{GeoArrowArray, PolygonArray};
+use geoarrow::datatypes::Metadata;
 use geoparquet::reader::{GeoParquetReaderBuilder, GeoParquetRecordBatchReader};
 use geoparquet::writer::{GeoParquetRecordBatchEncoder, GeoParquetWriterOptions};
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use parquet::arrow::ArrowWriter;
 use std::fs::{self, File};
 use std::sync::Arc;
+
+#[allow(dead_code)]
+mod geoarrow_reference {
+    include!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../fixtures/geoarrow/reference.rs"
+    ));
+}
 
 #[test]
 fn polygonizes_a_geoparquet_file() {
@@ -46,30 +53,14 @@ fn polygonizes_a_geoparquet_file() {
     assert!(reader.next().is_none());
 
     let polygons = PolygonArray::try_from((batch.column(0).as_ref(), schema.field(0))).unwrap();
-    assert_eq!(polygons.len(), 1);
-    let polygon = polygons.get(0).unwrap().unwrap();
-    assert_eq!(polygon.exterior().unwrap().num_coords(), 5);
+    geoarrow_reference::assert_square(&polygons);
 
     fs::remove_file(input_path).unwrap();
     fs::remove_file(output_path).unwrap();
 }
 
 fn write_square(path: &std::path::Path) {
-    let points = [
-        geo::coord! { x: 0.0, y: 0.0 },
-        geo::coord! { x: 10.0, y: 0.0 },
-        geo::coord! { x: 10.0, y: 10.0 },
-        geo::coord! { x: 0.0, y: 10.0 },
-        geo::coord! { x: 0.0, y: 0.0 },
-    ];
-    let typ = LineStringType::new(Dimension::XY, Arc::new(Default::default()));
-    let mut lines = LineStringBuilder::new(typ);
-    for pair in points.windows(2) {
-        lines
-            .push_line_string(Some(&geo::LineString::new(pair.to_vec())))
-            .unwrap();
-    }
-    let lines = lines.finish();
+    let lines = geoarrow_reference::square(Arc::new(Metadata::default()));
     let schema = Arc::new(arrow::datatypes::Schema::new(vec![lines
         .data_type()
         .to_field("geometry", false)]));

--- a/crates/geo-polygonize-wasm/Cargo.toml
+++ b/crates/geo-polygonize-wasm/Cargo.toml
@@ -30,4 +30,5 @@ default = ["console_error_panic_hook"]
 threads = ["wasm-bindgen-rayon", "geo-polygonize-core/parallel"]
 
 [dev-dependencies]
+geoarrow-test = "0.7.0"
 wasm-bindgen-test = "0.3.36"

--- a/crates/geo-polygonize-wasm/src/lib.rs
+++ b/crates/geo-polygonize-wasm/src/lib.rs
@@ -704,12 +704,17 @@ fn polygonize_and_flatten(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::datatypes::Schema;
-    use arrow::record_batch::RecordBatch;
-    use arrow_ipc::writer::StreamWriter;
     use geoarrow::array::PolygonArray;
     use std::sync::Arc;
     use wasm_bindgen_test::*;
+
+    #[allow(dead_code)]
+    mod geoarrow_reference {
+        include!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../fixtures/geoarrow/reference.rs"
+        ));
+    }
 
     #[wasm_bindgen_test]
     fn test_polygonize_geoarrow_empty() {
@@ -717,41 +722,9 @@ mod tests {
         assert!(result.is_err());
     }
 
-    fn generate_valid_geoarrow_ipc() -> Vec<u8> {
-        let coord0 = geo::Coord { x: 0.0, y: 0.0 };
-        let coord1 = geo::Coord { x: 10.0, y: 0.0 };
-        let coord2 = geo::Coord { x: 10.0, y: 10.0 };
-        let coord3 = geo::Coord { x: 0.0, y: 10.0 };
-
-        let line_string = geo::LineString::new(vec![coord0, coord1, coord2, coord3, coord0]);
-
-        use geoarrow::array::LineStringBuilder;
-        use geoarrow::datatypes::{Dimension, LineStringType};
-
-        let typ = LineStringType::new(Dimension::XY, Arc::new(Default::default()));
-        let mut builder = LineStringBuilder::new(typ);
-        builder.push_line_string(Some(&line_string)).unwrap();
-        let input_array = builder.finish();
-
-        use geoarrow::array::GeoArrowArray;
-        let field = input_array.data_type().to_field("geometry", true);
-        let arrow_array = input_array.into_array_ref();
-
-        let schema = Arc::new(Schema::new(vec![field]));
-        let batch = RecordBatch::try_new(schema.clone(), vec![arrow_array]).unwrap();
-
-        let mut buf = Vec::new();
-        {
-            let mut writer = StreamWriter::try_new(&mut buf, &schema).unwrap();
-            writer.write(&batch).unwrap();
-            writer.finish().unwrap();
-        }
-        buf
-    }
-
     #[wasm_bindgen_test]
     fn test_polygonize_geoarrow_valid() {
-        let ipc_bytes = generate_valid_geoarrow_ipc();
+        let ipc_bytes = geoarrow_reference::square_ipc(Arc::new(Default::default()));
         let result = polygonize_geoarrow(&ipc_bytes, false, 0.0, false);
 
         // Ensure success without unwrapping directly which can panic
@@ -782,6 +755,28 @@ mod tests {
 
         use std::convert::TryFrom;
         let poly_array = PolygonArray::try_from((geom_col.as_ref(), geom_field)).unwrap();
-        assert_eq!(poly_array.len(), 1);
+        geoarrow_reference::assert_square(&poly_array);
+    }
+
+    #[wasm_bindgen_test]
+    fn test_polygonize_official_geoarrow_reference_layouts() {
+        for ipc_bytes in [
+            geoarrow_reference::official_separated_ipc(),
+            geoarrow_reference::official_interleaved_ipc(),
+        ] {
+            let out_bytes = polygonize_geoarrow(&ipc_bytes, false, 0.0, false).unwrap();
+            let mut reader =
+                arrow_ipc::reader::StreamReader::try_new(std::io::Cursor::new(out_bytes), None)
+                    .unwrap();
+            let schema = reader.schema();
+            let batch = reader.next().unwrap().unwrap();
+            let polygons =
+                PolygonArray::try_from((batch.column(0).as_ref(), schema.field(0))).unwrap();
+            assert_eq!(polygons.len(), 0);
+        }
+
+        for ipc_bytes in geoarrow_reference::official_non_xy_ipc() {
+            assert!(polygonize_geoarrow(&ipc_bytes, false, 0.0, false).is_err());
+        }
     }
 }

--- a/fixtures/geoarrow/README.md
+++ b/fixtures/geoarrow/README.md
@@ -1,0 +1,10 @@
+# GeoArrow conformance fixtures
+
+The shared test helper builds the official GeoArrow toy LineString corpus from
+the MIT/Apache-2.0 licensed `geoarrow-test` 0.7 crate in both supported layouts:
+
+- [separated coordinates](https://geoarrow.org/data.html)
+- [interleaved coordinates](https://geoarrow.org/data.html)
+
+Both contain two LineStrings, one null, and one empty geometry. Tests generate
+the Arrow IPC in memory; no network access is required.

--- a/fixtures/geoarrow/reference.rs
+++ b/fixtures/geoarrow/reference.rs
@@ -1,0 +1,120 @@
+use arrow::array::ArrayRef;
+use arrow::datatypes::Field;
+use arrow::ipc::reader::StreamReader;
+use arrow::ipc::writer::StreamWriter;
+use arrow::record_batch::RecordBatch;
+use geo_traits::{CoordTrait, LineStringTrait, PolygonTrait};
+use geoarrow::array::{
+    GeoArrowArray, GeoArrowArrayAccessor, LineStringArray, LineStringBuilder, PolygonArray,
+};
+use geoarrow::datatypes::{CoordType, Dimension, LineStringType, Metadata};
+use std::io::Cursor;
+use std::sync::Arc;
+
+pub fn official_separated_ipc() -> Vec<u8> {
+    write_ipc(official_array(
+        Dimension::XY,
+        CoordType::Separated,
+        geoarrow_test::raw::linestring::xy::geoms(),
+    ))
+}
+
+pub fn official_interleaved_ipc() -> Vec<u8> {
+    write_ipc(official_array(
+        Dimension::XY,
+        CoordType::Interleaved,
+        geoarrow_test::raw::linestring::xy::geoms(),
+    ))
+}
+
+pub fn official_non_xy_ipc() -> Vec<Vec<u8>> {
+    vec![
+        write_ipc(official_array(
+            Dimension::XYZ,
+            CoordType::Separated,
+            geoarrow_test::raw::linestring::xyz::geoms(),
+        )),
+        write_ipc(official_array(
+            Dimension::XYM,
+            CoordType::Separated,
+            geoarrow_test::raw::linestring::xym::geoms(),
+        )),
+        write_ipc(official_array(
+            Dimension::XYZM,
+            CoordType::Separated,
+            geoarrow_test::raw::linestring::xyzm::geoms(),
+        )),
+    ]
+}
+
+fn official_array<G: LineStringTrait<T = f64>>(
+    dimension: Dimension,
+    coord_type: CoordType,
+    geometries: Vec<Option<G>>,
+) -> LineStringArray {
+    let typ = LineStringType::new(dimension, Arc::new(Metadata::default()))
+        .with_coord_type(coord_type);
+    let mut builder = LineStringBuilder::new(typ);
+    for geometry in geometries {
+        builder.push_line_string(geometry.as_ref()).unwrap();
+    }
+    builder.finish()
+}
+
+pub fn read_geometry_ipc(bytes: &[u8]) -> (ArrayRef, Field) {
+    let mut reader = StreamReader::try_new(Cursor::new(bytes), None).unwrap();
+    let schema = reader.schema();
+    let geometry_index = schema.index_of("geometry").unwrap();
+    let batch = reader.next().unwrap().unwrap();
+    assert!(reader.next().is_none());
+    (
+        batch.column(geometry_index).clone(),
+        schema.field(geometry_index).clone(),
+    )
+}
+
+pub fn square(metadata: Arc<Metadata>) -> LineStringArray {
+    let mut builder = LineStringBuilder::new(LineStringType::new(Dimension::XY, metadata));
+    builder
+        .push_line_string(Some(&geo::LineString::from(vec![
+            (0., 0.),
+            (10., 0.),
+            (10., 10.),
+            (0., 10.),
+            (0., 0.),
+        ])))
+        .unwrap();
+    builder.finish()
+}
+
+pub fn square_ipc(metadata: Arc<Metadata>) -> Vec<u8> {
+    write_ipc(square(metadata))
+}
+
+fn write_ipc(array: LineStringArray) -> Vec<u8> {
+    let schema = Arc::new(arrow::datatypes::Schema::new(vec![array
+        .data_type()
+        .to_field("geometry", true)]));
+    let batch = RecordBatch::try_new(schema.clone(), vec![array.into_array_ref()]).unwrap();
+    let mut bytes = Vec::new();
+    let mut writer = StreamWriter::try_new(&mut bytes, &schema).unwrap();
+    writer.write(&batch).unwrap();
+    writer.finish().unwrap();
+    drop(writer);
+    bytes
+}
+
+pub fn assert_square(array: &PolygonArray) {
+    assert_eq!(array.len(), 1);
+    let polygon = array.get(0).unwrap().unwrap();
+    let exterior = polygon.exterior().unwrap();
+    assert_eq!(exterior.num_coords(), 5);
+
+    let mut twice_area = 0.0;
+    for index in 0..exterior.num_coords() - 1 {
+        let start = exterior.coord(index).unwrap();
+        let end = exterior.coord(index + 1).unwrap();
+        twice_area += start.x() * end.y() - end.x() * start.y();
+    }
+    assert_eq!(twice_area.abs() / 2.0, 100.0);
+}


### PR DESCRIPTION
Advances #710.

## What changed

- Build the official GeoArrow LineString corpus from the licensed `geoarrow-test` crate in separated, interleaved, XYZ, XYM, and XYZM layouts.
- Reuse one square topology assertion across native Arrow, C Data Interface, Wasm IPC, and GeoParquet tests.
- Cover authority-code, WKT2:2019, and unknown CRS metadata preservation.
- Extend the existing dhat benchmark with warmed per-boundary allocation and minimum transfer-byte baselines.

## Baseline

| Boundary | Allocations/op | Allocated bytes/op | Minimum boundary bytes |
|---|---:|---:|---:|
| Rust Arrow | 82 | 9,788 | 0 |
| C Data Interface | 380 | 29,219 | 0 |
| Wasm Arrow IPC | 269 | 30,646 | 2,576 |
| Official Arrow IPC corpus | 114 | 11,222 | 1,224 |
| GeoParquet file | 458 | 83,349 | 2,131 |

Zero minimum boundary bytes means no serialization boundary; it does not mean the complete call is allocation-free. The measurements make C FFI/IPC allocation reduction the first evidence-backed optimization target, without adding a parallel API.

## Validation

- `cargo test -p geo-polygonize-core --features geoparquet,flatgeobuf`
- Focused Arrow, FFI, GeoParquet, and official-corpus tests
- Clippy with warnings denied for the changed core library/tests/benchmark and Wasm library
- `cargo bench -p geo-polygonize-core --bench allocation_bench --features geoparquet`

The direct Wasm target check remains blocked locally because Apple clang cannot emit the zstd `wasm32-unknown-unknown` objects; native Wasm clippy passes and CI has the target toolchain.
