### PR TITLE
test(core): cover canonical options contract

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -171,11 +171,14 @@ describe the same contract.
 
 ### P0.3 Options and release synchronization
 
-- [ ] Round-trip every canonical option through Rust serde, generated
+Progress: Canonical option round-trips and migration coverage are complete;
+serialized metadata and release-policy synchronization remain.
+
+- [x] Round-trip every canonical option through Rust serde, generated
   TypeScript, Python helpers, Wasm, and C JSON options.
 - [ ] Add a CI gate preventing drift between Rust crate, npm, and PyPI releases.
 - [ ] Add explicit schema-version metadata to serialized reports and traces.
-- [ ] Publish migration tests for old supported option payloads.
+- [x] Publish migration tests for old supported option payloads.
 - [ ] Define which legacy positional APIs remain supported through `1.x`.
 
 ### P0.4 Versioned C ABI

--- a/crates/geo-polygonize-arrow/tests/arrow_integration.rs
+++ b/crates/geo-polygonize-arrow/tests/arrow_integration.rs
@@ -27,6 +27,13 @@ fn conformance_fixture() -> Value {
     .unwrap()
 }
 
+fn canonical_options_fixture() -> Value {
+    serde_json::from_str(include_str!(
+        "../../geo-polygonize-core/tests/fixtures/conformance/canonical_options_v1.json"
+    ))
+    .unwrap()
+}
+
 fn conformance_input(fixture: &Value) -> (LineStringArray, Field) {
     let coords = fixture["coords"].as_array().unwrap();
     let line = geo::LineString::from(
@@ -116,7 +123,7 @@ fn arrow_and_c_data_retain_the_shared_conformance_polygon() {
     let mut input_schema = std::mem::ManuallyDrop::new(input_schema);
     let mut output_array = FFI_ArrowArray::empty();
     let mut output_schema = FFI_ArrowSchema::empty();
-    let options = serde_json::to_vec(&fixture["options"]).unwrap();
+    let options = serde_json::to_vec(&canonical_options_fixture()["options"]).unwrap();
     let status = unsafe {
         polygonize_with_options_ffi(
             &mut *input_array,

--- a/crates/geo-polygonize-core/bindings/OutputFilterOptions.ts
+++ b/crates/geo-polygonize-core/bindings/OutputFilterOptions.ts
@@ -4,4 +4,4 @@ export type OutputFilterOptions = {
 /**
  * Keep faces whose area is greater than or equal to this value.
  */
-minimum_face_area?: number, };
+minimum_face_area?: number | null, };

--- a/crates/geo-polygonize-core/src/options.rs
+++ b/crates/geo-polygonize-core/src/options.rs
@@ -391,7 +391,7 @@ pub struct ZOptions {
 #[ts(export)]
 pub struct OutputFilterOptions {
     /// Keep faces whose area is greater than or equal to this value.
-    #[ts(optional)]
+    #[ts(type = "number | null", optional)]
     pub minimum_face_area: Option<f64>,
 }
 

--- a/crates/geo-polygonize-core/tests/fixtures/conformance/canonical_options_legacy_v0.json
+++ b/crates/geo-polygonize-core/tests/fixtures/conformance/canonical_options_legacy_v0.json
@@ -1,0 +1,20 @@
+{
+  "name": "canonical_options_legacy_v0",
+  "options": {
+    "node_input": true,
+    "precision_model": { "type": "fixed_grid", "grid_size": 0.1 },
+    "pre_snap_tolerance": 0.5,
+    "extract_only_polygonal": false,
+    "snap_strategy": "GeosCompat",
+    "noding": { "backend": "Snap" },
+    "containment": { "touch_policy": "AllowPointTouchDisallowEdgeShare" },
+    "determinism": {
+      "canonical_sort": true,
+      "canonical_ring_rotation": true,
+      "stable_tie_breaks": true
+    },
+    "diagnostics": { "enabled": true, "report_mode": true },
+    "provenance": { "enabled": true, "include_boundary_line_ids": true },
+    "input_profile_id": "cfb_robust_v1"
+  }
+}

--- a/crates/geo-polygonize-core/tests/fixtures/conformance/canonical_options_v1.json
+++ b/crates/geo-polygonize-core/tests/fixtures/conformance/canonical_options_v1.json
@@ -1,0 +1,22 @@
+{
+  "name": "canonical_options_v1",
+  "options": {
+    "node_input": true,
+    "precision_model": { "type": "fixed_grid", "grid_size": 0.1 },
+    "pre_snap_tolerance": 0.5,
+    "extract_only_polygonal": false,
+    "snap_strategy": "GeosCompat",
+    "noding": { "backend": "Snap", "guarantee": "Unchecked" },
+    "containment": { "touch_policy": "AllowPointTouchDisallowEdgeShare" },
+    "determinism": {
+      "canonical_sort": true,
+      "canonical_ring_rotation": true,
+      "stable_tie_breaks": true
+    },
+    "diagnostics": { "enabled": true, "report_mode": true, "timings": false },
+    "provenance": { "enabled": true, "include_boundary_line_ids": true },
+    "z": { "policy": "InterpolateAlongEdge", "conflict_tolerance": 0.0 },
+    "output_filter": { "minimum_face_area": null },
+    "input_profile_id": "cfb_robust_v1"
+  }
+}

--- a/crates/geo-polygonize-core/tests/options_contract.rs
+++ b/crates/geo-polygonize-core/tests/options_contract.rs
@@ -1,0 +1,29 @@
+use geo_polygonize_core::PolygonizerOptions;
+use serde_json::Value;
+
+fn canonical_fixture() -> Value {
+    serde_json::from_str(include_str!(
+        "fixtures/conformance/canonical_options_v1.json"
+    ))
+    .unwrap()
+}
+
+#[test]
+fn canonical_options_round_trip_through_rust_serde() {
+    let fixture = canonical_fixture();
+    let options: PolygonizerOptions = serde_json::from_value(fixture["options"].clone()).unwrap();
+    assert_eq!(serde_json::to_value(options).unwrap(), fixture["options"]);
+}
+
+#[test]
+fn legacy_canonical_options_payload_preserves_defaults() {
+    let legacy: Value = serde_json::from_str(include_str!(
+        "fixtures/conformance/canonical_options_legacy_v0.json"
+    ))
+    .unwrap();
+    let options: PolygonizerOptions = serde_json::from_value(legacy["options"].clone()).unwrap();
+    assert_eq!(
+        serde_json::to_value(options).unwrap(),
+        canonical_fixture()["options"]
+    );
+}

--- a/crates/geo-polygonize-wasm/tests/wasm.test.js
+++ b/crates/geo-polygonize-wasm/tests/wasm.test.js
@@ -132,6 +132,33 @@ describe('WASM Polygonizer', () => {
         ).toEqual(fixture.expected_fingerprint);
     });
 
+    it('should round-trip every canonical option through report APIs', async () => {
+        const {
+            default: initModule,
+            polygonizeReportWithOptions,
+            polygonizeWithOptionsBuffer,
+        } = await import('../../../dist/standard/es/index.js');
+        await initModule();
+        const input = JSON.parse(readFileSync(
+            resolve('crates/geo-polygonize-core/tests/fixtures/conformance/axis_aligned_ring_v1.json'),
+            'utf8',
+        ));
+        const options = JSON.parse(readFileSync(
+            resolve('crates/geo-polygonize-core/tests/fixtures/conformance/canonical_options_v1.json'),
+            'utf8',
+        )).options;
+
+        expect(JSON.parse(polygonizeReportWithOptions(JSON.stringify(input.geojson), options)).options)
+            .toEqual(options);
+        expect(polygonizeWithOptionsBuffer(
+            new Float64Array(input.coords),
+            new Uint32Array(input.offsets),
+            input.stride,
+            options,
+            new Uint32Array(input.line_ids),
+        ).topology_fingerprint.options).toEqual(options);
+    });
+
     it('should handle empty input', async () => {
         await init();
         const input = {

--- a/pkg-wrapper/cfb.ts
+++ b/pkg-wrapper/cfb.ts
@@ -32,7 +32,7 @@ export const cfbRobustOptions: PolygonizerOptions = {
         conflict_tolerance: 0,
     },
     output_filter: {
-        minimum_face_area: undefined,
+        minimum_face_area: null,
     },
     input_profile_id: "cfb_robust_v1",
 };

--- a/python/geo_polygonize/__init__.py
+++ b/python/geo_polygonize/__init__.py
@@ -161,6 +161,7 @@ def cfb_robust_options():
         "diagnostics": {
             "enabled": True,
             "report_mode": True,
+            "timings": False,
         },
         "provenance": {
             "enabled": True,

--- a/python/test_wrapper.py
+++ b/python/test_wrapper.py
@@ -201,7 +201,7 @@ def test_invalid_stride():
 
 def test_polygonize_with_options():
     print("\nTesting polygonize_with_options API...")
-    from geo_polygonize import PolygonizeTopologyError, polygonize_with_options
+    from geo_polygonize import cfb_robust_options, PolygonizeTopologyError, polygonize_with_options
 
     coords = np.array([
         0.0, 0.0, 10.0, 0.0,
@@ -211,37 +211,13 @@ def test_polygonize_with_options():
     ], dtype=np.float64)
     offsets = np.array([0, 2, 4, 6, 8], dtype=np.uint32)
 
-    options = {
-        "node_input": True,
-        "precision_model": {"type": "fixed_grid", "grid_size": 1e-5},
-        "extract_only_polygonal": False,
-        "snap_strategy": "Grid",
-        "noding": {
-            "backend": "Snap"
-        },
-        "containment": {
-            "touch_policy": "AllowPointTouchDisallowEdgeShare"
-        },
-        "determinism": {
-            "canonical_sort": True,
-            "canonical_ring_rotation": True,
-            "stable_tie_breaks": True
-        },
-        "diagnostics": {
-            "enabled": True,
-            "report_mode": True
-        },
-        "provenance": {
-            "enabled": True,
-            "include_boundary_line_ids": False
-        },
-        "input_profile_id": "test_profile_123"
-    }
+    options = cfb_robust_options()
 
     result = polygonize_with_options(coords=coords, offsets=offsets, options=options, return_polygons=False)
     assert len(result['polygons']) == 1
     fingerprint = result['topology_fingerprint']
     assert fingerprint['schema_version'] == 1
+    assert fingerprint['options'] == options
     assert fingerprint['polygons'][0]['exterior'][0]['x'].startswith('0x')
 
     default_result = polygonize_with_options(
@@ -321,7 +297,7 @@ def test_polygonize_with_options():
     sp = result['polygons'][0]
     assert hasattr(sp, "provenance")
     assert sp.provenance is not None
-    assert sp.provenance["input_profile_id"] == "test_profile_123"
+    assert sp.provenance["input_profile_id"] == "cfb_robust_v1"
 
     print("polygonize_with_options API test passed!")
 


### PR DESCRIPTION
## Summary

- add complete and legacy canonical-options fixtures
- round-trip the complete profile through Rust serde, Wasm report/buffer APIs, the Arrow C JSON entrypoint, and the Python helper
- verify older supported payloads receive current defaults
- correct the generated TypeScript type for the Rust-supported `null` minimum face area
- record P0.3 option-contract and migration progress

## Validation

- `cargo test -p geo-polygonize-core --test options_contract --locked`
- `cargo test -p geo-polygonize-arrow --test arrow_integration --locked`
- `npx vitest run crates/geo-polygonize-wasm/tests/wasm.test.js`
- isolated `maturin develop --release` plus `pytest -q python/test_wrapper.py::test_polygonize_with_options`
- `npm --prefix playground run build`
- `git diff --check`