### PR TITLE
feat(wasm): add adapter conformance fixture

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -111,20 +111,20 @@ the dependency notes allow it.
 ### P0.1 Canonical conformance harness
 
 Progress: Rust-side `TopologyFingerprintV1` and normalized errors are complete
-for the one-shot, workspace, and borrowed GeoRust paths. Python canonical
-options plus Wasm typed-buffer and GeoJSON canonical-options paths expose the
-shared success fingerprint. Fixture-level cross-adapter comparison, Arrow, and
-file-adapter execution remain open; normalized core failures are exposed by
+for the one-shot, workspace, and borrowed GeoRust paths. A shared exact fixture
+now runs through those three paths, Python canonical options, and both Wasm
+canonical-options paths (GeoJSON report/fingerprint and typed buffer). Arrow
+and file-adapter execution remain open; normalized core failures are exposed by
 Python and Wasm adapters.
 
 Build one fixture-driven conformance suite covering every supported entrypoint:
 
-- [ ] Rust one-shot `polygonize`.
-- [ ] Rust `polygonize_with_workspace`.
-- [ ] Borrowed `geo_traits` / GeoRust facade.
-- [ ] Python canonical-options API.
-- [ ] Wasm canonical-options GeoJSON API.
-- [ ] Wasm typed-buffer API.
+- [x] Rust one-shot `polygonize`.
+- [x] Rust `polygonize_with_workspace`.
+- [x] Borrowed `geo_traits` / GeoRust facade.
+- [x] Python canonical-options API.
+- [x] Wasm canonical-options GeoJSON API.
+- [x] Wasm typed-buffer API.
 - [ ] GeoArrow / Arrow IPC API.
 - [ ] Arrow C Data Interface API.
 - [ ] FlatGeobuf and GeoParquet adapters where their input contracts overlap.
@@ -159,7 +159,7 @@ result but its GeoJSON return path is polygon-only.
   rings, provenance, diagnostics, and selected options.
 - [ ] Make the playground use the canonical options/report API rather than the
   legacy positional wrapper.
-- [ ] Add TypeScript types generated from the same Rust schema and conformance
+- [x] Add TypeScript types generated from the same Rust schema and conformance
   tests for both JSON and typed-buffer paths.
 
 **Done when:** function names, generated types, docs, and runtime return values

--- a/crates/geo-polygonize-core/tests/conformance_fingerprint.rs
+++ b/crates/geo-polygonize-core/tests/conformance_fingerprint.rs
@@ -5,6 +5,7 @@ use geo_polygonize_core::{
 };
 use geo_types::LineString;
 use serde::Deserialize;
+use serde_json::Value;
 use std::path::Path;
 
 #[derive(Deserialize)]
@@ -25,6 +26,47 @@ struct FixtureCoordinate {
     x: f64,
     y: f64,
     z: f64,
+}
+
+#[derive(Deserialize)]
+struct AdapterFixture {
+    coords: Vec<f64>,
+    offsets: Vec<u32>,
+    stride: u8,
+    line_ids: Vec<u32>,
+    options: PolygonizerOptions,
+    expected_fingerprint: Value,
+}
+
+fn adapter_fixture() -> (Vec<Line3D>, PolygonizerOptions, Value) {
+    let fixture: AdapterFixture = serde_json::from_str(
+        &std::fs::read_to_string(
+            Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("tests/fixtures/conformance/axis_aligned_ring_v1.json"),
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(fixture.stride, 2);
+
+    let mut lines = Vec::new();
+    for (line_index, &start) in fixture.offsets.iter().enumerate() {
+        let end = fixture
+            .offsets
+            .get(line_index + 1)
+            .copied()
+            .unwrap_or((fixture.coords.len() / fixture.stride as usize) as u32);
+        for point_index in start..end - 1 {
+            let i = point_index as usize * fixture.stride as usize;
+            let j = i + fixture.stride as usize;
+            lines.push(Line3D::new(
+                Coord3D::new(fixture.coords[i], fixture.coords[i + 1], 0.0),
+                Coord3D::new(fixture.coords[j], fixture.coords[j + 1], 0.0),
+                fixture.line_ids[line_index],
+            ));
+        }
+    }
+    (lines, fixture.options, fixture.expected_fingerprint)
 }
 
 fn fixture(path: &str) -> (Vec<Line3D>, PolygonizerOptions) {
@@ -86,6 +128,37 @@ fn one_shot_and_workspace_share_the_same_fingerprint() {
         &options,
     );
     assert_eq!(one_shot, reused);
+}
+
+#[test]
+fn shared_adapter_fixture_matches_owned_workspace_and_borrowed_paths() {
+    let (lines, options, expected) = adapter_fixture();
+    let one_shot = fingerprint(&polygonize(lines.clone(), &options).unwrap(), &options);
+    assert_eq!(serde_json::to_value(&one_shot).unwrap(), expected);
+
+    let mut workspace = PolygonizerWorkspace::new();
+    assert_eq!(
+        one_shot,
+        fingerprint(
+            &polygonize_with_workspace(&lines, &options, &mut workspace).unwrap(),
+            &options,
+        )
+    );
+
+    let ring = LineString::from(vec![
+        (0.0, 0.0),
+        (4.0, 0.0),
+        (4.0, 3.0),
+        (0.0, 3.0),
+        (0.0, 0.0),
+    ]);
+    assert_eq!(
+        one_shot,
+        fingerprint(
+            &polygonize_line_strings([&ring], &options).unwrap(),
+            &options
+        )
+    );
 }
 
 #[test]

--- a/crates/geo-polygonize-core/tests/fixtures/conformance/axis_aligned_ring_v1.json
+++ b/crates/geo-polygonize-core/tests/fixtures/conformance/axis_aligned_ring_v1.json
@@ -1,0 +1,56 @@
+{
+  "name": "axis_aligned_ring_default_options_v1",
+  "geojson": {
+    "type": "FeatureCollection",
+    "features": [{
+      "type": "Feature",
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [[0, 0], [4, 0], [4, 3], [0, 3], [0, 0]]
+      }
+    }]
+  },
+  "coords": [0, 0, 4, 0, 4, 3, 0, 3, 0, 0],
+  "offsets": [0],
+  "stride": 2,
+  "line_ids": [0],
+  "options": {},
+  "expected_fingerprint": {
+    "schema_version": 1,
+    "options": {
+      "containment": { "touch_policy": "AllowPointTouchDisallowEdgeShare" },
+      "determinism": {
+        "canonical_ring_rotation": true,
+        "canonical_sort": true,
+        "stable_tie_breaks": true
+      },
+      "diagnostics": { "enabled": false, "report_mode": false, "timings": false },
+      "extract_only_polygonal": false,
+      "input_profile_id": null,
+      "node_input": false,
+      "noding": { "backend": "Snap", "guarantee": "Unchecked" },
+      "output_filter": { "minimum_face_area": null },
+      "pre_snap_tolerance": 0.0,
+      "precision_model": { "type": "floating" },
+      "provenance": { "enabled": false, "include_boundary_line_ids": false },
+      "snap_strategy": "Grid",
+      "z": { "conflict_tolerance": 0.0, "policy": "InterpolateAlongEdge" }
+    },
+    "polygons": [{
+      "exterior": [
+        { "x": "0x0000000000000000", "y": "0x0000000000000000", "z": "0x0000000000000000" },
+        { "x": "0x0000000000000000", "y": "0x4008000000000000", "z": "0x0000000000000000" },
+        { "x": "0x4010000000000000", "y": "0x4008000000000000", "z": "0x0000000000000000" },
+        { "x": "0x4010000000000000", "y": "0x0000000000000000", "z": "0x0000000000000000" },
+        { "x": "0x0000000000000000", "y": "0x0000000000000000", "z": "0x0000000000000000" }
+      ],
+      "interiors": [],
+      "exterior_edge_ids": ["0x00000000"],
+      "provenance": null
+    }],
+    "dangles": [],
+    "cut_edges": [],
+    "invalid_rings": [],
+    "diagnostics": null
+  }
+}

--- a/crates/geo-polygonize-core/tests/golden_fixtures.rs
+++ b/crates/geo-polygonize-core/tests/golden_fixtures.rs
@@ -242,8 +242,12 @@ fn test_all_fixtures() {
             .path()
             .components()
             .any(|c| c.as_os_str() == "provenance");
+        let is_conformance = entry
+            .path()
+            .components()
+            .any(|c| c.as_os_str() == "conformance");
 
-        if is_json && !is_provenance {
+        if is_json && !is_provenance && !is_conformance {
             run_golden_test(entry.path());
             count += 1;
         }

--- a/crates/geo-polygonize-wasm/src/lib.rs
+++ b/crates/geo-polygonize-wasm/src/lib.rs
@@ -647,6 +647,11 @@ fn polygonize_and_flatten(
     .map_err(from_polygonizer_error)?;
     let topology_fingerprint = TopologyFingerprintV1::try_from_result(&result, &options)
         .map_err(from_polygonizer_error)?;
+    let topology_fingerprint = js_sys::JSON::parse(
+        &serde_json::to_string(&topology_fingerprint)
+            .map_err(|e| to_js_error("InternalInvariantViolation", e))?,
+    )
+    .map_err(|e| to_js_error("InternalInvariantViolation", format!("{e:?}")))?;
 
     let flatten_started = js_sys::Date::now();
     let mut flat_coords = Vec::new();
@@ -725,8 +730,7 @@ fn polygonize_and_flatten(
         cut_edges: js_cut_edges,
         invalid_rings: js_invalid_rings,
         diagnostics: js_diagnostics,
-        topology_fingerprint: serde_wasm_bindgen::to_value(&topology_fingerprint)
-            .unwrap_or(JsValue::NULL),
+        topology_fingerprint,
     })
 }
 

--- a/crates/geo-polygonize-wasm/tests/wasm.test.js
+++ b/crates/geo-polygonize-wasm/tests/wasm.test.js
@@ -102,6 +102,36 @@ describe('WASM Polygonizer', () => {
         })).features).toHaveLength(0);
     });
 
+    it('should match the shared canonical fixture through GeoJSON and buffers', async () => {
+        const {
+            default: initModule,
+            polygonizeFingerprintWithOptions,
+            polygonizeReportWithOptions,
+            polygonizeWithOptionsBuffer,
+        } = await import('../../../dist/standard/es/index.js');
+        await initModule();
+        const fixture = JSON.parse(readFileSync(
+            resolve('crates/geo-polygonize-core/tests/fixtures/conformance/axis_aligned_ring_v1.json'),
+            'utf8',
+        ));
+
+        const input = JSON.stringify(fixture.geojson);
+        const report = JSON.parse(polygonizeReportWithOptions(input, fixture.options));
+        expect(JSON.parse(polygonizeFingerprintWithOptions(input, fixture.options))).toEqual(
+            fixture.expected_fingerprint,
+        );
+        expect(report).toEqual(fixture.expected_fingerprint);
+        expect(
+            polygonizeWithOptionsBuffer(
+                new Float64Array(fixture.coords),
+                new Uint32Array(fixture.offsets),
+                fixture.stride,
+                fixture.options,
+                new Uint32Array(fixture.line_ids),
+            ).topology_fingerprint,
+        ).toEqual(fixture.expected_fingerprint);
+    });
+
     it('should handle empty input', async () => {
         await init();
         const input = {

--- a/tests/test_adapter_conformance.py
+++ b/tests/test_adapter_conformance.py
@@ -1,0 +1,24 @@
+import json
+from pathlib import Path
+
+import numpy as np
+
+import geo_polygonize
+
+
+FIXTURE = (
+    Path(__file__).resolve().parents[1]
+    / "crates/geo-polygonize-core/tests/fixtures/conformance/axis_aligned_ring_v1.json"
+)
+
+
+def test_python_canonical_options_matches_shared_fingerprint_fixture():
+    fixture = json.loads(FIXTURE.read_text())
+    result = geo_polygonize.polygonize_with_options(
+        coords=np.asarray(fixture["coords"], dtype=np.float64),
+        offsets=np.asarray(fixture["offsets"], dtype=np.uint32),
+        stride=fixture["stride"],
+        line_ids=np.asarray(fixture["line_ids"], dtype=np.uint32),
+        options=fixture["options"],
+    )
+    assert result["topology_fingerprint"] == fixture["expected_fingerprint"]


### PR DESCRIPTION
## Summary

- add one exact, versioned topology-fingerprint fixture shared by Rust, Python, and Wasm tests
- cover Rust one-shot/workspace/borrowed inputs plus Wasm GeoJSON/report and typed-buffer APIs
- preserve the complete typed-buffer fingerprint by converting canonical Rust JSON into a JS object
- update P0.1 and P0.2 roadmap progress only for the newly executable coverage

## Why

The typed-buffer getter previously passed the report through `serde_wasm_bindgen`, which dropped default-valued option fields. That made it differ semantically from the GeoJSON report despite both representing the same core result.

## Validation

- `cargo test -p geo-polygonize-core --test conformance_fingerprint`
- `npx vitest run crates/geo-polygonize-wasm/tests/wasm.test.js`
- `maturin build --manifest-path crates/geo-polygonize-python/Cargo.toml --out target/wheels`
- `pytest -q tests/test_adapter_conformance.py`

## Handoff

Next grouped slice: bring the same fixture through GeoArrow / Arrow C Data and the file adapters where their contracts overlap; leave the remaining roadmap boxes unchecked until those paths run in CI.