### PR TITLE
perf(core): prefer scalar point location on Linux ARM

### DIFF
--- a/.github/workflows/cross-architecture-benchmarks.yml
+++ b/.github/workflows/cross-architecture-benchmarks.yml
@@ -9,6 +9,7 @@ on:
       - ".github/workflows/cross-architecture-benchmarks.yml"
       - "scripts/benchmark_wasm_browser.mjs"
       - "scripts/build_wasm.sh"
+      - "crates/geo-polygonize-core/benches/hole_sort_bench.rs"
       - "package.json"
       - "package-lock.json"
 
@@ -48,13 +49,17 @@ jobs:
       - name: Benchmark representative workloads
         env:
           BENCH_FAST_CI: "1"
-        run: cargo bench -p geo-polygonize-core --bench polygonize_bench -- 'polygonize/(grid/100|random/(100|200))' --noplot | tee native-${{ matrix.arch }}.txt
+        run: |
+          set -o pipefail
+          cargo bench -p geo-polygonize-core --bench polygonize_bench -- 'polygonize/(grid/100|random/(100|200))' --noplot | tee native-${{ matrix.arch }}.txt
+          cargo bench -p geo-polygonize-core --bench hole_sort_bench -- point_in_ring_crossover --noplot --warm-up-time 1 --measurement-time 2 --sample-size 30 | tee native-${{ matrix.arch }}-point-in-ring.txt
 
       - uses: actions/upload-artifact@v4
         with:
           name: native-${{ matrix.arch }}-benchmarks
           path: |
             native-${{ matrix.arch }}.txt
+            native-${{ matrix.arch }}-point-in-ring.txt
             target/criterion/
           retention-days: 30
 

--- a/crates/geo-polygonize-core/benches/hole_sort_bench.rs
+++ b/crates/geo-polygonize-core/benches/hole_sort_bench.rs
@@ -5,7 +5,9 @@ use geo_polygonize_core::containment::ContainmentForest;
 use geo_polygonize_core::options::{PolygonizerOptions, TouchPolicy};
 use geo_polygonize_core::utils::simd::SimdRing;
 use geo_polygonize_core::{Coord3D, Line3D, Polygon3D, Polygonizer};
+use multiversion::multiversion;
 use std::f64::consts::PI;
+use wide::{f64x4, CmpGt};
 
 fn circle_points(center_x: f64, center_y: f64, radius: f64, edges: usize) -> Vec<Coord3D> {
     let mut points = Vec::with_capacity(edges + 1);
@@ -81,6 +83,108 @@ fn locator_query_points(count: usize) -> Vec<Coord<f64>> {
             }
         })
         .collect()
+}
+
+fn scalar_contains(x: &[f64], y: &[f64], len: usize, point: Coord<f64>) -> bool {
+    let mut crossings = 0;
+    for i in 0..len - 1 {
+        if ((y[i] > point.y) != (y[i + 1] > point.y))
+            && point.x < (x[i + 1] - x[i]) * (point.y - y[i]) / (y[i + 1] - y[i]) + x[i]
+        {
+            crossings += 1;
+        }
+    }
+    crossings % 2 != 0
+}
+
+#[multiversion(targets(
+    "x86_64+avx512f+avx512dq",
+    "x86_64+avx2",
+    "x86+avx2",
+    "x86_64+avx",
+    "x86+avx",
+    "x86_64+sse2",
+    "x86+sse2",
+))]
+fn wide_contains(x: &[f64], y: &[f64], len: usize, point: Coord<f64>) -> bool {
+    let px = f64x4::splat(point.x);
+    let py = f64x4::splat(point.y);
+    let mut crossings = 0;
+    let mut i = 0;
+    let segments = len - 1;
+
+    while i + 4 <= segments {
+        let xi = f64x4::from(&x[i..i + 4]);
+        let yi = f64x4::from(&y[i..i + 4]);
+        let xj = f64x4::from(&x[i + 1..i + 5]);
+        let yj = f64x4::from(&y[i + 1..i + 5]);
+        let crossings_mask =
+            (yi.cmp_gt(py) ^ yj.cmp_gt(py)) & (((xj - xi) * (py - yi) / (yj - yi)) + xi).cmp_gt(px);
+        crossings += crossings_mask.move_mask().count_ones();
+        i += 4;
+    }
+
+    while i < segments {
+        if ((y[i] > point.y) != (y[i + 1] > point.y))
+            && point.x < (x[i + 1] - x[i]) * (point.y - y[i]) / (y[i + 1] - y[i]) + x[i]
+        {
+            crossings += 1;
+        }
+        i += 1;
+    }
+    crossings % 2 != 0
+}
+
+fn bench_point_in_ring_crossover(c: &mut Criterion) {
+    let points = locator_query_points(1_024);
+
+    for query_count in [1, points.len()] {
+        let mut group = c.benchmark_group(format!(
+            "point_in_ring_crossover/{}",
+            if query_count == 1 {
+                "one_shot"
+            } else {
+                "repeated"
+            }
+        ));
+
+        for edges in [32, 64, 96, 128, 192, 256, 384, 512, 1_024] {
+            let polygon = circle_polygon(0.0, 0.0, 100.0, edges);
+            let ring = SimdRing::new_3d(&polygon.exterior);
+            let len = polygon.exterior.len();
+            let queries = &points[..query_count];
+            let scalar_count = queries
+                .iter()
+                .filter(|point| scalar_contains(&ring.x, &ring.y, len, **point))
+                .count();
+            assert_eq!(
+                scalar_count,
+                queries
+                    .iter()
+                    .filter(|point| wide_contains(&ring.x, &ring.y, len, **point))
+                    .count()
+            );
+
+            group.throughput(Throughput::Elements((edges * query_count) as u64));
+            group.bench_function(BenchmarkId::new("scalar", edges), |b| {
+                b.iter(|| {
+                    black_box(queries)
+                        .iter()
+                        .filter(|point| scalar_contains(&ring.x, &ring.y, len, **point))
+                        .count()
+                });
+            });
+            group.bench_function(BenchmarkId::new("wide", edges), |b| {
+                b.iter(|| {
+                    black_box(queries)
+                        .iter()
+                        .filter(|point| wide_contains(&ring.x, &ring.y, len, **point))
+                        .count()
+                });
+            });
+        }
+        group.finish();
+    }
 }
 
 fn bench_point_locators(c: &mut Criterion) {
@@ -335,6 +439,7 @@ fn bench_end_to_end(c: &mut Criterion) {
 
 criterion_group!(
     benches,
+    bench_point_in_ring_crossover,
     bench_point_locators,
     bench_preparation,
     bench_filtering,

--- a/crates/geo-polygonize-core/src/utils/simd.rs
+++ b/crates/geo-polygonize-core/src/utils/simd.rs
@@ -4,6 +4,9 @@ use multiversion::multiversion;
 use wide::f64x4;
 use wide::CmpGt;
 
+#[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+const SCALAR_MIN_COORDS: usize = 1;
+#[cfg(not(all(target_arch = "aarch64", target_os = "linux")))]
 const SCALAR_MIN_COORDS: usize = 257;
 
 pub struct SimdRing {


### PR DESCRIPTION
## What changed

- add direct production-equivalent scalar vs `wide` point-in-ring benchmarks at 32–1,024 edges
- cover one-shot and 1,024-query workloads with parity assertions
- collect the benchmark in the existing x86-64/AArch64 workflow artifacts
- use scalar point location for all non-empty rings on Linux AArch64

Closes #838.

## Evidence

- x86-64: `wide` wins repeated queries through 256 edges; scalar wins from 384, supporting the existing 257-coordinate cutoff
- Apple M1 Max: `wide` wins repeated queries through 192, ties at 256, and scalar wins from 384
- Linux AArch64: scalar wins every measured size by roughly 1.7× over `wide`

Linux AArch64 end-to-end medians before → after:

- `random/100`: 3.0748 ms → 3.0068 ms (2.2% faster)
- `random/200`: 11.408 ms → 11.297 ms (1.0% faster)
- `grid/100`: 19.163 ms → 19.716 ms (2.9% slower)

The random workloads exercise the relevant polygonization path; the grid movement is reported rather than hidden.

A direct Wasm kernel sweep is blocked because Criterion is native-only and the kernels are private. This PR avoids adding a benchmark-only public ABI; existing Wasm scalar, `simd128`, threads, and browser crossover checks pass, so Wasm retains the existing cutoff.

## Validation

- `cargo test -p geo-polygonize-core --locked` (121 unit tests plus integration suites)
- `cargo clippy -p geo-polygonize-core --bench hole_sort_bench --locked -- -D warnings`
- direct crossover benchmark with 30 samples per case and parity assertions
- `containment/end_to_end/1000_holes`: no performance change detected
- GitHub x86-64 and AArch64 benchmark matrix