### PR TITLE
feat(core): extract FlatGeoBuf adapter crate

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,15 @@ jobs:
           done
           exit 1
 
+      - name: Publish geo-polygonize-flatgeobuf to crates.io
+        run: |
+          for i in 1 2 3 4 5 6; do
+            cargo publish -p geo-polygonize-flatgeobuf && exit 0
+            echo "Publish failed, waiting before retrying..."
+            sleep 30
+          done
+          exit 1
+
       - name: Publish geo-polygonize-wasm to crates.io
         run: |
           for i in 1 2 3 4 5 6; do

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1033,13 +1033,11 @@ dependencies = [
  "clap",
  "criterion",
  "dhat",
- "flatgeobuf",
  "float_next_after",
  "geo",
  "geo-traits",
  "geo-types",
  "geojson",
- "geozero",
  "getrandom 0.2.17",
  "humantime-serde",
  "iai-callgrind",
@@ -1057,6 +1055,17 @@ dependencies = [
  "walkdir",
  "web-time",
  "wide",
+]
+
+[[package]]
+name = "geo-polygonize-flatgeobuf"
+version = "0.50.0"
+dependencies = [
+ "flatgeobuf",
+ "geo",
+ "geo-polygonize-core",
+ "geo-traits",
+ "geozero",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "crates/geo-polygonize-arrow",
+    "crates/geo-polygonize-flatgeobuf",
     "crates/geo-polygonize-python",
     "xtask",
     "crates/geo-polygonize-core",

--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ use geo_polygonize_arrow::{polygonize_arrow, PolygonizerOptions};
 // let result = polygonize_arrow(&array, &field, options);
 ```
 
+The FlatGeoBuf file adapter lives in the `geo-polygonize-flatgeobuf` crate.
+
 ### Python
 
 The Python package is published as `geo-polygonize-py` and imported as `geo_polygonize`.

--- a/crates/geo-polygonize-core/Cargo.toml
+++ b/crates/geo-polygonize-core/Cargo.toml
@@ -22,8 +22,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 humantime-serde = "1.1.1"
 ts-rs = "12.0.1"
-flatgeobuf = { version = "6.0.1", optional = true, default-features = false }
-geozero = { version = "0.15.1", optional = true, default-features = false, features = ["with-geo"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 multiversion = "0.8.0"
@@ -42,7 +40,6 @@ dhat = "0.3.3"
 
 [features]
 default = ["parallel"]
-flatgeobuf = ["dep:flatgeobuf", "dep:geozero"]
 parallel = ["dep:rayon"]
 
 [[bench]]

--- a/crates/geo-polygonize-core/src/lib.rs
+++ b/crates/geo-polygonize-core/src/lib.rs
@@ -52,6 +52,3 @@ pub use polygonizer::{
 #[doc(hidden)]
 pub use tiling::{StitchingReport, TileReport, TiledPolygonizeResult, TiledPolygonizer};
 pub use types::{Coord3D, Line3D, Polygon3D, PolygonProvenance};
-
-#[cfg(feature = "flatgeobuf")]
-pub mod flatgeobuf_api;

--- a/crates/geo-polygonize-flatgeobuf/Cargo.toml
+++ b/crates/geo-polygonize-flatgeobuf/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "geo-polygonize-flatgeobuf"
+version = "0.50.0"
+edition = "2021"
+description = "FlatGeoBuf file adapter for geo-polygonize-core."
+license = "MIT OR Apache-2.0"
+readme = "../../README.md"
+
+[dependencies]
+geo-polygonize-core = { path = "../geo-polygonize-core", version = "0.50.0" }
+flatgeobuf = { version = "6.0.1", default-features = false }
+geozero = { version = "0.15.1", default-features = false, features = ["with-geo"] }
+geo = "0.32"
+geo-traits = "0.3.0"

--- a/crates/geo-polygonize-flatgeobuf/src/lib.rs
+++ b/crates/geo-polygonize-flatgeobuf/src/lib.rs
@@ -1,9 +1,8 @@
-use crate::error::PolygonizeError;
-use crate::options::PolygonizerOptions;
-use crate::polygonizer::polygonize;
-use crate::types::{Coord3D, Line3D, Polygon3D};
 use flatgeobuf::{
     FallibleStreamingIterator, FgbCrs, FgbReader, FgbWriter, FgbWriterOptions, GeometryType,
+};
+use geo_polygonize_core::{
+    polygonize, Coord3D, Line3D, Polygon3D, PolygonizeError, PolygonizerOptions,
 };
 use geo_traits::to_geo::ToGeoGeometry;
 use std::fs::File;

--- a/crates/geo-polygonize-flatgeobuf/tests/flatgeobuf_integration.rs
+++ b/crates/geo-polygonize-flatgeobuf/tests/flatgeobuf_integration.rs
@@ -1,11 +1,9 @@
-#![cfg(feature = "flatgeobuf")]
-
 use flatgeobuf::{
     FallibleStreamingIterator, FgbCrs, FgbReader, FgbWriter, FgbWriterOptions, GeometryType,
 };
 use geo::Area;
-use geo_polygonize_core::flatgeobuf_api::polygonize_flatgeobuf_file;
 use geo_polygonize_core::PolygonizerOptions;
+use geo_polygonize_flatgeobuf::polygonize_flatgeobuf_file;
 use geo_traits::to_geo::ToGeoGeometry;
 use std::fs::{self, File};
 use std::io::{BufReader, BufWriter};

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -48,6 +48,16 @@
         },
         {
           "type": "toml",
+          "path": "crates/geo-polygonize-flatgeobuf/Cargo.toml",
+          "jsonpath": "$.package.version"
+        },
+        {
+          "type": "toml",
+          "path": "crates/geo-polygonize-flatgeobuf/Cargo.toml",
+          "jsonpath": "$.dependencies.geo-polygonize-core.version"
+        },
+        {
+          "type": "toml",
           "path": "crates/geo-polygonize-wasm/Cargo.toml",
           "jsonpath": "$.package.version"
         },


### PR DESCRIPTION
## Summary

- publish the FlatGeoBuf file adapter as `geo-polygonize-flatgeobuf`
- remove the FlatGeoBuf/GeoZero dependencies and `flatgeobuf` feature from core
- move the adapter integration test with the new crate
- wire the crate into release-please and crates.io publishing

## Migration

Replace `geo_polygonize_core::flatgeobuf_api::polygonize_flatgeobuf_file` (and the core `flatgeobuf` feature) with `geo_polygonize_flatgeobuf::polygonize_flatgeobuf_file`.

## Validation

- `cargo test --workspace`
- `cargo test -p geo-polygonize-core --no-default-features`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check --locked --workspace`
- `cargo publish -p geo-polygonize-flatgeobuf --dry-run --allow-dirty`
- `cargo fmt --all -- --check`
- `git diff --check`