### PR TITLE
feat(core): harden tiled polygonization contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ needed.
 Rust consumers should import the supported facade from the crate root. Graph,
 noding, containment, utility, mutable-builder, and tiled APIs are internal or
 experimental and may change without compatibility guarantees before `1.0`.
+`TiledPolygonizer` validates its grid/options and propagates per-tile errors,
+but callers must still choose a sufficient buffer and verify untiled equivalence
+for their workload.
 
 ### Choosing noding and precision
 

--- a/crates/geo-polygonize-core/benches/polygonize_bench.rs
+++ b/crates/geo-polygonize-core/benches/polygonize_bench.rs
@@ -104,7 +104,7 @@ fn bench_grid_scenarios<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
                     for geom in &geometries {
                         tiler.add_geometry(geom);
                     }
-                    tiler.polygonize();
+                    tiler.polygonize().unwrap();
                 });
             });
         }

--- a/crates/geo-polygonize-core/benches/wasm_bench/src/lib.rs
+++ b/crates/geo-polygonize-core/benches/wasm_bench/src/lib.rs
@@ -71,7 +71,9 @@ pub fn polygonize_tiled(lines: JsValue, size: f64) -> Result<JsValue, JsValue> {
     for geom in &geoms {
         tiler.add_geometry(geom);
     }
-    let results = tiler.polygonize();
+    let results = tiler
+        .polygonize()
+        .map_err(|error| JsValue::from_str(&error.to_string()))?;
 
     let count: usize = results.len();
     Ok(JsValue::from(count))

--- a/crates/geo-polygonize-core/src/options.rs
+++ b/crates/geo-polygonize-core/src/options.rs
@@ -259,9 +259,13 @@ pub enum TouchPolicy {
 #[derive(Clone, Debug, Serialize, Deserialize, TS)]
 #[ts(export)]
 pub enum TileOwnershipPolicy {
+    /// Fast ownership using the polygon centroid, which may lie outside a concave polygon.
     Centroid,
+    /// Ownership using a point guaranteed to intersect the polygon interior when one exists.
     RepresentativePointInsidePolygon,
+    /// Ownership using the smallest boundary vertex in XY order.
     LexicographicMinVertex,
+    /// Legacy deterministic ownership policy; now uses a safe interior point.
     CanonicalBoundaryHash,
 }
 

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -1,16 +1,16 @@
 use crate::options::{DedupPolicy, TileOwnershipPolicy};
 use crate::types::Polygon3D;
-use crate::Polygonizer;
+use crate::{PolygonizeError, Polygonizer, PolygonizerOptions, Result};
 use geo::bounding_rect::BoundingRect;
 use geo::intersects::Intersects;
-use geo_types::{Coord, Geometry, Rect};
+use geo::InteriorPoint;
+use geo_types::{Coord, Geometry, Point, Rect};
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
-use std::hash::{DefaultHasher, Hash, Hasher};
 
 /// Experimental tiled polygonization.
 ///
-/// Errors are currently omitted and equivalence with untiled output is not guaranteed.
+/// Equivalence with untiled output is not guaranteed.
 pub struct TiledPolygonizer<'a> {
     bbox: Rect<f64>,
     tile_size: f64,
@@ -18,10 +18,15 @@ pub struct TiledPolygonizer<'a> {
     geometries: Vec<(&'a Geometry<f64>, Option<Rect<f64>>)>,
     ownership_policy: TileOwnershipPolicy,
     dedup_policy: DedupPolicy,
+    options: PolygonizerOptions,
 }
 
 impl<'a> TiledPolygonizer<'a> {
     pub fn new(bbox: Rect<f64>, tile_size: f64) -> Self {
+        let options = PolygonizerOptions {
+            node_input: true,
+            ..Default::default()
+        };
         Self {
             bbox,
             tile_size,
@@ -29,6 +34,7 @@ impl<'a> TiledPolygonizer<'a> {
             geometries: Vec::new(),
             ownership_policy: TileOwnershipPolicy::Centroid,
             dedup_policy: DedupPolicy::KeepAll,
+            options,
         }
     }
 
@@ -47,14 +53,18 @@ impl<'a> TiledPolygonizer<'a> {
         self
     }
 
+    pub fn with_options(mut self, options: PolygonizerOptions) -> Self {
+        self.options = options;
+        self
+    }
+
     pub fn add_geometry(&mut self, geom: &'a Geometry<f64>) {
         let bbox = geom.bounding_rect();
         self.geometries.push((geom, bbox));
     }
 
-    fn process_tile(&self, tile_bbox: Rect<f64>) -> Vec<Polygon3D> {
-        let mut local_poly = Polygonizer::new();
-        local_poly.options_mut().node_input = true;
+    fn process_tile(&self, tile_bbox: Rect<f64>) -> Result<Vec<Polygon3D>> {
+        let mut local_poly = Polygonizer::with_options(self.options.clone());
 
         // Define buffered bbox
         let buffered_bbox = Rect::new(
@@ -78,98 +88,52 @@ impl<'a> TiledPolygonizer<'a> {
         }
 
         if relevant_lines == 0 {
-            return Vec::new();
+            return Ok(Vec::new());
         }
 
         // Run polygonization
-        if let Ok(result) = local_poly.polygonize() {
-            // Ownership check:
-            let mut valid_polys = Vec::new();
-            for poly in result.polygons {
-                let ownership_point = match self.ownership_policy {
-                    TileOwnershipPolicy::Centroid
-                    | TileOwnershipPolicy::RepresentativePointInsidePolygon => poly.centroid_2d(),
-                    TileOwnershipPolicy::LexicographicMinVertex => {
-                        let mut min_pt = None;
-                        for coord in &poly.exterior {
-                            if let Some(curr) = min_pt {
-                                let curr_coord: geo_types::Point<f64> = curr;
-                                if coord.x < curr_coord.x()
-                                    || (coord.x == curr_coord.x() && coord.y < curr_coord.y())
-                                {
-                                    min_pt = Some(geo_types::Point::new(coord.x, coord.y));
-                                }
-                            } else {
-                                min_pt = Some(geo_types::Point::new(coord.x, coord.y));
-                            }
-                        }
-                        min_pt
-                    }
-                    TileOwnershipPolicy::CanonicalBoundaryHash => {
-                        if poly.exterior.is_empty() {
-                            poly.centroid_2d()
-                        } else {
-                            let mut coords = poly.exterior.clone();
-                            coords.sort_unstable_by(|a, b| {
-                                a.x.total_cmp(&b.x).then(a.y.total_cmp(&b.y))
-                            });
-                            let mut hasher = DefaultHasher::new();
-                            for c in &coords {
-                                c.x.to_bits().hash(&mut hasher);
-                                c.y.to_bits().hash(&mut hasher);
-                            }
-                            let hash_val = hasher.finish();
+        let result = local_poly.polygonize()?;
+        // Ownership check:
+        let mut valid_polys = Vec::new();
+        for poly in result.polygons {
+            if let Some(pt) = self.ownership_point(&poly) {
+                let c = pt;
 
-                            let mut min_x = f64::INFINITY;
-                            let mut min_y = f64::INFINITY;
-                            let mut max_x = f64::NEG_INFINITY;
-                            let mut max_y = f64::NEG_INFINITY;
-                            for c in &poly.exterior {
-                                min_x = min_x.min(c.x);
-                                min_y = min_y.min(c.y);
-                                max_x = max_x.max(c.x);
-                                max_y = max_y.max(c.y);
-                            }
+                // Check inclusion [min, max)
+                // For the last tile in a row/col, we include the max boundary to cover the full bbox.
+                let max_x_inclusive = tile_bbox.max().x >= self.bbox.max().x;
+                let max_y_inclusive = tile_bbox.max().y >= self.bbox.max().y;
 
-                            let width = max_x - min_x;
-                            let height = max_y - min_y;
-
-                            let u = (hash_val % 1000) as f64 / 1000.0;
-                            let v = ((hash_val / 1000) % 1000) as f64 / 1000.0;
-
-                            Some(geo_types::Point::new(min_x + u * width, min_y + v * height))
-                        }
-                    }
+                let in_x = if max_x_inclusive {
+                    c.x() >= tile_bbox.min().x && c.x() <= tile_bbox.max().x
+                } else {
+                    c.x() >= tile_bbox.min().x && c.x() < tile_bbox.max().x
                 };
 
-                if let Some(pt) = ownership_point {
-                    let c = pt;
+                let in_y = if max_y_inclusive {
+                    c.y() >= tile_bbox.min().y && c.y() <= tile_bbox.max().y
+                } else {
+                    c.y() >= tile_bbox.min().y && c.y() < tile_bbox.max().y
+                };
 
-                    // Check inclusion [min, max)
-                    // For the last tile in a row/col, we include the max boundary to cover the full bbox.
-                    let max_x_inclusive = tile_bbox.max().x >= self.bbox.max().x;
-                    let max_y_inclusive = tile_bbox.max().y >= self.bbox.max().y;
-
-                    let in_x = if max_x_inclusive {
-                        c.x() >= tile_bbox.min().x && c.x() <= tile_bbox.max().x
-                    } else {
-                        c.x() >= tile_bbox.min().x && c.x() < tile_bbox.max().x
-                    };
-
-                    let in_y = if max_y_inclusive {
-                        c.y() >= tile_bbox.min().y && c.y() <= tile_bbox.max().y
-                    } else {
-                        c.y() >= tile_bbox.min().y && c.y() < tile_bbox.max().y
-                    };
-
-                    if in_x && in_y {
-                        valid_polys.push(poly);
-                    }
+                if in_x && in_y {
+                    valid_polys.push(poly);
                 }
             }
-            valid_polys
-        } else {
-            Vec::new()
+        }
+        Ok(valid_polys)
+    }
+
+    fn ownership_point(&self, poly: &Polygon3D) -> Option<Point<f64>> {
+        match self.ownership_policy {
+            TileOwnershipPolicy::Centroid => poly.centroid_2d(),
+            TileOwnershipPolicy::RepresentativePointInsidePolygon
+            | TileOwnershipPolicy::CanonicalBoundaryHash => poly.to_polygon_2d().interior_point(),
+            TileOwnershipPolicy::LexicographicMinVertex => poly
+                .exterior
+                .iter()
+                .min_by(|a, b| a.x.total_cmp(&b.x).then(a.y.total_cmp(&b.y)))
+                .map(|coord| Point::new(coord.x, coord.y)),
         }
     }
 
@@ -196,27 +160,30 @@ impl<'a> TiledPolygonizer<'a> {
         tiles
     }
 
-    pub fn polygonize(&self) -> Vec<Polygon3D> {
+    pub fn polygonize(&self) -> Result<Vec<Polygon3D>> {
+        self.validate()?;
         let tiles = self.generate_tiles();
 
         // Process tiles in parallel or sequential
-        let result_polygons: Vec<Polygon3D>;
+        let tile_results: Vec<Result<Vec<Polygon3D>>>;
         #[cfg(feature = "parallel")]
         {
-            result_polygons = tiles
+            tile_results = tiles
                 .into_par_iter()
-                .flat_map(|tile| self.process_tile(tile))
+                .map(|tile| self.process_tile(tile))
                 .collect();
         }
         #[cfg(not(feature = "parallel"))]
         {
-            result_polygons = tiles
+            tile_results = tiles
                 .into_iter()
-                .flat_map(|tile| self.process_tile(tile))
+                .map(|tile| self.process_tile(tile))
                 .collect();
         }
+        let tile_polygons = tile_results.into_iter().collect::<Result<Vec<_>>>()?;
+        let result_polygons = tile_polygons.into_iter().flatten().collect();
 
-        match self.dedup_policy {
+        Ok(match self.dedup_policy {
             DedupPolicy::KeepAll => result_polygons,
             DedupPolicy::CanonicalRingHash => {
                 use std::collections::HashSet;
@@ -314,7 +281,37 @@ impl<'a> TiledPolygonizer<'a> {
 
                 unique_polygons
             }
+        })
+    }
+
+    fn validate(&self) -> Result<()> {
+        self.options.validate()?;
+        if !self.tile_size.is_finite() || self.tile_size <= 0.0 {
+            return Err(PolygonizeError::InvalidArgumentType {
+                field: "tile_size".to_string(),
+                expected: "a finite positive number".to_string(),
+                actual: self.tile_size.to_string(),
+            });
         }
+        if !self.buffer.is_finite() || self.buffer < 0.0 {
+            return Err(PolygonizeError::InvalidArgumentType {
+                field: "buffer".to_string(),
+                expected: "a finite non-negative number".to_string(),
+                actual: self.buffer.to_string(),
+            });
+        }
+        let min = self.bbox.min();
+        let max = self.bbox.max();
+        if ![min.x, min.y, max.x, max.y].iter().all(|v| v.is_finite())
+            || min.x >= max.x
+            || min.y >= max.y
+        {
+            return Err(PolygonizeError::InvalidGeometry {
+                reason: "tile bounding box must be finite with positive width and height"
+                    .to_string(),
+            });
+        }
+        Ok(())
     }
 }
 

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -1,8 +1,8 @@
 #[cfg(test)]
 #[allow(clippy::module_inception)]
 mod tests {
-    use crate::TiledPolygonizer;
-    use geo::{Coord, Geometry, LineString, Rect};
+    use crate::{Coord3D, PolygonizeError, PolygonizerOptions, TiledPolygonizer};
+    use geo::{Contains, Coord, Geometry, LineString, Rect};
 
     #[test]
     fn test_tiled_polygonization_grid() {
@@ -54,7 +54,7 @@ mod tests {
             tiler.add_geometry(g);
         }
 
-        let polys = tiler.polygonize();
+        let polys = tiler.polygonize().unwrap();
 
         // Should find 4 polygons
         assert_eq!(polys.len(), 4);
@@ -109,7 +109,7 @@ mod tests {
             tiler.add_geometry(g);
         }
 
-        let polys = tiler.polygonize();
+        let polys = tiler.polygonize().unwrap();
 
         assert_eq!(polys.len(), 4);
     }
@@ -141,7 +141,7 @@ mod tests {
             tiler.add_geometry(g);
         }
 
-        let polys = tiler.polygonize();
+        let polys = tiler.polygonize().unwrap();
         assert_eq!(
             polys.len(),
             1,
@@ -175,7 +175,7 @@ mod tests {
             tiler.add_geometry(g);
         }
 
-        let polys = tiler.polygonize();
+        let polys = tiler.polygonize().unwrap();
         assert_eq!(
             polys.len(),
             1,
@@ -205,12 +205,91 @@ mod tests {
             tiler.add_geometry(g);
         }
 
-        let polys = tiler.polygonize();
+        let polys = tiler.polygonize().unwrap();
         assert_eq!(
             polys.len(),
             1,
             "Should identify polygon based on CanonicalBoundaryHash ownership policy"
         );
+    }
+
+    #[test]
+    fn representative_ownership_uses_an_interior_point() {
+        use crate::options::TileOwnershipPolicy;
+        use crate::Polygon3D;
+
+        let polygon = Polygon3D::new(
+            vec![
+                Coord3D::new(0.0, 0.0, 0.0),
+                Coord3D::new(4.0, 0.0, 0.0),
+                Coord3D::new(4.0, 4.0, 0.0),
+                Coord3D::new(3.0, 4.0, 0.0),
+                Coord3D::new(3.0, 1.0, 0.0),
+                Coord3D::new(1.0, 1.0, 0.0),
+                Coord3D::new(1.0, 4.0, 0.0),
+                Coord3D::new(0.0, 4.0, 0.0),
+                Coord3D::new(0.0, 0.0, 0.0),
+            ],
+            vec![],
+            vec![],
+            vec![],
+        );
+        let polygon_2d = polygon.to_polygon_2d();
+        assert!(!polygon_2d.contains(&polygon.centroid_2d().unwrap()));
+
+        let tiler = TiledPolygonizer::new(
+            Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 4.0, y: 4.0 }),
+            2.0,
+        )
+        .with_ownership_policy(TileOwnershipPolicy::RepresentativePointInsidePolygon);
+        assert!(polygon_2d.contains(&tiler.ownership_point(&polygon).unwrap()));
+    }
+
+    #[test]
+    fn rejects_invalid_tiling_configuration_and_options() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 1.0, y: 1.0 });
+        assert!(matches!(
+            TiledPolygonizer::new(bbox, 0.0).polygonize(),
+            Err(PolygonizeError::InvalidArgumentType { field, .. }) if field == "tile_size"
+        ));
+        assert!(matches!(
+            TiledPolygonizer::new(bbox, 1.0)
+                .with_buffer(f64::NAN)
+                .polygonize(),
+            Err(PolygonizeError::InvalidArgumentType { field, .. }) if field == "buffer"
+        ));
+        assert!(matches!(
+            TiledPolygonizer::new(
+                Rect::new(Coord { x: 1.0, y: 1.0 }, Coord { x: 1.0, y: 1.0 }),
+                1.0,
+            )
+            .polygonize(),
+            Err(PolygonizeError::InvalidGeometry { .. })
+        ));
+
+        let options = PolygonizerOptions {
+            pre_snap_tolerance: 1.0,
+            ..Default::default()
+        };
+        assert!(matches!(
+            TiledPolygonizer::new(bbox, 1.0)
+                .with_options(options)
+                .polygonize(),
+            Err(PolygonizeError::UnsupportedOptionCombination { .. })
+        ));
+
+        let square = Geometry::LineString(LineString::new(vec![
+            Coord { x: 0.0, y: 0.0 },
+            Coord { x: 1.0, y: 0.0 },
+            Coord { x: 1.0, y: 1.0 },
+            Coord { x: 0.0, y: 1.0 },
+            Coord { x: 0.0, y: 0.0 },
+        ]));
+        let mut options = PolygonizerOptions::default();
+        options.output_filter.minimum_face_area = Some(2.0);
+        let mut tiler = TiledPolygonizer::new(bbox, 1.0).with_options(options);
+        tiler.add_geometry(&square);
+        assert!(tiler.polygonize().unwrap().is_empty());
     }
 }
 
@@ -243,7 +322,7 @@ fn test_dedup_policy_canonical_ring_hash() {
     .with_dedup_policy(DedupPolicy::KeepAll);
     t_keep.add_geometry(&geom1);
     t_keep.add_geometry(&geom2);
-    let polys_keep = t_keep.polygonize();
+    let polys_keep = t_keep.polygonize().unwrap();
     assert_eq!(polys_keep.len(), 1);
 
     let mut t_dedup = TiledPolygonizer::new(
@@ -253,6 +332,6 @@ fn test_dedup_policy_canonical_ring_hash() {
     .with_dedup_policy(DedupPolicy::CanonicalRingHash);
     t_dedup.add_geometry(&geom1);
     t_dedup.add_geometry(&geom2);
-    let polys_dedup = t_dedup.polygonize();
+    let polys_dedup = t_dedup.polygonize().unwrap();
     assert_eq!(polys_dedup.len(), 1);
 }


### PR DESCRIPTION
## Summary

- return `Result` from experimental tiled polygonization and propagate tile failures instead of returning empty output
- validate tile size, buffer, bounding box, and canonical polygonizer options before work begins
- allow callers to provide `PolygonizerOptions` and use `geo::InteriorPoint` for safe representative ownership
- update benchmark callers, focused regressions, and the documented tiling contract

This does not claim tiled/untiled equivalence or add stitching reports; those still require a dedicated cross-boundary corpus and measured halo guarantees.

## Validation

- `cargo test --workspace`
- `cargo test -p geo-polygonize-core --no-default-features`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy -p geo-polygonize-core --no-default-features --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- focused tiling tests in both parallel and sequential builds

The excluded Wasm benchmark build remains locally blocked by Apple Clang lacking the wasm32 target required by `zstd-sys`; the workspace Wasm crate compiles and passes Clippy.
