### PR TITLE
perf(wasm): measure threaded crossover workloads

### DIFF
--- a/.github/workflows/cross-architecture-benchmarks.yml
+++ b/.github/workflows/cross-architecture-benchmarks.yml
@@ -59,37 +59,25 @@ jobs:
           retention-days: 30
 
   wasm:
-    name: Wasm (${{ matrix.variant }}-${{ matrix.threads }})
+    name: Wasm crossover
     runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - variant: scalar
-            threads: 1
-          - variant: threads
-            threads: 2
-          - variant: threads
-            threads: 4
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up stable Rust
-        if: matrix.variant == 'scalar'
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
-
       - name: Set up nightly Rust
-        if: matrix.variant == 'threads'
         uses: dtolnay/rust-toolchain@nightly
         with:
           components: rust-src
           targets: wasm32-unknown-unknown
 
+      - name: Set up stable Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: benchmark-wasm-${{ matrix.variant }}
+          shared-key: benchmark-wasm-crossover
 
       - uses: actions/setup-node@v4
         with:
@@ -100,16 +88,21 @@ jobs:
 
       - uses: cargo-bins/cargo-binstall@main
 
-      - name: Build release package
-        run: ./scripts/build_wasm.sh --variant "${{ matrix.variant }}" --no-bundle
-
-      - name: Benchmark in cross-origin-isolated Chrome
+      - name: Build and benchmark scalar package
         run: |
           set -o pipefail
-          node scripts/benchmark_wasm_browser.mjs "${{ matrix.variant }}" "${{ matrix.threads }}" | tee wasm-${{ matrix.variant }}-${{ matrix.threads }}.json
+          ./scripts/build_wasm.sh --variant scalar --no-bundle
+          node scripts/benchmark_wasm_browser.mjs scalar 1 | tee wasm-scalar-1.json
+
+      - name: Build and benchmark threaded package
+        run: |
+          set -o pipefail
+          ./scripts/build_wasm.sh --variant threads --no-bundle
+          node scripts/benchmark_wasm_browser.mjs threads 2 | tee wasm-threads-2.json
+          node scripts/benchmark_wasm_browser.mjs threads 4 | tee wasm-threads-4.json
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wasm-${{ matrix.variant }}-${{ matrix.threads }}-benchmarks
-          path: wasm-${{ matrix.variant }}-${{ matrix.threads }}.json
+          name: wasm-crossover-benchmarks
+          path: wasm-*.json
           retention-days: 30

--- a/.github/workflows/cross-architecture-benchmarks.yml
+++ b/.github/workflows/cross-architecture-benchmarks.yml
@@ -59,7 +59,7 @@ jobs:
           retention-days: 30
 
   wasm:
-    name: Wasm (${{ matrix.variant }})
+    name: Wasm (${{ matrix.variant }}-${{ matrix.threads }})
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false

--- a/.github/workflows/cross-architecture-benchmarks.yml
+++ b/.github/workflows/cross-architecture-benchmarks.yml
@@ -64,7 +64,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        variant: [scalar, threads]
+        include:
+          - variant: scalar
+            threads: 1
+          - variant: threads
+            threads: 2
+          - variant: threads
+            threads: 4
     steps:
       - uses: actions/checkout@v4
 
@@ -100,10 +106,10 @@ jobs:
       - name: Benchmark in cross-origin-isolated Chrome
         run: |
           set -o pipefail
-          node scripts/benchmark_wasm_browser.mjs "${{ matrix.variant }}" | tee wasm-${{ matrix.variant }}.json
+          node scripts/benchmark_wasm_browser.mjs "${{ matrix.variant }}" "${{ matrix.threads }}" | tee wasm-${{ matrix.variant }}-${{ matrix.threads }}.json
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wasm-${{ matrix.variant }}-benchmarks
-          path: wasm-${{ matrix.variant }}.json
+          name: wasm-${{ matrix.variant }}-${{ matrix.threads }}-benchmarks
+          path: wasm-${{ matrix.variant }}-${{ matrix.threads }}.json
           retention-days: 30

--- a/scripts/benchmark_wasm_browser.mjs
+++ b/scripts/benchmark_wasm_browser.mjs
@@ -5,7 +5,17 @@ import { chromium } from "playwright-core";
 
 const variant = process.argv[2];
 if (!new Set(["scalar", "threads"]).has(variant)) {
-  throw new Error("usage: node scripts/benchmark_wasm_browser.mjs <scalar|threads>");
+  throw new Error("usage: node scripts/benchmark_wasm_browser.mjs <scalar|threads> [thread-count]");
+}
+const requestedThreadCount = Number(process.argv[3] ?? 4);
+if (!Number.isInteger(requestedThreadCount) || requestedThreadCount < 1) {
+  throw new Error("thread-count must be a positive integer");
+}
+const sizes = (process.env.WASM_BENCH_SIZES ?? "100,200,500,1000")
+  .split(",")
+  .map(Number);
+if (sizes.some((size) => !Number.isInteger(size) || size < 1)) {
+  throw new Error("WASM_BENCH_SIZES must be comma-separated positive integers");
 }
 
 const root = process.cwd();
@@ -55,7 +65,7 @@ try {
   browser = await chromium.launch(launchOptions);
   const page = await browser.newPage();
   await page.goto(`http://127.0.0.1:${port}/`);
-  const result = await page.evaluate(async (selectedVariant) => {
+  const result = await page.evaluate(async ({ selectedVariant, requestedThreadCount, sizes }) => {
     const wasm = await import(`/pkg-${selectedVariant}/geo_polygonize.js`);
     const instance = await wasm.default();
 
@@ -65,55 +75,58 @@ try {
       if (!(instance.memory.buffer instanceof SharedArrayBuffer)) {
         throw new Error("threaded build did not export shared Wasm memory");
       }
-      threadCount = Math.min(4, navigator.hardwareConcurrency || 4);
+      threadCount = Math.min(requestedThreadCount, navigator.hardwareConcurrency || requestedThreadCount);
       await wasm.initThreadPool(threadCount);
     }
 
-    const random = (() => {
+    const results = sizes.map((size) => {
       let state = 42;
-      return () => {
+      const random = () => {
         state += 0x6d2b79f5;
         let value = state;
         value = Math.imul(value ^ (value >>> 15), value | 1);
         value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
         return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
       };
-    })();
-    const features = Array.from({ length: 100 }, () => ({
-      type: "Feature",
-      properties: {},
-      geometry: {
-        type: "LineString",
-        coordinates: [
-          [random() * 100, random() * 100],
-          [random() * 100, random() * 100],
-        ],
-      },
-    }));
-    const input = JSON.stringify({ type: "FeatureCollection", features });
-    const run = () => JSON.parse(wasm.polygonize(input, true, 1e-10, false, false)).features.length;
+      const features = Array.from({ length: size }, () => ({
+        type: "Feature",
+        properties: {},
+        geometry: {
+          type: "LineString",
+          coordinates: [
+            [random() * 100, random() * 100],
+            [random() * 100, random() * 100],
+          ],
+        },
+      }));
+      const input = JSON.stringify({ type: "FeatureCollection", features });
+      const run = () => JSON.parse(wasm.polygonize(input, true, 1e-10, false, false)).features.length;
 
-    for (let index = 0; index < 3; index += 1) run();
-    const samplesMs = [];
-    let polygonCount = 0;
-    for (let index = 0; index < 10; index += 1) {
-      const start = performance.now();
-      polygonCount = run();
-      samplesMs.push(performance.now() - start);
-    }
-    samplesMs.sort((a, b) => a - b);
-    const meanMs = samplesMs.reduce((sum, sample) => sum + sample, 0) / samplesMs.length;
+      for (let index = 0; index < 3; index += 1) run();
+      const samplesMs = [];
+      let polygonCount = 0;
+      for (let index = 0; index < 10; index += 1) {
+        const start = performance.now();
+        polygonCount = run();
+        samplesMs.push(performance.now() - start);
+      }
+      samplesMs.sort((a, b) => a - b);
+      return {
+        size,
+        polygonCount,
+        samples: samplesMs.length,
+        minMs: samplesMs[0],
+        medianMs: (samplesMs[4] + samplesMs[5]) / 2,
+        meanMs: samplesMs.reduce((sum, sample) => sum + sample, 0) / samplesMs.length,
+        p95Ms: samplesMs[9],
+      };
+    });
     return {
       variant: selectedVariant,
       threadCount,
-      polygonCount,
-      samples: samplesMs.length,
-      minMs: samplesMs[0],
-      medianMs: (samplesMs[4] + samplesMs[5]) / 2,
-      meanMs,
-      p95Ms: samplesMs[9],
+      results,
     };
-  }, variant);
+  }, { selectedVariant: variant, requestedThreadCount, sizes });
   console.log(JSON.stringify(result, null, 2));
 } finally {
   await browser?.close();


### PR DESCRIPTION
## What changed

- benchmark seeded random workloads at 100, 200, 500, and 1000 input lines in real cross-origin-isolated Chrome
- compare the scalar package with threaded packages using 2 and 4 workers
- retain polygon counts and latency summaries for each workload in the existing 30-day artifacts

## Why

The corrected threaded build is about 20% slower than scalar at 100 lines. We need the actual crossover curve before changing parallel thresholds or recommending the threaded package for smaller workloads.

## Validation

- `node --check scripts/benchmark_wasm_browser.mjs`
- `actionlint .github/workflows/cross-architecture-benchmarks.yml`
- `git diff --check`
- the draft PR matrix is the end-to-end browser benchmark; local macOS uses an Apple clang build without a wasm32 backend for the Arrow/zstd dependency