### PR TITLE
test(core): complete compatibility classifications

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -48,7 +48,7 @@ fields, and reuse.
 
 ### 2. Add a compatibility corpus
 
-- [ ] Classify cases as expected parity, expected divergence, or invalid /
+- [x] Classify cases as expected parity, expected divergence, or invalid /
   ambiguous input.
 - [x] Record GEOS/Shapely comparison results without turning compatibility
   observations into unsupported robustness guarantees.

--- a/crates/geo-polygonize-core/tests/compatibility_corpus.rs
+++ b/crates/geo-polygonize-core/tests/compatibility_corpus.rs
@@ -12,7 +12,7 @@ struct CompatibilityCase {
     rust_profiles: Vec<RustProfile>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Copy, Debug, Deserialize)]
 #[serde(rename_all = "snake_case")]
 enum Classification {
     ExpectedParity,
@@ -70,6 +70,7 @@ fn repository_root() -> PathBuf {
 #[test]
 fn compatibility_corpus_matches_recorded_contracts() {
     let root = repository_root();
+    let mut seen_classifications = [false; 3];
     let mut manifests: Vec<_> = fs::read_dir(root.join("fixtures/compat"))
         .expect("compatibility fixture directory should exist")
         .map(|entry| {
@@ -90,6 +91,11 @@ fn compatibility_corpus_matches_recorded_contracts() {
             &fs::read_to_string(&manifest).expect("compatibility fixture should be readable"),
         )
         .expect("compatibility fixture should parse");
+        seen_classifications[match case.classification {
+            Classification::ExpectedParity => 0,
+            Classification::ExpectedDivergence => 1,
+            Classification::InvalidAmbiguous => 2,
+        }] = true;
         let golden: GoldenFixture = serde_json::from_str(
             &fs::read_to_string(root.join(&case.fixture))
                 .expect("golden fixture should be readable"),
@@ -155,4 +161,9 @@ fn compatibility_corpus_matches_recorded_contracts() {
             );
         }
     }
+
+    assert_eq!(
+        seen_classifications, [true; 3],
+        "expected parity, divergence, and invalid/ambiguous cases"
+    );
 }

--- a/crates/geo-polygonize-core/tests/fixtures/compat/zero_length_segment.json
+++ b/crates/geo-polygonize-core/tests/fixtures/compat/zero_length_segment.json
@@ -1,0 +1,25 @@
+{
+  "name": "compat_zero_length_segment",
+  "options": { "node_input": true },
+  "inputs": [
+    {
+      "start": { "x": 0.0, "y": 0.0, "z": 0.0 },
+      "end": { "x": 0.0, "y": 0.0, "z": 0.0 },
+      "id": 1
+    }
+  ],
+  "expected_metrics": {
+    "polygon_count": 0,
+    "total_area": 0.0,
+    "area_tolerance": 0.0,
+    "dangle_count": 0,
+    "cut_edge_count": 0,
+    "invalid_ring_count": 0
+  },
+  "expected": {
+    "polygons": [],
+    "dangles": [],
+    "cut_edges": [],
+    "invalid_rings": []
+  }
+}

--- a/fixtures/compat/zero_length_segment.json
+++ b/fixtures/compat/zero_length_segment.json
@@ -1,0 +1,13 @@
+{
+  "case_id": "zero_length_segment_invalid_ambiguous",
+  "fixture": "crates/geo-polygonize-core/tests/fixtures/compat/zero_length_segment.json",
+  "classification": "invalid_ambiguous",
+  "reason": "An exact zero-length segment has no topological edge; matching empty results only document how both engines discard this degenerate input.",
+  "shapely_reference": {
+    "recipe": "polygonize(unary_union(lines))",
+    "polygon_count": 0,
+    "total_area": 0.0,
+    "area_tolerance": 0.0
+  },
+  "rust_profiles": []
+}


### PR DESCRIPTION
## Summary

- add an exact zero-length segment as the persisted invalid/ambiguous compatibility case
- record matching empty Shapely output without treating it as supported parity
- require the corpus to retain parity, divergence, and invalid/ambiguous classifications
- mark compatibility classification complete in the roadmap

## Impact

The corpus now distinguishes all three contract classes, and its test fails if any class disappears.

## Validation

- `cargo test -p geo-polygonize-core --test golden_fixtures --test compatibility_corpus`
- `cargo test -p geo-polygonize-core --no-default-features --test golden_fixtures --test compatibility_corpus`
- `pytest tests/differential_shapely.py -k persisted -v`
- `cargo clippy -p geo-polygonize-core --test compatibility_corpus -- -D warnings`
- `git diff --check`