### PR TITLE
feat(core): add topology conformance fingerprint

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -110,6 +110,10 @@ the dependency notes allow it.
 
 ### P0.1 Canonical conformance harness
 
+Progress: Rust-side `TopologyFingerprintV1` and normalized errors are complete
+for the one-shot, workspace, and borrowed GeoRust paths. Python, Wasm, Arrow,
+and file-adapter execution remains open below.
+
 Build one fixture-driven conformance suite covering every supported entrypoint:
 
 - [ ] Rust one-shot `polygonize`.

--- a/crates/geo-polygonize-core/src/fingerprint.rs
+++ b/crates/geo-polygonize-core/src/fingerprint.rs
@@ -1,0 +1,436 @@
+//! Versioned, exact conformance values for adapter test harnesses.
+//!
+//! This is intentionally `#[doc(hidden)]`: it is a shared contract for the
+//! repository's adapters, not an additional stable polygonization entrypoint.
+
+use crate::{Coord3D, PolygonizeError, PolygonizerOptions, PolygonizerResult};
+use serde::Serialize;
+use serde_json::Value;
+
+/// The current topology fingerprint schema version.
+pub const TOPOLOGY_FINGERPRINT_V1_SCHEMA_VERSION: u32 = 1;
+
+/// A versioned, structured canonical representation of a successful run.
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct TopologyFingerprintV1 {
+    pub schema_version: u32,
+    /// The serialized canonical options object is part of the semantic contract.
+    pub options: Value,
+    pub polygons: Vec<PolygonFingerprintV1>,
+    pub dangles: Vec<Vec<CoordinateFingerprintV1>>,
+    pub cut_edges: Vec<Vec<CoordinateFingerprintV1>>,
+    pub invalid_rings: Vec<Vec<CoordinateFingerprintV1>>,
+    pub diagnostics: Option<TopologyDiagnosticsFingerprintV1>,
+}
+
+/// An exact finite coordinate. Every component is an IEEE-754 bit pattern.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct CoordinateFingerprintV1 {
+    pub x: String,
+    pub y: String,
+    pub z: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct PolygonFingerprintV1 {
+    pub exterior: Vec<CoordinateFingerprintV1>,
+    pub interiors: Vec<RingFingerprintV1>,
+    /// Per-edge representative input IDs, encoded as fixed-width hex strings.
+    pub exterior_edge_ids: Vec<String>,
+    pub provenance: Option<ProvenanceFingerprintV1>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct RingFingerprintV1 {
+    pub coordinates: Vec<CoordinateFingerprintV1>,
+    pub edge_ids: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct ProvenanceFingerprintV1 {
+    /// Complete source sets, never JSON numbers, so JavaScript cannot lose IDs.
+    pub boundary_line_ids: Vec<String>,
+    pub input_profile_id: Option<String>,
+}
+
+/// Only topology-level diagnostics. Timings and work counters are deliberately excluded.
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct TopologyDiagnosticsFingerprintV1 {
+    pub dangle_count: usize,
+    pub cut_edge_count: usize,
+    pub ring_count: usize,
+    pub shell_count: usize,
+    pub hole_count: usize,
+    pub unassigned_hole_count: usize,
+    pub unassigned_hole_area: String,
+    pub invalid_ring_count: usize,
+    pub z_conflict_node_count: usize,
+    pub z_conflicting_line_ids: Vec<String>,
+}
+
+/// A structured, stable error equality contract.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct NormalizedPolygonizeErrorV1 {
+    pub schema_version: u32,
+    pub family: String,
+    pub code: String,
+    pub stage: String,
+    pub field: Option<String>,
+    pub expected: Option<String>,
+    pub actual: Option<String>,
+    pub limit: Option<String>,
+    pub observed: Option<String>,
+    pub witness: Option<ErrorWitnessV1>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ErrorWitnessV1 {
+    pub ids: Vec<String>,
+    pub coordinate: Option<CoordinateFingerprintV1>,
+}
+
+/// A first, field-level difference suitable for terse CI failures.
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct FingerprintDiffV1 {
+    pub path: String,
+    pub expected: Value,
+    pub actual: Value,
+}
+
+impl TopologyFingerprintV1 {
+    /// Builds a canonical, exact representation. Inputs must have finite coordinates.
+    pub fn try_from_result(
+        result: &PolygonizerResult,
+        options: &PolygonizerOptions,
+    ) -> crate::Result<Self> {
+        let mut polygons: Vec<_> = result
+            .polygons
+            .iter()
+            .map(|polygon| {
+                let mut interiors: Vec<_> = polygon
+                    .interiors
+                    .iter()
+                    .zip(&polygon.interiors_ids)
+                    .map(|(coordinates, ids)| {
+                        Ok(RingFingerprintV1 {
+                            coordinates: canonical_ring(coordinates)?,
+                            edge_ids: canonical_ids(ids),
+                        })
+                    })
+                    .collect::<crate::Result<_>>()?;
+                interiors.sort_by_key(sort_key);
+                Ok(PolygonFingerprintV1 {
+                    exterior: canonical_ring(&polygon.exterior)?,
+                    interiors,
+                    exterior_edge_ids: canonical_ids(&polygon.exterior_ids),
+                    provenance: polygon.provenance.as_ref().map(|provenance| {
+                        let mut boundary_line_ids: Vec<_> = provenance
+                            .boundary_line_ids
+                            .iter()
+                            .copied()
+                            .map(id64)
+                            .collect();
+                        boundary_line_ids.sort();
+                        boundary_line_ids.dedup();
+                        ProvenanceFingerprintV1 {
+                            boundary_line_ids,
+                            input_profile_id: provenance.input_profile_id.clone(),
+                        }
+                    }),
+                })
+            })
+            .collect::<crate::Result<_>>()?;
+        polygons.sort_by_key(sort_key);
+
+        Ok(Self {
+            schema_version: TOPOLOGY_FINGERPRINT_V1_SCHEMA_VERSION,
+            options: serde_json::to_value(options).expect("validated options serialize"),
+            polygons,
+            dangles: canonical_open_lines(&result.dangles)?,
+            cut_edges: canonical_open_lines(&result.cut_edges)?,
+            invalid_rings: canonical_rings(&result.invalid_rings)?,
+            diagnostics: result.diagnostics.as_ref().map(|diagnostics| {
+                let mut z_conflicting_line_ids: Vec<_> = diagnostics
+                    .z_conflicts
+                    .contributing_line_ids
+                    .iter()
+                    .copied()
+                    .map(id32)
+                    .collect();
+                z_conflicting_line_ids.sort();
+                z_conflicting_line_ids.dedup();
+                TopologyDiagnosticsFingerprintV1 {
+                    dangle_count: diagnostics.dangle_count,
+                    cut_edge_count: diagnostics.cut_edge_count,
+                    ring_count: diagnostics.ring_count,
+                    shell_count: diagnostics.shell_count,
+                    hole_count: diagnostics.hole_count,
+                    unassigned_hole_count: diagnostics.unassigned_hole_count,
+                    unassigned_hole_area: float_bits(diagnostics.unassigned_hole_area)
+                        .expect("pipeline diagnostics are finite"),
+                    invalid_ring_count: diagnostics.invalid_ring_count,
+                    z_conflict_node_count: diagnostics.z_conflicts.conflict_node_count,
+                    z_conflicting_line_ids,
+                }
+            }),
+        })
+    }
+
+    /// Returns the first deterministic structural mismatch.
+    pub fn diff(&self, actual: &Self) -> Option<FingerprintDiffV1> {
+        diff_value(
+            "$",
+            &serde_json::to_value(self).expect("fingerprint serializes"),
+            &serde_json::to_value(actual).expect("fingerprint serializes"),
+        )
+    }
+}
+
+/// Normalizes a failure without making user-facing message text part of equality.
+pub fn normalize_polygonize_error(error: &PolygonizeError) -> NormalizedPolygonizeErrorV1 {
+    let base = |family: &str, code: &str, stage: &str| NormalizedPolygonizeErrorV1 {
+        schema_version: TOPOLOGY_FINGERPRINT_V1_SCHEMA_VERSION,
+        family: family.to_string(),
+        code: code.to_string(),
+        stage: stage.to_string(),
+        field: None,
+        expected: None,
+        actual: None,
+        limit: None,
+        observed: None,
+        witness: None,
+    };
+    match error {
+        PolygonizeError::InvalidArgumentType {
+            field,
+            expected,
+            actual,
+        } => NormalizedPolygonizeErrorV1 {
+            field: Some(field.clone()),
+            expected: Some(expected.clone()),
+            actual: Some(actual.clone()),
+            ..base("invalid_argument", "invalid_argument_type", "options")
+        },
+        PolygonizeError::InvalidGeometry { reason } => base(
+            "invalid_geometry",
+            if reason == "line coordinates must be finite" {
+                "non_finite_coordinate"
+            } else {
+                "invalid_geometry"
+            },
+            "input_validation",
+        ),
+        PolygonizeError::InvalidBufferShape { .. } => base(
+            "invalid_argument",
+            "invalid_buffer_shape",
+            "input_validation",
+        ),
+        PolygonizeError::UnsupportedOptionCombination { .. } => base(
+            "invalid_argument",
+            "unsupported_option_combination",
+            "options",
+        ),
+        PolygonizeError::TopologyFailure { .. } => base("topology", "topology_failure", "topology"),
+        PolygonizeError::ZConflict { x, y, line_ids } => {
+            let mut ids: Vec<_> = line_ids.iter().copied().map(id32).collect();
+            ids.sort();
+            ids.dedup();
+            NormalizedPolygonizeErrorV1 {
+                witness: Some(ErrorWitnessV1 {
+                    ids,
+                    coordinate: Some(CoordinateFingerprintV1 {
+                        x: float_bits(*x).expect("validated coordinate"),
+                        y: float_bits(*y).expect("validated coordinate"),
+                        z: float_bits(0.0).expect("zero is finite"),
+                    }),
+                }),
+                ..base("topology", "z_conflict", "z_reconciliation")
+            }
+        }
+        PolygonizeError::NodingValidationFailure {
+            first_segment,
+            second_segment,
+            reason,
+        } => NormalizedPolygonizeErrorV1 {
+            witness: Some(ErrorWitnessV1 {
+                ids: vec![id_usize(*first_segment), id_usize(*second_segment)],
+                coordinate: None,
+            }),
+            ..base(
+                "topology",
+                if reason.starts_with("zero-length") {
+                    "zero_length_segment"
+                } else if reason.starts_with("collinear overlap") {
+                    "collinear_overlap"
+                } else if reason.starts_with("intersection") {
+                    "interior_intersection"
+                } else {
+                    "noding_validation_failure"
+                },
+                "noding_validation",
+            )
+        },
+        PolygonizeError::InternalInvariantViolation { .. } => {
+            base("internal", "invariant_violation", "internal")
+        }
+        PolygonizeError::ArrowError { .. } => base("adapter", "arrow_error", "adapter"),
+        PolygonizeError::NullPointer { .. } => base("adapter", "null_pointer", "adapter"),
+        PolygonizeError::Panic { .. } => base("internal", "panic", "boundary"),
+    }
+}
+
+fn canonical_open_lines(
+    lines: &[Vec<Coord3D>],
+) -> crate::Result<Vec<Vec<CoordinateFingerprintV1>>> {
+    let mut result: Vec<_> = lines
+        .iter()
+        .map(|line| {
+            let forward = coordinates(line)?;
+            let mut reverse = forward.clone();
+            reverse.reverse();
+            Ok(forward.min(reverse))
+        })
+        .collect::<crate::Result<_>>()?;
+    result.sort_by_key(sort_key);
+    Ok(result)
+}
+
+fn canonical_rings(rings: &[Vec<Coord3D>]) -> crate::Result<Vec<Vec<CoordinateFingerprintV1>>> {
+    let mut result: Vec<_> = rings
+        .iter()
+        .map(|ring| canonical_ring(ring))
+        .collect::<crate::Result<_>>()?;
+    result.sort_by_key(sort_key);
+    Ok(result)
+}
+
+fn canonical_ring(ring: &[Coord3D]) -> crate::Result<Vec<CoordinateFingerprintV1>> {
+    let mut ring = coordinates(ring)?;
+    if ring.len() > 1 && ring.first() == ring.last() {
+        ring.pop();
+    }
+    if ring.is_empty() {
+        return Ok(ring);
+    }
+    let forward = rotate_minimum(&ring);
+    let mut backwards = ring;
+    backwards.reverse();
+    let backwards = rotate_minimum(&backwards);
+    let mut canonical = forward.min(backwards);
+    canonical.push(canonical[0].clone());
+    Ok(canonical)
+}
+
+fn rotate_minimum(ring: &[CoordinateFingerprintV1]) -> Vec<CoordinateFingerprintV1> {
+    (0..ring.len())
+        .map(|start| {
+            ring[start..]
+                .iter()
+                .chain(&ring[..start])
+                .cloned()
+                .collect::<Vec<_>>()
+        })
+        .min()
+        .expect("ring is non-empty")
+}
+
+fn coordinates(points: &[Coord3D]) -> crate::Result<Vec<CoordinateFingerprintV1>> {
+    points
+        .iter()
+        .map(|point| {
+            Ok(CoordinateFingerprintV1 {
+                x: float_bits(point.x)?,
+                y: float_bits(point.y)?,
+                z: float_bits(point.z)?,
+            })
+        })
+        .collect()
+}
+
+fn float_bits(value: f64) -> crate::Result<String> {
+    if !value.is_finite() {
+        return Err(PolygonizeError::InvalidGeometry {
+            reason: "fingerprint coordinates must be finite".to_string(),
+        });
+    }
+    Ok(format!(
+        "0x{:016x}",
+        if value == 0.0 { 0 } else { value.to_bits() }
+    ))
+}
+
+fn id32(value: u32) -> String {
+    format!("0x{value:08x}")
+}
+
+fn canonical_ids(ids: &[u32]) -> Vec<String> {
+    let mut ids: Vec<_> = ids.iter().copied().map(id32).collect();
+    ids.sort();
+    ids.dedup();
+    ids
+}
+
+fn id64(value: u64) -> String {
+    format!("0x{value:016x}")
+}
+
+fn id_usize(value: usize) -> String {
+    format!("0x{value:016x}")
+}
+
+fn sort_key<T: Serialize>(value: &T) -> String {
+    serde_json::to_string(value).expect("fingerprint serializes")
+}
+
+fn diff_value(path: &str, expected: &Value, actual: &Value) -> Option<FingerprintDiffV1> {
+    match (expected, actual) {
+        (Value::Object(expected), Value::Object(actual)) => {
+            let keys: std::collections::BTreeSet<_> =
+                expected.keys().chain(actual.keys()).collect();
+            for key in keys {
+                let next = format!("{path}.{key}");
+                match (expected.get(key), actual.get(key)) {
+                    (Some(expected), Some(actual)) => {
+                        if let Some(diff) = diff_value(&next, expected, actual) {
+                            return Some(diff);
+                        }
+                    }
+                    _ => {
+                        return Some(FingerprintDiffV1 {
+                            path: next,
+                            expected: expected.get(key).cloned().unwrap_or(Value::Null),
+                            actual: actual.get(key).cloned().unwrap_or(Value::Null),
+                        })
+                    }
+                }
+            }
+            None
+        }
+        (Value::Array(expected), Value::Array(actual)) => {
+            for index in 0..expected.len().max(actual.len()) {
+                let next = format!("{path}[{index}]");
+                match (expected.get(index), actual.get(index)) {
+                    (Some(expected), Some(actual)) => {
+                        if let Some(diff) = diff_value(&next, expected, actual) {
+                            return Some(diff);
+                        }
+                    }
+                    _ => {
+                        return Some(FingerprintDiffV1 {
+                            path: next,
+                            expected: expected.get(index).cloned().unwrap_or(Value::Null),
+                            actual: actual.get(index).cloned().unwrap_or(Value::Null),
+                        })
+                    }
+                }
+            }
+            None
+        }
+        _ if expected == actual => None,
+        _ => Some(FingerprintDiffV1 {
+            path: path.to_string(),
+            expected: expected.clone(),
+            actual: actual.clone(),
+        }),
+    }
+}

--- a/crates/geo-polygonize-core/src/lib.rs
+++ b/crates/geo-polygonize-core/src/lib.rs
@@ -12,6 +12,8 @@
 pub mod containment;
 mod diagnostics;
 mod error;
+#[doc(hidden)]
+pub mod fingerprint;
 // Kept compiler-public for the repository's microbenchmarks; not a supported API.
 #[doc(hidden)]
 pub mod graph;
@@ -36,6 +38,11 @@ pub use diagnostics::{
     PolygonizerDiagnostics, PolygonizerPhaseTimes, SnapStats, ZConflictStats,
 };
 pub use error::{PolygonizeError, Result};
+#[doc(hidden)]
+pub use fingerprint::{
+    normalize_polygonize_error, CoordinateFingerprintV1, ErrorWitnessV1, FingerprintDiffV1,
+    NormalizedPolygonizeErrorV1, TopologyFingerprintV1, TOPOLOGY_FINGERPRINT_V1_SCHEMA_VERSION,
+};
 pub use options::{
     ContainmentOptions, DeterminismOptions, DiagnosticsOptions, NodingBackend, NodingGuarantee,
     NodingOptions, OutputFilterOptions, PolygonizerOptions, PrecisionModel, ProvenanceOptions,

--- a/crates/geo-polygonize-core/tests/conformance_fingerprint.rs
+++ b/crates/geo-polygonize-core/tests/conformance_fingerprint.rs
@@ -1,0 +1,232 @@
+use geo_polygonize_core::{
+    normalize_polygonize_error, polygonize, polygonize_line_strings, polygonize_with_workspace,
+    Coord3D, DeterminismOptions, DiagnosticsOptions, Line3D, NodingGuarantee, NodingOptions,
+    PolygonizerOptions, PolygonizerWorkspace, ProvenanceOptions, TopologyFingerprintV1,
+};
+use geo_types::LineString;
+use serde::Deserialize;
+use std::path::Path;
+
+#[derive(Deserialize)]
+struct Fixture {
+    options: Option<PolygonizerOptions>,
+    inputs: Vec<FixtureLine>,
+}
+
+#[derive(Deserialize)]
+struct FixtureLine {
+    start: FixtureCoordinate,
+    end: FixtureCoordinate,
+    id: u32,
+}
+
+#[derive(Deserialize)]
+struct FixtureCoordinate {
+    x: f64,
+    y: f64,
+    z: f64,
+}
+
+fn fixture(path: &str) -> (Vec<Line3D>, PolygonizerOptions) {
+    let fixture: Fixture = serde_json::from_str(
+        &std::fs::read_to_string(
+            Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("tests/fixtures")
+                .join(path),
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    let options = PolygonizerOptions {
+        determinism: DeterminismOptions {
+            canonical_sort: true,
+            canonical_ring_rotation: true,
+            stable_tie_breaks: true,
+        },
+        diagnostics: DiagnosticsOptions {
+            enabled: true,
+            ..Default::default()
+        },
+        provenance: ProvenanceOptions {
+            enabled: true,
+            include_boundary_line_ids: true,
+        },
+        ..fixture.options.unwrap_or_default()
+    };
+    (
+        fixture
+            .inputs
+            .into_iter()
+            .map(|line| {
+                Line3D::new(
+                    Coord3D::new(line.start.x, line.start.y, line.start.z),
+                    Coord3D::new(line.end.x, line.end.y, line.end.z),
+                    line.id,
+                )
+            })
+            .collect(),
+        options,
+    )
+}
+
+fn fingerprint(
+    result: &geo_polygonize_core::PolygonizerResult,
+    options: &PolygonizerOptions,
+) -> TopologyFingerprintV1 {
+    TopologyFingerprintV1::try_from_result(result, options).unwrap()
+}
+
+#[test]
+fn one_shot_and_workspace_share_the_same_fingerprint() {
+    let (lines, options) = fixture("topology/reported_outputs.json");
+    let one_shot = fingerprint(&polygonize(lines.clone(), &options).unwrap(), &options);
+    let mut workspace = PolygonizerWorkspace::new();
+    let reused = fingerprint(
+        &polygonize_with_workspace(&lines, &options, &mut workspace).unwrap(),
+        &options,
+    );
+    assert_eq!(one_shot, reused);
+}
+
+#[test]
+fn borrowed_georust_input_retains_the_owned_contract() {
+    let ring = LineString::from(vec![
+        (0.0, 0.0),
+        (4.0, 0.0),
+        (4.0, 3.0),
+        (0.0, 3.0),
+        (0.0, 0.0),
+    ]);
+    let options = PolygonizerOptions {
+        provenance: ProvenanceOptions {
+            enabled: true,
+            include_boundary_line_ids: true,
+        },
+        ..Default::default()
+    };
+    let owned = vec![
+        Line3D::new(Coord3D::new(0.0, 0.0, 0.0), Coord3D::new(4.0, 0.0, 0.0), 0),
+        Line3D::new(Coord3D::new(4.0, 0.0, 0.0), Coord3D::new(4.0, 3.0, 0.0), 0),
+        Line3D::new(Coord3D::new(4.0, 3.0, 0.0), Coord3D::new(0.0, 3.0, 0.0), 0),
+        Line3D::new(Coord3D::new(0.0, 3.0, 0.0), Coord3D::new(0.0, 0.0, 0.0), 0),
+    ];
+    assert_eq!(
+        fingerprint(&polygonize(owned, &options).unwrap(), &options),
+        fingerprint(
+            &polygonize_line_strings([&ring], &options).unwrap(),
+            &options
+        ),
+    );
+}
+
+#[test]
+fn permutation_and_feature_builds_keep_the_canonical_fingerprint() {
+    let (lines, options) = fixture("topology/reported_outputs.json");
+    let expected = fingerprint(&polygonize(lines.clone(), &options).unwrap(), &options);
+    let mut permuted = lines;
+    permuted.reverse();
+    assert_eq!(
+        expected,
+        fingerprint(&polygonize(permuted, &options).unwrap(), &options)
+    );
+}
+
+#[test]
+fn golden_output_families_and_provenance_are_retained() {
+    let (lines, options) = fixture("topology/reported_outputs.json");
+    let report = fingerprint(&polygonize(lines, &options).unwrap(), &options);
+    assert_eq!(report.polygons.len(), 3);
+    assert_eq!(report.dangles.len(), 1);
+    assert_eq!(report.cut_edges.len(), 1);
+    assert_eq!(report.invalid_rings.len(), 2);
+    assert_eq!(
+        report.polygons[0]
+            .provenance
+            .as_ref()
+            .unwrap()
+            .boundary_line_ids[0],
+        "0x0000000000000001"
+    );
+
+    let (lines, options) = fixture("provenance/mixed_boundary_with_profile.json");
+    let report = fingerprint(&polygonize(lines, &options).unwrap(), &options);
+    assert_eq!(report.polygons.len(), 2);
+    assert!(report
+        .polygons
+        .iter()
+        .all(|polygon| polygon.provenance.is_some()));
+    let (lines, options) = fixture("provenance/mixed_boundary_with_profile.json");
+    assert_eq!(
+        report,
+        fingerprint(&polygonize(lines, &options).unwrap(), &options)
+    );
+}
+
+#[test]
+fn z_output_is_exact_and_negative_zero_is_normalized() {
+    let (lines, options) = fixture("z/ignore_conflicts.json");
+    let report = fingerprint(&polygonize(lines, &options).unwrap(), &options);
+    assert!(report.polygons[0]
+        .exterior
+        .iter()
+        .all(|coordinate| coordinate.z == "0x0000000000000000"));
+    let synthetic = geo_polygonize_core::PolygonizerResult {
+        polygons: Vec::new(),
+        dangles: vec![vec![Coord3D::new(-0.0, -0.0, -0.0)]],
+        cut_edges: Vec::new(),
+        invalid_rings: Vec::new(),
+        diagnostics: None,
+    };
+    let coordinate = fingerprint(&synthetic, &PolygonizerOptions::default()).dangles[0][0].clone();
+    assert_eq!(coordinate.x, "0x0000000000000000");
+    assert_eq!(coordinate.y, "0x0000000000000000");
+    assert_eq!(coordinate.z, "0x0000000000000000");
+}
+
+#[test]
+fn validation_and_option_failures_normalize_deterministically() {
+    let crossing = vec![
+        Line3D::new(Coord3D::new(-1.0, 0.0, 0.0), Coord3D::new(1.0, 0.0, 0.0), 1),
+        Line3D::new(Coord3D::new(0.0, -1.0, 0.0), Coord3D::new(0.0, 1.0, 0.0), 2),
+    ];
+    let validation = polygonize(
+        crossing,
+        &PolygonizerOptions {
+            noding: NodingOptions {
+                guarantee: NodingGuarantee::Validate,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    )
+    .unwrap_err();
+    let normalized = normalize_polygonize_error(&validation);
+    assert_eq!(normalized.code, "interior_intersection");
+    assert_eq!(
+        normalized.witness.unwrap().ids,
+        ["0x0000000000000000", "0x0000000000000001"]
+    );
+
+    let options = PolygonizerOptions {
+        pre_snap_tolerance: -1.0,
+        ..Default::default()
+    };
+    let first =
+        normalize_polygonize_error(&polygonize(Vec::<Line3D>::new(), &options).unwrap_err());
+    let second =
+        normalize_polygonize_error(&polygonize(Vec::<Line3D>::new(), &options).unwrap_err());
+    assert_eq!(first, second);
+    assert_eq!(first.field.as_deref(), Some("pre_snap_tolerance"));
+}
+
+#[test]
+fn field_level_diffs_name_the_changed_value() {
+    let (lines, options) = fixture("basic/square.json");
+    let expected = fingerprint(&polygonize(lines, &options).unwrap(), &options);
+    let mut actual = expected.clone();
+    actual.polygons[0].exterior[0].x = "0x3ff0000000000000".into();
+    let diff = expected.diff(&actual).unwrap();
+    assert_eq!(diff.path, "$.polygons[0].exterior[0].x");
+    assert_eq!(diff.expected, "0x0000000000000000");
+    assert_eq!(diff.actual, "0x3ff0000000000000");
+}

--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -1,0 +1,32 @@
+# Canonical conformance
+
+`TopologyFingerprintV1` is the repository's Rust-side conformance value. It is
+versioned, structured, and diffable; adapters must compare it (or the subset of
+it their format retains), never a digest alone. The Rust type is doc-hidden so
+the stable polygonization API stays narrow while bindings gain one shared test
+contract.
+
+The fingerprint includes canonical polygons, exterior and interior rings,
+representative edge IDs, complete boundary provenance sets, Z output, dangles,
+cut edges, invalid rings, selected canonical options, and deterministic
+topology diagnostics. It deliberately excludes timings, allocator data, work
+counters, thread data, and architecture metadata.
+
+Coordinates are finite IEEE-754 `f64` bit strings such as
+`"0x3ff0000000000000"`. `-0.0` is normalized to positive zero. IDs use fixed
+width hexadecimal strings, including `u64` provenance IDs, so JSON and
+JavaScript never silently round them. The same encoding is used in normalized
+error witnesses.
+
+`NormalizedPolygonizeErrorV1` compares schema version, family, code, pipeline
+stage, structured option values, and available witness IDs/coordinates. Human
+messages remain useful to callers but are intentionally not equality input.
+`TopologyFingerprintV1::diff` returns the first JSON-style field path for CI.
+
+Direct `MultiPolygon` conversion is intentionally lossy: it discards dangles,
+cut edges, invalid rings, diagnostics, representative IDs, provenance, and Z.
+Adapter tests for such APIs compare only the polygon subset they can retain.
+
+Future incompatible additions use `V2` rather than changing V1. Adapters must
+declare the highest schema they consume and retain V1 comparisons during a
+supported migration window.


### PR DESCRIPTION
## Summary

- add a doc-hidden, versioned `TopologyFingerprintV1` plus structured `NormalizedPolygonizeErrorV1`
- encode finite coordinates as normalized IEEE-754 hexadecimal bits and IDs as fixed-width hexadecimal strings
- canonicalize result families and expose first-field diff output for CI
- cover one-shot, workspace, borrowed GeoRust, permutations, output families, provenance, Z, validation, invalid options, and deliberate diffs using existing fixtures
- document schema/versioning, exclusions, lossy conversion, and adapter expectations

## Why

P0.1 needs one exact Rust representation before Python, Wasm, Arrow, and file adapters can compare retained semantics without independently reimplementing canonicalization.

## Stable-contract impact

No polygonization behavior or stable public API changes. The representation is doc-hidden and versioned; future incompatible changes require `V2`.

## Design decisions

- Coordinate and ID JSON values are strings so `-0.0` normalizes, binary `f64` values round-trip exactly, and JavaScript cannot lose `u64` provenance IDs.
- Only topology diagnostics are included; timings, allocation data, work counters, thread data, and architecture metadata are excluded.
- Human error messages are excluded from equality; family/code/stage/structured values and available witnesses are compared.

## Rejected alternatives

- Digest-only comparison: cannot provide field-level CI failures.
- Per-adapter canonicalization: risks semantic drift and duplicates Rust logic.
- A new crate: no dependency boundary exists; this stays inside core.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo test -p geo-polygonize-core --no-default-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p geo-polygonize-core --no-deps`
- focused conformance test under default and no-default features

## Roadmap

Completed the Rust-only P0.1 vertical slice. Cross-binding execution remains open.

## Agent handoff

Delivered:
- Rust fingerprint/error schema and exact encoding.
- Rust API conformance coverage and field-level diffing.

Still open:
- Python and Wasm exposure and fixture execution.
- Arrow and file-adapter retained-contract comparison.

Next dependency-ready task:
- Expose the Rust fingerprint/error JSON through Python and Wasm canonical-options paths, then run the same fixtures there.

Relevant files:
- `crates/geo-polygonize-core/src/fingerprint.rs`
- `crates/geo-polygonize-core/tests/conformance_fingerprint.rs`
- `docs/CONFORMANCE.md`

Validation:
- All commands above passed locally.