### PR TITLE
test(core): benchmark noding workloads across architectures

### DIFF
--- a/.github/workflows/cross-architecture-benchmarks.yml
+++ b/.github/workflows/cross-architecture-benchmarks.yml
@@ -9,6 +9,7 @@ on:
       - ".github/workflows/cross-architecture-benchmarks.yml"
       - "scripts/benchmark_wasm_browser.mjs"
       - "scripts/build_wasm.sh"
+      - "crates/geo-polygonize-core/benches/polygonize_bench.rs"
       - "crates/geo-polygonize-core/benches/hole_sort_bench.rs"
       - "package.json"
       - "package-lock.json"
@@ -52,6 +53,7 @@ jobs:
         run: |
           set -o pipefail
           cargo bench -p geo-polygonize-core --bench polygonize_bench -- 'polygonize/(grid/100|random/(100|200))' --noplot | tee native-${{ matrix.arch }}.txt
+          cargo bench -p geo-polygonize-core --bench polygonize_bench -- noding_workloads --noplot | tee native-${{ matrix.arch }}-noding.txt
           cargo bench -p geo-polygonize-core --bench hole_sort_bench -- point_in_ring_crossover --noplot --warm-up-time 1 --measurement-time 2 --sample-size 30 | tee native-${{ matrix.arch }}-point-in-ring.txt
 
       - uses: actions/upload-artifact@v4
@@ -59,6 +61,7 @@ jobs:
           name: native-${{ matrix.arch }}-benchmarks
           path: |
             native-${{ matrix.arch }}.txt
+            native-${{ matrix.arch }}-noding.txt
             native-${{ matrix.arch }}-point-in-ring.txt
             target/criterion/
           retention-days: 30

--- a/crates/geo-polygonize-core/benches/polygonize_bench.rs
+++ b/crates/geo-polygonize-core/benches/polygonize_bench.rs
@@ -299,6 +299,105 @@ fn make_random_lines(count: usize) -> Vec<Line3D> {
         .collect()
 }
 
+fn make_noding_workloads() -> Vec<(&'static str, Vec<Line3D>)> {
+    let sparse = (0..512)
+        .map(|i| {
+            let y = i as f64 * 2.0;
+            Line3D::new(
+                Coord3D::new(0.0, y, 0.0),
+                Coord3D::new(1.0, y + 0.5, 0.0),
+                i,
+            )
+        })
+        .collect();
+    let dense = (0..256)
+        .map(|i| {
+            let angle = std::f64::consts::PI * i as f64 / 256.0;
+            let (sin, cos) = angle.sin_cos();
+            Line3D::new(
+                Coord3D::new(-cos, -sin, 0.0),
+                Coord3D::new(cos, sin, 0.0),
+                i,
+            )
+        })
+        .collect();
+    let skewed = (0..600)
+        .map(|i| {
+            let end = i as f64 * 0.0001;
+            Line3D::new(
+                Coord3D::new(0.0, 0.0, 0.0),
+                Coord3D::new(end, end + 0.00001, 0.0),
+                i,
+            )
+        })
+        .chain(std::iter::once(Line3D::new(
+            Coord3D::new(100.0, 100.0, 0.0),
+            Coord3D::new(101.0, 101.0, 0.0),
+            600,
+        )))
+        .collect();
+    let crossing = (0..4)
+        .flat_map(|x| {
+            (0..4).flat_map(move |y| {
+                let id = (x * 4 + y) * 2;
+                let (x, y) = (x as f64 * 2.0, y as f64 * 2.0);
+                [
+                    Line3D::new(
+                        Coord3D::new(x, y, 0.0),
+                        Coord3D::new(x + 1.0, y + 1.0, 0.0),
+                        id,
+                    ),
+                    Line3D::new(
+                        Coord3D::new(x + 1.0, y, 0.0),
+                        Coord3D::new(x, y + 1.0, 0.0),
+                        id + 1,
+                    ),
+                ]
+            })
+        })
+        .collect();
+
+    vec![
+        ("sparse", sparse),
+        ("dense", dense),
+        ("skewed", skewed),
+        ("crossing", crossing),
+    ]
+}
+
+fn bench_noding_workloads(c: &mut Criterion) {
+    let mut group = c.benchmark_group("noding_workloads");
+    group.sample_size(10);
+    if fast_ci() {
+        group.warm_up_time(Duration::from_secs(1));
+        group.measurement_time(Duration::from_secs(2));
+    }
+
+    for (workload, lines) in make_noding_workloads() {
+        group.throughput(Throughput::Elements(lines.len() as u64));
+        for (strategy_name, strategy) in [
+            ("auto", NodingStrategy::Auto),
+            ("grid", NodingStrategy::Grid),
+            ("simd", NodingStrategy::Simd),
+        ] {
+            // ponytail: forced Grid repeatedly re-nodes crossing splits; benchmark it after that
+            // pathology has a bounded one-shot reproducer instead of hanging every CI run.
+            if workload == "crossing" && strategy == NodingStrategy::Grid {
+                continue;
+            }
+            group.bench_with_input(
+                BenchmarkId::new(workload, strategy_name),
+                &lines,
+                |b, lines| {
+                    let noder = SnapNoder::new(1e-10).with_strategy(strategy);
+                    b.iter(|| noder.node(criterion::black_box(lines.clone())));
+                },
+            );
+        }
+    }
+    group.finish();
+}
+
 fn make_pre_snap_lines(bands: usize) -> Vec<Line3D> {
     (0..bands)
         .flat_map(|i| {
@@ -358,6 +457,7 @@ fn bench_kernel_node(c: &mut Criterion) {
 
 criterion_group!(
     kernel_benches,
+    bench_noding_workloads,
     bench_kernel_grid_build,
     bench_kernel_find_splits,
     bench_kernel_node,

--- a/scripts/benchmark_wasm_browser.mjs
+++ b/scripts/benchmark_wasm_browser.mjs
@@ -90,6 +90,23 @@ try {
       };
     };
     const durationMs = ({ secs, nanos }) => Number(secs) * 1_000 + nanos / 1_000_000;
+    const nodingOptions = {
+      node_input: true,
+      snap_grid_size: 1e-10,
+      pre_snap_tolerance: 0,
+      extract_only_polygonal: false,
+      snap_strategy: "Grid",
+      noding: { backend: "Snap" },
+      containment: { touch_policy: "AllowPointTouchDisallowEdgeShare" },
+      determinism: {
+        canonical_sort: false,
+        canonical_ring_rotation: false,
+        stable_tie_breaks: false,
+      },
+      diagnostics: { enabled: false, report_mode: false, timings: true },
+      provenance: { enabled: false, include_boundary_line_ids: false },
+      input_profile_id: null,
+    };
     const profileSize = Math.max(...sizes);
     const results = sizes.map((size) => {
       let state = 42;
@@ -150,26 +167,9 @@ try {
           coords.set(features[index].geometry.coordinates.flat(), index * 4);
         }
         const offsets = Uint32Array.from({ length: size }, (_, index) => index * 2);
-        const options = {
-          node_input: true,
-          snap_grid_size: 1e-10,
-          pre_snap_tolerance: 0,
-          extract_only_polygonal: false,
-          snap_strategy: "Grid",
-          noding: { backend: "Snap" },
-          containment: { touch_policy: "AllowPointTouchDisallowEdgeShare" },
-          determinism: {
-            canonical_sort: false,
-            canonical_ring_rotation: false,
-            stable_tie_breaks: false,
-          },
-          diagnostics: { enabled: false, report_mode: false, timings: true },
-          provenance: { enabled: false, include_boundary_line_ids: false },
-          input_profile_id: null,
-        };
         const runBuffer = () => {
           const started = performance.now();
-          const output = wasm.polygonizeWithOptionsBuffer(coords, offsets, 2, options);
+          const output = wasm.polygonizeWithOptionsBuffer(coords, offsets, 2, nodingOptions);
           const totalMs = performance.now() - started;
           const diagnostics = output.diagnostics;
           const count = output.polygon_offsets_len();
@@ -209,10 +209,53 @@ try {
       }
       return result;
     });
+
+    const sparse = Array.from({ length: 512 }, (_, i) => [[0, i * 2], [1, i * 2 + 0.5]]);
+    const dense = Array.from({ length: 256 }, (_, i) => {
+      const angle = Math.PI * i / 256;
+      return [[-Math.cos(angle), -Math.sin(angle)], [Math.cos(angle), Math.sin(angle)]];
+    });
+    const skewed = Array.from({ length: 600 }, (_, i) => {
+      const end = i * 0.0001;
+      return [[0, 0], [end, end + 0.00001]];
+    });
+    skewed.push([[100, 100], [101, 101]]);
+    // ponytail: stay below Auto's Grid threshold until crossing re-noding has a bounded reproducer.
+    const crossing = Array.from({ length: 4 * 4 * 2 }, (_, index) => {
+      const cell = Math.floor(index / 2);
+      const x = Math.floor(cell / 4) * 2;
+      const y = (cell % 4) * 2;
+      return index % 2 === 0
+        ? [[x, y], [x + 1, y + 1]]
+        : [[x + 1, y], [x, y + 1]];
+    });
+    const nodingWorkloads = Object.entries({ sparse, dense, skewed, crossing }).map(
+      ([name, lines]) => {
+        const coords = new Float64Array(lines.flat(2));
+        const offsets = Uint32Array.from({ length: lines.length }, (_, index) => index * 2);
+        const run = () => {
+          const started = performance.now();
+          const output = wasm.polygonizeWithOptionsBuffer(coords, offsets, 2, nodingOptions);
+          const totalMs = performance.now() - started;
+          const ingestAndNodeMs = durationMs(output.diagnostics.phase_times.ingest_and_node);
+          output.free();
+          return { totalMs, ingestAndNodeMs };
+        };
+        for (let index = 0; index < 3; index += 1) run();
+        const samples = Array.from({ length: 10 }, run);
+        return {
+          name,
+          segments: lines.length,
+          total: summarize(samples.map(({ totalMs }) => totalMs)),
+          ingestAndNode: summarize(samples.map(({ ingestAndNodeMs }) => ingestAndNodeMs)),
+        };
+      },
+    );
     return {
       variant: selectedVariant,
       threadCount,
       results,
+      nodingWorkloads,
     };
   }, { selectedVariant: variant, requestedThreadCount, sizes });
   console.log(JSON.stringify(result, null, 2));


### PR DESCRIPTION
## What changed

- add deterministic sparse, dense, skewed, and crossing-heavy noding workloads to the existing Criterion harness
- compare production `Auto` dispatch with forced `Grid` and forced brute-force/SIMD where each completes in bounded time
- run the noding matrix on Linux x86_64 and Linux aarch64 in the existing cross-architecture workflow
- add production ingest+noding phase profiles for the same shapes to the existing scalar and threaded browser-Wasm benchmark

This changes benchmarks and CI only; polygonization behavior is unchanged.

## Why

The latest Wasm stage profile left ingest+noding as a major measured phase. The public `Advanced` backend is currently only an exact-`SnapNoder` compatibility alias, so comparing it as if it were a distinct engine would be misleading. This measures the real dispatch choices before changing production thresholds or algorithms.

## Native results

Median comparison against the faster forced strategy:

| Workload | Apple arm64 | Linux x86_64 | Linux aarch64 |
|---|---:|---:|---:|
| sparse / 512 | SIMD 2.97× faster | SIMD 1.29× faster | Grid 1.20× faster |
| dense / 256 | SIMD 1.40× faster | SIMD 1.13× faster | SIMD 1.37× faster |
| skewed / 601 | SIMD 1.37× faster | Grid 1.30× faster | SIMD 1.22× faster |
| crossing / 32 | effectively tied | effectively tied | effectively tied |

At 256+ segments, `Auto` selects Grid and closely tracks its result. Dense inputs favor SIMD on all three machines, but sparse and skewed inputs reverse by architecture. A single global segment-count cutoff cannot select the fastest backend reliably.

## Browser-Wasm results

Ingest+noding medians:

| Workload | Scalar | 2 workers | 4 workers |
|---|---:|---:|---:|
| sparse / 512 | 0.2325 ms | 0.3500 ms | 0.3824 ms |
| dense / 256 | 23.8100 ms | 23.1599 ms | **20.2675 ms** |
| skewed / 601 | **6.4075 ms** | 6.5775 ms | 6.8225 ms |
| crossing / 32 | **0.0400 ms** | 0.0400 ms | 0.0449 ms |

Four workers improve dense noding by about 15%, but threading regresses sparse and skewed inputs. This independently supports workload-shape-aware dispatch rather than a lower global worker threshold.

## Crossing/Grid limitation

Forced Grid on even 32 independent X crossings repeatedly re-nodes split segments and does not complete Criterion warmup promptly. It is excluded from recurring CI until that pathology has a bounded one-shot reproducer; Auto stays below the Grid threshold for this workload.

## Conclusion

Do not change production dispatch in this PR. The next focused experiment should identify the cheapest existing signal—such as grid occupancy or bounding-box overlap—that distinguishes dense from sparse/skewed inputs without duplicating noding work. The crossing/Grid pathology should be isolated separately before optimization.

## Validation

- `cargo test -p geo-polygonize-core`
- `cargo clippy -p geo-polygonize-core --bench polygonize_bench -- -D warnings`
- `cargo fmt --all --check`
- `node --check scripts/benchmark_wasm_browser.mjs`
- `actionlint .github/workflows/cross-architecture-benchmarks.yml`
- `git diff --check`
- Apple arm64 Criterion matrix with `BENCH_FAST_CI=1`
- cross-architecture workflow: Linux x86_64, Linux aarch64, scalar Wasm, 2-worker Wasm, and 4-worker Wasm