### PR TITLE
ci(github): restrict automerge to default-branch PRs

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -15,6 +15,7 @@ jobs:
     if: >
       github.event.pull_request.user.login == 'graydonpleasants' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.base.ref == github.event.repository.default_branch &&
       !github.event.pull_request.draft
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Summary
- Add a workflow guard so the automerge job only runs when the PR targets the repository default branch.
- Prevent stacked or non-mainline PRs from being auto-merged by the GitHub Action.

## Testing
- Not run (not requested)