### PR TITLE
fix(core): stabilize containment benchmark contract

### DIFF
--- a/crates/geo-polygonize-core/benches/hole_sort_bench.rs
+++ b/crates/geo-polygonize-core/benches/hole_sort_bench.rs
@@ -387,8 +387,15 @@ fn bench_end_to_end(c: &mut Criterion) {
         .containment_stats;
     assert_eq!(stats.max_point_in_ring_calls_per_shell, 1_000);
     assert_eq!(stats.shells_with_64_plus_point_in_ring_calls, 1);
-    assert_eq!(stats.shared_edge_checks, 1_000);
-    assert_eq!(stats.shared_edge_pair_checks, 65_536_000);
+    // Equal-radius rings can differ by a few ulps after translation, so exact
+    // area ordering (and the number of short-circuited touch checks) is
+    // target-dependent. Keep the benchmark contract focused on its workload.
+    assert!(stats.shared_edge_checks >= 1_000);
+    assert_eq!(stats.shared_edge_checks, stats.point_in_ring_calls);
+    assert_eq!(
+        stats.shared_edge_pair_checks,
+        65_536_000 + stats.shared_edge_checks - 1_000
+    );
     assert_eq!(stats.graph_edge_key_checks, 0);
 
     c.bench_function("containment/end_to_end/1000_holes", |b| {


### PR DESCRIPTION
## Summary

- keep the containment benchmark's 1,000-hole workload assertion
- account for target-dependent exact ordering of equal-radius translated rings
- retain exact relational checks for point-in-ring, touch-check, and pair-check counters

## Verification

- `cargo bench --locked -p geo-polygonize-core --bench hole_sort_bench -- containment/end_to_end/1000_holes --sample-size 10`
- `cargo fmt --check`
- `git diff --check`
