### PR TITLE
test(core): add compatibility corpus

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -52,7 +52,7 @@ fields, and reuse.
   ambiguous input.
 - [ ] Record GEOS/Shapely comparison results without turning compatibility
   observations into unsupported robustness guarantees.
-- [ ] Exercise `grid`, `geos_compat`, and certified fixed-precision policies on
+- [x] Exercise `grid`, `geos_compat`, and certified fixed-precision policies on
   the same inputs.
 
 Done means regressions can be distinguished from documented semantic

--- a/crates/geo-polygonize-core/tests/compatibility_corpus.rs
+++ b/crates/geo-polygonize-core/tests/compatibility_corpus.rs
@@ -1,0 +1,158 @@
+use geo_polygonize_core::{polygonize, Coord3D, Line3D, PolygonizerOptions};
+use serde::Deserialize;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Deserialize)]
+struct CompatibilityCase {
+    case_id: String,
+    fixture: PathBuf,
+    classification: Classification,
+    shapely_reference: ShapelyReference,
+    rust_profiles: Vec<RustProfile>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum Classification {
+    ExpectedParity,
+    ExpectedDivergence,
+    InvalidAmbiguous,
+}
+
+#[derive(Debug, Deserialize)]
+struct ShapelyReference {
+    polygon_count: usize,
+    total_area: f64,
+    area_tolerance: f64,
+}
+
+#[derive(Debug, Deserialize)]
+struct RustProfile {
+    name: String,
+    options: PolygonizerOptions,
+}
+
+#[derive(Debug, Deserialize)]
+struct GoldenFixture {
+    inputs: Vec<GoldenLine>,
+    expected_metrics: ExpectedMetrics,
+}
+
+#[derive(Debug, Deserialize)]
+struct GoldenLine {
+    start: GoldenCoord,
+    end: GoldenCoord,
+    id: u32,
+}
+
+#[derive(Debug, Deserialize)]
+struct GoldenCoord {
+    x: f64,
+    y: f64,
+    z: f64,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedMetrics {
+    polygon_count: usize,
+    total_area: f64,
+    area_tolerance: f64,
+    dangle_count: usize,
+    cut_edge_count: usize,
+    invalid_ring_count: usize,
+}
+
+fn repository_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+#[test]
+fn compatibility_corpus_matches_recorded_contracts() {
+    let root = repository_root();
+    let mut manifests: Vec<_> = fs::read_dir(root.join("fixtures/compat"))
+        .expect("compatibility fixture directory should exist")
+        .map(|entry| {
+            entry
+                .expect("compatibility fixture should be readable")
+                .path()
+        })
+        .filter(|path| {
+            path.extension()
+                .is_some_and(|extension| extension == "json")
+        })
+        .collect();
+    manifests.sort();
+    assert!(!manifests.is_empty(), "expected compatibility fixtures");
+
+    for manifest in manifests {
+        let case: CompatibilityCase = serde_json::from_str(
+            &fs::read_to_string(&manifest).expect("compatibility fixture should be readable"),
+        )
+        .expect("compatibility fixture should parse");
+        let golden: GoldenFixture = serde_json::from_str(
+            &fs::read_to_string(root.join(&case.fixture))
+                .expect("golden fixture should be readable"),
+        )
+        .expect("golden fixture should parse");
+        let lines: Vec<_> = golden
+            .inputs
+            .into_iter()
+            .map(|line| {
+                Line3D::new(
+                    Coord3D::new(line.start.x, line.start.y, line.start.z),
+                    Coord3D::new(line.end.x, line.end.y, line.end.z),
+                    line.id,
+                )
+            })
+            .collect();
+
+        if matches!(case.classification, Classification::ExpectedParity) {
+            assert_eq!(
+                case.shapely_reference.polygon_count, golden.expected_metrics.polygon_count,
+                "{} Shapely polygon count",
+                case.case_id
+            );
+            assert!(
+                (case.shapely_reference.total_area - golden.expected_metrics.total_area).abs()
+                    <= case.shapely_reference.area_tolerance,
+                "{} Shapely total area",
+                case.case_id
+            );
+        }
+
+        for profile in case.rust_profiles {
+            let result = polygonize(lines.iter().copied(), &profile.options)
+                .unwrap_or_else(|error| panic!("{} / {}: {error}", case.case_id, profile.name));
+            let total_area: f64 = result
+                .polygons
+                .iter()
+                .map(|polygon| polygon.unsigned_area_2d())
+                .sum();
+            assert_eq!(
+                [
+                    result.polygons.len(),
+                    result.dangles.len(),
+                    result.cut_edges.len(),
+                    result.invalid_rings.len(),
+                ],
+                [
+                    golden.expected_metrics.polygon_count,
+                    golden.expected_metrics.dangle_count,
+                    golden.expected_metrics.cut_edge_count,
+                    golden.expected_metrics.invalid_ring_count,
+                ],
+                "{} / {} topology counts",
+                case.case_id,
+                profile.name
+            );
+            assert!(
+                (total_area - golden.expected_metrics.total_area).abs()
+                    <= golden.expected_metrics.area_tolerance,
+                "{} / {} total area",
+                case.case_id,
+                profile.name
+            );
+        }
+    }
+}

--- a/fixtures/compat/bowtie.json
+++ b/fixtures/compat/bowtie.json
@@ -1,0 +1,39 @@
+{
+  "case_id": "bowtie_expected_parity",
+  "fixture": "crates/geo-polygonize-core/tests/fixtures/dirty/bowtie.json",
+  "classification": "expected_parity",
+  "reason": "A proper crossing with an exact fixed-grid intersection should produce the same two faces.",
+  "shapely_reference": {
+    "recipe": "polygonize(unary_union(lines))",
+    "polygon_count": 2,
+    "total_area": 50.0,
+    "area_tolerance": 0.0
+  },
+  "rust_profiles": [
+    {
+      "name": "grid_unchecked",
+      "options": {
+        "node_input": true,
+        "precision_model": { "type": "fixed_grid", "grid_size": 0.000001 },
+        "snap_strategy": "Grid"
+      }
+    },
+    {
+      "name": "geos_compat_unchecked",
+      "options": {
+        "node_input": true,
+        "precision_model": { "type": "fixed_grid", "grid_size": 0.000001 },
+        "snap_strategy": "GeosCompat"
+      }
+    },
+    {
+      "name": "certified_fixed_precision",
+      "options": {
+        "node_input": true,
+        "precision_model": { "type": "fixed_grid", "grid_size": 0.000001 },
+        "snap_strategy": "Grid",
+        "noding": { "guarantee": "CertifiedFixedPrecision" }
+      }
+    }
+  ]
+}

--- a/tests/differential_shapely.py
+++ b/tests/differential_shapely.py
@@ -6,6 +6,7 @@ import pytest
 import numpy as np
 import os
 import random
+from pathlib import Path
 from shapely.geometry import LineString, shape, mapping, Point
 from shapely.ops import polygonize, unary_union
 
@@ -296,3 +297,43 @@ def test_differential_parity(generator):
     # Using a constant floor of 1.0s to account for CLI startup and IO overhead
     assert rust_time < max(shapely_time * 10.0, 1.0), \
         f"Rust performance regression: Rust {rust_time:.4f}s > max(Shapely {shapely_time:.4f}s * 10, 1.0s)"
+
+
+COMPAT_DIR = Path(__file__).resolve().parents[1] / "fixtures" / "compat"
+
+
+@pytest.mark.parametrize("path", sorted(COMPAT_DIR.glob("*.json")))
+def test_persisted_compatibility_case(path):
+    case = json.loads(path.read_text())
+    fixture_path = Path(__file__).resolve().parents[1] / case["fixture"]
+    fixture = json.loads(fixture_path.read_text())
+    lines = [
+        LineString([
+            (line["start"]["x"], line["start"]["y"]),
+            (line["end"]["x"], line["end"]["y"]),
+        ])
+        for line in fixture["inputs"]
+    ]
+
+    shapely_result = run_shapely(lines)
+    reference = case["shapely_reference"]
+    assert len(shapely_result) == reference["polygon_count"]
+    assert sum(polygon.area for polygon in shapely_result) == pytest.approx(
+        reference["total_area"], abs=reference["area_tolerance"]
+    )
+
+    classification = case["classification"]
+    assert classification in {
+        "expected_parity",
+        "expected_divergence",
+        "invalid_ambiguous",
+    }
+    if classification == "invalid_ambiguous":
+        return
+
+    rust_result = run_rust_cli(lines)
+    if classification == "expected_parity":
+        assert_parity(shapely_result, rust_result)
+    else:
+        with pytest.raises(AssertionError):
+            assert_parity(shapely_result, rust_result)


### PR DESCRIPTION
## Summary

- add a persisted compatibility manifest that references the existing dirty bowtie golden instead of duplicating geometry
- validate the same input under Grid, GeosCompat, and certified fixed-precision Rust profiles
- make the Shapely differential runner consume recorded compatibility classifications and reference metrics
- record the completed cross-policy matrix in the roadmap

## Why

The differential suite previously generated every case in code, so parity observations were not durable or reusable. This adds the first checked-in expected-parity case while preserving the strict golden as the single geometry source.

## Validation

- `cargo test -p geo-polygonize-core --test compatibility_corpus`
- `cargo test -p geo-polygonize-core --no-default-features --test compatibility_corpus`
- `cargo clippy -p geo-polygonize-core --test compatibility_corpus -- -D warnings`
- `pytest tests/differential_shapely.py -k persisted -v`
- manifest parses with `jq`
- `cargo fmt --all -- --check`
- `git diff --check`