### PR TITLE
feat(core): report tiled polygonization outcomes

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,11 @@ noding, containment, utility, mutable-builder, and tiled APIs are internal or
 experimental and may change without compatibility guarantees before `1.0`.
 `TiledPolygonizer` validates its grid/options and propagates per-tile errors,
 but callers must still choose a sufficient buffer and verify untiled equivalence
-for their workload. Canonical mode applies the same final ordering pass after
-tile merge; the equivalence gate covers one, two, four, and many boundary
-crossings plus concave, hole, dirty-intersection, and dangle cases.
+for their workload. Its result includes per-tile topology counts and merge/dedup
+counts; these are observational and do not certify buffer sufficiency. Canonical
+mode applies the same final ordering pass after tile merge; the equivalence gate
+covers one, two, four, and many boundary crossings plus concave, hole,
+dirty-intersection, and dangle cases.
 
 ### Choosing noding and precision
 

--- a/crates/geo-polygonize-core/benches/wasm_bench/src/lib.rs
+++ b/crates/geo-polygonize-core/benches/wasm_bench/src/lib.rs
@@ -75,7 +75,7 @@ pub fn polygonize_tiled(lines: JsValue, size: f64) -> Result<JsValue, JsValue> {
         .polygonize()
         .map_err(|error| JsValue::from_str(&error.to_string()))?;
 
-    let count: usize = results.len();
+    let count: usize = results.polygons.len();
     Ok(JsValue::from(count))
 }
 

--- a/crates/geo-polygonize-core/src/lib.rs
+++ b/crates/geo-polygonize-core/src/lib.rs
@@ -55,7 +55,7 @@ pub use polygonizer::{
     PolygonizerResult, PolygonizerWorkspace,
 };
 #[doc(hidden)]
-pub use tiling::TiledPolygonizer;
+pub use tiling::{StitchingReport, TileReport, TiledPolygonizeResult, TiledPolygonizer};
 pub use types::{Coord3D, Line3D, Polygon3D, PolygonProvenance};
 
 #[cfg(feature = "geoparquet")]

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -30,6 +30,38 @@ fn canonical_polygon_key(poly: &Polygon3D) -> (Vec<[u64; 3]>, Vec<Vec<[u64; 3]>>
     (canonical_ring_key(&poly.exterior), interiors)
 }
 
+/// Observed work and topology output for one tile.
+#[derive(Debug)]
+pub struct TileReport {
+    pub tile_bbox: Rect<f64>,
+    /// Geometries whose bounds intersected the buffered tile.
+    pub input_geometry_count: usize,
+    /// Polygons produced before tile ownership filtering.
+    pub polygon_count: usize,
+    pub owned_polygon_count: usize,
+    pub dangle_count: usize,
+    pub cut_edge_count: usize,
+    pub invalid_ring_count: usize,
+}
+
+/// Counts from merging and deduplicating owned tile polygons.
+///
+/// These counts do not certify that the configured buffer was sufficient.
+#[derive(Debug)]
+pub struct StitchingReport {
+    pub merged_polygon_count: usize,
+    pub duplicate_polygon_count: usize,
+    pub output_polygon_count: usize,
+}
+
+/// Experimental tiled output with per-tile and merge diagnostics.
+#[derive(Debug)]
+pub struct TiledPolygonizeResult {
+    pub polygons: Vec<Polygon3D>,
+    pub tile_reports: Vec<TileReport>,
+    pub stitching_report: StitchingReport,
+}
+
 /// Experimental tiled polygonization.
 ///
 /// Equivalence with untiled output is not guaranteed.
@@ -85,7 +117,7 @@ impl<'a> TiledPolygonizer<'a> {
         self.geometries.push((geom, bbox));
     }
 
-    fn process_tile(&self, tile_bbox: Rect<f64>) -> Result<Vec<Polygon3D>> {
+    fn process_tile(&self, tile_bbox: Rect<f64>) -> Result<(Vec<Polygon3D>, TileReport)> {
         let mut local_poly = Polygonizer::with_options(self.options.clone());
 
         // Define buffered bbox
@@ -109,12 +141,25 @@ impl<'a> TiledPolygonizer<'a> {
             }
         }
 
+        let mut report = TileReport {
+            tile_bbox,
+            input_geometry_count: relevant_lines,
+            polygon_count: 0,
+            owned_polygon_count: 0,
+            dangle_count: 0,
+            cut_edge_count: 0,
+            invalid_ring_count: 0,
+        };
         if relevant_lines == 0 {
-            return Ok(Vec::new());
+            return Ok((Vec::new(), report));
         }
 
         // Run polygonization
         let result = local_poly.polygonize()?;
+        report.polygon_count = result.polygons.len();
+        report.dangle_count = result.dangles.len();
+        report.cut_edge_count = result.cut_edges.len();
+        report.invalid_ring_count = result.invalid_rings.len();
         // Ownership check:
         let mut valid_polys = Vec::new();
         for poly in result.polygons {
@@ -143,7 +188,8 @@ impl<'a> TiledPolygonizer<'a> {
                 }
             }
         }
-        Ok(valid_polys)
+        report.owned_polygon_count = valid_polys.len();
+        Ok((valid_polys, report))
     }
 
     fn ownership_point(&self, poly: &Polygon3D) -> Option<Point<f64>> {
@@ -182,12 +228,12 @@ impl<'a> TiledPolygonizer<'a> {
         tiles
     }
 
-    pub fn polygonize(&self) -> Result<Vec<Polygon3D>> {
+    pub fn polygonize(&self) -> Result<TiledPolygonizeResult> {
         self.validate()?;
         let tiles = self.generate_tiles();
 
         // Process tiles in parallel or sequential
-        let tile_results: Vec<Result<Vec<Polygon3D>>>;
+        let tile_results: Vec<Result<(Vec<Polygon3D>, TileReport)>>;
         #[cfg(feature = "parallel")]
         {
             tile_results = tiles
@@ -202,8 +248,13 @@ impl<'a> TiledPolygonizer<'a> {
                 .map(|tile| self.process_tile(tile))
                 .collect();
         }
-        let tile_polygons = tile_results.into_iter().collect::<Result<Vec<_>>>()?;
+        let (tile_polygons, tile_reports): (Vec<_>, Vec<_>) = tile_results
+            .into_iter()
+            .collect::<Result<Vec<_>>>()?
+            .into_iter()
+            .unzip();
         let result_polygons: Vec<Polygon3D> = tile_polygons.into_iter().flatten().collect();
+        let merged_polygon_count = result_polygons.len();
 
         let polygons = match self.dedup_policy {
             DedupPolicy::KeepAll => result_polygons,
@@ -223,13 +274,23 @@ impl<'a> TiledPolygonizer<'a> {
         let mut dangles = Vec::new();
         let mut cut_edges = Vec::new();
         let mut invalid_rings = Vec::new();
-        Ok(apply_determinism(
+        let polygons = apply_determinism(
             polygons,
             &mut dangles,
             &mut cut_edges,
             &mut invalid_rings,
             &self.options,
-        ))
+        );
+        let output_polygon_count = polygons.len();
+        Ok(TiledPolygonizeResult {
+            polygons,
+            tile_reports,
+            stitching_report: StitchingReport {
+                merged_polygon_count,
+                duplicate_polygon_count: merged_polygon_count - output_polygon_count,
+                output_polygon_count,
+            },
+        })
     }
 
     fn validate(&self) -> Result<()> {

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -54,7 +54,7 @@ mod tests {
             tiler.add_geometry(g);
         }
 
-        let polys = tiler.polygonize().unwrap();
+        let polys = tiler.polygonize().unwrap().polygons;
 
         // Should find 4 polygons
         assert_eq!(polys.len(), 4);
@@ -109,7 +109,7 @@ mod tests {
             tiler.add_geometry(g);
         }
 
-        let polys = tiler.polygonize().unwrap();
+        let polys = tiler.polygonize().unwrap().polygons;
 
         assert_eq!(polys.len(), 4);
     }
@@ -141,7 +141,7 @@ mod tests {
             tiler.add_geometry(g);
         }
 
-        let polys = tiler.polygonize().unwrap();
+        let polys = tiler.polygonize().unwrap().polygons;
         assert_eq!(
             polys.len(),
             1,
@@ -175,7 +175,7 @@ mod tests {
             tiler.add_geometry(g);
         }
 
-        let polys = tiler.polygonize().unwrap();
+        let polys = tiler.polygonize().unwrap().polygons;
         assert_eq!(
             polys.len(),
             1,
@@ -205,7 +205,7 @@ mod tests {
             tiler.add_geometry(g);
         }
 
-        let polys = tiler.polygonize().unwrap();
+        let polys = tiler.polygonize().unwrap().polygons;
         assert_eq!(
             polys.len(),
             1,
@@ -289,7 +289,39 @@ mod tests {
         options.output_filter.minimum_face_area = Some(2.0);
         let mut tiler = TiledPolygonizer::new(bbox, 1.0).with_options(options);
         tiler.add_geometry(&square);
-        assert!(tiler.polygonize().unwrap().is_empty());
+        assert!(tiler.polygonize().unwrap().polygons.is_empty());
+    }
+
+    #[test]
+    fn reports_tile_topology_and_merge_counts() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 2.0, y: 2.0 });
+        let square = Geometry::LineString(LineString::new(vec![
+            Coord { x: 0.0, y: 0.0 },
+            Coord { x: 1.0, y: 0.0 },
+            Coord { x: 1.0, y: 1.0 },
+            Coord { x: 0.0, y: 1.0 },
+            Coord { x: 0.0, y: 0.0 },
+        ]));
+        let dangle = Geometry::LineString(LineString::new(vec![
+            Coord { x: 1.5, y: 0.0 },
+            Coord { x: 1.5, y: 1.0 },
+        ]));
+        let mut tiler = TiledPolygonizer::new(bbox, 2.0);
+        tiler.add_geometry(&square);
+        tiler.add_geometry(&dangle);
+
+        let result = tiler.polygonize().unwrap();
+        assert_eq!(result.tile_reports.len(), 1);
+        let report = &result.tile_reports[0];
+        assert_eq!(report.input_geometry_count, 2);
+        assert_eq!(report.polygon_count, 1);
+        assert_eq!(report.owned_polygon_count, 1);
+        assert_eq!(report.dangle_count, 1);
+        assert_eq!(report.cut_edge_count, 0);
+        assert_eq!(report.invalid_ring_count, 0);
+        assert_eq!(result.stitching_report.merged_polygon_count, 1);
+        assert_eq!(result.stitching_report.duplicate_polygon_count, 0);
+        assert_eq!(result.stitching_report.output_polygon_count, 1);
     }
 }
 
@@ -322,7 +354,7 @@ fn test_dedup_policy_canonical_ring_hash() {
     .with_dedup_policy(DedupPolicy::KeepAll);
     t_keep.add_geometry(&geom1);
     t_keep.add_geometry(&geom2);
-    let polys_keep = t_keep.polygonize().unwrap();
+    let polys_keep = t_keep.polygonize().unwrap().polygons;
     assert_eq!(polys_keep.len(), 1);
 
     let mut t_dedup = TiledPolygonizer::new(
@@ -332,7 +364,7 @@ fn test_dedup_policy_canonical_ring_hash() {
     .with_dedup_policy(DedupPolicy::CanonicalRingHash);
     t_dedup.add_geometry(&geom1);
     t_dedup.add_geometry(&geom2);
-    let polys_dedup = t_dedup.polygonize().unwrap();
+    let polys_dedup = t_dedup.polygonize().unwrap().polygons;
     assert_eq!(polys_dedup.len(), 1);
 }
 

--- a/crates/geo-polygonize-core/tests/tiling_equivalence.rs
+++ b/crates/geo-polygonize-core/tests/tiling_equivalence.rs
@@ -139,8 +139,13 @@ fn tiled_output_matches_untiled_when_the_halo_contains_each_owned_face() {
             .polygonize()
             .unwrap_or_else(|error| panic!("{} tiled: {error}", case.name));
 
-        assert_eq!(actual.len(), expected.polygons.len(), "{} count", case.name);
-        for (actual, expected) in actual.iter().zip(&expected.polygons) {
+        assert_eq!(
+            actual.polygons.len(),
+            expected.polygons.len(),
+            "{} count",
+            case.name
+        );
+        for (actual, expected) in actual.polygons.iter().zip(&expected.polygons) {
             assert_eq!(actual.exterior, expected.exterior, "{} exterior", case.name);
             assert_eq!(actual.interiors, expected.interiors, "{} holes", case.name);
         }


### PR DESCRIPTION
## Summary

- return `TiledPolygonizeResult` with polygons, per-tile reports, and a stitching report
- report relevant geometry, polygon ownership, dangle, cut-edge, invalid-ring, merge, dedup, and output counts
- update tiled callers and document that reports are observational rather than proof of halo sufficiency

This intentionally changes the hidden experimental tiled API from `Result<Vec<Polygon3D>>` to `Result<TiledPolygonizeResult>`. Per-tile errors still propagate through `Result`; successful runs now retain the topology evidence that was previously discarded.

## Validation

- `cargo test --workspace`
- `cargo test -p geo-polygonize-core --no-default-features`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy -p geo-polygonize-core --no-default-features --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo check --manifest-path crates/geo-polygonize-core/benches/wasm_bench/Cargo.toml`
