### PR TITLE
test(core): require golden topology metrics

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,7 +34,7 @@ change.
 
 ### 1. Broaden the golden corpus
 
-- [ ] Add explicit expected topology metrics to every golden fixture.
+- [x] Add explicit expected topology metrics to every golden fixture.
 - [ ] Cover dirty inputs, tiling, Z policy, compatibility, and benchmark-sized
   inputs in addition to the existing basic, topology, and provenance cases.
 - [ ] Reuse the same fixtures in canonical, benchmark, and differential paths

--- a/crates/geo-polygonize-core/tests/fixtures/basic/square.json
+++ b/crates/geo-polygonize-core/tests/fixtures/basic/square.json
@@ -1,5 +1,6 @@
 {
   "name": "basic_square",
+  "options": { "node_input": true },
   "inputs": [
     {
       "start": {
@@ -54,6 +55,14 @@
       "id": 4
     }
   ],
+  "expected_metrics": {
+    "polygon_count": 1,
+    "total_area": 100.0,
+    "area_tolerance": 0.0,
+    "dangle_count": 0,
+    "cut_edge_count": 0,
+    "invalid_ring_count": 0
+  },
   "expected": {
     "polygons": [
       {

--- a/crates/geo-polygonize-core/tests/fixtures/basic/square_with_hole.json
+++ b/crates/geo-polygonize-core/tests/fixtures/basic/square_with_hole.json
@@ -1,5 +1,6 @@
 {
   "name": "basic_square_with_hole",
+  "options": { "node_input": true },
   "inputs": [
     {
       "start": {
@@ -106,6 +107,14 @@
       "id": 8
     }
   ],
+  "expected_metrics": {
+    "polygon_count": 2,
+    "total_area": 100.0,
+    "area_tolerance": 0.0,
+    "dangle_count": 0,
+    "cut_edge_count": 0,
+    "invalid_ring_count": 0
+  },
   "expected": {
     "polygons": [
       {

--- a/crates/geo-polygonize-core/tests/fixtures/dirty/bowtie.json
+++ b/crates/geo-polygonize-core/tests/fixtures/dirty/bowtie.json
@@ -1,0 +1,57 @@
+{
+  "name": "dirty_bowtie",
+  "options": {
+    "node_input": true,
+    "precision_model": {
+      "type": "fixed_grid",
+      "grid_size": 0.000001
+    }
+  },
+  "inputs": [
+    { "start": { "x": 0.0, "y": 0.0, "z": 0.0 }, "end": { "x": 10.0, "y": 10.0, "z": 0.0 }, "id": 1 },
+    { "start": { "x": 10.0, "y": 10.0, "z": 0.0 }, "end": { "x": 10.0, "y": 0.0, "z": 0.0 }, "id": 2 },
+    { "start": { "x": 10.0, "y": 0.0, "z": 0.0 }, "end": { "x": 0.0, "y": 10.0, "z": 0.0 }, "id": 3 },
+    { "start": { "x": 0.0, "y": 10.0, "z": 0.0 }, "end": { "x": 0.0, "y": 0.0, "z": 0.0 }, "id": 4 }
+  ],
+  "expected_metrics": {
+    "polygon_count": 2,
+    "total_area": 50.0,
+    "area_tolerance": 0.0,
+    "dangle_count": 0,
+    "cut_edge_count": 0,
+    "invalid_ring_count": 0
+  },
+  "expected": {
+    "polygons": [
+      {
+        "exterior": [
+          { "x": 0.0, "y": 0.0, "z": 0.0 },
+          { "x": 5.0, "y": 5.0, "z": 0.0 },
+          { "x": 0.0, "y": 10.0, "z": 0.0 },
+          { "x": 0.0, "y": 0.0, "z": 0.0 }
+        ],
+        "interiors": [],
+        "exterior_ids": [1, 3, 4],
+        "interiors_ids": [],
+        "boundary_line_ids": [1, 3, 4],
+        "input_profile_id": null
+      },
+      {
+        "exterior": [
+          { "x": 5.0, "y": 5.0, "z": 0.0 },
+          { "x": 10.0, "y": 0.0, "z": 0.0 },
+          { "x": 10.0, "y": 10.0, "z": 0.0 },
+          { "x": 5.0, "y": 5.0, "z": 0.0 }
+        ],
+        "interiors": [],
+        "exterior_ids": [3, 2, 1],
+        "interiors_ids": [],
+        "boundary_line_ids": [1, 2, 3],
+        "input_profile_id": null
+      }
+    ],
+    "dangles": [],
+    "cut_edges": [],
+    "invalid_rings": []
+  }
+}

--- a/crates/geo-polygonize-core/tests/fixtures/topology/reported_outputs.json
+++ b/crates/geo-polygonize-core/tests/fixtures/topology/reported_outputs.json
@@ -1,6 +1,6 @@
 {
   "name": "reported_output_families",
-  "node_input": false,
+  "options": { "node_input": false },
   "inputs": [
     { "start": { "x": 0.0, "y": 0.0, "z": 0.0 }, "end": { "x": 10.0, "y": 0.0, "z": 0.0 }, "id": 1 },
     { "start": { "x": 10.0, "y": 0.0, "z": 0.0 }, "end": { "x": 10.0, "y": 10.0, "z": 0.0 }, "id": 2 },
@@ -26,6 +26,14 @@
     { "start": { "x": 60.0, "y": 10.0, "z": 0.0 }, "end": { "x": 70.0, "y": 0.0, "z": 0.0 }, "id": 19 },
     { "start": { "x": 70.0, "y": 0.0, "z": 0.0 }, "end": { "x": 60.0, "y": 0.0, "z": 0.0 }, "id": 20 }
   ],
+  "expected_metrics": {
+    "polygon_count": 3,
+    "total_area": 300.0,
+    "area_tolerance": 0.0,
+    "dangle_count": 1,
+    "cut_edge_count": 1,
+    "invalid_ring_count": 2
+  },
   "expected": {
     "polygons": [
       {

--- a/crates/geo-polygonize-core/tests/golden_fixtures.rs
+++ b/crates/geo-polygonize-core/tests/golden_fixtures.rs
@@ -1,6 +1,6 @@
-use geo_polygonize_core::DeterminismOptions;
-use geo_polygonize_core::Polygonizer;
-use geo_polygonize_core::{Coord3D, Line3D};
+use geo_polygonize_core::{
+    polygonize, Coord3D, DeterminismOptions, Line3D, PolygonizerOptions, ProvenanceOptions,
+};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::Path;
@@ -72,9 +72,20 @@ struct GoldenResult {
 #[derive(Serialize, Deserialize, Debug)]
 struct GoldenFixture {
     name: String,
-    node_input: Option<bool>,
+    options: PolygonizerOptions,
     inputs: Vec<GoldenLine>,
+    expected_metrics: GoldenMetrics,
     expected: GoldenResult,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct GoldenMetrics {
+    polygon_count: usize,
+    total_area: f64,
+    area_tolerance: f64,
+    dangle_count: usize,
+    cut_edge_count: usize,
+    invalid_ring_count: usize,
 }
 
 fn run_golden_test(path: &Path) {
@@ -82,20 +93,47 @@ fn run_golden_test(path: &Path) {
     let fixture: GoldenFixture = serde_json::from_str(&content).expect("Failed to parse fixture");
 
     let input_lines: Vec<Line3D> = fixture.inputs.iter().map(|l| l.into()).collect();
-
-    let mut poly = Polygonizer::new();
-    poly.options_mut().node_input = fixture.node_input.unwrap_or(true);
-    poly.options_mut().determinism = DeterminismOptions {
+    let mut options = fixture.options;
+    options.determinism = DeterminismOptions {
         canonical_sort: true,
         canonical_ring_rotation: true,
         stable_tie_breaks: true,
     };
-    poly.options_mut().provenance.enabled = true;
-    poly.options_mut().provenance.include_boundary_line_ids = true;
-    poly.add_lines(input_lines);
+    options.provenance = ProvenanceOptions {
+        enabled: true,
+        include_boundary_line_ids: true,
+    };
 
-    let res = poly.polygonize().unwrap();
-
+    let res = polygonize(input_lines, &options).unwrap();
+    let actual_area: f64 = res
+        .polygons
+        .iter()
+        .map(|polygon| polygon.unsigned_area_2d())
+        .sum();
+    assert_eq!(
+        [
+            res.polygons.len(),
+            res.dangles.len(),
+            res.cut_edges.len(),
+            res.invalid_rings.len(),
+        ],
+        [
+            fixture.expected_metrics.polygon_count,
+            fixture.expected_metrics.dangle_count,
+            fixture.expected_metrics.cut_edge_count,
+            fixture.expected_metrics.invalid_ring_count,
+        ],
+        "{} counts [polygons, dangles, cut edges, invalid rings]",
+        fixture.name
+    );
+    assert!(
+        (actual_area - fixture.expected_metrics.total_area).abs()
+            <= fixture.expected_metrics.area_tolerance,
+        "{} total area: expected {}, got {}",
+        fixture.name,
+        fixture.expected_metrics.total_area,
+        actual_area
+    );
     let actual_result = GoldenResult {
         polygons: res
             .polygons


### PR DESCRIPTION
## Summary

- require explicit polygon, area, dangle, cut-edge, and invalid-ring metrics in every strict golden fixture
- run the golden harness through the canonical one-shot `polygonize` options API
- add a fixed-precision dirty bowtie fixture that verifies noding, canonical geometry, line IDs, and provenance
- mark the roadmap metrics item complete

## Why

The golden files compared full outputs but did not state their intended topology metrics, and the harness still used the transitional mutable builder. This makes both contracts explicit without adding another fixture framework.

## Validation

- `cargo test -p geo-polygonize-core` — 147 unit tests plus all integration and golden suites passed
- `cargo test -p geo-polygonize-core --no-default-features` — passed
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- all strict fixture JSON parsed with `jq`
- `git diff --check`