### PR TITLE
feat(core): extract Arrow adapter crate

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,15 @@ jobs:
       - name: Publish geo-polygonize-core to crates.io
         run: cargo publish -p geo-polygonize-core
 
+      - name: Publish geo-polygonize-arrow to crates.io
+        run: |
+          for i in 1 2 3 4 5 6; do
+            cargo publish -p geo-polygonize-arrow && exit 0
+            echo "Publish failed, waiting before retrying..."
+            sleep 30
+          done
+          exit 1
+
       - name: Publish geo-polygonize-wasm to crates.io
         run: |
           for i in 1 2 3 4 5 6; do

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,11 +1008,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "geo-polygonize-arrow"
+version = "0.48.0"
+dependencies = [
+ "arrow",
+ "dhat",
+ "geo",
+ "geo-polygonize-core",
+ "geo-traits",
+ "geo-types",
+ "geoarrow",
+ "geoarrow-test",
+ "geoparquet",
+ "parquet",
+ "rand",
+ "serde_json",
+]
+
+[[package]]
 name = "geo-polygonize-core"
 version = "0.48.0"
 dependencies = [
  "approx",
- "arrow",
  "clap",
  "criterion",
  "dhat",
@@ -1021,10 +1038,7 @@ dependencies = [
  "geo",
  "geo-traits",
  "geo-types",
- "geoarrow",
- "geoarrow-test",
  "geojson",
- "geoparquet",
  "geozero",
  "getrandom 0.2.17",
  "humantime-serde",
@@ -1032,7 +1046,6 @@ dependencies = [
  "log",
  "multiversion",
  "numpy",
- "parquet",
  "pyo3",
  "rand",
  "rayon",
@@ -1056,6 +1069,7 @@ dependencies = [
  "arrow-ipc",
  "console_error_panic_hook",
  "geo",
+ "geo-polygonize-arrow",
  "geo-polygonize-core",
  "geo-traits",
  "geoarrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "crates/geo-polygonize-arrow",
     "xtask",
     "crates/geo-polygonize-core",
     "crates/geo-polygonize-wasm"

--- a/README.md
+++ b/README.md
@@ -112,11 +112,11 @@ This behavior matches classical JTS/GEOS polygonization semantics and is useful 
 
 ### GeoArrow Integration
 
-The Rust `arrow_api` and `ffi` modules require the opt-in `arrow` Cargo feature;
-the Wasm crate enables it automatically.
+Rust Arrow and GeoArrow adapters live in the `geo-polygonize-arrow` crate;
+the Wasm crate includes it automatically.
 
 ```rust
-use geo_polygonize_core::arrow_api::{polygonize_arrow, PolygonizerOptions};
+use geo_polygonize_arrow::{polygonize_arrow, PolygonizerOptions};
 // ... create Arrow array ...
 // let result = polygonize_arrow(&array, &field, options);
 ```

--- a/crates/geo-polygonize-arrow/Cargo.toml
+++ b/crates/geo-polygonize-arrow/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "geo-polygonize-arrow"
+version = "0.48.0"
+edition = "2021"
+description = "Arrow and GeoArrow adapters for geo-polygonize-core."
+license = "MIT OR Apache-2.0"
+readme = "../../README.md"
+
+[lib]
+crate-type = ["rlib", "cdylib"]
+
+[dependencies]
+geo-polygonize-core = { path = "../geo-polygonize-core", version = "0.48.0" }
+arrow = { version = "57", features = ["ffi"] }
+geoarrow = "0.7.0"
+geo = "0.32"
+geo-traits = "0.3.0"
+serde_json = "1.0"
+geoparquet = { version = "0.7.0", optional = true }
+parquet = { version = "57.3.0", optional = true }
+
+[dev-dependencies]
+geoarrow-test = "0.7.0"
+geo-types = "0.7"
+rand = "0.8"
+dhat = "0.3.3"
+
+[features]
+geoparquet = ["dep:geoparquet", "dep:parquet"]
+
+[[bench]]
+name = "allocation_bench"
+harness = false

--- a/crates/geo-polygonize-arrow/benches/allocation_bench.rs
+++ b/crates/geo-polygonize-arrow/benches/allocation_bench.rs
@@ -4,8 +4,8 @@ static ALLOC: dhat::Alloc = dhat::Alloc;
 use arrow::array::make_array;
 use arrow::datatypes::Field;
 use arrow::ffi::{from_ffi_and_data_type, FFI_ArrowArray, FFI_ArrowSchema};
-use geo_polygonize_core::arrow_api::polygonize_arrow;
-use geo_polygonize_core::ffi::{polygonize_ffi, PolygonizerOptions as FfiOptions};
+use geo_polygonize_arrow::ffi::{polygonize_ffi, PolygonizerOptions as FfiOptions};
+use geo_polygonize_arrow::polygonize_arrow;
 use geo_polygonize_core::Polygonizer;
 use geo_polygonize_core::PolygonizerOptions;
 use geo_types::{Coord, LineString};
@@ -156,7 +156,7 @@ fn main() {
 #[cfg(feature = "geoparquet")]
 fn measure_geoparquet() {
     use arrow::record_batch::RecordBatch;
-    use geo_polygonize_core::geoparquet_api::polygonize_geoparquet_file;
+    use geo_polygonize_arrow::geoparquet_api::polygonize_geoparquet_file;
     use geoparquet::writer::{GeoParquetRecordBatchEncoder, GeoParquetWriterOptions};
     use parquet::arrow::ArrowWriter;
     use std::fs::{self, File};

--- a/crates/geo-polygonize-arrow/src/arrow_api.rs
+++ b/crates/geo-polygonize-arrow/src/arrow_api.rs
@@ -1,15 +1,13 @@
-use crate::error::PolygonizeError;
-use crate::polygonize;
-use crate::types::{Coord3D, Line3D};
 use arrow::array::{Array, AsArray, GenericListArray};
 use arrow::datatypes::{DataType, Field, Float64Type};
+use geo_polygonize_core::{polygonize, Coord3D, Line3D, PolygonizeError};
 use geo_traits::to_geo::ToGeoLineString;
 use geoarrow::array::{GeoArrowArray, GeoArrowArrayAccessor, LineStringArray, PolygonBuilder};
 use geoarrow::datatypes::{Dimension, GeoArrowType, Metadata, PolygonType};
 use std::convert::TryFrom;
 use std::sync::Arc;
 
-pub use crate::options::PolygonizerOptions;
+pub use geo_polygonize_core::PolygonizerOptions;
 
 pub fn polygonize_arrow(
     array: &dyn Array,

--- a/crates/geo-polygonize-arrow/src/ffi.rs
+++ b/crates/geo-polygonize-arrow/src/ffi.rs
@@ -1,8 +1,9 @@
-use crate::arrow_api::polygonize_arrow;
+use crate::polygonize_arrow;
 use arrow::array::Array;
 use arrow::datatypes::Field;
 use arrow::error::ArrowError;
 use arrow::ffi::{from_ffi_and_data_type, FFI_ArrowArray, FFI_ArrowSchema};
+use geo_polygonize_core::{PolygonizeError, PolygonizerOptions as CoreOptions, PrecisionModel};
 use geoarrow::array::IntoArrow;
 use std::convert::TryFrom;
 
@@ -82,12 +83,12 @@ pub unsafe extern "C" fn polygonize_ffi(
         }
         let opts = &*options;
         let node_input = opts.node_input != 0;
-        let mut arrow_opts = crate::options::PolygonizerOptions {
+        let mut arrow_opts = CoreOptions {
             node_input,
             precision_model: if node_input {
-                crate::options::PrecisionModel::from_grid_size(opts.snap_grid_size)
+                PrecisionModel::from_grid_size(opts.snap_grid_size)
             } else {
-                crate::options::PrecisionModel::Floating
+                PrecisionModel::Floating
             },
             extract_only_polygonal: opts.extract_only_polygonal != 0,
             ..Default::default()
@@ -131,8 +132,7 @@ pub unsafe extern "C" fn polygonize_with_options_ffi(
             Err(_) => return 1,
         };
 
-        let arrow_opts: crate::options::PolygonizerOptions = match serde_json::from_str(options_str)
-        {
+        let arrow_opts: CoreOptions = match serde_json::from_str(options_str) {
             Ok(o) => o,
             Err(_) => return 1,
         };
@@ -153,7 +153,7 @@ unsafe fn polygonize_ffi_internal(
     input_schema: *mut FFI_ArrowSchema,
     output_array: *mut FFI_ArrowArray,
     output_schema: *mut FFI_ArrowSchema,
-    arrow_opts: crate::options::PolygonizerOptions,
+    arrow_opts: CoreOptions,
 ) -> i32 {
     if input_array.is_null()
         || input_schema.is_null()
@@ -195,15 +195,15 @@ unsafe fn polygonize_ffi_internal(
             0
         }
         Err(e) => match e {
-            crate::error::PolygonizeError::InvalidBufferShape { .. } => 5,
-            crate::error::PolygonizeError::InvalidArgumentType { .. } => 6,
-            crate::error::PolygonizeError::InvalidGeometry { .. } => 7,
-            crate::error::PolygonizeError::TopologyFailure { .. } => 8,
-            crate::error::PolygonizeError::ZConflict { .. } => 8,
-            crate::error::PolygonizeError::NodingValidationFailure { .. } => 8,
-            crate::error::PolygonizeError::UnsupportedOptionCombination { .. } => 9,
-            crate::error::PolygonizeError::InternalInvariantViolation { .. } => 10,
-            crate::error::PolygonizeError::ArrowError(_) => 11,
+            PolygonizeError::InvalidBufferShape { .. } => 5,
+            PolygonizeError::InvalidArgumentType { .. } => 6,
+            PolygonizeError::InvalidGeometry { .. } => 7,
+            PolygonizeError::TopologyFailure { .. } => 8,
+            PolygonizeError::ZConflict { .. } => 8,
+            PolygonizeError::NodingValidationFailure { .. } => 8,
+            PolygonizeError::UnsupportedOptionCombination { .. } => 9,
+            PolygonizeError::InternalInvariantViolation { .. } => 10,
+            PolygonizeError::ArrowError(_) => 11,
             _ => 12,
         },
     }

--- a/crates/geo-polygonize-arrow/src/geoparquet_api.rs
+++ b/crates/geo-polygonize-arrow/src/geoparquet_api.rs
@@ -1,9 +1,8 @@
-use crate::arrow_api::polygonize_arrow;
-use crate::error::PolygonizeError;
-use crate::options::PolygonizerOptions;
+use crate::polygonize_arrow;
 use arrow::array::Array;
 use arrow::datatypes::Schema;
 use arrow::record_batch::RecordBatch;
+use geo_polygonize_core::{PolygonizeError, PolygonizerOptions};
 use geoarrow::array::GeoArrowArray;
 use geoarrow::datatypes::CoordType;
 use geoparquet::reader::{GeoParquetReaderBuilder, GeoParquetRecordBatchReader};

--- a/crates/geo-polygonize-arrow/src/lib.rs
+++ b/crates/geo-polygonize-arrow/src/lib.rs
@@ -1,0 +1,7 @@
+mod arrow_api;
+pub mod ffi;
+
+#[cfg(feature = "geoparquet")]
+pub mod geoparquet_api;
+
+pub use arrow_api::{polygonize_arrow, PolygonizerOptions};

--- a/crates/geo-polygonize-arrow/tests/arrow_api_tests.rs
+++ b/crates/geo-polygonize-arrow/tests/arrow_api_tests.rs
@@ -1,9 +1,7 @@
-#![cfg(feature = "arrow")]
-
 use arrow::array::{Array, Float64Array, LargeListArray, StructArray};
 use arrow::buffer::OffsetBuffer;
 use arrow::datatypes::{DataType, Field};
-use geo_polygonize_core::arrow_api::{polygonize_arrow, PolygonizerOptions};
+use geo_polygonize_arrow::{polygonize_arrow, PolygonizerOptions};
 use geo_traits::{LineStringTrait, PolygonTrait};
 use geoarrow::array::{GeoArrowArray, GeoArrowArrayAccessor, LineStringBuilder};
 use geoarrow::datatypes::{Crs, Dimension, Edges, LineStringType, Metadata};

--- a/crates/geo-polygonize-arrow/tests/arrow_integration.rs
+++ b/crates/geo-polygonize-arrow/tests/arrow_integration.rs
@@ -1,9 +1,7 @@
-#![cfg(feature = "arrow")]
-
 use arrow::array::Array;
 use arrow::datatypes::Field;
 use arrow::ffi::{FFI_ArrowArray, FFI_ArrowSchema};
-use geo_polygonize_core::ffi::{polygonize_ffi, PolygonizerOptions};
+use geo_polygonize_arrow::ffi::{polygonize_ffi, PolygonizerOptions};
 use geoarrow::array::{GeoArrowArray, PolygonArray};
 use geoarrow::datatypes::{Crs, Metadata};
 use std::convert::TryFrom;

--- a/crates/geo-polygonize-arrow/tests/geoparquet_integration.rs
+++ b/crates/geo-polygonize-arrow/tests/geoparquet_integration.rs
@@ -1,8 +1,8 @@
 #![cfg(feature = "geoparquet")]
 
 use arrow::record_batch::RecordBatch;
-use geo_polygonize_core::geoparquet_api::polygonize_geoparquet_file;
-use geo_polygonize_core::PolygonizerOptions;
+use geo_polygonize_arrow::geoparquet_api::polygonize_geoparquet_file;
+use geo_polygonize_arrow::PolygonizerOptions;
 use geoarrow::array::{GeoArrowArray, PolygonArray};
 use geoarrow::datatypes::Metadata;
 use geoparquet::reader::{GeoParquetReaderBuilder, GeoParquetRecordBatchReader};

--- a/crates/geo-polygonize-arrow/tests/test_ffi_errors.rs
+++ b/crates/geo-polygonize-arrow/tests/test_ffi_errors.rs
@@ -1,7 +1,5 @@
-#![cfg(feature = "arrow")]
-
 use arrow::ffi::{FFI_ArrowArray, FFI_ArrowSchema};
-use geo_polygonize_core::ffi::{polygonize_ffi, PolygonizerOptions};
+use geo_polygonize_arrow::ffi::{polygonize_ffi, PolygonizerOptions};
 
 #[test]
 fn test_ffi_null_pointers() {

--- a/crates/geo-polygonize-core/Cargo.toml
+++ b/crates/geo-polygonize-core/Cargo.toml
@@ -22,17 +22,13 @@ float_next_after = "1.0"
 smallvec = "1.11"
 pyo3 = { version = "0.29", features = ["extension-module", "abi3-py38"], optional = true }
 numpy = { version = "0.29", optional = true }
-arrow = { version = "57", features = ["ffi"], optional = true }
-geoarrow = { version = "0.7.0", optional = true }
 geo-traits = "0.3.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 humantime-serde = "1.1.1"
 ts-rs = "12.0.1"
-geoparquet = { version = "0.7.0", optional = true }
 flatgeobuf = { version = "6.0.1", optional = true, default-features = false }
 geozero = { version = "0.15.1", optional = true, default-features = false, features = ["with-geo"] }
-parquet = { version = "57.3.0", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 multiversion = "0.8.0"
@@ -44,7 +40,6 @@ criterion = "0.5"
 rand = "0.8"
 clap = { version = "4.5", features = ["derive"] }
 geojson = "0.24"
-geoarrow-test = "0.7.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 walkdir = "2.5.0"
@@ -52,8 +47,6 @@ dhat = "0.3.3"
 
 [features]
 default = ["parallel"]
-arrow = ["dep:arrow", "dep:geoarrow"]
-geoparquet = ["arrow", "dep:geoparquet", "dep:parquet"]
 flatgeobuf = ["dep:flatgeobuf", "dep:geozero"]
 parallel = ["dep:rayon"]
 python = ["dep:pyo3", "dep:numpy"]
@@ -77,11 +70,6 @@ harness = false
 [[bench]]
 name = "hole_sort_bench"
 harness = false
-
-[[bench]]
-name = "allocation_bench"
-harness = false
-required-features = ["arrow"]
 
 [[bench]]
 name = "iai_bench"

--- a/crates/geo-polygonize-core/src/lib.rs
+++ b/crates/geo-polygonize-core/src/lib.rs
@@ -8,14 +8,10 @@
 //! - **Performance**: SIMD-accelerated predicates and efficient memory layout.
 //! - **Wasm**: Optimized for WebAssembly environments.
 
-#[cfg(feature = "arrow")]
-pub mod arrow_api;
 #[doc(hidden)]
 pub mod containment;
 mod diagnostics;
 mod error;
-#[cfg(feature = "arrow")]
-pub mod ffi;
 // Kept compiler-public for the repository's microbenchmarks; not a supported API.
 #[doc(hidden)]
 pub mod graph;
@@ -59,9 +55,6 @@ pub use polygonizer::{
 #[doc(hidden)]
 pub use tiling::{StitchingReport, TileReport, TiledPolygonizeResult, TiledPolygonizer};
 pub use types::{Coord3D, Line3D, Polygon3D, PolygonProvenance};
-
-#[cfg(feature = "geoparquet")]
-pub mod geoparquet_api;
 
 #[cfg(feature = "flatgeobuf")]
 pub mod flatgeobuf_api;

--- a/crates/geo-polygonize-wasm/Cargo.toml
+++ b/crates/geo-polygonize-wasm/Cargo.toml
@@ -10,7 +10,8 @@ readme = "../../README.md"
 crate-type = ["cdylib"]
 
 [dependencies]
-geo-polygonize-core = { path = "../geo-polygonize-core", version = "0.48.0", features = ["arrow"] }
+geo-polygonize-core = { path = "../geo-polygonize-core", version = "0.48.0" }
+geo-polygonize-arrow = { path = "../geo-polygonize-arrow", version = "0.48.0" }
 wasm-bindgen = "0.2"
 console_error_panic_hook = { version = "0.1.7", optional = true }
 js-sys = "0.3"

--- a/crates/geo-polygonize-wasm/src/lib.rs
+++ b/crates/geo-polygonize-wasm/src/lib.rs
@@ -2,7 +2,7 @@ mod error;
 
 use arrow::compute::concat;
 use arrow_ipc::reader::StreamReader;
-use geo_polygonize_core::arrow_api::{polygonize_arrow, PolygonizerOptions};
+use geo_polygonize_arrow::{polygonize_arrow, PolygonizerOptions};
 use geo_polygonize_core::{polygonize as polygonize_lines, Coord3D, Line3D, Polygonizer};
 use geoarrow::array::GeoArrowArray;
 use geojson::{GeoJson, Geometry, Value};

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -28,6 +28,16 @@
         },
         {
           "type": "toml",
+          "path": "crates/geo-polygonize-arrow/Cargo.toml",
+          "jsonpath": "$.package.version"
+        },
+        {
+          "type": "toml",
+          "path": "crates/geo-polygonize-arrow/Cargo.toml",
+          "jsonpath": "$.dependencies.geo-polygonize-core.version"
+        },
+        {
+          "type": "toml",
           "path": "crates/geo-polygonize-wasm/Cargo.toml",
           "jsonpath": "$.package.version"
         },
@@ -35,6 +45,11 @@
           "type": "toml",
           "path": "crates/geo-polygonize-wasm/Cargo.toml",
           "jsonpath": "$.dependencies.geo-polygonize-core.version"
+        },
+        {
+          "type": "toml",
+          "path": "crates/geo-polygonize-wasm/Cargo.toml",
+          "jsonpath": "$.dependencies.geo-polygonize-arrow.version"
         }
       ]
     }


### PR DESCRIPTION
## Summary

- add `geo-polygonize-arrow` for GeoArrow conversion, Arrow C Data Interface exports, and optional GeoParquet file support
- remove Arrow, GeoArrow, GeoParquet, and Parquet dependencies and features from `geo-polygonize-core`
- move the adapter tests and allocation benchmark with their implementation
- update Wasm to depend on the adapter crate without changing its public behavior
- version and publish the new crate through the existing unified release flow

Rust Arrow consumers should replace `geo-polygonize-core`'s `arrow` feature and `geo_polygonize_core::arrow_api` imports with the `geo-polygonize-arrow` crate and `geo_polygonize_arrow::polygonize_arrow`. FFI lives at `geo_polygonize_arrow::ffi`; GeoParquet remains behind its `geoparquet` feature.

## Verification

- `cargo test --workspace`
- `cargo test -p geo-polygonize-core --no-default-features` (147 core tests plus integrations)
- `cargo test -p geo-polygonize-arrow` (11 tests)
- `cargo test -p geo-polygonize-arrow --features geoparquet --test geoparquet_integration`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy -p geo-polygonize-arrow --all-features --all-targets -- -D warnings`
- `cargo check -p geo-polygonize-core --all-features --all-targets`
- `cargo check -p geo-polygonize-wasm --target wasm32-unknown-unknown`
- `cargo check --locked --workspace`
- `cargo publish -p geo-polygonize-arrow --dry-run --allow-dirty`
- `cargo fmt --all -- --check`

The normal core dependency tree contains neither Arrow nor Parquet.