### PR TITLE
feat(python): expose normalized adapter errors

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -113,8 +113,9 @@ the dependency notes allow it.
 Progress: Rust-side `TopologyFingerprintV1` and normalized errors are complete
 for the one-shot, workspace, and borrowed GeoRust paths. Python canonical
 options plus Wasm typed-buffer and GeoJSON canonical-options paths expose the
-shared success fingerprint. Fixture-level cross-adapter comparison, normalized
-adapter failures, Arrow, and file-adapter execution remain open.
+shared success fingerprint. Fixture-level cross-adapter comparison, Arrow, and
+file-adapter execution remain open; normalized core failures are exposed by
+Python and Wasm adapters.
 
 Build one fixture-driven conformance suite covering every supported entrypoint:
 

--- a/crates/geo-polygonize-python/src/lib.rs
+++ b/crates/geo-polygonize-python/src/lib.rs
@@ -1,7 +1,7 @@
 use numpy::{PyArray1, PyReadonlyArray1};
 use polygonize_core::{
-    polygonize as polygonize_lines, Coord3D, Line3D, PolygonizeError, PolygonizerOptions,
-    PrecisionModel, TopologyFingerprintV1,
+    normalize_polygonize_error, polygonize as polygonize_lines, Coord3D, Line3D, PolygonizeError,
+    PolygonizerOptions, PrecisionModel, TopologyFingerprintV1,
 };
 use pyo3::create_exception;
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
@@ -30,7 +30,9 @@ create_exception!(
 );
 
 fn to_py_err(err: PolygonizeError) -> PyErr {
-    match err {
+    let normalized = serde_json::to_string(&normalize_polygonize_error(&err))
+        .expect("normalized errors serialize");
+    let py_err = match err {
         PolygonizeError::InvalidArgumentType {
             field,
             expected,
@@ -54,7 +56,15 @@ fn to_py_err(err: PolygonizeError) -> PyErr {
         PolygonizeError::ArrowError(msg) => PyValueError::new_err(msg),
         PolygonizeError::NullPointer(msg) => PyValueError::new_err(msg),
         PolygonizeError::Panic(msg) => PyRuntimeError::new_err(msg),
-    }
+    };
+    Python::try_attach(|py| {
+        py_err
+            .value(py)
+            .setattr("normalized", normalized)
+            .expect("exceptions accept attributes");
+    })
+    .expect("Python exception conversion runs while attached");
+    py_err
 }
 
 #[pyfunction]

--- a/crates/geo-polygonize-wasm/src/error.rs
+++ b/crates/geo-polygonize-wasm/src/error.rs
@@ -1,17 +1,22 @@
-use geo_polygonize_core::PolygonizeError;
+use geo_polygonize_core::{normalize_polygonize_error, PolygonizeError};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 pub struct PolygonizerWasmError {
     name: String,
     message: String,
+    normalized: JsValue,
 }
 
 #[wasm_bindgen]
 impl PolygonizerWasmError {
     #[wasm_bindgen(constructor)]
     pub fn new(name: String, message: String) -> PolygonizerWasmError {
-        Self { name, message }
+        Self {
+            name,
+            message,
+            normalized: JsValue::NULL,
+        }
     }
 
     #[wasm_bindgen(getter)]
@@ -22,6 +27,11 @@ impl PolygonizerWasmError {
     #[wasm_bindgen(getter)]
     pub fn message(&self) -> String {
         self.message.clone()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn normalized(&self) -> JsValue {
+        self.normalized.clone()
     }
 }
 
@@ -44,7 +54,9 @@ pub fn from_polygonizer_error(e: PolygonizeError) -> JsValue {
         PolygonizeError::Panic(_) => "Panic".to_string(),
     };
 
-    let err = PolygonizerWasmError::new(name, e.to_string());
+    let mut err = PolygonizerWasmError::new(name, e.to_string());
+    err.normalized =
+        serde_wasm_bindgen::to_value(&normalize_polygonize_error(&e)).unwrap_or(JsValue::NULL);
     JsValue::from(err)
 }
 


### PR DESCRIPTION
## Summary

- attach Rust `NormalizedPolygonizeErrorV1` metadata to Python exceptions and Wasm errors
- preserve existing names/messages for compatibility
- update P0.1 roadmap progress precisely

## Contract

This is additive: Python exposes a JSON `normalized` exception attribute and Wasm exposes a structured `normalized` error property. Human-readable error messages remain unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p geo-polygonize-python -p geo-polygonize-wasm`
- `cargo clippy -p geo-polygonize-python -p geo-polygonize-wasm --all-targets -- -D warnings`
- `cargo test -p geo-polygonize-wasm`
- `git diff --check`

## Agent handoff

Delivered:
- Structured normalized core-error metadata across Python and Wasm.
- Roadmap progress update.

Still open:
- Fixture-level cross-adapter conformance comparisons.
- Adapter normalization for parsing/input-shape failures that originate before core polygonization.

Next dependency-ready task:
- Add checked-in fixture execution that compares Python and Wasm reports to Rust and prints first-field diffs.

Relevant files:
- `crates/geo-polygonize-python/src/lib.rs`
- `crates/geo-polygonize-wasm/src/error.rs`
- `ROADMAP.md`

Validation:
- Commands above passed locally.