### PR TITLE
perf(core): reduce FFI allocation overhead

### DIFF
--- a/crates/geo-polygonize-core/benches/allocation_bench.rs
+++ b/crates/geo-polygonize-core/benches/allocation_bench.rs
@@ -3,7 +3,7 @@ static ALLOC: dhat::Alloc = dhat::Alloc;
 
 use arrow::array::make_array;
 use arrow::datatypes::Field;
-use arrow::ffi::{from_ffi, FFI_ArrowArray, FFI_ArrowSchema};
+use arrow::ffi::{from_ffi_and_data_type, FFI_ArrowArray, FFI_ArrowSchema};
 use geo_polygonize_core::arrow_api::polygonize_arrow;
 use geo_polygonize_core::ffi::{polygonize_ffi, PolygonizerOptions as FfiOptions};
 use geo_polygonize_core::options::PolygonizerOptions;
@@ -65,7 +65,7 @@ fn main() {
     let input_field = input.data_type().to_field("geometry", true);
     let input_array = input.into_array_ref();
     measure("c_data_interface", 10, true, || {
-        let (mut ffi_input_array, _) = arrow::ffi::to_ffi(&input_array.to_data()).unwrap();
+        let mut ffi_input_array = FFI_ArrowArray::new(&input_array.to_data());
         let mut ffi_input_schema = FFI_ArrowSchema::try_from(&input_field).unwrap();
         let mut output_array = FFI_ArrowArray::empty();
         let mut output_schema = FFI_ArrowSchema::empty();
@@ -85,9 +85,10 @@ fn main() {
             )
         };
         assert_eq!(status, 0);
-        let data = unsafe { from_ffi(output_array, &output_schema).unwrap() };
-        let array = make_array(data);
         let field = Field::try_from(&output_schema).unwrap();
+        let data =
+            unsafe { from_ffi_and_data_type(output_array, field.data_type().clone()).unwrap() };
+        let array = make_array(data);
         let polygons = PolygonArray::try_from((array.as_ref(), &field)).unwrap();
         geoarrow_reference::assert_square(&polygons);
         0

--- a/crates/geo-polygonize-core/src/ffi.rs
+++ b/crates/geo-polygonize-core/src/ffi.rs
@@ -1,8 +1,9 @@
 use crate::arrow_api::polygonize_arrow;
+use arrow::array::Array;
 use arrow::datatypes::Field;
 use arrow::error::ArrowError;
-use arrow::ffi::{from_ffi, FFI_ArrowArray, FFI_ArrowSchema};
-use geoarrow::array::GeoArrowArray;
+use arrow::ffi::{from_ffi_and_data_type, FFI_ArrowArray, FFI_ArrowSchema};
+use geoarrow::array::IntoArrow;
 use std::convert::TryFrom;
 
 #[repr(C)]
@@ -163,7 +164,7 @@ unsafe fn polygonize_ffi_internal(
     };
 
     let array_val = std::ptr::replace(input_array, FFI_ArrowArray::empty());
-    let arrow_data = match from_ffi(array_val, &*input_schema) {
+    let arrow_data = match from_ffi_and_data_type(array_val, field.data_type().clone()) {
         Ok(data) => data,
         Err(_) => return 2,
     };
@@ -171,9 +172,11 @@ unsafe fn polygonize_ffi_internal(
 
     match polygonize_arrow(array.as_ref(), &field, arrow_opts) {
         Ok(polygon_array) => {
-            let field = polygon_array.data_type().to_field("geometry", true);
-            let array_ref = polygon_array.into_array_ref();
-            let data = array_ref.to_data();
+            let extension_type = polygon_array.extension_type().clone();
+            let arrow_array = polygon_array.into_arrow();
+            let field = Field::new("geometry", arrow_array.data_type().clone(), true)
+                .with_extension_type(extension_type);
+            let data = arrow_array.into_data();
 
             let ffi_array = FFI_ArrowArray::new(&data);
             std::ptr::write(output_array, ffi_array);


### PR DESCRIPTION
## What changed

- reuse the already-parsed input `DataType` when importing the Arrow C Data Interface array
- consume the GeoArrow output directly and reuse its physical Arrow type when constructing the extension field
- remove redundant schema conversions from the allocation benchmark harness

## Why

The #822 DHAT baseline measured the C Data Interface path at 380 allocations and 29,219 allocated bytes per operation. Profiling showed repeated schema/type reconstruction in both the production adapter and the benchmark caller.

The production changes reduce the path to 361 allocations and 27,850 bytes. Correcting the caller-side benchmark setup produces the final representative baseline of 333 allocations and 26,444 bytes: 47 fewer allocations (12.4%) and 2,775 fewer bytes (9.5%) overall.

This preserves the existing Arrow-only API and zero-copy buffer semantics; it removes structural conversion work rather than adding a parallel compatibility path.

Advances #710.

## Validation

- `cargo test -p geo-polygonize-core --features geoparquet,flatgeobuf` (159 tests)
- `cargo clippy -p geo-polygonize-core --lib --features geoparquet,flatgeobuf -- -D warnings`
- `cargo clippy -p geo-polygonize-core --bench allocation_bench --features geoparquet -- -D warnings`
- `cargo bench -p geo-polygonize-core --bench allocation_bench --features geoparquet`

Other benchmark boundaries were unchanged: Rust Arrow 82 / 9,788, Wasm IPC 269 / 30,646, official Arrow IPC 114 / 11,222, GeoParquet 458 / 83,349.