### PR TITLE
feat(core): preserve provenance through edge dissolve

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,10 @@ The default return shape is a stable dictionary with `polygons` as
 `SimplePolygon` values. Use `return_polygons=True` only when you want Shapely
 `Polygon` objects.
 
+When provenance is enabled, coincident and partially overlapping input lines
+are dissolved into one topology edge while every contributing nonzero
+`line_id` remains in the polygon's sorted `boundary_line_ids`.
+
 `SnapStrategy::Grid` keeps topology and output coordinates on a configured
 fixed precision grid. The CFB profile uses `GeosCompat`: the grid establishes robust
 topology, then output nodes regain deterministic source coordinates to better

--- a/crates/geo-polygonize-core/src/graph/planar_graph.rs
+++ b/crates/geo-polygonize-core/src/graph/planar_graph.rs
@@ -1,4 +1,4 @@
-use crate::types::{Coord3D, Line3D};
+use crate::types::{Coord3D, EdgeSources, Line3D};
 use crate::utils::parallel::{par_flat_map, par_sort_unstable, par_zip_for_each};
 use crate::utils::{compare_angular, z_order_index};
 use geo_types::{Coord, LineString};
@@ -22,6 +22,7 @@ pub type DirEdgeId = usize;
 pub(crate) struct ExtractedRing {
     pub coords: Vec<Coord3D>,
     pub line_ids: Vec<u32>,
+    pub source_line_ids: Vec<u32>,
     pub edge_keys: Vec<(NodeId, NodeId)>,
     pub node_ids: Vec<NodeId>,
 }
@@ -33,6 +34,8 @@ pub struct Edge {
     /// In JTS this might be a full LineString, but for the graph we mainly care about connectivity.
     /// We store Line to reduce heap allocations compared to LineString.
     pub line: Line3D,
+    /// All input lines that contribute to this geometric edge.
+    pub sources: EdgeSources,
     /// Indices of the two directed edges associated with this undirected edge.
     pub dir_edges: [DirEdgeId; 2],
     /// Flag indicating if the edge is marked (e.g. visited or pruned).
@@ -136,6 +139,7 @@ fn create_edge_components(
     u: NodeId,
     v: NodeId,
     line: Line3D,
+    sources: EdgeSources,
     edges_start_len: usize,
     dir_edges_start_len: usize,
 ) -> (
@@ -173,6 +177,7 @@ fn create_edge_components(
 
     let edge = Edge {
         line,
+        sources,
         dir_edges: [de_u_v_idx, de_v_u_idx],
         is_marked: false,
         deleted: false,
@@ -308,7 +313,7 @@ impl PlanarGraph {
         // This allows us to reserve exact capacity for outgoing_edges.
         // It also avoids repeated binary searches in the second pass.
 
-        // Store valid edges as (u, v, line)
+        // Store valid edges as (u, v, line), then dissolve coincident XY edges.
         let mut valid_edges = Vec::with_capacity(lines.len());
         let mut degrees = vec![0usize; self.nodes_x.len()]; // This might be large?
 
@@ -325,9 +330,32 @@ impl PlanarGraph {
 
             if let (Some(u), Some(v)) = (u_opt, v_opt) {
                 valid_edges.push((u, v, line));
-                degrees[u] += 1;
-                degrees[v] += 1;
             }
+        }
+
+        valid_edges.sort_unstable_by(|(u1, v1, l1), (u2, v2, l2)| {
+            let key1 = ((*u1).min(*v1), (*u1).max(*v1));
+            let key2 = ((*u2).min(*v2), (*u2).max(*v2));
+            key1.cmp(&key2)
+                .then(l1.line_id.cmp(&l2.line_id))
+                .then(u1.cmp(u2))
+                .then(v1.cmp(v2))
+        });
+
+        let mut dissolved: Vec<(NodeId, NodeId, Line3D, EdgeSources)> = Vec::new();
+        for (u, v, line) in valid_edges {
+            let key = (u.min(v), u.max(v));
+            if let Some((last_u, last_v, _, sources)) = dissolved.last_mut() {
+                if ((*last_u).min(*last_v), (*last_u).max(*last_v)) == key {
+                    sources.merge_line_id(line.line_id);
+                    continue;
+                }
+            }
+            dissolved.push((u, v, line, EdgeSources::from_line_id(line.line_id)));
+        }
+        for (u, v, _, _) in &dissolved {
+            degrees[*u] += 1;
+            degrees[*v] += 1;
         }
 
         // Reserve exact capacity
@@ -340,15 +368,22 @@ impl PlanarGraph {
         );
 
         // 5. Build Edges
-        self.edges.reserve(valid_edges.len());
-        self.directed_edges.reserve(valid_edges.len() * 2);
+        self.edges.reserve(dissolved.len());
+        self.directed_edges.reserve(dissolved.len() * 2);
 
         let edges_start_len = self.edges.len();
         let directed_edges_start_len = self.directed_edges.len();
 
-        for (i, (u, v, line)) in valid_edges.into_iter().enumerate() {
-            let (u, v, de_u_v_idx, de_v_u_idx, de_u_v, de_v_u, edge) =
-                create_edge_components(i, u, v, line, edges_start_len, directed_edges_start_len);
+        for (i, (u, v, line, sources)) in dissolved.into_iter().enumerate() {
+            let (u, v, de_u_v_idx, de_v_u_idx, de_u_v, de_v_u, edge) = create_edge_components(
+                i,
+                u,
+                v,
+                line,
+                sources,
+                edges_start_len,
+                directed_edges_start_len,
+            );
             self.directed_edges.push(de_u_v);
             self.directed_edges.push(de_v_u);
             self.edges.push(edge);
@@ -367,6 +402,20 @@ impl PlanarGraph {
 
         let u = self.add_node(p0);
         let v = self.add_node(p1);
+
+        if let Some(edge_idx) = self.nodes_outgoing[u]
+            .iter()
+            .find_map(|&directed_edge_idx| {
+                let directed_edge = &self.directed_edges[directed_edge_idx];
+                (directed_edge.dst == v && !self.edges[directed_edge.edge_idx].deleted)
+                    .then_some(directed_edge.edge_idx)
+            })
+        {
+            let edge = &mut self.edges[edge_idx];
+            edge.sources.merge_line_id(line.line_id);
+            edge.line.line_id = edge.sources.line_ids[0];
+            return edge_idx;
+        }
 
         let edge_idx = self.edges.len();
         let de_u_v_idx = self.directed_edges.len();
@@ -397,6 +446,7 @@ impl PlanarGraph {
 
         self.edges.push(Edge {
             line,
+            sources: EdgeSources::from_line_id(line.line_id),
             dir_edges: [de_u_v_idx, de_v_u_idx],
             is_marked: false,
             deleted: false,
@@ -414,8 +464,12 @@ impl PlanarGraph {
     /// Removes an edge by marking it as deleted by matching line ID.
     pub fn remove_line_by_id(&mut self, line_id: u32) -> bool {
         for edge in &mut self.edges {
-            if !edge.deleted && edge.line.line_id == line_id {
-                edge.deleted = true;
+            if !edge.deleted && edge.sources.remove_line_id(line_id) {
+                if edge.sources.line_ids.is_empty() {
+                    edge.deleted = true;
+                } else if edge.line.line_id == line_id {
+                    edge.line.line_id = edge.sources.line_ids[0];
+                }
                 return true;
             }
         }
@@ -466,49 +520,7 @@ impl PlanarGraph {
                 continue;
             }
 
-            let u = self.add_node(p0.into());
-            let v = self.add_node(p1.into());
-
-            let edge_idx = self.edges.len();
-
-            let de_u_v_idx = self.directed_edges.len();
-            let de_v_u_idx = self.directed_edges.len() + 1;
-
-            let de_u_v = DirectedEdge {
-                src: u,
-                dst: v,
-                edge_idx,
-                sym_idx: de_v_u_idx,
-                is_visited: false,
-                is_marked: false,
-                edge_direction: true,
-            };
-
-            let de_v_u = DirectedEdge {
-                src: v,
-                dst: u,
-                edge_idx,
-                sym_idx: de_u_v_idx,
-                is_visited: false,
-                is_marked: false,
-                edge_direction: false,
-            };
-
-            self.directed_edges.push(de_u_v);
-            self.directed_edges.push(de_v_u);
-
-            self.edges.push(Edge {
-                line: Line3D::new(p0.into(), p1.into(), 0),
-                dir_edges: [de_u_v_idx, de_v_u_idx],
-                is_marked: false,
-                deleted: false,
-            });
-
-            self.nodes_outgoing[u].push(de_u_v_idx);
-            self.nodes_degree[u] += 1;
-
-            self.nodes_outgoing[v].push(de_v_u_idx);
-            self.nodes_degree[v] += 1;
+            self.add_line(Line3D::new(p0.into(), p1.into(), 0));
         }
     }
 
@@ -664,7 +676,7 @@ impl PlanarGraph {
 
     /// Extracts rings from the graph following the GEOS flow.
     pub fn get_edge_rings(&mut self) -> Vec<(Vec<Coord3D>, Vec<u32>)> {
-        self.get_edge_rings_with_graph_ids(false)
+        self.get_edge_rings_with_graph_ids(false, false)
             .into_iter()
             .map(|ring| (ring.coords, ring.line_ids))
             .collect()
@@ -673,6 +685,7 @@ impl PlanarGraph {
     pub(crate) fn get_edge_rings_with_graph_ids(
         &mut self,
         include_graph_ids: bool,
+        include_source_ids: bool,
     ) -> Vec<ExtractedRing> {
         NEXT_POINTERS.with(|cell| {
             let mut next_pointers = cell.borrow_mut();
@@ -696,7 +709,7 @@ impl PlanarGraph {
             );
 
             // Extract the minimal rings from the graph.
-            self.extract_valid_rings(&next_pointers, include_graph_ids)
+            self.extract_valid_rings(&next_pointers, include_graph_ids, include_source_ids)
         })
     }
 
@@ -845,6 +858,7 @@ impl PlanarGraph {
         &mut self,
         next_pointers: &[usize],
         include_graph_ids: bool,
+        include_source_ids: bool,
     ) -> Vec<ExtractedRing> {
         for de in &mut self.directed_edges {
             de.is_visited = false;
@@ -896,6 +910,7 @@ impl PlanarGraph {
             if is_valid_ring && !ring_edges.is_empty() {
                 let mut coords = Vec::with_capacity(ring_edges.len() + 1);
                 let mut ids = Vec::with_capacity(ring_edges.len());
+                let mut source_ids = Vec::new();
                 let mut edge_keys = if include_graph_ids {
                     Vec::with_capacity(ring_edges.len())
                 } else {
@@ -917,6 +932,9 @@ impl PlanarGraph {
                     let de = &self.directed_edges[de_idx];
                     let edge_idx = de.edge_idx;
                     ids.push(self.edges[edge_idx].line.line_id);
+                    if include_source_ids {
+                        source_ids.extend_from_slice(&self.edges[edge_idx].sources.line_ids);
+                    }
                     if include_graph_ids {
                         edge_keys.push(if de.src < de.dst {
                             (de.src, de.dst)
@@ -934,9 +952,12 @@ impl PlanarGraph {
                     });
                 }
 
+                source_ids.sort_unstable();
+                source_ids.dedup();
                 rings.push(ExtractedRing {
                     coords,
                     line_ids: ids,
+                    source_line_ids: source_ids,
                     edge_keys,
                     node_ids,
                 });

--- a/crates/geo-polygonize-core/src/graph/tests.rs
+++ b/crates/geo-polygonize-core/src/graph/tests.rs
@@ -60,19 +60,37 @@ mod tests {
         // We expect only 2 nodes (p1, p2) to be added.
         assert_eq!(graph.nodes_x.len(), 2);
 
-        // However, the edges will remain because they aren't duplicates
-        // in terms of the list provided, and they don't have zero length.
-        assert_eq!(graph.edges.len(), 2);
-        assert_eq!(graph.directed_edges.len(), 4);
+        // Coincident XY edges are dissolved while all source IDs are retained.
+        assert_eq!(graph.edges.len(), 1);
+        assert_eq!(graph.directed_edges.len(), 2);
+        assert_eq!(graph.edges[0].sources.line_ids.as_slice(), &[0, 1]);
 
         // Verify that the edges point to the same two nodes.
         // We sort the src, dst to safely verify the topology.
         let mut n1 = [graph.directed_edges[0].src, graph.directed_edges[0].dst];
-        let mut n2 = [graph.directed_edges[2].src, graph.directed_edges[2].dst];
         n1.sort_unstable();
-        n2.sort_unstable();
+        assert_ne!(n1[0], n1[1]);
+    }
 
-        assert_eq!(n1, n2);
+    #[test]
+    fn test_incremental_edges_merge_and_remove_sources() {
+        use crate::types::Coord3D;
+
+        let mut graph = PlanarGraph::new();
+        let start = Coord3D::new(0.0, 0.0, 0.0);
+        let end = Coord3D::new(1.0, 0.0, 0.0);
+        let first = graph.add_line(Line3D::new(start, end, 10));
+        let second = graph.add_line(Line3D::new(end, start, 20));
+
+        assert_eq!(first, second);
+        assert_eq!(graph.edges.len(), 1);
+        assert_eq!(graph.edges[0].sources.line_ids.as_slice(), &[10, 20]);
+
+        assert!(graph.remove_line_by_id(10));
+        assert!(!graph.edges[0].deleted);
+        assert_eq!(graph.edges[0].line.line_id, 20);
+        assert!(graph.remove_line_by_id(20));
+        assert!(graph.edges[0].deleted);
     }
 
     #[test]

--- a/crates/geo-polygonize-core/src/lib.rs
+++ b/crates/geo-polygonize-core/src/lib.rs
@@ -30,7 +30,7 @@ pub use polygonizer::{
     polygonize, polygonize_with_workspace, Polygonizer, PolygonizerResult, PolygonizerWorkspace,
 };
 pub use tiling::TiledPolygonizer;
-pub use types::{Coord3D, Line3D, Polygon3D};
+pub use types::{Coord3D, EdgeSources, Line3D, Polygon3D};
 
 #[cfg(feature = "geoparquet")]
 pub mod geoparquet_api;

--- a/crates/geo-polygonize-core/src/noding/snap.rs
+++ b/crates/geo-polygonize-core/src/noding/snap.rs
@@ -516,8 +516,15 @@ impl SnapNoder {
                 .then(a.start.y.total_cmp(&b.start.y))
                 .then(a.end.x.total_cmp(&b.end.x))
                 .then(a.end.y.total_cmp(&b.end.y))
+                .then(a.line_id.cmp(&b.line_id))
         });
-        lines.dedup();
+        lines.dedup_by(|a, b| {
+            a.start.x == b.start.x
+                && a.start.y == b.start.y
+                && a.end.x == b.end.x
+                && a.end.y == b.end.y
+                && a.line_id == b.line_id
+        });
     }
 
     pub(crate) fn snap(&self, c: Coord3D) -> Coord3D {

--- a/crates/geo-polygonize-core/src/noding/validate.rs
+++ b/crates/geo-polygonize-core/src/noding/validate.rs
@@ -43,6 +43,9 @@ impl ValidatingNoder {
             candidates.sort_unstable();
             for second_index in candidates {
                 let second = &lines[second_index];
+                if same_segment_xy(first, second) {
+                    continue;
+                }
                 match line_intersection(first.to_line_2d(), second.to_line_2d()) {
                     Some(LineIntersection::SinglePoint {
                         intersection,
@@ -80,6 +83,13 @@ impl ValidatingNoder {
 
         Ok(())
     }
+}
+
+fn same_segment_xy(first: &Line3D, second: &Line3D) -> bool {
+    ((first.start.x == second.start.x && first.start.y == second.start.y)
+        && (first.end.x == second.end.x && first.end.y == second.end.y))
+        || ((first.start.x == second.end.x && first.start.y == second.end.y)
+            && (first.end.x == second.start.x && first.end.y == second.start.y))
 }
 
 fn envelope(line: &Line3D) -> AABB<[f64; 2]> {
@@ -145,5 +155,11 @@ mod tests {
     fn rejects_collinear_overlap() {
         let lines = [line((0.0, 0.0), (2.0, 0.0)), line((1.0, 0.0), (3.0, 0.0))];
         assert!(ValidatingNoder::new().validate(&lines).is_err());
+    }
+
+    #[test]
+    fn accepts_coincident_segments_as_source_carriers() {
+        let lines = [line((0.0, 0.0), (2.0, 0.0)), line((2.0, 0.0), (0.0, 0.0))];
+        ValidatingNoder::new().validate(&lines).unwrap();
     }
 }

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -193,6 +193,7 @@ impl Polygonizer {
                 // Ignore Z for initial dedup of "same projected line" if that's what we want?
                 // Probably better to keep exact duplicates removed.
                 && a.start.z == b.start.z && a.end.z == b.end.z
+                && a.line_id == b.line_id
             });
 
             // OPTIMIZATION: Spatial Sort (Z-Order 2D)
@@ -348,9 +349,10 @@ impl Polygonizer {
         let mut dangles = self.graph.prune_dangles();
 
         // 3. Find rings (3D)
-        let rings_with_ids = self
-            .graph
-            .get_edge_rings_with_graph_ids(self.options.node_input);
+        let rings_with_ids = self.graph.get_edge_rings_with_graph_ids(
+            self.options.node_input,
+            self.options.provenance.enabled && self.options.provenance.include_boundary_line_ids,
+        );
 
         // 3b. Find cut edges
         let mut cut_edges = self.graph.get_cut_edges();
@@ -549,7 +551,8 @@ pub(crate) fn extract_and_classify_rings(
     let mut invalid_rings_candidates = Vec::new();
 
     for ring in rings_with_ids {
-        let poly3d = Polygon3D::new(ring.coords, vec![], ring.line_ids, vec![]);
+        let mut poly3d = Polygon3D::new(ring.coords, vec![], ring.line_ids, vec![]);
+        poly3d.set_boundary_source_line_ids(ring.source_line_ids);
         let area = poly3d.signed_area_2d();
 
         if !has_three_distinct_xy(&poly3d.exterior) || !area.is_finite() || area == 0.0 {
@@ -670,6 +673,9 @@ fn establish_topology(
     for (idx, hole, stats) in assignments {
         containment_stats.merge(stats);
         if let Some(idx) = idx {
+            shells[idx]
+                .boundary_source_line_ids
+                .extend_from_slice(&hole.boundary_source_line_ids);
             shell_holes[idx].push(hole.exterior);
             shell_holes_ids[idx].push(hole.exterior_ids);
         } else {
@@ -701,6 +707,7 @@ pub(crate) fn construct_final_polygons(
     for ((shell, mut holes), mut holes_ids) in
         shells.into_iter().zip(shell_holes).zip(shell_holes_ids)
     {
+        let boundary_source_line_ids = shell.boundary_source_line_ids;
         let mut exterior = shell.exterior;
         let mut exterior_ids = shell.exterior_ids;
 
@@ -769,20 +776,14 @@ pub(crate) fn construct_final_polygons(
         }
 
         let mut p = Polygon3D::new(exterior, holes, exterior_ids, holes_ids);
+        p.set_boundary_source_line_ids(boundary_source_line_ids);
 
         if options.provenance.enabled {
             let mut b_ids = Vec::new();
             if options.provenance.include_boundary_line_ids {
-                for &id in &p.exterior_ids {
+                for &id in &p.boundary_source_line_ids {
                     if id != 0 {
                         b_ids.push(id as u64);
-                    }
-                }
-                for hole_ids in &p.interiors_ids {
-                    for &id in hole_ids {
-                        if id != 0 {
-                            b_ids.push(id as u64);
-                        }
                     }
                 }
                 b_ids.sort_unstable();

--- a/crates/geo-polygonize-core/src/types.rs
+++ b/crates/geo-polygonize-core/src/types.rs
@@ -1,4 +1,5 @@
 use geo_types::{Coord, Line, LineString, Polygon};
+use smallvec::SmallVec;
 use std::ops::{Add, Mul, Sub};
 
 #[derive(Clone, Copy, Debug, PartialEq, serde::Serialize)]
@@ -49,6 +50,35 @@ pub struct Line3D {
     pub start: Coord3D,
     pub end: Coord3D,
     pub line_id: u32,
+}
+
+/// Sorted, unique input line identifiers contributing to a graph edge.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct EdgeSources {
+    pub line_ids: SmallVec<[u32; 2]>,
+}
+
+impl EdgeSources {
+    pub fn from_line_id(line_id: u32) -> Self {
+        Self {
+            line_ids: SmallVec::from_slice(&[line_id]),
+        }
+    }
+
+    pub fn merge_line_id(&mut self, line_id: u32) {
+        match self.line_ids.binary_search(&line_id) {
+            Ok(_) => {}
+            Err(index) => self.line_ids.insert(index, line_id),
+        }
+    }
+
+    pub fn remove_line_id(&mut self, line_id: u32) -> bool {
+        let Ok(index) = self.line_ids.binary_search(&line_id) else {
+            return false;
+        };
+        self.line_ids.remove(index);
+        true
+    }
 }
 
 impl PartialEq for Line3D {
@@ -113,6 +143,8 @@ pub struct Polygon3D {
     pub exterior_ids: Vec<u32>,
     pub interiors_ids: Vec<Vec<u32>>,
     pub provenance: Option<PolygonProvenance>,
+    #[serde(skip)]
+    pub(crate) boundary_source_line_ids: Vec<u32>,
 }
 
 impl Polygon3D {
@@ -128,7 +160,14 @@ impl Polygon3D {
             exterior_ids,
             interiors_ids,
             provenance: None,
+            boundary_source_line_ids: Vec::new(),
         }
+    }
+
+    pub(crate) fn set_boundary_source_line_ids(&mut self, mut line_ids: Vec<u32>) {
+        line_ids.sort_unstable();
+        line_ids.dedup();
+        self.boundary_source_line_ids = line_ids;
     }
 
     pub fn to_polygon_2d(&self) -> Polygon<f64> {

--- a/crates/geo-polygonize-core/tests/provenance_acceptance.rs
+++ b/crates/geo-polygonize-core/tests/provenance_acceptance.rs
@@ -74,7 +74,7 @@ struct ProvenanceFixture {
 
 fn run_provenance_test(path: &Path) {
     let content = fs::read_to_string(path).expect("Failed to read fixture file");
-    let mut fixture: ProvenanceFixture =
+    let fixture: ProvenanceFixture =
         serde_json::from_str(&content).expect("Failed to parse fixture");
 
     let input_lines: Vec<Line3D> = fixture.inputs.iter().map(|l| l.into()).collect();
@@ -115,19 +115,46 @@ fn run_provenance_test(path: &Path) {
             .collect(),
     };
 
-    if let Some(ref expected) = fixture.expected {
-        assert_eq!(
-            &actual_result, expected,
-            "Mismatch in fixture {}",
-            fixture.name
-        );
-    } else {
-        // Bootstrap the fixture
-        fixture.expected = Some(actual_result);
-        let output = serde_json::to_string_pretty(&fixture).unwrap();
-        fs::write(path, output).unwrap();
-        println!("Bootstrapped expected output for {}", fixture.name);
-    }
+    let expected = fixture
+        .expected
+        .as_ref()
+        .unwrap_or_else(|| panic!("Missing mandatory expected output for {}", fixture.name));
+    assert_eq!(
+        &actual_result, expected,
+        "Mismatch in fixture {}",
+        fixture.name
+    );
+}
+
+#[test]
+fn collinear_overlap_preserves_every_boundary_source() {
+    let coord = |x, y| Coord3D::new(x, y, 0.0);
+    let lines = vec![
+        Line3D::new(coord(0.0, 0.0), coord(10.0, 0.0), 100),
+        Line3D::new(coord(10.0, 0.0), coord(10.0, 10.0), 101),
+        Line3D::new(coord(10.0, 10.0), coord(0.0, 10.0), 102),
+        Line3D::new(coord(0.0, 10.0), coord(0.0, 0.0), 103),
+        Line3D::new(coord(2.0, 0.0), coord(8.0, 0.0), 200),
+    ];
+    let options = PolygonizerOptions {
+        node_input: true,
+        provenance: ProvenanceOptions {
+            enabled: true,
+            include_boundary_line_ids: true,
+        },
+        ..PolygonizerOptions::default()
+    };
+
+    let result = polygonize(lines, &options).unwrap();
+    assert_eq!(result.polygons.len(), 1);
+    assert_eq!(
+        result.polygons[0]
+            .provenance
+            .as_ref()
+            .unwrap()
+            .boundary_line_ids,
+        vec![100, 101, 102, 103, 200]
+    );
 }
 
 #[test]

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -141,6 +141,7 @@ pub struct PolygonProvenance {
 ### 4.3 Provenance semantics
 `boundary_line_ids` should mean:
 - IDs of caller-provided source lines that contributed to the polygon boundary
+- all IDs on coincident or partially overlapping boundary segments; geometric dissolve must not discard source multiplicity
 - deduplicated
 - deterministically ordered in canonical mode
 


### PR DESCRIPTION
## Summary

- preserve distinct source IDs through segment splitting and collinear-overlap noding
- dissolve coincident XY graph edges into one topology edge with inline, sorted source sets
- derive polygon provenance from complete boundary source sets, including assigned holes
- keep legacy per-edge representative IDs stable and make provenance fixtures strictly read-only

## Verification

- `cargo test --locked --workspace`
- `cargo test --locked -p geo-polygonize-core --no-default-features`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `cargo fmt --check` / `git diff --check`
- compiled README/getting-started doctests
- fresh abi3 Python wheel: partial collinear overlap returned all contributing boundary IDs

Based on the released `0.42.0` commit.