### PR TITLE
test(core): add Z-policy golden

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -35,8 +35,8 @@ change.
 ### 1. Broaden the golden corpus
 
 - [x] Add explicit expected topology metrics to every golden fixture.
-- [ ] Cover tiling, compatibility, and benchmark-sized inputs in addition to
-  the existing basic, topology, provenance, dirty-input, and Z-policy cases.
+- [ ] Cover compatibility and benchmark-sized inputs in addition to the
+  existing basic, topology, provenance, dirty-input, Z-policy, and tiling cases.
 - [ ] Reuse the same fixtures in canonical, benchmark, and differential paths
   where their contracts overlap.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -35,8 +35,8 @@ change.
 ### 1. Broaden the golden corpus
 
 - [x] Add explicit expected topology metrics to every golden fixture.
-- [ ] Cover dirty inputs, tiling, Z policy, compatibility, and benchmark-sized
-  inputs in addition to the existing basic, topology, and provenance cases.
+- [ ] Cover tiling, compatibility, and benchmark-sized inputs in addition to
+  the existing basic, topology, provenance, dirty-input, and Z-policy cases.
 - [ ] Reuse the same fixtures in canonical, benchmark, and differential paths
   where their contracts overlap.
 

--- a/crates/geo-polygonize-core/tests/fixtures/tiling/four_tile_square.json
+++ b/crates/geo-polygonize-core/tests/fixtures/tiling/four_tile_square.json
@@ -1,0 +1,46 @@
+{
+  "name": "tiling_four_tile_square",
+  "options": { "node_input": true },
+  "tiling": {
+    "bbox": [0.0, 0.0, 20.0, 20.0],
+    "tile_size": 10.0,
+    "buffer": 4.0,
+    "ownership_policy": "RepresentativePointInsidePolygon",
+    "dedup_policy": "CanonicalRingHash"
+  },
+  "inputs": [
+    { "start": { "x": 8.0, "y": 8.0, "z": 0.0 }, "end": { "x": 12.0, "y": 8.0, "z": 0.0 }, "id": 1 },
+    { "start": { "x": 12.0, "y": 8.0, "z": 0.0 }, "end": { "x": 12.0, "y": 12.0, "z": 0.0 }, "id": 2 },
+    { "start": { "x": 12.0, "y": 12.0, "z": 0.0 }, "end": { "x": 8.0, "y": 12.0, "z": 0.0 }, "id": 3 },
+    { "start": { "x": 8.0, "y": 12.0, "z": 0.0 }, "end": { "x": 8.0, "y": 8.0, "z": 0.0 }, "id": 4 }
+  ],
+  "expected_metrics": {
+    "polygon_count": 1,
+    "total_area": 16.0,
+    "area_tolerance": 0.0,
+    "dangle_count": 0,
+    "cut_edge_count": 0,
+    "invalid_ring_count": 0
+  },
+  "expected": {
+    "polygons": [
+      {
+        "exterior": [
+          { "x": 8.0, "y": 8.0, "z": 0.0 },
+          { "x": 12.0, "y": 8.0, "z": 0.0 },
+          { "x": 12.0, "y": 12.0, "z": 0.0 },
+          { "x": 8.0, "y": 12.0, "z": 0.0 },
+          { "x": 8.0, "y": 8.0, "z": 0.0 }
+        ],
+        "interiors": [],
+        "exterior_ids": [0, 0, 0, 0],
+        "interiors_ids": [],
+        "boundary_line_ids": [],
+        "input_profile_id": null
+      }
+    ],
+    "dangles": [],
+    "cut_edges": [],
+    "invalid_rings": []
+  }
+}

--- a/crates/geo-polygonize-core/tests/fixtures/z/ignore_conflicts.json
+++ b/crates/geo-polygonize-core/tests/fixtures/z/ignore_conflicts.json
@@ -1,0 +1,41 @@
+{
+  "name": "z_ignore_conflicts",
+  "options": {
+    "z": { "policy": "Ignore" }
+  },
+  "inputs": [
+    { "start": { "x": 0.0, "y": 0.0, "z": 0.0 }, "end": { "x": 1.0, "y": 0.0, "z": 0.0 }, "id": 10 },
+    { "start": { "x": 1.0, "y": 0.0, "z": 10.0 }, "end": { "x": 1.0, "y": 1.0, "z": 10.0 }, "id": 20 },
+    { "start": { "x": 1.0, "y": 1.0, "z": 20.0 }, "end": { "x": 0.0, "y": 1.0, "z": 20.0 }, "id": 30 },
+    { "start": { "x": 0.0, "y": 1.0, "z": 30.0 }, "end": { "x": 0.0, "y": 0.0, "z": 30.0 }, "id": 40 }
+  ],
+  "expected_metrics": {
+    "polygon_count": 1,
+    "total_area": 1.0,
+    "area_tolerance": 0.0,
+    "dangle_count": 0,
+    "cut_edge_count": 0,
+    "invalid_ring_count": 0
+  },
+  "expected": {
+    "polygons": [
+      {
+        "exterior": [
+          { "x": 0.0, "y": 0.0, "z": 0.0 },
+          { "x": 1.0, "y": 0.0, "z": 0.0 },
+          { "x": 1.0, "y": 1.0, "z": 0.0 },
+          { "x": 0.0, "y": 1.0, "z": 0.0 },
+          { "x": 0.0, "y": 0.0, "z": 0.0 }
+        ],
+        "interiors": [],
+        "exterior_ids": [10, 20, 30, 40],
+        "interiors_ids": [],
+        "boundary_line_ids": [10, 20, 30, 40],
+        "input_profile_id": null
+      }
+    ],
+    "dangles": [],
+    "cut_edges": [],
+    "invalid_rings": []
+  }
+}

--- a/crates/geo-polygonize-core/tests/golden_fixtures.rs
+++ b/crates/geo-polygonize-core/tests/golden_fixtures.rs
@@ -1,6 +1,8 @@
 use geo_polygonize_core::{
-    polygonize, Coord3D, DeterminismOptions, Line3D, PolygonizerOptions, ProvenanceOptions,
+    polygonize, Coord3D, DedupPolicy, DeterminismOptions, Line3D, PolygonizerOptions,
+    ProvenanceOptions, TileOwnershipPolicy, TiledPolygonizer,
 };
+use geo_types::{Coord, Geometry, LineString, Rect};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::Path;
@@ -73,9 +75,19 @@ struct GoldenResult {
 struct GoldenFixture {
     name: String,
     options: PolygonizerOptions,
+    tiling: Option<GoldenTiling>,
     inputs: Vec<GoldenLine>,
     expected_metrics: GoldenMetrics,
     expected: GoldenResult,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct GoldenTiling {
+    bbox: [f64; 4],
+    tile_size: f64,
+    buffer: f64,
+    ownership_policy: TileOwnershipPolicy,
+    dedup_policy: DedupPolicy,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -104,18 +116,57 @@ fn run_golden_test(path: &Path) {
         include_boundary_line_ids: true,
     };
 
-    let res = polygonize(input_lines, &options).unwrap();
-    let actual_area: f64 = res
-        .polygons
+    let (polygons, dangles, cut_edges, invalid_rings) = if let Some(tiling) = fixture.tiling {
+        let geometries: Vec<_> = input_lines
+            .iter()
+            .map(|line| {
+                Geometry::LineString(LineString::new(vec![
+                    line.start.to_coord_2d(),
+                    line.end.to_coord_2d(),
+                ]))
+            })
+            .collect();
+        let mut polygonizer = TiledPolygonizer::new(
+            Rect::new(
+                Coord {
+                    x: tiling.bbox[0],
+                    y: tiling.bbox[1],
+                },
+                Coord {
+                    x: tiling.bbox[2],
+                    y: tiling.bbox[3],
+                },
+            ),
+            tiling.tile_size,
+        )
+        .with_buffer(tiling.buffer)
+        .with_options(options)
+        .with_ownership_policy(tiling.ownership_policy)
+        .with_dedup_policy(tiling.dedup_policy);
+        for geometry in &geometries {
+            polygonizer.add_geometry(geometry);
+        }
+        let result = polygonizer.polygonize().unwrap();
+        (result.polygons, Vec::new(), Vec::new(), Vec::new())
+    } else {
+        let result = polygonize(input_lines, &options).unwrap();
+        (
+            result.polygons,
+            result.dangles,
+            result.cut_edges,
+            result.invalid_rings,
+        )
+    };
+    let actual_area: f64 = polygons
         .iter()
         .map(|polygon| polygon.unsigned_area_2d())
         .sum();
     assert_eq!(
         [
-            res.polygons.len(),
-            res.dangles.len(),
-            res.cut_edges.len(),
-            res.invalid_rings.len(),
+            polygons.len(),
+            dangles.len(),
+            cut_edges.len(),
+            invalid_rings.len(),
         ],
         [
             fixture.expected_metrics.polygon_count,
@@ -135,8 +186,7 @@ fn run_golden_test(path: &Path) {
         actual_area
     );
     let actual_result = GoldenResult {
-        polygons: res
-            .polygons
+        polygons: polygons
             .into_iter()
             .map(|p| {
                 let provenance = p.provenance.unwrap_or_default();
@@ -154,18 +204,15 @@ fn run_golden_test(path: &Path) {
                 }
             })
             .collect(),
-        dangles: res
-            .dangles
+        dangles: dangles
             .into_iter()
             .map(|d| d.into_iter().map(|c| c.into()).collect())
             .collect(),
-        cut_edges: res
-            .cut_edges
+        cut_edges: cut_edges
             .into_iter()
             .map(|edge| edge.into_iter().map(|c| c.into()).collect())
             .collect(),
-        invalid_rings: res
-            .invalid_rings
+        invalid_rings: invalid_rings
             .into_iter()
             .map(|r| r.into_iter().map(|c| c.into()).collect())
             .collect(),


### PR DESCRIPTION
## Summary

- add a strict end-to-end golden for conflicting input Z values under `ZPolicy::Ignore`
- verify canonical geometry, zeroed output Z, source edge IDs, provenance, and topology metrics
- update the roadmap to record delivered dirty-input and Z-policy coverage

## Why

Z policies had focused Rust tests but no strict persisted golden covering options deserialization through final polygon output.

## Validation

- `cargo test -p geo-polygonize-core --test golden_fixtures`
- `cargo test -p geo-polygonize-core --no-default-features --test golden_fixtures`
- fixture parses with `jq`
- `cargo fmt --all -- --check`
- `git diff --check`