### PR TITLE
feat(python): extract extension crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1045,8 +1045,6 @@ dependencies = [
  "iai-callgrind",
  "log",
  "multiversion",
- "numpy",
- "pyo3",
  "rand",
  "rayon",
  "robust",
@@ -1059,6 +1057,16 @@ dependencies = [
  "walkdir",
  "web-time",
  "wide",
+]
+
+[[package]]
+name = "geo-polygonize-python"
+version = "0.49.0"
+dependencies = [
+ "geo-polygonize-core",
+ "numpy",
+ "pyo3",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "crates/geo-polygonize-arrow",
+    "crates/geo-polygonize-python",
     "xtask",
     "crates/geo-polygonize-core",
     "crates/geo-polygonize-wasm"

--- a/crates/geo-polygonize-core/Cargo.toml
+++ b/crates/geo-polygonize-core/Cargo.toml
@@ -6,9 +6,6 @@ description = "A native Rust port of the JTS/GEOS polygonization algorithm. Reco
 license = "MIT OR Apache-2.0"
 readme = "../../README.md"
 
-[lib]
-crate-type = ["rlib", "cdylib"]
-
 [dependencies]
 geo = "0.32"
 geo-types = "0.7"
@@ -20,8 +17,6 @@ log = "0.4"
 thiserror = "1.0"
 float_next_after = "1.0"
 smallvec = "1.11"
-pyo3 = { version = "0.29", features = ["extension-module", "abi3-py38"], optional = true }
-numpy = { version = "0.29", optional = true }
 geo-traits = "0.3.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -49,7 +44,6 @@ dhat = "0.3.3"
 default = ["parallel"]
 flatgeobuf = ["dep:flatgeobuf", "dep:geozero"]
 parallel = ["dep:rayon"]
-python = ["dep:pyo3", "dep:numpy"]
 
 [[bench]]
 name = "polygonize_bench"

--- a/crates/geo-polygonize-core/src/lib.rs
+++ b/crates/geo-polygonize-core/src/lib.rs
@@ -28,9 +28,6 @@ mod types;
 #[doc(hidden)]
 pub mod utils;
 
-#[cfg(feature = "python")]
-pub mod python;
-
 #[cfg(test)]
 mod polygonizer_tests;
 

--- a/crates/geo-polygonize-python/Cargo.toml
+++ b/crates/geo-polygonize-python/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "geo-polygonize-python"
+version = "0.49.0"
+edition = "2021"
+publish = false
+description = "Python extension module for geo-polygonize-core."
+license = "MIT OR Apache-2.0"
+
+[lib]
+name = "geo_polygonize_core"
+crate-type = ["cdylib"]
+test = false
+doctest = false
+
+[dependencies]
+polygonize-core = { package = "geo-polygonize-core", path = "../geo-polygonize-core", version = "0.49.0" }
+pyo3 = { version = "0.29", features = ["abi3-py38"] }
+numpy = "0.29"
+serde_json = "1.0"
+
+[features]
+extension-module = ["pyo3/extension-module"]

--- a/crates/geo-polygonize-python/src/lib.rs
+++ b/crates/geo-polygonize-python/src/lib.rs
@@ -1,7 +1,8 @@
-use crate::error::PolygonizeError;
-use crate::polygonize as polygonize_lines;
-use crate::types::{Coord3D, Line3D};
 use numpy::{PyArray1, PyReadonlyArray1};
+use polygonize_core::{
+    polygonize as polygonize_lines, Coord3D, Line3D, PolygonizeError, PolygonizerOptions,
+    PrecisionModel,
+};
 use pyo3::create_exception;
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
@@ -28,35 +29,31 @@ create_exception!(
     pyo3::exceptions::PyException
 );
 
-impl std::convert::From<PolygonizeError> for PyErr {
-    fn from(err: PolygonizeError) -> PyErr {
-        match err {
-            PolygonizeError::InvalidArgumentType {
-                field,
-                expected,
-                actual,
-            } => PolygonizeTypeError::new_err(format!(
-                "Invalid argument type for {field}: expected {expected}, got {actual}"
-            )),
-            PolygonizeError::InvalidGeometry { reason } => PolygonizeGeometryError::new_err(reason),
-            PolygonizeError::InvalidBufferShape { reason } => PolygonizeTypeError::new_err(reason),
-            PolygonizeError::UnsupportedOptionCombination { reason } => {
-                PolygonizeOptionsError::new_err(reason)
-            }
-            PolygonizeError::TopologyFailure { reason } => PolygonizeTopologyError::new_err(reason),
-            err @ PolygonizeError::ZConflict { .. } => {
-                PolygonizeTopologyError::new_err(err.to_string())
-            }
-            err @ PolygonizeError::NodingValidationFailure { .. } => {
-                PolygonizeTopologyError::new_err(err.to_string())
-            }
-            PolygonizeError::InternalInvariantViolation { reason } => {
-                PyRuntimeError::new_err(reason)
-            }
-            PolygonizeError::ArrowError(msg) => PyValueError::new_err(msg),
-            PolygonizeError::NullPointer(msg) => PyValueError::new_err(msg),
-            PolygonizeError::Panic(msg) => PyRuntimeError::new_err(msg),
+fn to_py_err(err: PolygonizeError) -> PyErr {
+    match err {
+        PolygonizeError::InvalidArgumentType {
+            field,
+            expected,
+            actual,
+        } => PolygonizeTypeError::new_err(format!(
+            "Invalid argument type for {field}: expected {expected}, got {actual}"
+        )),
+        PolygonizeError::InvalidGeometry { reason } => PolygonizeGeometryError::new_err(reason),
+        PolygonizeError::InvalidBufferShape { reason } => PolygonizeTypeError::new_err(reason),
+        PolygonizeError::UnsupportedOptionCombination { reason } => {
+            PolygonizeOptionsError::new_err(reason)
         }
+        PolygonizeError::TopologyFailure { reason } => PolygonizeTopologyError::new_err(reason),
+        err @ PolygonizeError::ZConflict { .. } => {
+            PolygonizeTopologyError::new_err(err.to_string())
+        }
+        err @ PolygonizeError::NodingValidationFailure { .. } => {
+            PolygonizeTopologyError::new_err(err.to_string())
+        }
+        PolygonizeError::InternalInvariantViolation { reason } => PyRuntimeError::new_err(reason),
+        PolygonizeError::ArrowError(msg) => PyValueError::new_err(msg),
+        PolygonizeError::NullPointer(msg) => PyValueError::new_err(msg),
+        PolygonizeError::Panic(msg) => PyRuntimeError::new_err(msg),
     }
 }
 
@@ -71,11 +68,11 @@ fn polygonize_with_options<'py>(
     options_json: Option<&str>,
     line_ids: Option<PyReadonlyArray1<'py, u32>>,
 ) -> PyResult<Py<PyAny>> {
-    let options: crate::options::PolygonizerOptions = if let Some(json) = options_json {
+    let options: PolygonizerOptions = if let Some(json) = options_json {
         serde_json::from_str(json)
             .map_err(|e| PolygonizeOptionsError::new_err(format!("Invalid options json: {}", e)))?
     } else {
-        crate::options::PolygonizerOptions::default()
+        PolygonizerOptions::default()
     };
 
     polygonize_internal(py, coords, offsets, stride, options, line_ids)
@@ -95,14 +92,14 @@ fn polygonize<'py>(
     line_ids: Option<PyReadonlyArray1<'py, u32>>,
     report_mode: bool,
 ) -> PyResult<Py<PyAny>> {
-    let mut options = crate::options::PolygonizerOptions::default();
+    let mut options = PolygonizerOptions::default();
     options.diagnostics.enabled = report_mode;
     options.diagnostics.report_mode = report_mode;
     options.node_input = node;
     options.precision_model = if node {
-        crate::options::PrecisionModel::from_grid_size(snap)
+        PrecisionModel::from_grid_size(snap)
     } else {
-        crate::options::PrecisionModel::Floating
+        PrecisionModel::Floating
     };
     options.extract_only_polygonal = extract_only_polygonal;
 
@@ -114,43 +111,40 @@ fn polygonize_internal<'py>(
     coords: PyReadonlyArray1<'py, f64>,
     offsets: PyReadonlyArray1<'py, u32>,
     stride: u8,
-    options: crate::options::PolygonizerOptions,
+    options: PolygonizerOptions,
     line_ids: Option<PyReadonlyArray1<'py, u32>>,
 ) -> PyResult<Py<PyAny>> {
     let coords_slice = coords.as_slice()?;
     let offsets_slice = offsets.as_slice()?;
 
     if stride != 2 && stride != 3 {
-        return Err(PolygonizeError::InvalidBufferShape {
+        return Err(to_py_err(PolygonizeError::InvalidBufferShape {
             reason: "stride must be 2 or 3".to_string(),
-        }
-        .into());
+        }));
     }
 
     let stride_usize = stride as usize;
 
     if coords_slice.len() % stride_usize != 0 {
-        return Err(PolygonizeError::InvalidBufferShape {
+        return Err(to_py_err(PolygonizeError::InvalidBufferShape {
             reason: format!(
                 "Coordinates array length {} is not a multiple of stride {}",
                 coords_slice.len(),
                 stride_usize
             ),
-        }
-        .into());
+        }));
     }
 
     if let Some(ref ids) = line_ids {
         let ids_slice = ids.as_slice()?;
         if !offsets_slice.is_empty() && ids_slice.len() != offsets_slice.len() {
-            return Err(PolygonizeError::InvalidBufferShape {
+            return Err(to_py_err(PolygonizeError::InvalidBufferShape {
                 reason: format!(
                     "line_ids length {} does not match line count {}",
                     ids_slice.len(),
                     offsets_slice.len()
                 ),
-            }
-            .into());
+            }));
         }
     }
 
@@ -166,20 +160,20 @@ fn polygonize_internal<'py>(
             };
 
             if start > end {
-                return Err(PolygonizeError::InvalidBufferShape {
+                return Err(to_py_err(PolygonizeError::InvalidBufferShape {
                     reason: format!(
                         "Invalid offsets: start offset ({}) is greater than end offset ({}) at index {}",
                         start, end, i
                     ),
-                }.into());
+                }));
             }
             if end * stride_usize > coords_slice.len() {
-                return Err(PolygonizeError::InvalidBufferShape {
+                return Err(to_py_err(PolygonizeError::InvalidBufferShape {
                     reason: format!(
                         "Invalid offsets: calculated end offset {} exceeds coordinate capacity {} for stride {}",
                         end * stride_usize, coords_slice.len(), stride_usize
                     ),
-                }.into());
+                }));
             }
 
             // Get line ID if provided
@@ -223,7 +217,8 @@ fn polygonize_internal<'py>(
         Err(PolygonizeError::Panic(
             "Panic occurred in Rust core".to_string(),
         ))
-    })?;
+    })
+    .map_err(to_py_err)?;
 
     // Flatten logic
     let mut num_points = 0;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,9 +18,9 @@ dependencies = ["numpy"]
 
 [tool.maturin]
 python-source = "python"
-manifest-path = "crates/geo-polygonize-core/Cargo.toml"
+manifest-path = "crates/geo-polygonize-python/Cargo.toml"
 module-name = "geo_polygonize.geo_polygonize_core"
-features = ["python"]
+features = ["extension-module"]
 include = [
     { path = "LICENSE-APACHE", format = "sdist" },
     { path = "LICENSE-MIT", format = "sdist" },

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -28,6 +28,16 @@
         },
         {
           "type": "toml",
+          "path": "crates/geo-polygonize-python/Cargo.toml",
+          "jsonpath": "$.package.version"
+        },
+        {
+          "type": "toml",
+          "path": "crates/geo-polygonize-python/Cargo.toml",
+          "jsonpath": "$.dependencies.polygonize-core.version"
+        },
+        {
+          "type": "toml",
           "path": "crates/geo-polygonize-arrow/Cargo.toml",
           "jsonpath": "$.package.version"
         },


### PR DESCRIPTION
## Summary

- add the internal `geo-polygonize-python` workspace crate for the PyO3/NumPy extension
- remove PyO3, NumPy, the `python` feature, and `cdylib` output from `geo-polygonize-core`
- retarget Maturin to the new crate while preserving the `geo-polygonize-py` wheel and `geo_polygonize.geo_polygonize_core` module names
- keep extension-module linking opt-in for Maturin and disable the empty Rust test harness; Python integration tests remain the executable binding contract
- version the new manifest through the existing unified release flow

Python installation, imports, ABI3 support, and public behavior are unchanged. The adapter crate is `publish = false`; distribution remains through the existing PyPI workflow.

## Verification

- `python3 -m maturin build --release --out target/wheels`
- clean-venv wheel install and Python binding suite: 28 passed
- `python3 -m maturin sdist --out target/wheels`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy -p geo-polygonize-python --features extension-module --all-targets -- -D warnings`
- `cargo check --locked --workspace`
- `cargo fmt --all -- --check`

The normal core dependency tree contains neither PyO3 nor NumPy.