### PR TITLE
perf(core): reduce polygonization staging allocations

### DIFF
--- a/crates/geo-polygonize-core/src/graph/planar_graph.rs
+++ b/crates/geo-polygonize-core/src/graph/planar_graph.rs
@@ -1,7 +1,5 @@
 use crate::types::{Coord3D, Line3D};
-use crate::utils::parallel::{
-    par_flat_map, par_into_enumerate_map, par_sort_unstable, par_zip_for_each,
-};
+use crate::utils::parallel::{par_flat_map, par_sort_unstable, par_zip_for_each};
 use crate::utils::{compare_angular, z_order_index};
 use geo_types::{Coord, LineString};
 #[cfg(feature = "parallel")]
@@ -336,13 +334,9 @@ impl PlanarGraph {
         let edges_start_len = self.edges.len();
         let directed_edges_start_len = self.directed_edges.len();
 
-        let mapper = |(i, (u, v, line)): (usize, (NodeId, NodeId, Line3D))| {
-            create_edge_components(i, u, v, line, edges_start_len, directed_edges_start_len)
-        };
-
-        let new_edges_data: Vec<_> = par_into_enumerate_map(valid_edges, mapper);
-
-        for (u, v, de_u_v_idx, de_v_u_idx, de_u_v, de_v_u, edge) in new_edges_data {
+        for (i, (u, v, line)) in valid_edges.into_iter().enumerate() {
+            let (u, v, de_u_v_idx, de_v_u_idx, de_u_v, de_v_u, edge) =
+                create_edge_components(i, u, v, line, edges_start_len, directed_edges_start_len);
             self.directed_edges.push(de_u_v);
             self.directed_edges.push(de_v_u);
             self.edges.push(edge);

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -753,6 +753,18 @@ mod topology_tests {
         assert_eq!(unassigned_count, 1);
         assert!((unassigned_area - 100.0).abs() < 1e-9);
     }
+
+    #[test]
+    fn reorder_polygons_applies_sorted_old_indices() {
+        let polygon =
+            |label| Polygon3D::new(vec![Coord3D::new(label, 0.0, 0.0)], vec![], vec![], vec![]);
+        let mut polygons = vec![polygon(0.0), polygon(1.0), polygon(2.0)];
+
+        reorder_polygons(&mut polygons, [2, 0, 1].into_iter());
+
+        let labels: Vec<_> = polygons.iter().map(|p| p.exterior[0].x).collect();
+        assert_eq!(labels, [2.0, 0.0, 1.0]);
+    }
 }
 
 pub(crate) fn apply_determinism(
@@ -765,41 +777,46 @@ pub(crate) fn apply_determinism(
     if options.determinism.canonical_sort {
         let use_stable_tie_breaks = options.determinism.stable_tie_breaks;
         if use_stable_tie_breaks {
-            let mut result_with_cache: Vec<_> = result
-                .into_iter()
-                .map(|p| {
+            let mut sort_keys: Vec<_> = result
+                .iter()
+                .enumerate()
+                .map(|(index, p)| {
                     let area = p.exterior_unsigned_area_2d();
                     let b = bounding_rect_3d(&p.exterior).unwrap_or(geo::Rect::new(
                         geo::Coord { x: 0.0, y: 0.0 },
                         geo::Coord { x: 0.0, y: 0.0 },
                     ));
-                    (p, area, b)
+                    (index, area, b, p.interiors.len())
                 })
                 .collect();
 
-            result_with_cache.sort_unstable_by(|(p1, area1, b1), (p2, area2, b2)| {
+            sort_keys.sort_unstable_by(|(_, area1, b1, holes1), (_, area2, b2, holes2)| {
                 area2.total_cmp(area1).then_with(|| {
                     b1.min()
                         .x
                         .total_cmp(&b2.min().x)
                         .then(b1.min().y.total_cmp(&b2.min().y))
-                        .then(p1.interiors.len().cmp(&p2.interiors.len()))
+                        .then(holes1.cmp(holes2))
                 })
             });
 
-            result = result_with_cache.into_iter().map(|(p, _, _)| p).collect();
+            reorder_polygons(
+                &mut result,
+                sort_keys.into_iter().map(|(index, _, _, _)| index),
+            );
         } else {
-            let mut result_with_cache: Vec<_> = result
-                .into_iter()
-                .map(|p| {
+            let mut sort_keys: Vec<_> = result
+                .iter()
+                .enumerate()
+                .map(|(index, p)| {
                     let area = p.exterior_unsigned_area_2d();
-                    (p, area)
+                    (index, area)
                 })
                 .collect();
 
-            result_with_cache.sort_unstable_by(|(_, area1), (_, area2)| area2.total_cmp(area1));
+            sort_keys.sort_unstable_by(|(_, area1), (_, area2)| area2.total_cmp(area1));
 
-            result = result_with_cache.into_iter().map(|(p, _)| p).collect();
+            reorder_polygons(&mut result, sort_keys.into_iter().map(|(index, _)| index));
         }
 
         if options.determinism.canonical_ring_rotation {
@@ -879,6 +896,20 @@ pub(crate) fn apply_determinism(
         }
     }
     result
+}
+
+fn reorder_polygons(result: &mut [Polygon3D], old_indices: impl Iterator<Item = usize>) {
+    let mut destinations = vec![0; result.len()];
+    for (new_index, old_index) in old_indices.enumerate() {
+        destinations[old_index] = new_index;
+    }
+    for index in 0..destinations.len() {
+        while destinations[index] != index {
+            let destination = destinations[index];
+            result.swap(index, destination);
+            destinations.swap(index, destination);
+        }
+    }
 }
 
 fn sort_open_lines(lines: &mut [Vec<Coord3D>]) {

--- a/crates/geo-polygonize-core/src/utils/parallel.rs
+++ b/crates/geo-polygonize-core/src/utils/parallel.rs
@@ -102,21 +102,3 @@ where
         a.iter_mut().zip(b.iter()).for_each(|(x, y)| f(x, y));
     }
 }
-
-/// Helper for parallel consume, enumerate, map and collect
-#[inline]
-pub fn par_into_enumerate_map<T, F, U>(vec: Vec<T>, f: F) -> Vec<U>
-where
-    T: Send,
-    F: Fn((usize, T)) -> U + Sync + Send,
-    U: Send,
-{
-    #[cfg(all(feature = "parallel", not(target_arch = "wasm32")))]
-    {
-        vec.into_par_iter().enumerate().map(f).collect()
-    }
-    #[cfg(any(not(feature = "parallel"), target_arch = "wasm32"))]
-    {
-        vec.into_iter().enumerate().map(f).collect()
-    }
-}


### PR DESCRIPTION
## What changed

- build planar-graph edges directly into their final arenas instead of collecting a temporary parallel staging vector
- sort compact polygon determinism keys, then apply the resulting permutation in place
- remove the single-use `par_into_enumerate_map` helper
- add a focused test for in-place polygon reordering

## Why

Post-#827 DHAT profiling identified two large output-independent staging allocations in `core_random_100`: 54.4 MB in `PlanarGraph::bulk_load` and 51.6 MB around deterministic polygon sorting. Both copied or moved data through temporary vectors before writing the final result.

The new paths preserve the existing edge construction and deterministic sort keys while retaining data in its final allocation.

## Impact

On the seeded `core_random_100` allocation workload:

- post-#827 baseline: 712,486,518 allocated bytes
- this branch: 615,624,438 allocated bytes
- reduction: 96,862,080 bytes (13.6%)

Criterion on `polygonize/random/100` found no detectable runtime change from direct edge construction, then a 4.4% improvement from compact-key deterministic sorting (95% interval: 2.4–6.9% faster).

## Validation

- `cargo fmt --all --check`
- `cargo test --locked --verbose` (120 core unit tests plus integration, fixture, determinism, and doc tests)
- `cargo clippy --locked -- -D warnings`
- DHAT allocation benchmark with debug symbols
- Criterion A/B benchmark against the post-#827 implementation