### PR TITLE
feat(python): expose conformance fingerprints

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -114,6 +114,10 @@ Progress: Rust-side `TopologyFingerprintV1` and normalized errors are complete
 for the one-shot, workspace, and borrowed GeoRust paths. Python, Wasm, Arrow,
 and file-adapter execution remains open below.
 
+The Python canonical-options and Wasm typed-buffer adapters now expose the
+shared success fingerprint; fixture-level cross-adapter comparison and the
+Wasm GeoJSON path remain open.
+
 Build one fixture-driven conformance suite covering every supported entrypoint:
 
 - [ ] Rust one-shot `polygonize`.

--- a/crates/geo-polygonize-python/src/lib.rs
+++ b/crates/geo-polygonize-python/src/lib.rs
@@ -1,7 +1,7 @@
 use numpy::{PyArray1, PyReadonlyArray1};
 use polygonize_core::{
     polygonize as polygonize_lines, Coord3D, Line3D, PolygonizeError, PolygonizerOptions,
-    PrecisionModel,
+    PrecisionModel, TopologyFingerprintV1,
 };
 use pyo3::create_exception;
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
@@ -219,6 +219,8 @@ fn polygonize_internal<'py>(
         ))
     })
     .map_err(to_py_err)?;
+    let topology_fingerprint =
+        TopologyFingerprintV1::try_from_result(&result, &options).map_err(to_py_err)?;
 
     // Flatten logic
     let mut num_points = 0;
@@ -390,12 +392,16 @@ fn polygonize_internal<'py>(
     dict.set_item("dangles", py_dangles)?;
     dict.set_item("cut_edges", py_cut_edges)?;
     dict.set_item("invalid_rings", py_invalid_rings)?;
+    let json_module = py.import("json")?;
+    let loads_func = json_module.getattr("loads")?;
+    dict.set_item(
+        "topology_fingerprint",
+        loads_func.call1((serde_json::to_string(&topology_fingerprint).unwrap(),))?,
+    )?;
 
     if let Some(ref diag) = result.diagnostics {
         // Map diagnostics using serde to a Python dict
         if let Ok(diag_json) = serde_json::to_string(diag) {
-            let json_module = py.import("json")?;
-            let loads_func = json_module.getattr("loads")?;
             let py_diag = loads_func.call1((diag_json,))?;
             dict.set_item("diagnostics", py_diag)?;
         }

--- a/crates/geo-polygonize-wasm/src/lib.rs
+++ b/crates/geo-polygonize-wasm/src/lib.rs
@@ -3,7 +3,9 @@ mod error;
 use arrow::compute::concat;
 use arrow_ipc::reader::StreamReader;
 use geo_polygonize_arrow::{polygonize_arrow, PolygonizerOptions};
-use geo_polygonize_core::{polygonize as polygonize_lines, Coord3D, Line3D, Polygonizer};
+use geo_polygonize_core::{
+    polygonize as polygonize_lines, Coord3D, Line3D, Polygonizer, TopologyFingerprintV1,
+};
 use geoarrow::array::GeoArrowArray;
 use geojson::{GeoJson, Geometry, Value};
 use std::convert::TryInto;
@@ -226,6 +228,7 @@ pub struct WasmPolygonResult {
     cut_edges: JsValue,
     invalid_rings: JsValue,
     diagnostics: JsValue,
+    topology_fingerprint: JsValue,
 }
 
 #[wasm_bindgen]
@@ -284,6 +287,11 @@ impl WasmPolygonResult {
     #[wasm_bindgen(getter)]
     pub fn diagnostics(&self) -> JsValue {
         self.diagnostics.clone()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn topology_fingerprint(&self) -> JsValue {
+        self.topology_fingerprint.clone()
     }
 }
 
@@ -604,6 +612,8 @@ fn polygonize_and_flatten(
         ))
     })
     .map_err(from_polygonizer_error)?;
+    let topology_fingerprint = TopologyFingerprintV1::try_from_result(&result, &options)
+        .map_err(from_polygonizer_error)?;
 
     let flatten_started = js_sys::Date::now();
     let mut flat_coords = Vec::new();
@@ -682,6 +692,8 @@ fn polygonize_and_flatten(
         cut_edges: js_cut_edges,
         invalid_rings: js_invalid_rings,
         diagnostics: js_diagnostics,
+        topology_fingerprint: serde_wasm_bindgen::to_value(&topology_fingerprint)
+            .unwrap_or(JsValue::NULL),
     })
 }
 

--- a/crates/geo-polygonize-wasm/tests/wasm.test.js
+++ b/crates/geo-polygonize-wasm/tests/wasm.test.js
@@ -229,6 +229,8 @@ describe('WASM Polygonizer', () => {
         // but we can at least assert the binding doesn't crash and returns the expected length.
         // It returns 5 elements for the single ring (5 coordinates)
         expect(numIds).toBe(5);
+        expect(result.topology_fingerprint.schema_version).toBe(1);
+        expect(result.topology_fingerprint.polygons[0].exterior[0].x).toMatch(/^0x/);
     });
 
     it('should report and reject Z conflicts through buffer options', async () => {

--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -30,3 +30,8 @@ Adapter tests for such APIs compare only the polygon subset they can retain.
 Future incompatible additions use `V2` rather than changing V1. Adapters must
 declare the highest schema they consume and retain V1 comparisons during a
 supported migration window.
+
+The Python canonical-options result exposes this value as
+`topology_fingerprint`. The Wasm typed-buffer result exposes the same value as
+`topology_fingerprint`; both are serialized directly by Rust rather than
+reconstructed in the adapter.

--- a/python/test_wrapper.py
+++ b/python/test_wrapper.py
@@ -240,6 +240,9 @@ def test_polygonize_with_options():
 
     result = polygonize_with_options(coords=coords, offsets=offsets, options=options, return_polygons=False)
     assert len(result['polygons']) == 1
+    fingerprint = result['topology_fingerprint']
+    assert fingerprint['schema_version'] == 1
+    assert fingerprint['polygons'][0]['exterior'][0]['x'].startswith('0x')
 
     default_result = polygonize_with_options(
         coords=coords,


### PR DESCRIPTION
## Summary

- expose the Rust-produced `TopologyFingerprintV1` in the Python canonical-options result
- expose the same fingerprint on the Wasm typed-buffer result
- add Python and Wasm assertions for schema/bit-string fields without reimplementing canonicalization

## Why

This advances P0.1 beyond the merged Rust foundation while preserving the narrow stable core API. Adapters serialize the shared Rust value directly.

## Stable-contract impact

Additive report fields only: Python returns `topology_fingerprint`; `WasmPolygonResult` exposes `topology_fingerprint`. Existing output fields and polygonization semantics are unchanged.

## Design decisions

- Reused `TopologyFingerprintV1` rather than duplicating sorting, bit encoding, provenance handling, or error logic in Python/JavaScript.
- Kept the Wasm GeoJSON path out of this focused adapter-field slice; it is still polygon-only and will be aligned by the planned full-report API.

## Rejected alternatives

- Adapter-local fingerprints: would create a second semantic contract.
- A new public core API or crate: neither is required to serialize the existing doc-hidden value.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p geo-polygonize-python -p geo-polygonize-wasm`
- `cargo clippy -p geo-polygonize-python -p geo-polygonize-wasm --all-targets -- -D warnings`
- `cargo test -p geo-polygonize-core --test conformance_fingerprint`
- `maturin build --manifest-path crates/geo-polygonize-python/Cargo.toml --out target/wheels`
- direct installed-wheel Python fingerprint check
- `cargo test -p geo-polygonize-wasm`

`wasm-pack` is unavailable locally, so the browser-package Vitest suite was not run; CI covers it. Running `pytest python/test_wrapper.py` directly shadows the wheel package with the source directory, so its extension import is not a valid wheel check.

## Roadmap

P0.1 progress only: Python canonical-options and Wasm typed-buffer now expose the shared success fingerprint. Fixture-level cross-adapter comparison, normalized adapter failures, and the Wasm GeoJSON path remain open.

## Agent handoff

Delivered:
- Rust-generated success fingerprints in Python canonical-options and Wasm buffer results.

Still open:
- Cross-adapter fixture runner and normalized failure results.
- Wasm GeoJSON full-report/fingerprint path.

Next dependency-ready task:
- Add the Wasm GeoJSON full-report API and run shared fixtures through Python, GeoJSON Wasm, and typed-buffer Wasm with field-level mismatches.

Relevant files:
- `crates/geo-polygonize-python/src/lib.rs`
- `crates/geo-polygonize-wasm/src/lib.rs`
- `docs/CONFORMANCE.md`

Validation:
- Commands above; browser package tests deferred to CI.