### PR TITLE
test(core): reuse golden benchmark fixture

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -37,7 +37,7 @@ change.
 - [x] Add explicit expected topology metrics to every golden fixture.
 - [x] Cover benchmark-sized inputs in addition to the existing basic, topology,
   provenance, dirty-input, Z-policy, tiling, and compatibility cases.
-- [ ] Reuse the same fixtures in canonical, benchmark, and differential paths
+- [x] Reuse the same fixtures in canonical, benchmark, and differential paths
   where their contracts overlap.
 
 Done means a missing expected result fails, all result families (including cut

--- a/crates/geo-polygonize-core/benches/common/mod.rs
+++ b/crates/geo-polygonize-core/benches/common/mod.rs
@@ -1,0 +1,49 @@
+use geo_types::LineString;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct GridFixture {
+    inputs: Vec<GridLine>,
+}
+
+#[derive(Deserialize)]
+struct GridLine {
+    start: GridCoord,
+    end: GridCoord,
+}
+
+#[derive(Deserialize)]
+struct GridCoord {
+    x: f64,
+    y: f64,
+}
+
+pub fn generate_grid(n: usize) -> Vec<LineString<f64>> {
+    if n == 10 {
+        let fixture: GridFixture = serde_json::from_str(include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/fixtures/benchmark/grid_10.json"
+        )))
+        .expect("benchmark golden fixture should parse");
+        return fixture
+            .inputs
+            .into_iter()
+            .map(|line| {
+                LineString::from(vec![(line.start.x, line.start.y), (line.end.x, line.end.y)])
+            })
+            .collect();
+    }
+
+    let mut lines = Vec::new();
+    for i in 0..=n {
+        lines.push(LineString::from(vec![
+            (0.0, i as f64),
+            (n as f64, i as f64),
+        ]));
+        lines.push(LineString::from(vec![
+            (i as f64, 0.0),
+            (i as f64, n as f64),
+        ]));
+    }
+    lines
+}

--- a/crates/geo-polygonize-core/benches/iai_bench.rs
+++ b/crates/geo-polygonize-core/benches/iai_bench.rs
@@ -1,23 +1,11 @@
+mod common;
+
+use common::generate_grid;
 use geo_polygonize_core::Polygonizer;
 use geo_types::LineString;
 use iai_callgrind::{library_benchmark, library_benchmark_group, main};
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
-
-fn generate_grid(n: usize) -> Vec<LineString<f64>> {
-    let mut lines = Vec::new();
-    for i in 0..=n {
-        lines.push(LineString::from(vec![
-            (0.0, i as f64),
-            (n as f64, i as f64),
-        ]));
-        lines.push(LineString::from(vec![
-            (i as f64, 0.0),
-            (i as f64, n as f64),
-        ]));
-    }
-    lines
-}
 
 fn generate_random_lines(n: usize, seed: u64) -> Vec<LineString<f64>> {
     let mut rng = StdRng::seed_from_u64(seed);

--- a/crates/geo-polygonize-core/benches/polygonize_bench.rs
+++ b/crates/geo-polygonize-core/benches/polygonize_bench.rs
@@ -1,3 +1,6 @@
+mod common;
+
+use common::generate_grid;
 use criterion::measurement::Measurement;
 use criterion::{
     criterion_group, criterion_main, BenchmarkGroup, BenchmarkId, Criterion, Throughput,
@@ -11,23 +14,6 @@ use std::time::Duration;
 
 fn fast_ci() -> bool {
     std::env::var_os("BENCH_FAST_CI").is_some()
-}
-
-fn generate_grid(n: usize) -> Vec<LineString<f64>> {
-    let mut lines = Vec::new();
-    for i in 0..=n {
-        // Horizontal
-        lines.push(LineString::from(vec![
-            (0.0, i as f64),
-            (n as f64, i as f64),
-        ]));
-        // Vertical
-        lines.push(LineString::from(vec![
-            (i as f64, 0.0),
-            (i as f64, n as f64),
-        ]));
-    }
-    lines
 }
 
 // Generates a grid with bowtie patterns in every cell, guaranteeing intersections.

--- a/fixtures/compat/grid_10.json
+++ b/fixtures/compat/grid_10.json
@@ -1,0 +1,18 @@
+{
+  "case_id": "benchmark_grid_10_expected_parity",
+  "fixture": "crates/geo-polygonize-core/tests/fixtures/benchmark/grid_10.json",
+  "classification": "expected_parity",
+  "reason": "The benchmark grid has exact integer crossings and should match GEOS topology and area.",
+  "shapely_reference": {
+    "recipe": "polygonize(unary_union(lines))",
+    "polygon_count": 100,
+    "total_area": 100.0,
+    "area_tolerance": 0.0
+  },
+  "rust_profiles": [
+    {
+      "name": "canonical",
+      "options": { "node_input": true }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- use the checked-in `grid_10` golden as the input for both Criterion and IAI `grid/10` benchmarks
- remove the duplicated Rust grid generators behind one shared benchmark helper
- add the same golden to the persisted Shapely parity corpus
- mark cross-path fixture reuse complete in the roadmap

## Impact

Canonical correctness, Rust performance, and GEOS differential checks now exercise the same benchmark-scale input instead of independently reconstructed grids.

## Validation

- `cargo test -p geo-polygonize-core --test golden_fixtures --test compatibility_corpus`
- `cargo test -p geo-polygonize-core --no-default-features --test golden_fixtures --test compatibility_corpus`
- `pytest tests/differential_shapely.py -k persisted -q`
- `cargo clippy -p geo-polygonize-core --benches -- -D warnings`
- `cargo bench -p geo-polygonize-core --bench polygonize_bench -- 'polygonize/grid/10' --test`
- `git diff --check`