### PR TITLE
docs(core): document Arrow C ABI ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ This behavior matches classical JTS/GEOS polygonization semantics and is useful 
 Rust Arrow and GeoArrow adapters live in the `geo-polygonize-arrow` crate;
 the Wasm crate includes it automatically.
 
+For the Arrow C Data Interface ABI, including ownership and error retrieval,
+see [docs/C_ABI.md](docs/C_ABI.md).
+
 ```rust
 use geo_polygonize_arrow::{polygonize_arrow, PolygonizerOptions};
 // ... create Arrow array ...

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -184,13 +184,15 @@ reports carry schema metadata, and release versions are checked in CI.
 ### P0.4 Versioned C ABI
 
 The Arrow C Data Interface adapter has panic containment and atomic output
-publication, but the surrounding ABI still needs a stable production contract.
+publication. ABI discovery, fixed return codes, and thread-local structured
+error retrieval are now available; request evolution, ownership documentation,
+and transfer-boundary fault injection remain.
 
-- [ ] Add an ABI version query.
+- [x] Add an ABI version query.
 - [ ] Prefer a versioned/size-tagged request struct or the canonical JSON options
   entrypoint over extending the legacy `repr(C)` options struct.
-- [ ] Define stable numeric status codes.
-- [ ] Add structured last-error retrieval with error family, stage, message, and
+- [x] Define stable numeric status codes.
+- [x] Add structured last-error retrieval with error family, stage, message, and
   optional noding witness.
 - [ ] Document ownership transfer, cleanup, nullability, thread-safety, and
   reentrancy.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -184,19 +184,19 @@ reports carry schema metadata, and release versions are checked in CI.
 ### P0.4 Versioned C ABI
 
 The Arrow C Data Interface adapter has panic containment and atomic output
-publication. ABI discovery, fixed return codes, and thread-local structured
-error retrieval are now available; request evolution, ownership documentation,
-and transfer-boundary fault injection remain.
+publication. ABI discovery, fixed return codes, thread-local structured error
+retrieval, canonical JSON request evolution, and ownership-boundary tests are
+now available.
 
 - [x] Add an ABI version query.
-- [ ] Prefer a versioned/size-tagged request struct or the canonical JSON options
+- [x] Prefer a versioned/size-tagged request struct or the canonical JSON options
   entrypoint over extending the legacy `repr(C)` options struct.
 - [x] Define stable numeric status codes.
 - [x] Add structured last-error retrieval with error family, stage, message, and
   optional noding witness.
-- [ ] Document ownership transfer, cleanup, nullability, thread-safety, and
+- [x] Document ownership transfer, cleanup, nullability, thread-safety, and
   reentrancy.
-- [ ] Test failure injection before and after every ownership-transfer boundary.
+- [x] Test failure injection before and after every ownership-transfer boundary.
 
 **Done when:** a C consumer can detect ABI compatibility and diagnose a failure
 without parsing logs or relying on Rust enum layout.

--- a/crates/geo-polygonize-arrow/src/ffi.rs
+++ b/crates/geo-polygonize-arrow/src/ffi.rs
@@ -3,9 +3,146 @@ use arrow::array::Array;
 use arrow::datatypes::Field;
 use arrow::error::ArrowError;
 use arrow::ffi::{from_ffi_and_data_type, FFI_ArrowArray, FFI_ArrowSchema};
-use geo_polygonize_core::{PolygonizeError, PolygonizerOptions as CoreOptions, PrecisionModel};
+use geo_polygonize_core::{
+    normalize_polygonize_error, PolygonizeError, PolygonizerOptions as CoreOptions, PrecisionModel,
+};
 use geoarrow::array::IntoArrow;
 use std::convert::TryFrom;
+use std::ffi::{c_char, CString};
+
+pub const POLYGONIZE_FFI_ABI_VERSION: u32 = 1;
+
+#[repr(i32)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PolygonizeFfiStatus {
+    Success = 0,
+    InvalidArgument = 1,
+    InvalidArrowCData = 2,
+    SchemaExport = 4,
+    InvalidBufferShape = 5,
+    InvalidOption = 6,
+    InvalidGeometry = 7,
+    Topology = 8,
+    UnsupportedOptionCombination = 9,
+    InternalInvariant = 10,
+    Arrow = 11,
+    Unknown = 12,
+    Panic = 99,
+}
+
+#[repr(C)]
+pub struct PolygonizeFfiLastError {
+    pub status: i32,
+    pub family: *const c_char,
+    pub stage: *const c_char,
+    pub message: *const c_char,
+    pub witness: *const c_char,
+}
+
+struct LastErrorStorage {
+    _family: CString,
+    _stage: CString,
+    _message: CString,
+    _witness: CString,
+    value: PolygonizeFfiLastError,
+}
+
+thread_local! {
+    static LAST_ERROR: std::cell::RefCell<Option<LastErrorStorage>> = const { std::cell::RefCell::new(None) };
+}
+
+fn c_string(value: &str) -> CString {
+    CString::new(value).unwrap_or_else(|_| CString::new("invalid error text").unwrap())
+}
+
+fn clear_last_error() {
+    LAST_ERROR.with(|last| *last.borrow_mut() = None);
+}
+
+fn set_last_error(
+    status: PolygonizeFfiStatus,
+    family: &str,
+    stage: &str,
+    message: &str,
+    witness: &str,
+) -> i32 {
+    let family = c_string(family);
+    let stage = c_string(stage);
+    let message = c_string(message);
+    let witness = c_string(witness);
+    let value = PolygonizeFfiLastError {
+        status: status as i32,
+        family: family.as_ptr(),
+        stage: stage.as_ptr(),
+        message: message.as_ptr(),
+        witness: witness.as_ptr(),
+    };
+    LAST_ERROR.with(|last| {
+        *last.borrow_mut() = Some(LastErrorStorage {
+            _family: family,
+            _stage: stage,
+            _message: message,
+            _witness: witness,
+            value,
+        });
+    });
+    status as i32
+}
+
+fn set_static_error(status: PolygonizeFfiStatus, family: &str, stage: &str, message: &str) -> i32 {
+    set_last_error(status, family, stage, message, "")
+}
+
+fn set_polygonize_error(error: &PolygonizeError) -> i32 {
+    let normalized = normalize_polygonize_error(error);
+    let status = match error {
+        PolygonizeError::InvalidBufferShape { .. } => PolygonizeFfiStatus::InvalidBufferShape,
+        PolygonizeError::InvalidArgumentType { .. } => PolygonizeFfiStatus::InvalidOption,
+        PolygonizeError::InvalidGeometry { .. } => PolygonizeFfiStatus::InvalidGeometry,
+        PolygonizeError::TopologyFailure { .. }
+        | PolygonizeError::ZConflict { .. }
+        | PolygonizeError::NodingValidationFailure { .. } => PolygonizeFfiStatus::Topology,
+        PolygonizeError::UnsupportedOptionCombination { .. } => {
+            PolygonizeFfiStatus::UnsupportedOptionCombination
+        }
+        PolygonizeError::InternalInvariantViolation { .. } => {
+            PolygonizeFfiStatus::InternalInvariant
+        }
+        PolygonizeError::ArrowError(_) => PolygonizeFfiStatus::Arrow,
+        PolygonizeError::NullPointer(_) => PolygonizeFfiStatus::InvalidArgument,
+        PolygonizeError::Panic(_) => PolygonizeFfiStatus::Panic,
+    };
+    let witness = normalized
+        .witness
+        .map(|value| serde_json::to_string(&value).unwrap())
+        .unwrap_or_default();
+    set_last_error(
+        status,
+        &normalized.family,
+        &normalized.stage,
+        &error.to_string(),
+        &witness,
+    )
+}
+
+#[no_mangle]
+pub extern "C" fn polygonize_ffi_abi_version() -> u32 {
+    POLYGONIZE_FFI_ABI_VERSION
+}
+
+/// Returns the current thread's most recent FFI error, or null after success.
+///
+/// The returned pointer remains valid until the next polygonize FFI call on the
+/// same thread. Callers must copy any strings they need to retain.
+#[no_mangle]
+pub extern "C" fn polygonize_ffi_last_error() -> *const PolygonizeFfiLastError {
+    LAST_ERROR.with(|last| {
+        last.borrow()
+            .as_ref()
+            .map(|error| &error.value as *const PolygonizeFfiLastError)
+            .unwrap_or(std::ptr::null())
+    })
+}
 
 #[repr(C)]
 pub struct PolygonizerOptions {
@@ -79,7 +216,12 @@ pub unsafe extern "C" fn polygonize_ffi(
 ) -> i32 {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
         if options.is_null() {
-            return 1;
+            return set_static_error(
+                PolygonizeFfiStatus::InvalidArgument,
+                "invalid_argument",
+                "options",
+                "options must not be null",
+            );
         }
         let opts = &*options;
         let node_input = opts.node_input != 0;
@@ -104,7 +246,14 @@ pub unsafe extern "C" fn polygonize_ffi(
             arrow_opts,
         )
     }))
-    .unwrap_or(99)
+    .unwrap_or_else(|_| {
+        set_static_error(
+            PolygonizeFfiStatus::Panic,
+            "internal",
+            "boundary",
+            "panic crossed the FFI boundary",
+        )
+    })
 }
 
 /// # Safety
@@ -123,18 +272,37 @@ pub unsafe extern "C" fn polygonize_with_options_ffi(
 ) -> i32 {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
         if options_json.is_null() {
-            return 1;
+            return set_static_error(
+                PolygonizeFfiStatus::InvalidArgument,
+                "invalid_argument",
+                "options",
+                "options_json must not be null",
+            );
         }
 
         let slice = std::slice::from_raw_parts(options_json, options_json_len);
         let options_str = match std::str::from_utf8(slice) {
             Ok(s) => s,
-            Err(_) => return 1,
+            Err(_) => {
+                return set_static_error(
+                    PolygonizeFfiStatus::InvalidArgument,
+                    "invalid_argument",
+                    "options",
+                    "options_json must be valid UTF-8",
+                )
+            }
         };
 
         let arrow_opts: CoreOptions = match serde_json::from_str(options_str) {
             Ok(o) => o,
-            Err(_) => return 1,
+            Err(_) => {
+                return set_static_error(
+                    PolygonizeFfiStatus::InvalidArgument,
+                    "invalid_argument",
+                    "options",
+                    "options_json must match PolygonizerOptions",
+                )
+            }
         };
 
         polygonize_ffi_internal(
@@ -145,7 +313,14 @@ pub unsafe extern "C" fn polygonize_with_options_ffi(
             arrow_opts,
         )
     }))
-    .unwrap_or(99)
+    .unwrap_or_else(|_| {
+        set_static_error(
+            PolygonizeFfiStatus::Panic,
+            "internal",
+            "boundary",
+            "panic crossed the FFI boundary",
+        )
+    })
 }
 
 unsafe fn polygonize_ffi_internal(
@@ -160,18 +335,37 @@ unsafe fn polygonize_ffi_internal(
         || output_array.is_null()
         || output_schema.is_null()
     {
-        return 1;
+        return set_static_error(
+            PolygonizeFfiStatus::InvalidArgument,
+            "invalid_argument",
+            "ffi",
+            "input and output pointers must not be null",
+        );
     }
 
     let field = match Field::try_from(&*input_schema) {
         Ok(f) => f,
-        Err(_) => return 2,
+        Err(_) => {
+            return set_static_error(
+                PolygonizeFfiStatus::InvalidArrowCData,
+                "arrow_c_data",
+                "input",
+                "input schema is invalid",
+            )
+        }
     };
 
     let array_val = std::ptr::replace(input_array, FFI_ArrowArray::empty());
     let arrow_data = match from_ffi_and_data_type(array_val, field.data_type().clone()) {
         Ok(data) => data,
-        Err(_) => return 2,
+        Err(_) => {
+            return set_static_error(
+                PolygonizeFfiStatus::InvalidArrowCData,
+                "arrow_c_data",
+                "input",
+                "input array is invalid",
+            )
+        }
     };
     let array = arrow::array::make_array(arrow_data);
 
@@ -186,26 +380,23 @@ unsafe fn polygonize_ffi_internal(
             let ffi_array = FFI_ArrowArray::new(&data);
             let ffi_schema = match DefaultSchemaExporter::try_export(&field) {
                 Ok(s) => s,
-                Err(_) => return 4,
+                Err(_) => {
+                    return set_static_error(
+                        PolygonizeFfiStatus::SchemaExport,
+                        "arrow_c_data",
+                        "output",
+                        "output schema export failed",
+                    )
+                }
             };
 
             std::ptr::write(output_array, ffi_array);
             std::ptr::write(output_schema, ffi_schema);
 
-            0
+            clear_last_error();
+            PolygonizeFfiStatus::Success as i32
         }
-        Err(e) => match e {
-            PolygonizeError::InvalidBufferShape { .. } => 5,
-            PolygonizeError::InvalidArgumentType { .. } => 6,
-            PolygonizeError::InvalidGeometry { .. } => 7,
-            PolygonizeError::TopologyFailure { .. } => 8,
-            PolygonizeError::ZConflict { .. } => 8,
-            PolygonizeError::NodingValidationFailure { .. } => 8,
-            PolygonizeError::UnsupportedOptionCombination { .. } => 9,
-            PolygonizeError::InternalInvariantViolation { .. } => 10,
-            PolygonizeError::ArrowError(_) => 11,
-            _ => 12,
-        },
+        Err(e) => set_polygonize_error(&e),
     }
 }
 
@@ -215,6 +406,7 @@ mod tests {
     use arrow::ffi::{FFI_ArrowArray, FFI_ArrowSchema};
     use geoarrow::array::GeoArrowArray;
     use geoarrow::datatypes::{Dimension, LineStringType};
+    use std::ffi::CStr;
     use std::sync::Arc;
 
     struct MockGuard;
@@ -250,7 +442,7 @@ mod tests {
                 &options,
             )
         };
-        assert_eq!(status, 1);
+        assert_eq!(status, PolygonizeFfiStatus::InvalidArgument as i32);
     }
 
     #[test]
@@ -288,8 +480,56 @@ mod tests {
             )
         };
 
-        assert_eq!(status, 4);
+        assert_eq!(status, PolygonizeFfiStatus::SchemaExport as i32);
         assert_eq!(format!("{output_array:?}"), output_array_before);
         assert_eq!(format!("{output_schema:?}"), output_schema_before);
+    }
+
+    #[test]
+    fn test_ffi_version_and_last_error() {
+        assert_eq!(polygonize_ffi_abi_version(), POLYGONIZE_FFI_ABI_VERSION);
+
+        let status = unsafe {
+            polygonize_with_options_ffi(
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                std::ptr::null(),
+                0,
+            )
+        };
+        assert_eq!(status, PolygonizeFfiStatus::InvalidArgument as i32);
+
+        let error = unsafe { &*polygonize_ffi_last_error() };
+        assert_eq!(error.status, status);
+        assert_eq!(
+            unsafe { CStr::from_ptr(error.family) }.to_str().unwrap(),
+            "invalid_argument"
+        );
+        assert_eq!(
+            unsafe { CStr::from_ptr(error.stage) }.to_str().unwrap(),
+            "options"
+        );
+    }
+
+    #[test]
+    fn test_ffi_last_error_includes_noding_witness() {
+        set_polygonize_error(&PolygonizeError::NodingValidationFailure {
+            first_segment: 3,
+            second_segment: 8,
+            reason: "intersection".to_string(),
+        });
+
+        let error = unsafe { &*polygonize_ffi_last_error() };
+        assert_eq!(error.status, PolygonizeFfiStatus::Topology as i32);
+        assert_eq!(
+            unsafe { CStr::from_ptr(error.family) }.to_str().unwrap(),
+            "topology"
+        );
+        assert_eq!(
+            unsafe { CStr::from_ptr(error.witness) }.to_str().unwrap(),
+            r#"{"ids":["0x0000000000000003","0x0000000000000008"],"coordinate":null}"#
+        );
     }
 }

--- a/crates/geo-polygonize-arrow/src/ffi.rs
+++ b/crates/geo-polygonize-arrow/src/ffi.rs
@@ -205,7 +205,10 @@ impl SchemaExporter for MockSchemaExporter {
 /// - `input_array` and `input_schema` must be valid, non-null pointers to valid Arrow C Data Interface structures.
 /// - `output_array` and `output_schema` must be valid, non-null pointers to allocated but uninitialized or safe-to-overwrite Arrow C Data Interface structures.
 /// - `options` must be a valid, non-null pointer to a `PolygonizerOptions` struct.
+/// - A valid input array is consumed after its schema is accepted; output ownership transfers only on success.
 /// - We use `std::panic::catch_unwind` at this boundary to ensure panics don't cross the FFI boundary, returning a defined error code (99) instead.
+///
+/// See `docs/C_ABI.md` for the complete ABI and ownership contract.
 #[no_mangle]
 pub unsafe extern "C" fn polygonize_ffi(
     input_array: *mut FFI_ArrowArray,
@@ -259,6 +262,9 @@ pub unsafe extern "C" fn polygonize_ffi(
 /// # Safety
 ///
 /// This function is unsafe because it dereferences raw pointers.
+///
+/// `options_json` is borrowed for this call. A valid input array is consumed
+/// after schema validation, while outputs transfer only on success.
 ///
 /// We use `std::panic::catch_unwind` at this boundary to ensure panics don't cross the FFI boundary, returning a defined error code (99) instead.
 #[no_mangle]
@@ -343,9 +349,11 @@ unsafe fn polygonize_ffi_internal(
         );
     }
 
-    let field = match Field::try_from(&*input_schema) {
-        Ok(f) => f,
-        Err(_) => {
+    let field = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        Field::try_from(&*input_schema)
+    })) {
+        Ok(Ok(field)) => field,
+        Ok(Err(_)) | Err(_) => {
             return set_static_error(
                 PolygonizeFfiStatus::InvalidArrowCData,
                 "arrow_c_data",
@@ -481,6 +489,45 @@ mod tests {
         };
 
         assert_eq!(status, PolygonizeFfiStatus::SchemaExport as i32);
+        assert_eq!(
+            format!("{:?}", &*input_array_ffi),
+            format!("{:?}", FFI_ArrowArray::empty())
+        );
+        assert_eq!(format!("{output_array:?}"), output_array_before);
+        assert_eq!(format!("{output_schema:?}"), output_schema_before);
+    }
+
+    #[test]
+    fn test_ffi_invalid_schema_keeps_input_and_outputs() {
+        let typ = LineStringType::new(Dimension::XY, Arc::new(Default::default()));
+        let input_arrow_array = geoarrow::array::LineStringBuilder::new(typ).finish();
+        let array_ref = input_arrow_array.into_array_ref();
+        let (mut input_array, _) = arrow::ffi::to_ffi(&array_ref.to_data()).unwrap();
+        let mut input_schema = FFI_ArrowSchema::empty();
+        let input_array_before = format!("{input_array:?}");
+        let mut output_array = FFI_ArrowArray::empty();
+        let mut output_schema = FFI_ArrowSchema::empty();
+        let output_array_before = format!("{output_array:?}");
+        let output_schema_before = format!("{output_schema:?}");
+        let options = PolygonizerOptions {
+            node_input: 0,
+            snap_grid_size: 1e-10,
+            extract_only_polygonal: 0,
+            report_mode: 0,
+        };
+
+        let status = unsafe {
+            polygonize_ffi(
+                &mut input_array,
+                &mut input_schema,
+                &mut output_array,
+                &mut output_schema,
+                &options,
+            )
+        };
+
+        assert_eq!(status, PolygonizeFfiStatus::InvalidArrowCData as i32);
+        assert_eq!(format!("{input_array:?}"), input_array_before);
         assert_eq!(format!("{output_array:?}"), output_array_before);
         assert_eq!(format!("{output_schema:?}"), output_schema_before);
     }

--- a/docs/C_ABI.md
+++ b/docs/C_ABI.md
@@ -1,0 +1,59 @@
+# Arrow C ABI
+
+`geo-polygonize-arrow` exposes an Arrow C Data Interface boundary for C and
+other FFI consumers. Query `polygonize_ffi_abi_version()` before calling it;
+version `1` is the current compatible ABI.
+
+New callers must use `polygonize_with_options_ffi` with the canonical JSON
+`PolygonizerOptions` payload. `polygonize_ffi` and its `PolygonizerOptions`
+`repr(C)` request remain supported through `1.x`, but are legacy and will not
+gain fields.
+
+```c
+uint32_t polygonize_ffi_abi_version(void);
+int32_t polygonize_with_options_ffi(
+    struct ArrowArray *input_array,
+    struct ArrowSchema *input_schema,
+    struct ArrowArray *output_array,
+    struct ArrowSchema *output_schema,
+    const uint8_t *options_json,
+    size_t options_json_len);
+const struct PolygonizeFfiLastError *polygonize_ffi_last_error(void);
+```
+
+## Status and error contract
+
+The returned `int32_t` values are ABI-stable: `0` success, `1` invalid
+argument, `2` invalid Arrow C input, `4` output schema export failure, `5`
+invalid buffer shape, `6` invalid option, `7` invalid geometry, `8` topology
+failure, `9` unsupported option combination, `10` internal invariant failure,
+`11` Arrow adapter failure, `12` unknown failure, and `99` contained panic.
+
+On a nonzero result, `polygonize_ffi_last_error()` returns a thread-local
+`PolygonizeFfiLastError` with the matching status plus NUL-terminated `family`,
+`stage`, `message`, and `witness` strings. `witness` is empty when unavailable;
+otherwise it is normalized-error JSON, including noding witness IDs when
+present. The pointer and strings remain valid until the next polygonize FFI
+call on that thread. A successful call clears the error and the query returns
+null. Copy strings before another call.
+
+## Ownership and nullability
+
+All Arrow pointers and the options pointer must be non-null. `options_json` is
+borrowed only for the call. `input_schema` is borrowed and is never consumed.
+
+After a valid input schema is accepted, `input_array` is consumed regardless
+of success or failure; callers must not release or reuse it afterwards. If
+schema validation fails before that point, both inputs remain caller-owned.
+
+`output_array` and `output_schema` are caller-provided, safe-to-overwrite
+destinations. They are unchanged on failure. On success, they receive Arrow C
+objects owned by the caller; release each through its Arrow C `release`
+callback exactly once. `polygonize_result_free` is a legacy no-op and must not
+be used for Arrow C outputs.
+
+Calls are thread-safe when every call uses separate Arrow objects. Last-error
+state is per-thread. Do not concurrently access, reuse, or release any request
+or output object while a call using it is in progress; the API makes no
+callbacks and requires no special reentrancy handling beyond that ownership
+rule.


### PR DESCRIPTION
## What changed

- document canonical JSON requests, return statuses, error lifetime, ownership, nullability, and concurrency rules for the Arrow C ABI
- add boundary tests for schema rejection before input transfer and output export failure after input transfer
- classify malformed Arrow schemas as stable invalid-C-data errors instead of contained panics
- complete P0.4 in the roadmap

## Why

C callers need an explicit ownership contract, and malformed C Data schemas must not be reported as internal panics.

## Validation

- `cargo fmt --check`
- `cargo test -p geo-polygonize-arrow --locked`