### PR TITLE
fix(github): allow BSD-2-Clause dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,7 @@ jobs:
         run: npm test
 
   test:
-    name: test
+    name: CI Required
     needs: [changes, rust, supply-chain, wasm-build, js]
     if: always()
     runs-on: ubuntu-latest

--- a/deny.toml
+++ b/deny.toml
@@ -91,6 +91,7 @@ ignore = [
 allow = [
     "MIT",
     "Apache-2.0",
+    "BSD-2-Clause",
     "BSD-3-Clause",
     "ISC",
     "Zlib",


### PR DESCRIPTION
## Summary

- allow `BSD-2-Clause` in the cargo-deny license policy for the extracted adapter crates
- give the aggregate CI gate the unique check name `CI Required`
- update the active `main` ruleset to require `CI Required` instead of the collision-prone generic `test`

## Root cause

The extracted adapter crates introduced approved BSD-2-Clause transitive dependencies. Separately, both the aggregate CI job and Differential Fuzzer published a check named `test`, so a passing fuzzer check could satisfy the branch rule before the real CI aggregate finished.

## Validation

- `cargo deny check`
- `actionlint .github/workflows/ci.yml`
- verified the active ruleset requires `maintenance`, `Validate PR title`, and `CI Required`

The existing duplicate/stale advisory warnings remain unchanged and are outside this fix.