### PR TITLE
fix(github): skip release benchmark refreshes

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -28,12 +28,12 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: "${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(main): release') && 'release' || 'code' }}"
   cancel-in-progress: true
 
 jobs:
   maintenance:
-    if: "${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(github): update benchmarks') }}"
+    if: "${{ github.event_name != 'push' || (!startsWith(github.event.head_commit.message, 'chore(github): update benchmarks') && !startsWith(github.event.head_commit.message, 'chore(main): release')) }}"
     continue-on-error: true
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

- isolate release-only pushes from code-change maintenance concurrency
- skip maintenance benchmarks for `chore(main): release` commits

## Root cause

Release 0.39.11 generated benchmark PR #857. Before it merged, release 0.39.12 ran the same maintenance benchmark and generated #859 from another sample. #857 then merged 11 seconds before #859's commit, leaving the fixed `update-benchmarks` branch conflicted over benchmark noise.

A release push currently cancels the preceding code-change benchmark because both use the same concurrency group. Giving release pushes their own group lets the meaningful run finish, while the job condition makes the release-only run exit without generating another benchmark PR.

## Validation

- `actionlint .github/workflows/maintenance.yml`
- `git diff --check`

#859 was closed as the duplicate refresh.