### PR TITLE
feat(wasm): add full topology report API

### DIFF
--- a/crates/geo-polygonize-wasm/src/lib.rs
+++ b/crates/geo-polygonize-wasm/src/lib.rs
@@ -23,9 +23,9 @@ pub use wasm_bindgen_rayon::init_thread_pool;
 #[wasm_bindgen(js_name = polygonizeWithOptions)]
 /// Polygonizes a GeoJSON FeatureCollection using the canonical `PolygonizerOptions`.
 ///
-/// This is the primary entry point for JavaScript users. It accepts a JSON string
-/// of options and returns a JSON string representing the result, including faces,
-/// dangles, cut-lines, and (optionally) provenance/diagnostics.
+/// This compatibility entry point returns polygons only. Use
+/// [`polygonize_report_with_options_js`] when dangles, cut edges, invalid rings,
+/// provenance, diagnostics, and exact coordinate encoding are required.
 pub fn polygonize_with_options_js(
     geojson_str: &str,
     options_val: JsValue,
@@ -94,6 +94,18 @@ pub fn polygonize_fingerprint_with_options_js(
             .map_err(from_polygonizer_error)?,
     )
     .map_err(|e| to_js_error("InternalInvariantViolation", e))
+}
+
+#[wasm_bindgen(js_name = polygonizeReportWithOptions)]
+/// Returns the complete versioned topology report for a GeoJSON canonical-options call.
+///
+/// The report is the JSON serialization of `TopologyFingerprintV1`; it is the
+/// stable cross-binding success contract, not a polygon-only GeoJSON projection.
+pub fn polygonize_report_with_options_js(
+    geojson_str: &str,
+    options_val: JsValue,
+) -> Result<String, JsValue> {
+    polygonize_fingerprint_with_options_js(geojson_str, options_val)
 }
 
 fn polygonize_geojson(

--- a/crates/geo-polygonize-wasm/tests/wasm.test.js
+++ b/crates/geo-polygonize-wasm/tests/wasm.test.js
@@ -63,7 +63,7 @@ describe('WASM Polygonizer', () => {
     });
 
     it('should apply defaults to partial options', async () => {
-        const { default: initModule, polygonizeFingerprintWithOptions, polygonizeWithOptions } = await import('../../../dist/standard/es/index.js');
+        const { default: initModule, polygonizeFingerprintWithOptions, polygonizeReportWithOptions, polygonizeWithOptions } = await import('../../../dist/standard/es/index.js');
         await initModule();
         const input = {
             type: "FeatureCollection",
@@ -80,6 +80,7 @@ describe('WASM Polygonizer', () => {
         const fingerprint = JSON.parse(polygonizeFingerprintWithOptions(JSON.stringify(input), {}));
         expect(fingerprint.schema_version).toBe(1);
         expect(fingerprint.polygons[0].exterior[0].x).toMatch(/^0x/);
+        expect(JSON.parse(polygonizeReportWithOptions(JSON.stringify(input), {}))).toEqual(fingerprint);
         expect(() => polygonizeWithOptions(JSON.stringify(input), {
             precision_model: { type: "fixed_grid", grid_size: -1 },
         })).toThrow(/precision_model.grid_size/);

--- a/docs/WASM_API.md
+++ b/docs/WASM_API.md
@@ -51,6 +51,7 @@ const wasm = await initBest(
   { module_or_path: simdUrl },
 );
 
+// This compatibility API returns polygons only.
 const resultStr = wasm.polygonizeWithOptions(
   JSON.stringify(geojson),
   cfbRobustOptions,

--- a/pkg-wrapper/shims.d.ts
+++ b/pkg-wrapper/shims.d.ts
@@ -12,6 +12,12 @@ export declare function polygonizeWithOptions(
     options_val: Partial<PolygonizerOptions>
 ): string;
 
+/** Versioned full topology report; unlike `polygonizeWithOptions`, this retains non-polygon output. */
+export declare function polygonizeReportWithOptions(
+    geojson_str: string,
+    options_val: Partial<PolygonizerOptions>
+): string;
+
 export declare function polygonizeGeoArrowWithOptions(
     ipc_bytes: Uint8Array,
     options_val: Partial<PolygonizerOptions>


### PR DESCRIPTION
## Summary

- document `polygonizeWithOptions` accurately as polygon-only compatibility output
- add `polygonizeReportWithOptions`, returning the full versioned Rust topology report
- add a wrapper declaration and browser assertion

## Contract

Legacy entrypoints remain unchanged. The new report endpoint returns all retained success families through `TopologyFingerprintV1`, including provenance, diagnostics, dangles, cut edges, invalid rings, selected options, and exact coordinate strings.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p geo-polygonize-wasm`
- `cargo clippy -p geo-polygonize-wasm --all-targets -- -D warnings`
- `cargo test -p geo-polygonize-wasm`

Browser bundle tests await CI because `wasm-pack` is unavailable locally.

## Agent handoff

Delivered:
- Named full-report Wasm API while preserving polygon-only compatibility.

Still open:
- Generated structural TypeScript schema types and canonical fixture runner across adapters.
- Normalized adapter failure payloads.

Next dependency-ready task:
- Add fixture-driven Python/Wasm report comparisons with first-field mismatch output.

Relevant files:
- `crates/geo-polygonize-wasm/src/lib.rs`
- `pkg-wrapper/shims.d.ts`
- `docs/WASM_API.md`

Validation:
- Commands above; browser bundle test deferred to CI.