### PR TITLE
fix(wasm): use canonical report in playground

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -153,12 +153,15 @@ reports a field-level semantic diff for any mismatch.
 The current high-level Wasm options endpoint is documented as returning a full
 result but its GeoJSON return path is polygon-only.
 
+Progress: Complete. The playground uses the canonical options/report API and
+projects its exact report coordinates only for visualization.
+
 - [x] Keep the existing polygon-only API for compatibility and document it
   accurately.
 - [x] Add a clearly named full-result endpoint,
   `polygonizeReportWithOptions`, returning polygons, dangles, cut edges, invalid
   rings, provenance, diagnostics, and selected options.
-- [ ] Make the playground use the canonical options/report API rather than the
+- [x] Make the playground use the canonical options/report API rather than the
   legacy positional wrapper.
 - [x] Add TypeScript types generated from the same Rust schema and conformance
   tests for both JSON and typed-buffer paths.

--- a/playground/src/main.tsx
+++ b/playground/src/main.tsx
@@ -1,6 +1,10 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import ReactDOM from 'react-dom/client';
-import init, { polygonize } from 'geo-polygonize';
+import init, {
+  polygonizeReportWithOptions,
+  type PolygonizerOptions,
+  type TopologyFingerprintV1,
+} from 'geo-polygonize';
 import {
   Container,
   Typography,
@@ -66,6 +70,32 @@ function computeBoundingBox(geojson: any) {
   };
 }
 
+function reportToGeojson(report: TopologyFingerprintV1) {
+  const view = new DataView(new ArrayBuffer(8));
+  const coordinate = (value: { x: string; y: string }) => {
+    const number = (bits: string) => {
+      view.setBigUint64(0, BigInt(bits));
+      return view.getFloat64(0);
+    };
+    return [number(value.x), number(value.y)];
+  };
+
+  return {
+    type: 'FeatureCollection',
+    features: report.polygons.map((polygon) => ({
+      type: 'Feature',
+      properties: null,
+      geometry: {
+        type: 'Polygon',
+        coordinates: [
+          polygon.exterior.map(coordinate),
+          ...polygon.interiors.map((ring) => ring.coordinates.map(coordinate)),
+        ],
+      },
+    })),
+  };
+}
+
 // --- Main App Component ---
 function App() {
   const [manifest, setManifest] = useState<ManifestEntry[]>([]);
@@ -73,6 +103,7 @@ function App() {
   const [wasmReady, setWasmReady] = useState(false);
   const [inputGeojson, setInputGeojson] = useState<any>(null);
   const [outputGeojson, setOutputGeojson] = useState<any>(null);
+  const [report, setReport] = useState<TopologyFingerprintV1 | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   // Options
@@ -144,6 +175,7 @@ function App() {
     );
     setInputGeojson(null);
     setOutputGeojson(null);
+    setReport(null);
     setError(null);
 
     async function loadFixture() {
@@ -179,11 +211,22 @@ function App() {
   useEffect(() => {
     if (!wasmReady || !inputGeojson) return;
     try {
-      const resultStr = polygonize(JSON.stringify(inputGeojson), nodeInput, snapGridSize);
-      setOutputGeojson(JSON.parse(resultStr));
+      const options: Partial<PolygonizerOptions> = {
+        node_input: nodeInput,
+        precision_model:
+          nodeInput && snapGridSize !== 0
+            ? { type: 'fixed_grid', grid_size: snapGridSize }
+            : { type: 'floating' },
+      };
+      const nextReport = JSON.parse(
+        polygonizeReportWithOptions(JSON.stringify(inputGeojson), options),
+      ) as TopologyFingerprintV1;
+      setReport(nextReport);
+      setOutputGeojson(reportToGeojson(nextReport));
       setError(null);
     } catch (e: any) {
       setOutputGeojson(null);
+      setReport(null);
       setError("Polygonize Error: " + e.toString());
     }
   }, [wasmReady, inputGeojson, nodeInput, snapGridSize]);
@@ -248,10 +291,13 @@ function App() {
             </Typography>
           </Paper>
 
-          {outputGeojson && (
+          {report && (
             <Paper sx={{ p: 2, mt: 3 }}>
                <Typography variant="h6">Results</Typography>
-               <Typography>Polygons found: {outputGeojson.features.length}</Typography>
+               <Typography>Polygons found: {report.polygons.length}</Typography>
+               <Typography>Dangles: {report.dangles.length}</Typography>
+               <Typography>Cut edges: {report.cut_edges.length}</Typography>
+               <Typography>Invalid rings: {report.invalid_rings.length}</Typography>
             </Paper>
           )}
         </Grid>


### PR DESCRIPTION
## Summary

- replace the playground's positional Wasm call with `polygonizeReportWithOptions`
- project the versioned report's exact coordinate encoding only for SVG rendering
- display report counts for polygons, dangles, cut edges, and invalid rings
- mark P0.2 complete in the roadmap

The positional polygon-only API remains unchanged for compatibility.

## Validation

- `npm --prefix playground run build`
- `git diff --check`