### PR TITLE
fix(wasm): validate threaded builds across architectures

### DIFF
--- a/.github/workflows/cross-architecture-benchmarks.yml
+++ b/.github/workflows/cross-architecture-benchmarks.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - ".github/workflows/cross-architecture-benchmarks.yml"
       - "scripts/benchmark_wasm_browser.mjs"
+      - "scripts/build_wasm.sh"
       - "package.json"
       - "package-lock.json"
 
@@ -97,7 +98,9 @@ jobs:
         run: ./scripts/build_wasm.sh --variant "${{ matrix.variant }}" --no-bundle
 
       - name: Benchmark in cross-origin-isolated Chrome
-        run: node scripts/benchmark_wasm_browser.mjs "${{ matrix.variant }}" | tee wasm-${{ matrix.variant }}.json
+        run: |
+          set -o pipefail
+          node scripts/benchmark_wasm_browser.mjs "${{ matrix.variant }}" | tee wasm-${{ matrix.variant }}.json
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/cross-architecture-benchmarks.yml
+++ b/.github/workflows/cross-architecture-benchmarks.yml
@@ -1,0 +1,106 @@
+name: Cross-architecture benchmarks
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 1"
+  pull_request:
+    paths:
+      - ".github/workflows/cross-architecture-benchmarks.yml"
+      - "scripts/benchmark_wasm_browser.mjs"
+      - "package.json"
+      - "package-lock.json"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cross-architecture-benchmarks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  native:
+    name: Native (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-24.04
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: benchmark-${{ matrix.arch }}
+
+      - name: Record platform
+        run: |
+          uname -a
+          rustc -vV
+
+      - name: Benchmark representative workloads
+        env:
+          BENCH_FAST_CI: "1"
+        run: cargo bench -p geo-polygonize-core --bench polygonize_bench -- 'polygonize/(grid/100|random/(100|200))' --noplot | tee native-${{ matrix.arch }}.txt
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: native-${{ matrix.arch }}-benchmarks
+          path: |
+            native-${{ matrix.arch }}.txt
+            target/criterion/
+          retention-days: 30
+
+  wasm:
+    name: Wasm (${{ matrix.variant }})
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: [scalar, threads]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up stable Rust
+        if: matrix.variant == 'scalar'
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Set up nightly Rust
+        if: matrix.variant == 'threads'
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rust-src
+          targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: benchmark-wasm-${{ matrix.variant }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - run: npm ci
+
+      - uses: cargo-bins/cargo-binstall@main
+
+      - name: Build release package
+        run: ./scripts/build_wasm.sh --variant "${{ matrix.variant }}" --no-bundle
+
+      - name: Benchmark in cross-origin-isolated Chrome
+        run: node scripts/benchmark_wasm_browser.mjs "${{ matrix.variant }}" | tee wasm-${{ matrix.variant }}.json
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wasm-${{ matrix.variant }}-benchmarks
+          path: wasm-${{ matrix.variant }}.json
+          retention-days: 30

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@rollup/plugin-typescript": "^11.0.0",
         "@rollup/plugin-url": "^8.0.2",
         "husky": "^9.1.7",
+        "playwright-core": "^1.55.0",
         "rollup": "^4.0.0",
         "tslib": "^2.6.0",
         "typescript": "^5.0.0",
@@ -3514,6 +3515,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@rollup/plugin-typescript": "^11.0.0",
     "@rollup/plugin-url": "^8.0.2",
     "husky": "^9.1.7",
+    "playwright-core": "^1.55.0",
     "rollup": "^4.0.0",
     "tslib": "^2.6.0",
     "typescript": "^5.0.0",

--- a/scripts/benchmark_wasm_browser.mjs
+++ b/scripts/benchmark_wasm_browser.mjs
@@ -1,0 +1,118 @@
+import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+import { extname, resolve } from "node:path";
+import { chromium } from "playwright-core";
+
+const variant = process.argv[2];
+if (!new Set(["scalar", "threads"]).has(variant)) {
+  throw new Error("usage: node scripts/benchmark_wasm_browser.mjs <scalar|threads>");
+}
+
+const root = process.cwd();
+const contentTypes = new Map([
+  [".html", "text/html"],
+  [".js", "text/javascript"],
+  [".wasm", "application/wasm"],
+]);
+
+const server = createServer(async (request, response) => {
+  response.setHeader("Cross-Origin-Opener-Policy", "same-origin");
+  response.setHeader("Cross-Origin-Embedder-Policy", "require-corp");
+  response.setHeader("Cross-Origin-Resource-Policy", "same-origin");
+  response.setHeader("Cache-Control", "no-store");
+
+  let pathname = new URL(request.url, "http://localhost").pathname;
+  if (pathname === "/") {
+    response.setHeader("Content-Type", "text/html");
+    response.end("<!doctype html><title>geo-polygonize benchmark</title>");
+    return;
+  }
+  // wasm-bindgen-rayon's generated worker imports the package directory.
+  if (pathname === "/pkg-threads/") pathname += "geo_polygonize.js";
+
+  const path = resolve(root, `.${decodeURIComponent(pathname)}`);
+  if (!path.startsWith(`${root}/`)) {
+    response.writeHead(403).end();
+    return;
+  }
+
+  try {
+    response.setHeader("Content-Type", contentTypes.get(extname(path)) ?? "application/octet-stream");
+    response.end(await readFile(path));
+  } catch {
+    response.writeHead(404).end();
+  }
+});
+
+await new Promise((ready) => server.listen(0, "127.0.0.1", ready));
+const { port } = server.address();
+const launchOptions = process.env.CHROME_PATH
+  ? { executablePath: process.env.CHROME_PATH, headless: true }
+  : { channel: "chrome", headless: true };
+
+let browser;
+try {
+  browser = await chromium.launch(launchOptions);
+  const page = await browser.newPage();
+  await page.goto(`http://127.0.0.1:${port}/`);
+  const result = await page.evaluate(async (selectedVariant) => {
+    const wasm = await import(`/pkg-${selectedVariant}/geo_polygonize.js`);
+    await wasm.default();
+
+    let threadCount = 1;
+    if (selectedVariant === "threads") {
+      if (!crossOriginIsolated) throw new Error("threaded Wasm requires cross-origin isolation");
+      threadCount = Math.min(4, navigator.hardwareConcurrency || 4);
+      await wasm.initThreadPool(threadCount);
+    }
+
+    const random = (() => {
+      let state = 42;
+      return () => {
+        state += 0x6d2b79f5;
+        let value = state;
+        value = Math.imul(value ^ (value >>> 15), value | 1);
+        value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+        return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+      };
+    })();
+    const features = Array.from({ length: 100 }, () => ({
+      type: "Feature",
+      properties: {},
+      geometry: {
+        type: "LineString",
+        coordinates: [
+          [random() * 100, random() * 100],
+          [random() * 100, random() * 100],
+        ],
+      },
+    }));
+    const input = JSON.stringify({ type: "FeatureCollection", features });
+    const run = () => JSON.parse(wasm.polygonize(input, true, 1e-10, false, false)).features.length;
+
+    for (let index = 0; index < 3; index += 1) run();
+    const samplesMs = [];
+    let polygonCount = 0;
+    for (let index = 0; index < 10; index += 1) {
+      const start = performance.now();
+      polygonCount = run();
+      samplesMs.push(performance.now() - start);
+    }
+    samplesMs.sort((a, b) => a - b);
+    const meanMs = samplesMs.reduce((sum, sample) => sum + sample, 0) / samplesMs.length;
+    return {
+      variant: selectedVariant,
+      threadCount,
+      polygonCount,
+      samples: samplesMs.length,
+      minMs: samplesMs[0],
+      medianMs: (samplesMs[4] + samplesMs[5]) / 2,
+      meanMs,
+      p95Ms: samplesMs[9],
+    };
+  }, variant);
+  console.log(JSON.stringify(result, null, 2));
+} finally {
+  await browser?.close();
+  await new Promise((closed) => server.close(closed));
+}

--- a/scripts/benchmark_wasm_browser.mjs
+++ b/scripts/benchmark_wasm_browser.mjs
@@ -57,11 +57,14 @@ try {
   await page.goto(`http://127.0.0.1:${port}/`);
   const result = await page.evaluate(async (selectedVariant) => {
     const wasm = await import(`/pkg-${selectedVariant}/geo_polygonize.js`);
-    await wasm.default();
+    const instance = await wasm.default();
 
     let threadCount = 1;
     if (selectedVariant === "threads") {
       if (!crossOriginIsolated) throw new Error("threaded Wasm requires cross-origin isolation");
+      if (!(instance.memory.buffer instanceof SharedArrayBuffer)) {
+        throw new Error("threaded build did not export shared Wasm memory");
+      }
       threadCount = Math.min(4, navigator.hardwareConcurrency || 4);
       await wasm.initThreadPool(threadCount);
     }

--- a/scripts/build_wasm.sh
+++ b/scripts/build_wasm.sh
@@ -98,7 +98,7 @@ patch_threads_worker() {
 
 build_variant_threads() {
     local out_dir="pkg-threads"
-    local flags="-C target-feature=+atomics,+bulk-memory,+mutable-globals"
+    local flags="-C target-feature=+atomics,+bulk-memory,+mutable-globals -C link-arg=--shared-memory -C link-arg=--max-memory=1073741824 -C link-arg=--import-memory -C link-arg=--export=__wasm_init_tls -C link-arg=--export=__tls_size -C link-arg=--export=__tls_align -C link-arg=--export=__tls_base"
 
     echo "Building Threads version..."
     echo "Installing rust-src for nightly..."
@@ -123,7 +123,7 @@ build_variant_threads() {
 
     if command -v wasm-opt &> /dev/null; then
         echo "Optimizing Threads..."
-        wasm-opt -O3 -o "$out_dir/geo_polygonize_bg.wasm" "$out_dir/geo_polygonize_bg.wasm"
+        wasm-opt -O3 --enable-threads --enable-bulk-memory -o "$out_dir/geo_polygonize_bg.wasm" "$out_dir/geo_polygonize_bg.wasm"
     fi
 
     rm -f "$out_dir/.gitignore"

--- a/scripts/build_wasm.sh
+++ b/scripts/build_wasm.sh
@@ -98,7 +98,7 @@ patch_threads_worker() {
 
 build_variant_threads() {
     local out_dir="pkg-threads"
-    local flags="-C target-feature=+atomics,+bulk-memory,+mutable-globals -C link-arg=--shared-memory -C link-arg=--max-memory=1073741824 -C link-arg=--import-memory -C link-arg=--export=__wasm_init_tls -C link-arg=--export=__tls_size -C link-arg=--export=__tls_align -C link-arg=--export=__tls_base"
+    local flags="-C target-feature=+atomics,+bulk-memory,+mutable-globals -C link-arg=--shared-memory -C link-arg=--max-memory=1073741824 -C link-arg=--import-memory -C link-arg=--export=__heap_base -C link-arg=--export=__wasm_init_tls -C link-arg=--export=__tls_size -C link-arg=--export=__tls_align -C link-arg=--export=__tls_base"
 
     echo "Building Threads version..."
     echo "Installing rust-src for nightly..."


### PR DESCRIPTION
## What changed

- fix the threaded Wasm build to link shared/imported memory and TLS exports required by `wasm-bindgen-rayon`
- keep thread/bulk-memory features enabled through `wasm-opt`
- add a weekly/manual benchmark matrix for native x86_64, native ARM64, scalar Wasm, and threaded Wasm
- benchmark Wasm in real cross-origin-isolated Chrome and assert the threaded build exports `SharedArrayBuffer`-backed memory
- retain native Criterion data and Wasm JSON summaries as 30-day artifacts

## Root cause

The previous threaded build enabled atomics in Rust but omitted the linker flags that make Wasm linear memory shared and importable. It therefore compiled and packaged successfully, but `initThreadPool` failed when `wasm-bindgen-rayon` tried to clone ordinary `WebAssembly.Memory` into workers.

The first matrix run exposed that failure. It also exposed a CI false-green: the benchmark command piped through `tee` without `pipefail`. Both are fixed here.

## Measurement design

- native: seeded grid/100 and random/100,200 Criterion workloads on GitHub-hosted x86_64 and ARM64 Linux
- Wasm: seeded random/100 workload, three warmups, ten samples, and polygon-count validation
- threaded Wasm: real Chrome worker pool under COOP/COEP isolation
- cadence: weekly on `main`, manual dispatch, and PR validation when benchmark/build infrastructure changes

Absolute timings should be compared within each architecture/variant over time, not directly across different runner hardware.

## Validation

- `actionlint .github/workflows/cross-architecture-benchmarks.yml`
- `node --check scripts/benchmark_wasm_browser.mjs`
- `shellcheck -e SC2044 scripts/build_wasm.sh` (SC2044 is pre-existing)
- first matrix run passed native x86_64, native ARM64, and scalar Wasm and correctly exposed the threaded-memory defect
- corrected matrix rerun is the end-to-end regression check