### PR TITLE
feat(core): make Arrow adapters optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ This behavior matches classical JTS/GEOS polygonization semantics and is useful 
 
 ### GeoArrow Integration
 
-The library supports ingesting data directly from Arrow arrays via the `arrow_api` module and `ffi`.
+The Rust `arrow_api` and `ffi` modules require the opt-in `arrow` Cargo feature;
+the Wasm crate enables it automatically.
 
 ```rust
 use geo_polygonize_core::arrow_api::{polygonize_arrow, PolygonizerOptions};

--- a/crates/geo-polygonize-core/Cargo.toml
+++ b/crates/geo-polygonize-core/Cargo.toml
@@ -22,8 +22,8 @@ float_next_after = "1.0"
 smallvec = "1.11"
 pyo3 = { version = "0.29", features = ["extension-module", "abi3-py38"], optional = true }
 numpy = { version = "0.29", optional = true }
-arrow = { version = "57", features = ["ffi"] }
-geoarrow = "0.7.0"
+arrow = { version = "57", features = ["ffi"], optional = true }
+geoarrow = { version = "0.7.0", optional = true }
 geo-traits = "0.3.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -52,7 +52,8 @@ dhat = "0.3.3"
 
 [features]
 default = ["parallel"]
-geoparquet = ["dep:geoparquet", "dep:parquet"]
+arrow = ["dep:arrow", "dep:geoarrow"]
+geoparquet = ["arrow", "dep:geoparquet", "dep:parquet"]
 flatgeobuf = ["dep:flatgeobuf", "dep:geozero"]
 parallel = ["dep:rayon"]
 python = ["dep:pyo3", "dep:numpy"]
@@ -80,6 +81,7 @@ harness = false
 [[bench]]
 name = "allocation_bench"
 harness = false
+required-features = ["arrow"]
 
 [[bench]]
 name = "iai_bench"

--- a/crates/geo-polygonize-core/src/lib.rs
+++ b/crates/geo-polygonize-core/src/lib.rs
@@ -8,11 +8,13 @@
 //! - **Performance**: SIMD-accelerated predicates and efficient memory layout.
 //! - **Wasm**: Optimized for WebAssembly environments.
 
+#[cfg(feature = "arrow")]
 pub mod arrow_api;
 #[doc(hidden)]
 pub mod containment;
 mod diagnostics;
 mod error;
+#[cfg(feature = "arrow")]
 pub mod ffi;
 // Kept compiler-public for the repository's microbenchmarks; not a supported API.
 #[doc(hidden)]

--- a/crates/geo-polygonize-core/tests/arrow_api_tests.rs
+++ b/crates/geo-polygonize-core/tests/arrow_api_tests.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "arrow")]
+
 use arrow::array::{Array, Float64Array, LargeListArray, StructArray};
 use arrow::buffer::OffsetBuffer;
 use arrow::datatypes::{DataType, Field};

--- a/crates/geo-polygonize-core/tests/arrow_integration.rs
+++ b/crates/geo-polygonize-core/tests/arrow_integration.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "arrow")]
+
 use arrow::array::Array;
 use arrow::datatypes::Field;
 use arrow::ffi::{FFI_ArrowArray, FFI_ArrowSchema};

--- a/crates/geo-polygonize-core/tests/test_ffi_errors.rs
+++ b/crates/geo-polygonize-core/tests/test_ffi_errors.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "arrow")]
+
 use arrow::ffi::{FFI_ArrowArray, FFI_ArrowSchema};
 use geo_polygonize_core::ffi::{polygonize_ffi, PolygonizerOptions};
 

--- a/crates/geo-polygonize-wasm/Cargo.toml
+++ b/crates/geo-polygonize-wasm/Cargo.toml
@@ -10,7 +10,7 @@ readme = "../../README.md"
 crate-type = ["cdylib"]
 
 [dependencies]
-geo-polygonize-core = { path = "../geo-polygonize-core", version = "0.47.1" }
+geo-polygonize-core = { path = "../geo-polygonize-core", version = "0.47.1", features = ["arrow"] }
 wasm-bindgen = "0.2"
 console_error_panic_hook = { version = "0.1.7", optional = true }
 js-sys = "0.3"


### PR DESCRIPTION
## Summary

- make Arrow and GeoArrow dependencies opt-in through a new `arrow` feature
- gate the Rust `arrow_api` and `ffi` modules and their tests behind that feature
- make `geoparquet` imply `arrow`, while Wasm enables `arrow` explicitly
- keep Arrow-heavy allocation benchmarks out of minimal builds

Rust consumers using `arrow_api` or `ffi` must now enable `features = ["arrow"]`. Wasm behavior is unchanged.

## Verification

- `cargo test -p geo-polygonize-core --no-default-features` (147 core tests plus integrations)
- `cargo test -p geo-polygonize-core --features arrow --test arrow_api_tests --test arrow_integration --test test_ffi_errors` (9 tests)
- `cargo check -p geo-polygonize-wasm`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy -p geo-polygonize-core --no-default-features --all-targets -- -D warnings`
- `cargo clippy -p geo-polygonize-core --all-features --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- minimal dependency tree contains neither Arrow nor Parquet

`cargo test -p geo-polygonize-core --all-features` reaches the existing local macOS PyO3 linker limitation; the Python feature compiles independently and all feature combinations above pass.