### PR TITLE
perf(core): reduce parallel split merge allocations

### DIFF
--- a/crates/geo-polygonize-core/src/noding/grid.rs
+++ b/crates/geo-polygonize-core/src/noding/grid.rs
@@ -371,6 +371,7 @@ impl UniformGrid {
 
         #[cfg(feature = "parallel")]
         let mut splits = {
+            let chunks = std::sync::Mutex::new(Vec::new());
             (0..self.rows * self.cols)
                 .into_par_iter()
                 .fold(Vec::new, |mut acc, idx| {
@@ -385,10 +386,13 @@ impl UniformGrid {
                     }
                     acc
                 })
-                .reduce(Vec::new, |mut a, mut b| {
-                    a.append(&mut b);
-                    a
-                })
+                .for_each(|chunk| chunks.lock().unwrap().push(chunk));
+            let chunks = chunks.into_inner().unwrap();
+            let mut splits = Vec::with_capacity(chunks.iter().map(Vec::len).sum());
+            for chunk in chunks {
+                splits.extend(chunk);
+            }
+            splits
         };
 
         #[cfg(not(feature = "parallel"))]


### PR DESCRIPTION
## What changed

Collect each Rayon worker's grid split events as a chunk, reserve the exact combined length once, then move the chunks into the final vector.

## Why

DHAT attributed the largest avoidable allocation source in `core_random_100` to `UniformGrid::find_splits`: the parallel reduction repeatedly grew and copied intermediate vectors.

The existing event sort/dedup still defines output order, so worker completion order does not affect behavior.

## Result

`core_random_100` improved from:

- 1,556,482 allocations / 793,999,934 allocated bytes

to a repeated post-change result of:

- 1,555,736 allocations / 712,486,518 allocated bytes

That removes about 81.5 MB (10.3%) of cumulative allocation while slightly reducing allocation count. Rust Arrow, C Data Interface, Wasm IPC, official Arrow IPC, and GeoParquet baselines are unchanged.

## Validation

- `cargo test -p geo-polygonize-core --features geoparquet,flatgeobuf` (159 tests)
- `cargo clippy -p geo-polygonize-core --lib --features geoparquet,flatgeobuf -- -D warnings`
- `CARGO_PROFILE_BENCH_DEBUG=1 cargo bench -p geo-polygonize-core --bench allocation_bench --features geoparquet` (repeated)