### PR TITLE
test(core): cover file adapter conformance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1066,6 +1066,7 @@ dependencies = [
  "geo-polygonize-core",
  "geo-traits",
  "geozero",
+ "serde_json",
 ]
 
 [[package]]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -115,8 +115,8 @@ for the one-shot, workspace, and borrowed GeoRust paths. A shared exact fixture
 now runs through those three paths, Python canonical options, and both Wasm
 canonical-options paths (GeoJSON report/fingerprint and typed buffer). The
 same fixture's retained polygon contract now also runs through GeoArrow and
-the Arrow C Data Interface. File-adapter execution remains open; normalized
-core failures are exposed by Python and Wasm adapters.
+the Arrow C Data Interface, FlatGeobuf, and GeoParquet. Normalized core
+failures are exposed by Python and Wasm adapters.
 
 Build one fixture-driven conformance suite covering every supported entrypoint:
 
@@ -128,7 +128,7 @@ Build one fixture-driven conformance suite covering every supported entrypoint:
 - [x] Wasm typed-buffer API.
 - [x] GeoArrow / Arrow IPC API.
 - [x] Arrow C Data Interface API.
-- [ ] FlatGeobuf and GeoParquet adapters where their input contracts overlap.
+- [x] FlatGeobuf and GeoParquet adapters where their input contracts overlap.
 
 Define a versioned canonical fingerprint containing:
 

--- a/crates/geo-polygonize-arrow/tests/geoparquet_integration.rs
+++ b/crates/geo-polygonize-arrow/tests/geoparquet_integration.rs
@@ -3,25 +3,21 @@
 use arrow::record_batch::RecordBatch;
 use geo_polygonize_arrow::geoparquet_api::polygonize_geoparquet_file;
 use geo_polygonize_arrow::PolygonizerOptions;
-use geoarrow::array::{GeoArrowArray, PolygonArray};
-use geoarrow::datatypes::Metadata;
+use geo_traits::{CoordTrait, LineStringTrait, PolygonTrait};
+use geoarrow::array::{
+    GeoArrowArray, GeoArrowArrayAccessor, LineStringArray, LineStringBuilder, PolygonArray,
+};
+use geoarrow::datatypes::{Dimension, LineStringType};
 use geoparquet::reader::{GeoParquetReaderBuilder, GeoParquetRecordBatchReader};
 use geoparquet::writer::{GeoParquetRecordBatchEncoder, GeoParquetWriterOptions};
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use parquet::arrow::ArrowWriter;
+use serde_json::Value;
 use std::fs::{self, File};
 use std::sync::Arc;
 
-#[allow(dead_code)]
-mod geoarrow_reference {
-    include!(concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/../../fixtures/geoarrow/reference.rs"
-    ));
-}
-
 #[test]
-fn polygonizes_a_geoparquet_file() {
+fn polygonizes_the_shared_conformance_fixture() {
     let input_path = std::env::temp_dir().join(format!(
         "geo-polygonize-{}-input.parquet",
         std::process::id()
@@ -31,7 +27,8 @@ fn polygonizes_a_geoparquet_file() {
         std::process::id()
     ));
 
-    write_square(&input_path);
+    let fixture = conformance_fixture();
+    write_conformance_lines(&input_path, &fixture);
     polygonize_geoparquet_file(
         input_path.to_str().unwrap(),
         output_path.to_str().unwrap(),
@@ -53,14 +50,87 @@ fn polygonizes_a_geoparquet_file() {
     assert!(reader.next().is_none());
 
     let polygons = PolygonArray::try_from((batch.column(0).as_ref(), schema.field(0))).unwrap();
-    geoarrow_reference::assert_square(&polygons);
+    assert_conformance_polygon(&fixture, &polygons);
 
     fs::remove_file(input_path).unwrap();
     fs::remove_file(output_path).unwrap();
 }
 
-fn write_square(path: &std::path::Path) {
-    let lines = geoarrow_reference::square(Arc::new(Metadata::default()));
+fn conformance_fixture() -> Value {
+    serde_json::from_str(include_str!(
+        "../../geo-polygonize-core/tests/fixtures/conformance/axis_aligned_ring_v1.json"
+    ))
+    .unwrap()
+}
+
+fn conformance_input(fixture: &Value) -> LineStringArray {
+    let coords = fixture["coords"].as_array().unwrap();
+    let line = geo::LineString::from(
+        coords
+            .chunks_exact(2)
+            .map(|point| (point[0].as_f64().unwrap(), point[1].as_f64().unwrap()))
+            .collect::<Vec<_>>(),
+    );
+    let mut builder = LineStringBuilder::new(LineStringType::new(
+        Dimension::XY,
+        Arc::new(Default::default()),
+    ));
+    builder.push_line_string(Some(&line)).unwrap();
+    builder.finish()
+}
+
+fn canonical_ring(mut ring: Vec<(f64, f64)>) -> Vec<(f64, f64)> {
+    ring.pop();
+    let twice_area: f64 = ring
+        .iter()
+        .zip(ring.iter().cycle().skip(1))
+        .map(|((x1, y1), (x2, y2))| x1 * y2 - x2 * y1)
+        .sum();
+    if twice_area < 0.0 {
+        ring.reverse();
+    }
+    let first = ring
+        .iter()
+        .enumerate()
+        .min_by(|(_, left), (_, right)| {
+            left.0
+                .total_cmp(&right.0)
+                .then_with(|| left.1.total_cmp(&right.1))
+        })
+        .unwrap()
+        .0;
+    ring.rotate_left(first);
+    ring.push(ring[0]);
+    ring
+}
+
+fn assert_conformance_polygon(fixture: &Value, polygons: &PolygonArray) {
+    let expected = fixture["expected_fingerprint"]["polygons"][0]["exterior"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|coord| {
+            let parse = |name| {
+                f64::from_bits(
+                    u64::from_str_radix(&coord[name].as_str().unwrap()[2..], 16).unwrap(),
+                )
+            };
+            (parse("x"), parse("y"))
+        })
+        .collect::<Vec<_>>();
+    let polygon = polygons.get(0).unwrap().unwrap();
+    let exterior = polygon.exterior().unwrap();
+    let actual = (0..exterior.num_coords())
+        .map(|index| {
+            let coord = exterior.coord(index).unwrap();
+            (coord.x(), coord.y())
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(canonical_ring(actual), canonical_ring(expected));
+}
+
+fn write_conformance_lines(path: &std::path::Path, fixture: &Value) {
+    let lines = conformance_input(fixture);
     let schema = Arc::new(arrow::datatypes::Schema::new(vec![lines
         .data_type()
         .to_field("geometry", false)]));

--- a/crates/geo-polygonize-flatgeobuf/Cargo.toml
+++ b/crates/geo-polygonize-flatgeobuf/Cargo.toml
@@ -12,3 +12,6 @@ flatgeobuf = { version = "6.0.1", default-features = false }
 geozero = { version = "0.15.1", default-features = false, features = ["with-geo"] }
 geo = "0.32"
 geo-traits = "0.3.0"
+
+[dev-dependencies]
+serde_json = "1.0"

--- a/crates/geo-polygonize-flatgeobuf/tests/flatgeobuf_integration.rs
+++ b/crates/geo-polygonize-flatgeobuf/tests/flatgeobuf_integration.rs
@@ -1,20 +1,21 @@
 use flatgeobuf::{
     FallibleStreamingIterator, FgbCrs, FgbReader, FgbWriter, FgbWriterOptions, GeometryType,
 };
-use geo::Area;
 use geo_polygonize_core::PolygonizerOptions;
 use geo_polygonize_flatgeobuf::polygonize_flatgeobuf_file;
 use geo_traits::to_geo::ToGeoGeometry;
+use serde_json::Value;
 use std::fs::{self, File};
 use std::io::{BufReader, BufWriter};
 
 #[test]
-fn polygonizes_a_flatgeobuf_file() {
+fn polygonizes_the_shared_conformance_fixture() {
     let input_path =
         std::env::temp_dir().join(format!("geo-polygonize-{}-input.fgb", std::process::id()));
     let output_path =
         std::env::temp_dir().join(format!("geo-polygonize-{}-output.fgb", std::process::id()));
-    write_square(&input_path);
+    let fixture = conformance_fixture();
+    write_conformance_lines(&input_path, &fixture);
 
     polygonize_flatgeobuf_file(
         input_path.to_str().unwrap(),
@@ -37,14 +38,69 @@ fn polygonizes_a_flatgeobuf_file() {
     let geo::Geometry::Polygon(polygon) = geometry else {
         panic!("expected polygon output");
     };
-    assert_eq!(polygon.unsigned_area(), 100.0);
+    assert_conformance_polygon(&fixture, &polygon);
     assert!(features.next().unwrap().is_none());
 
     fs::remove_file(input_path).unwrap();
     fs::remove_file(output_path).unwrap();
 }
 
-fn write_square(path: &std::path::Path) {
+fn conformance_fixture() -> Value {
+    serde_json::from_str(include_str!(
+        "../../geo-polygonize-core/tests/fixtures/conformance/axis_aligned_ring_v1.json"
+    ))
+    .unwrap()
+}
+
+fn canonical_ring(mut ring: Vec<(f64, f64)>) -> Vec<(f64, f64)> {
+    ring.pop();
+    let twice_area: f64 = ring
+        .iter()
+        .zip(ring.iter().cycle().skip(1))
+        .map(|((x1, y1), (x2, y2))| x1 * y2 - x2 * y1)
+        .sum();
+    if twice_area < 0.0 {
+        ring.reverse();
+    }
+    let first = ring
+        .iter()
+        .enumerate()
+        .min_by(|(_, left), (_, right)| {
+            left.0
+                .total_cmp(&right.0)
+                .then_with(|| left.1.total_cmp(&right.1))
+        })
+        .unwrap()
+        .0;
+    ring.rotate_left(first);
+    ring.push(ring[0]);
+    ring
+}
+
+fn assert_conformance_polygon(fixture: &Value, polygon: &geo::Polygon) {
+    let expected = fixture["expected_fingerprint"]["polygons"][0]["exterior"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|coord| {
+            let parse = |name| {
+                f64::from_bits(
+                    u64::from_str_radix(&coord[name].as_str().unwrap()[2..], 16).unwrap(),
+                )
+            };
+            (parse("x"), parse("y"))
+        })
+        .collect::<Vec<_>>();
+    let actual = polygon
+        .exterior()
+        .0
+        .iter()
+        .map(|coord| (coord.x, coord.y))
+        .collect();
+    assert_eq!(canonical_ring(actual), canonical_ring(expected));
+}
+
+fn write_conformance_lines(path: &std::path::Path, fixture: &Value) {
     let options = FgbWriterOptions {
         crs: FgbCrs {
             code: 4326,
@@ -54,13 +110,14 @@ fn write_square(path: &std::path::Path) {
     };
     let mut writer =
         FgbWriter::create_with_options("lines", GeometryType::LineString, options).unwrap();
-    let points = [
-        geo::coord! { x: 0.0, y: 0.0 },
-        geo::coord! { x: 10.0, y: 0.0 },
-        geo::coord! { x: 10.0, y: 10.0 },
-        geo::coord! { x: 0.0, y: 10.0 },
-        geo::coord! { x: 0.0, y: 0.0 },
-    ];
+    let points = fixture["coords"]
+        .as_array()
+        .unwrap()
+        .chunks_exact(2)
+        .map(|point| {
+            geo::coord! { x: point[0].as_f64().unwrap(), y: point[1].as_f64().unwrap() }
+        })
+        .collect::<Vec<_>>();
     for pair in points.windows(2) {
         writer
             .add_feature_geom(


### PR DESCRIPTION
## Summary

- run the shared canonical conformance fixture through FlatGeobuf and GeoParquet file adapters
- compare the retained polygon exterior after winding and start-point normalization
- mark the completed P0.1 file-adapter checkpoint in the roadmap

These adapters emit polygons only, so the tests intentionally verify their overlapping retained-geometry contract rather than diagnostics or provenance fields.

## Validation

- `cargo test -p geo-polygonize-flatgeobuf --offline`
- `cargo test -p geo-polygonize-flatgeobuf --locked`
- `cargo test -p geo-polygonize-arrow --features geoparquet --test geoparquet_integration --locked`
- `git diff --check`