### PR TITLE
test(core): cover Arrow conformance fixture

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -113,9 +113,10 @@ the dependency notes allow it.
 Progress: Rust-side `TopologyFingerprintV1` and normalized errors are complete
 for the one-shot, workspace, and borrowed GeoRust paths. A shared exact fixture
 now runs through those three paths, Python canonical options, and both Wasm
-canonical-options paths (GeoJSON report/fingerprint and typed buffer). Arrow
-and file-adapter execution remain open; normalized core failures are exposed by
-Python and Wasm adapters.
+canonical-options paths (GeoJSON report/fingerprint and typed buffer). The
+same fixture's retained polygon contract now also runs through GeoArrow and
+the Arrow C Data Interface. File-adapter execution remains open; normalized
+core failures are exposed by Python and Wasm adapters.
 
 Build one fixture-driven conformance suite covering every supported entrypoint:
 
@@ -125,8 +126,8 @@ Build one fixture-driven conformance suite covering every supported entrypoint:
 - [x] Python canonical-options API.
 - [x] Wasm canonical-options GeoJSON API.
 - [x] Wasm typed-buffer API.
-- [ ] GeoArrow / Arrow IPC API.
-- [ ] Arrow C Data Interface API.
+- [x] GeoArrow / Arrow IPC API.
+- [x] Arrow C Data Interface API.
 - [ ] FlatGeobuf and GeoParquet adapters where their input contracts overlap.
 
 Define a versioned canonical fingerprint containing:

--- a/crates/geo-polygonize-arrow/tests/arrow_integration.rs
+++ b/crates/geo-polygonize-arrow/tests/arrow_integration.rs
@@ -1,9 +1,14 @@
 use arrow::array::Array;
 use arrow::datatypes::Field;
 use arrow::ffi::{FFI_ArrowArray, FFI_ArrowSchema};
-use geo_polygonize_arrow::ffi::{polygonize_ffi, PolygonizerOptions};
-use geoarrow::array::{GeoArrowArray, PolygonArray};
-use geoarrow::datatypes::{Crs, Metadata};
+use geo_polygonize_arrow::ffi::{polygonize_ffi, polygonize_with_options_ffi, PolygonizerOptions};
+use geo_polygonize_arrow::{polygonize_arrow, PolygonizerOptions as CoreOptions};
+use geo_traits::{CoordTrait, LineStringTrait, PolygonTrait};
+use geoarrow::array::{
+    GeoArrowArray, GeoArrowArrayAccessor, LineStringArray, LineStringBuilder, PolygonArray,
+};
+use geoarrow::datatypes::{Crs, Dimension, LineStringType, Metadata};
+use serde_json::Value;
 use std::convert::TryFrom;
 use std::sync::Arc;
 
@@ -13,6 +18,121 @@ mod geoarrow_reference {
         env!("CARGO_MANIFEST_DIR"),
         "/../../fixtures/geoarrow/reference.rs"
     ));
+}
+
+fn conformance_fixture() -> Value {
+    serde_json::from_str(include_str!(
+        "../../geo-polygonize-core/tests/fixtures/conformance/axis_aligned_ring_v1.json"
+    ))
+    .unwrap()
+}
+
+fn conformance_input(fixture: &Value) -> (LineStringArray, Field) {
+    let coords = fixture["coords"].as_array().unwrap();
+    let line = geo::LineString::from(
+        coords
+            .chunks_exact(2)
+            .map(|point| (point[0].as_f64().unwrap(), point[1].as_f64().unwrap()))
+            .collect::<Vec<_>>(),
+    );
+    let mut builder = LineStringBuilder::new(LineStringType::new(
+        Dimension::XY,
+        Arc::new(Default::default()),
+    ));
+    builder.push_line_string(Some(&line)).unwrap();
+    let array = builder.finish();
+    let field = array.data_type().to_field("geometry", true);
+    (array, field)
+}
+
+fn canonical_ring(mut ring: Vec<(f64, f64)>) -> Vec<(f64, f64)> {
+    ring.pop();
+    let twice_area: f64 = ring
+        .iter()
+        .zip(ring.iter().cycle().skip(1))
+        .map(|((x1, y1), (x2, y2))| x1 * y2 - x2 * y1)
+        .sum();
+    if twice_area < 0.0 {
+        ring.reverse();
+    }
+    let first = ring
+        .iter()
+        .enumerate()
+        .min_by(|(_, left), (_, right)| {
+            left.0
+                .total_cmp(&right.0)
+                .then_with(|| left.1.total_cmp(&right.1))
+        })
+        .unwrap()
+        .0;
+    ring.rotate_left(first);
+    ring.push(ring[0]);
+    ring
+}
+
+fn assert_conformance_polygon(fixture: &Value, polygons: &PolygonArray) {
+    let expected = fixture["expected_fingerprint"]["polygons"][0]["exterior"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|coord| {
+            let parse = |name| {
+                f64::from_bits(
+                    u64::from_str_radix(&coord[name].as_str().unwrap()[2..], 16).unwrap(),
+                )
+            };
+            (parse("x"), parse("y"))
+        })
+        .collect::<Vec<_>>();
+    let polygon = polygons.get(0).unwrap().unwrap();
+    let exterior = polygon.exterior().unwrap();
+    let actual = (0..exterior.num_coords())
+        .map(|index| {
+            let coord = exterior.coord(index).unwrap();
+            (coord.x(), coord.y())
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(canonical_ring(actual), canonical_ring(expected));
+}
+
+#[test]
+fn arrow_and_c_data_retain_the_shared_conformance_polygon() {
+    let fixture = conformance_fixture();
+
+    let (input, field) = conformance_input(&fixture);
+    let polygons = polygonize_arrow(
+        input.into_array_ref().as_ref(),
+        &field,
+        CoreOptions::default(),
+    )
+    .unwrap();
+    assert_conformance_polygon(&fixture, &polygons);
+
+    let (input, field) = conformance_input(&fixture);
+    let input = input.into_array_ref();
+    let (input_array, _) = arrow::ffi::to_ffi(&input.to_data()).unwrap();
+    let input_schema = FFI_ArrowSchema::try_from(&field).unwrap();
+    let mut input_array = std::mem::ManuallyDrop::new(input_array);
+    let mut input_schema = std::mem::ManuallyDrop::new(input_schema);
+    let mut output_array = FFI_ArrowArray::empty();
+    let mut output_schema = FFI_ArrowSchema::empty();
+    let options = serde_json::to_vec(&fixture["options"]).unwrap();
+    let status = unsafe {
+        polygonize_with_options_ffi(
+            &mut *input_array,
+            &mut *input_schema,
+            &mut output_array,
+            &mut output_schema,
+            options.as_ptr(),
+            options.len(),
+        )
+    };
+    assert_eq!(status, 0);
+    let output = unsafe { arrow::ffi::from_ffi(output_array, &output_schema).unwrap() };
+    let output = arrow::array::make_array(output);
+    let field = Field::try_from(&output_schema).unwrap();
+    let polygons = PolygonArray::try_from((output.as_ref(), &field)).unwrap();
+    assert_conformance_polygon(&fixture, &polygons);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- run the existing shared conformance fixture through native GeoArrow and Arrow C Data entrypoints
- compare their retained polygon-ring contract with winding and rotation normalized
- mark the two exercised Arrow paths complete in the P0.1 roadmap

## Why

Arrow outputs polygon geometry only, so it cannot retain diagnostics or provenance from the full topology fingerprint. The test compares the shared fixture's retained coordinate contract without treating ring winding as an API guarantee.

## Validation

- `cargo test -p geo-polygonize-arrow --locked`

## Handoff

Next grouped P0.1 slice: exercise the shared fixture through FlatGeobuf and GeoParquet where their file contracts overlap, then leave only unsupported/non-overlapping paths open.