### PR TITLE
feat(core): add GeoRust polygonization facade

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,25 +24,32 @@ For an ambitious, prioritized plan covering performance, security, API consisten
 ### Library
 
 ```rust
-use geo_polygonize_core::{polygonize, Coord3D, Line3D, PolygonizerOptions};
+use geo_polygonize_core::{polygonize_line_strings, PolygonizerOptions};
+use geo_types::LineString;
 
 fn main() {
-    let points = [
-        Coord3D::new(0.0, 0.0, 0.0),
-        Coord3D::new(10.0, 0.0, 0.0),
-        Coord3D::new(10.0, 10.0, 0.0),
-        Coord3D::new(0.0, 10.0, 0.0),
-    ];
-    let lines = (0..4).map(|i| Line3D::new(points[i], points[(i + 1) % 4], i as u32));
+    let ring = LineString::from(vec![
+        (0.0, 0.0),
+        (10.0, 0.0),
+        (10.0, 10.0),
+        (0.0, 10.0),
+        (0.0, 0.0),
+    ]);
 
-    let result = polygonize(lines, &PolygonizerOptions::default())
+    let result = polygonize_line_strings([&ring], &PolygonizerOptions::default())
         .expect("Polygonization failed");
+    let polygons = result.into_multi_polygon();
 
-    for polygon in result.polygons {
-        println!("Found polygon with area: {}", polygon.unsigned_area_2d());
+    for polygon in polygons {
+        println!("Found polygon: {polygon:?}");
     }
 }
 ```
+
+`polygonize_line_strings` accepts owned or borrowed `geo_traits::LineStringTrait`
+values. Use `polygonize` when source IDs or Z values must be supplied explicitly,
+and keep its full result when dangles, cut edges, invalid rings, or diagnostics are
+needed.
 
 Rust consumers should import the supported facade from the crate root. Graph,
 noding, containment, utility, mutable-builder, and tiled APIs are internal or

--- a/crates/geo-polygonize-core/src/lib.rs
+++ b/crates/geo-polygonize-core/src/lib.rs
@@ -47,7 +47,8 @@ pub use options::{DedupPolicy, TileOwnershipPolicy};
 #[doc(hidden)]
 pub use polygonizer::Polygonizer;
 pub use polygonizer::{
-    polygonize, polygonize_with_workspace, PolygonizerResult, PolygonizerWorkspace,
+    polygonize, polygonize_line_strings, polygonize_to_multi_polygon, polygonize_with_workspace,
+    PolygonizerResult, PolygonizerWorkspace,
 };
 #[doc(hidden)]
 pub use tiling::TiledPolygonizer;

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -12,7 +12,8 @@ use crate::utils::simd::SimdRing;
 use crate::utils::z_order_index;
 use float_next_after::NextAfter;
 use geo::Contains;
-use geo_types::{Coord, Geometry, Polygon};
+use geo_traits::{CoordTrait, LineStringTrait};
+use geo_types::{Coord, Geometry, MultiPolygon, Polygon};
 use std::collections::HashMap;
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -61,6 +62,18 @@ pub struct PolygonizerResult {
     pub diagnostics: Option<PolygonizerDiagnostics>,
 }
 
+impl PolygonizerResult {
+    /// Discard diagnostics and non-polygon outputs, returning GeoRust polygons.
+    pub fn into_multi_polygon(self) -> MultiPolygon<f64> {
+        MultiPolygon(
+            self.polygons
+                .into_iter()
+                .map(Polygon3D::into_polygon_2d)
+                .collect(),
+        )
+    }
+}
+
 impl Default for Polygonizer {
     fn default() -> Self {
         Self::new()
@@ -73,6 +86,45 @@ pub fn polygonize(
     options: &PolygonizerOptions,
 ) -> Result<PolygonizerResult> {
     Polygonizer::with_options(options.clone()).polygonize_owned(lines.into_iter().collect())
+}
+
+/// Polygonize borrowed or owned GeoRust line strings without first building [`Line3D`] values.
+///
+/// Coordinates are read through [`LineStringTrait`] and polygonized in XY. Each line string is
+/// assigned a stable zero-based source ID for provenance; Z coordinates are not imported.
+pub fn polygonize_line_strings<I, L>(
+    line_strings: I,
+    options: &PolygonizerOptions,
+) -> Result<PolygonizerResult>
+where
+    I: IntoIterator<Item = L>,
+    L: LineStringTrait<T = f64>,
+{
+    let mut segments = Vec::new();
+    for (line_id, line_string) in line_strings.into_iter().enumerate() {
+        let line_id = u32::try_from(line_id).map_err(|_| PolygonizeError::InvalidGeometry {
+            reason: "more than u32::MAX input line strings".to_string(),
+        })?;
+        let mut coordinates = line_string.coords();
+        let Some(first) = coordinates.next() else {
+            continue;
+        };
+        let mut previous = Coord3D::new(first.x(), first.y(), 0.0);
+        for coordinate in coordinates {
+            let current = Coord3D::new(coordinate.x(), coordinate.y(), 0.0);
+            segments.push(Line3D::new(previous, current, line_id));
+            previous = current;
+        }
+    }
+    polygonize(segments, options)
+}
+
+/// Polygonize line segments and return only the GeoRust polygon output.
+pub fn polygonize_to_multi_polygon(
+    lines: impl IntoIterator<Item = Line3D>,
+    options: &PolygonizerOptions,
+) -> Result<MultiPolygon<f64>> {
+    polygonize(lines, options).map(PolygonizerResult::into_multi_polygon)
 }
 
 /// Polygonize a borrowed slice while reusing graph allocations between calls.

--- a/crates/geo-polygonize-core/src/types.rs
+++ b/crates/geo-polygonize-core/src/types.rs
@@ -180,6 +180,21 @@ impl Polygon3D {
         Polygon::new(ext, ints)
     }
 
+    pub fn into_polygon_2d(self) -> Polygon<f64> {
+        let ext = LineString(
+            self.exterior
+                .into_iter()
+                .map(Coord3D::to_coord_2d)
+                .collect(),
+        );
+        let ints = self
+            .interiors
+            .into_iter()
+            .map(|ring| LineString(ring.into_iter().map(Coord3D::to_coord_2d).collect()))
+            .collect();
+        Polygon::new(ext, ints)
+    }
+
     /// Computes the signed 2D area directly without allocating intermediate geometry.
     /// This assumes standard winding order (exterior CCW, interior CW) where interior areas are implicitly negative.
     pub fn signed_area_2d(&self) -> f64 {

--- a/crates/geo-polygonize-core/tests/georust_api.rs
+++ b/crates/geo-polygonize-core/tests/georust_api.rs
@@ -1,0 +1,37 @@
+use geo::Area;
+use geo_polygonize_core::{
+    polygonize_line_strings, polygonize_to_multi_polygon, Coord3D, Line3D, PolygonizerOptions,
+};
+use geo_types::LineString;
+
+#[test]
+fn polygonizes_borrowed_geo_traits_line_strings() {
+    let ring = LineString::from(vec![
+        (0.0, 0.0),
+        (4.0, 0.0),
+        (4.0, 3.0),
+        (0.0, 3.0),
+        (0.0, 0.0),
+    ]);
+
+    let result = polygonize_line_strings([&ring], &PolygonizerOptions::default()).unwrap();
+    let polygons = result.into_multi_polygon();
+
+    assert_eq!(polygons.0.len(), 1);
+    assert_eq!(polygons.unsigned_area(), 12.0);
+}
+
+#[test]
+fn returns_geo_types_multi_polygon_directly() {
+    let points = [
+        Coord3D::new(0.0, 0.0, 0.0),
+        Coord3D::new(1.0, 0.0, 0.0),
+        Coord3D::new(0.0, 1.0, 0.0),
+    ];
+    let lines = (0..3).map(|i| Line3D::new(points[i], points[(i + 1) % 3], i as u32));
+
+    let polygons = polygonize_to_multi_polygon(lines, &PolygonizerOptions::default()).unwrap();
+
+    assert_eq!(polygons.0.len(), 1);
+    assert_eq!(polygons.unsigned_area(), 0.5);
+}

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -15,19 +15,19 @@ See the respective integration guides for details.
 Rust callers should use the stateless entrypoint and an explicit options object:
 
 ```rust
-use geo_polygonize_core::{polygonize, Coord3D, Line3D, PolygonizerOptions};
+use geo_polygonize_core::{polygonize_line_strings, PolygonizerOptions};
+use geo_types::LineString;
 
-let a = Coord3D::new(0.0, 0.0, 0.0);
-let b = Coord3D::new(1.0, 0.0, 0.0);
-let c = Coord3D::new(0.0, 1.0, 0.0);
-let lines = [
-    Line3D::new(a, b, 1),
-    Line3D::new(b, c, 2),
-    Line3D::new(c, a, 3),
-];
+let ring = LineString::from(vec![
+    (0.0, 0.0),
+    (1.0, 0.0),
+    (0.0, 1.0),
+    (0.0, 0.0),
+]);
 
-let result = polygonize(lines, &PolygonizerOptions::default())?;
+let result = polygonize_line_strings([&ring], &PolygonizerOptions::default())?;
 assert_eq!(result.polygons.len(), 1);
+assert_eq!(result.into_multi_polygon().0.len(), 1);
 # Ok::<(), geo_polygonize_core::PolygonizeError>(())
 ```
 


### PR DESCRIPTION
## Summary

- accept borrowed or owned `geo_traits::LineStringTrait<T = f64>` inputs
- convert full results into `geo_types::MultiPolygon<f64>` and provide a direct polygon-only entrypoint
- document and compile-test the GeoRust-native usage path

## API impact

The new adapter reads topology in XY, assigns stable zero-based source IDs per input line string, and leaves explicit Z/source-ID control on the existing `Line3D` API. Converting a full result consumes and intentionally discards dangles, cut edges, invalid rings, and diagnostics.

## Validation

- `cargo test --workspace`
- `cargo test -p geo-polygonize-core --no-default-features`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo doc -p geo-polygonize-core --no-deps`