### PR TITLE
fix(core): bound grid traversal at segment endpoints

### DIFF
--- a/crates/geo-polygonize-core/benches/polygonize_bench.rs
+++ b/crates/geo-polygonize-core/benches/polygonize_bench.rs
@@ -380,11 +380,6 @@ fn bench_noding_workloads(c: &mut Criterion) {
             ("grid", NodingStrategy::Grid),
             ("simd", NodingStrategy::Simd),
         ] {
-            // ponytail: forced Grid repeatedly re-nodes crossing splits; benchmark it after that
-            // pathology has a bounded one-shot reproducer instead of hanging every CI run.
-            if workload == "crossing" && strategy == NodingStrategy::Grid {
-                continue;
-            }
             group.bench_with_input(
                 BenchmarkId::new(workload, strategy_name),
                 &lines,

--- a/crates/geo-polygonize-core/src/noding/grid.rs
+++ b/crates/geo-polygonize-core/src/noding/grid.rs
@@ -38,10 +38,6 @@ fn segment_cells(
         }
     };
 
-    let (mut col, mut row) = cell(line.start.x, line.start.y);
-    let (end_col, end_row) = cell(line.end.x, line.end.y);
-    push(&mut cells, col, row);
-
     let dx = line.end.x - line.start.x;
     let dy = line.end.y - line.start.y;
     let step_x = if dx > 0.0 {
@@ -58,6 +54,11 @@ fn segment_cells(
     } else {
         0
     };
+    let on_boundary = |value: f64| (value - value.round()).abs() <= 1e-12;
+    let (mut col, mut row) = cell(line.start.x, line.start.y);
+    let (end_col, end_row) = cell(line.end.x, line.end.y);
+    push(&mut cells, col, row);
+
     let t_delta_x = if dx == 0.0 {
         f64::INFINITY
     } else {
@@ -83,6 +84,9 @@ fn segment_cells(
 
     while col != end_col || row != end_row {
         let tolerance = f64::EPSILON * t_max_x.abs().max(t_max_y.abs()).max(1.0) * 8.0;
+        if t_max_x.min(t_max_y) > 1.0 + tolerance {
+            break;
+        }
         if t_max_x.is_finite() && t_max_y.is_finite() && (t_max_x - t_max_y).abs() <= tolerance {
             push(&mut cells, col + step_x, row);
             push(&mut cells, col, row + step_y);
@@ -99,8 +103,8 @@ fn segment_cells(
         }
         push(&mut cells, col, row);
     }
+    push(&mut cells, end_col, end_row);
 
-    let on_boundary = |value: f64| (value - value.round()).abs() <= 1e-12;
     let vertical_boundary = dx == 0.0 && on_boundary((line.start.x - min_x) / cell_size);
     let horizontal_boundary = dy == 0.0 && on_boundary((line.start.y - min_y) / cell_size);
     let traversed = cells.clone();

--- a/crates/geo-polygonize-core/src/noding/snap.rs
+++ b/crates/geo-polygonize-core/src/noding/snap.rs
@@ -883,6 +883,30 @@ mod tests {
     }
 
     #[test]
+    fn test_grid_nodes_independent_crossings_once() {
+        let lines = (0..4)
+            .flat_map(|x| {
+                (0..4).flat_map(move |y| {
+                    let (x, y) = (x as f64 * 2.0, y as f64 * 2.0);
+                    [
+                        make_line(x, y, x + 1.0, y + 1.0),
+                        make_line(x + 1.0, y, x, y + 1.0),
+                    ]
+                })
+            })
+            .collect();
+        let noder = SnapNoder::new(1e-10).with_strategy(NodingStrategy::Grid);
+
+        let (noded, iterations, _) = noder.node_with_stats(lines);
+
+        assert_eq!(noded.len(), 64);
+        assert_eq!(iterations.len(), 2);
+        assert_eq!(iterations[0].intersections_found, 32);
+        assert_eq!(iterations[0].nodes_added, 32);
+        assert_eq!(iterations[1].intersections_found, 0);
+    }
+
+    #[test]
     fn test_pre_snap_inserts_nearby_reference_vertices() {
         let lines = vec![
             make_line(0.0, 0.0, 10.0, 0.0),

--- a/scripts/benchmark_wasm_browser.mjs
+++ b/scripts/benchmark_wasm_browser.mjs
@@ -220,7 +220,6 @@ try {
       return [[0, 0], [end, end + 0.00001]];
     });
     skewed.push([[100, 100], [101, 101]]);
-    // ponytail: stay below Auto's Grid threshold until crossing re-noding has a bounded reproducer.
     const crossing = Array.from({ length: 4 * 4 * 2 }, (_, index) => {
       const cell = Math.floor(index / 2);
       const x = Math.floor(cell / 4) * 2;


### PR DESCRIPTION
## What changed

- stop grid-cell traversal once the next boundary lies beyond the segment endpoint
- explicitly include the endpoint cell in the supercover
- add a regression proving 16 independent crossings node in one pass and terminate on the next
- restore the forced-Grid crossing benchmark skipped by #852

## Root cause

After the first noding pass, some split segments travel in the negative direction and end on a computed grid boundary. Floating-point cell sizing can put the endpoint in the adjacent cell, making the DDA traversal step past `t = 1` while waiting for a cell it can no longer reach.

Bounding traversal by the segment parameter fixes the shared grid path without adding a special case to the noder or benchmark.

## Result

The forced-Grid crossing benchmark previously did not finish Criterion warmup. It now completes at a 347.78 µs median on Apple arm64. Auto/SIMD remain around 7.2 µs for this deliberately small crossing workload.

## Validation

- `cargo test -p geo-polygonize-core`
- `cargo clippy -p geo-polygonize-core --lib --bench polygonize_bench -- -D warnings`
- `cargo fmt --all --check`
- `node --check scripts/benchmark_wasm_browser.mjs`
- `git diff --check`
- `BENCH_FAST_CI=1 cargo bench -p geo-polygonize-core --bench polygonize_bench -- 'noding_workloads/crossing' --noplot`