### PR TITLE
feat(core): bound noding work

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -208,13 +208,14 @@ execution policy rather than extending `PolygonizerOptions`.
 
 Progress: The core now has an opt-in, non-semantic `ExecutionPolicy` that
 rejects oversized input line-string, segment, coordinate, and noded-segment
-counts before graph construction.
+counts before graph construction, plus noding candidate and exact-intersection
+work before splitting.
 
 Add opt-in limits for:
 
 - [x] input line strings, segments, and coordinates;
 - [x] noded segment expansion;
-- [ ] candidate pairs and exact intersection calls;
+- [x] candidate pairs and exact intersection calls;
 - [ ] split events and iterative-noding passes;
 - [ ] graph nodes, edges, rings, polygons, and output coordinates;
 - [ ] per-stage and total trace bytes;

--- a/crates/geo-polygonize-core/src/noding/hot_pixel.rs
+++ b/crates/geo-polygonize-core/src/noding/hot_pixel.rs
@@ -3,7 +3,7 @@ use crate::error::{PolygonizeError, Result};
 use crate::index::{IndexedEnvelope, RStarBackend};
 use crate::noding::snap::SnapNoder;
 use crate::noding::validate::ValidatingNoder;
-use crate::options::ZPolicy;
+use crate::options::{ExecutionPolicy, ZPolicy};
 use crate::types::{Coord3D, IPoint, Line3D};
 use geo::algorithm::line_intersection::{line_intersection, LineIntersection};
 use rstar::AABB;
@@ -37,12 +37,38 @@ impl HotPixelNoder {
     }
 
     pub fn node(&self, lines: Vec<Line3D>) -> Result<Vec<Line3D>> {
-        self.node_with_stats(lines).map(|(lines, _, _)| lines)
+        self.node_with_stats_impl(lines, None)
+            .map(|(lines, _, _)| lines)
     }
 
     pub(crate) fn node_with_stats(
         &self,
+        lines: Vec<Line3D>,
+    ) -> Result<(Vec<Line3D>, usize, NodingWorkStats)> {
+        self.node_with_stats_impl(lines, None)
+    }
+
+    pub(crate) fn node_with_execution_policy(
+        &self,
+        lines: Vec<Line3D>,
+        execution_policy: &ExecutionPolicy,
+    ) -> Result<Vec<Line3D>> {
+        self.node_with_stats_impl(lines, Some(execution_policy))
+            .map(|(lines, _, _)| lines)
+    }
+
+    pub(crate) fn node_with_stats_and_execution_policy(
+        &self,
+        lines: Vec<Line3D>,
+        execution_policy: &ExecutionPolicy,
+    ) -> Result<(Vec<Line3D>, usize, NodingWorkStats)> {
+        self.node_with_stats_impl(lines, Some(execution_policy))
+    }
+
+    fn node_with_stats_impl(
+        &self,
         mut lines: Vec<Line3D>,
+        execution_policy: Option<&ExecutionPolicy>,
     ) -> Result<(Vec<Line3D>, usize, NodingWorkStats)> {
         for line in &mut lines {
             line.start = self.snap(line.start)?;
@@ -79,7 +105,15 @@ impl HotPixelNoder {
             candidates.sort_unstable();
             for second_index in candidates {
                 work.candidate_pairs += 1;
+                if let Some(execution_policy) = execution_policy {
+                    execution_policy
+                        .check_noding_work(work.candidate_pairs, work.exact_intersection_calls)?;
+                }
                 work.exact_intersection_calls += 1;
+                if let Some(execution_policy) = execution_policy {
+                    execution_policy
+                        .check_noding_work(work.candidate_pairs, work.exact_intersection_calls)?;
+                }
                 match line_intersection(first.to_line_2d(), lines[second_index].to_line_2d()) {
                     Some(LineIntersection::SinglePoint { intersection, .. }) => {
                         intersections += 1;

--- a/crates/geo-polygonize-core/src/noding/snap.rs
+++ b/crates/geo-polygonize-core/src/noding/snap.rs
@@ -1,7 +1,7 @@
 use crate::diagnostics::{NodingIterationStats, NodingWorkStats};
 use crate::index::{IndexedEnvelope, RStarBackend};
 use crate::noding::grid::UniformGrid;
-use crate::options::{SnapStrategy, ZPolicy};
+use crate::options::{ExecutionPolicy, SnapStrategy, ZPolicy};
 use crate::types::{Coord3D, Line3D};
 use crate::utils::soa::SoALines;
 use geo::algorithm::line_intersection::{line_intersection, LineIntersection};
@@ -113,7 +113,8 @@ impl SnapNoder {
     }
 
     pub fn node(&self, lines: Vec<Line3D>) -> Vec<Line3D> {
-        self.node_impl(lines, None, None)
+        self.node_impl(lines, None, None, None)
+            .expect("unlimited noding cannot fail")
     }
 
     pub(crate) fn node_with_stats(
@@ -122,8 +123,34 @@ impl SnapNoder {
     ) -> (Vec<Line3D>, Vec<NodingIterationStats>, NodingWorkStats) {
         let mut stats = Vec::new();
         let mut work_stats = NodingWorkStats::default();
-        let lines = self.node_impl(lines, Some(&mut stats), Some(&mut work_stats));
+        let lines = self
+            .node_impl(lines, Some(&mut stats), Some(&mut work_stats), None)
+            .expect("unlimited noding cannot fail");
         (lines, stats, work_stats)
+    }
+
+    pub(crate) fn node_with_execution_policy(
+        &self,
+        lines: Vec<Line3D>,
+        execution_policy: &ExecutionPolicy,
+    ) -> crate::Result<Vec<Line3D>> {
+        self.node_impl(lines, None, None, Some(execution_policy))
+    }
+
+    pub(crate) fn node_with_stats_and_execution_policy(
+        &self,
+        lines: Vec<Line3D>,
+        execution_policy: &ExecutionPolicy,
+    ) -> crate::Result<(Vec<Line3D>, Vec<NodingIterationStats>, NodingWorkStats)> {
+        let mut stats = Vec::new();
+        let mut work_stats = NodingWorkStats::default();
+        let lines = self.node_impl(
+            lines,
+            Some(&mut stats),
+            Some(&mut work_stats),
+            Some(execution_policy),
+        )?;
+        Ok((lines, stats, work_stats))
     }
 
     fn node_impl(
@@ -131,7 +158,8 @@ impl SnapNoder {
         mut lines: Vec<Line3D>,
         mut stats: Option<&mut Vec<NodingIterationStats>>,
         mut work_stats: Option<&mut NodingWorkStats>,
-    ) -> Vec<Line3D> {
+        execution_policy: Option<&ExecutionPolicy>,
+    ) -> crate::Result<Vec<Line3D>> {
         // 1. Initial Snap of endpoints
         for line in &mut lines {
             line.start = self.snap(line.start);
@@ -156,6 +184,7 @@ impl SnapNoder {
         let auto_prefers_simd =
             self.strategy == NodingStrategy::Auto && self.auto_prefers_simd(&lines);
         let mut new_lines = Vec::new();
+        let mut total_work = NodingWorkStats::default();
         for iteration_index in 0..self.max_iter {
             let input_segment_count = lines.len();
             let use_grid = match self.strategy {
@@ -169,15 +198,37 @@ impl SnapNoder {
 
             let mut events = if !use_grid {
                 // STRATEGY A: Small Input -> SIMD Brute Force
-                if let Some(work_stats) = work_stats.as_deref_mut() {
-                    work_stats.merge(Self::measure_simd_work(&lines));
+                let measured_work = (work_stats.is_some() || execution_policy.is_some())
+                    .then(|| Self::measure_simd_work(&lines));
+                if let Some(measured_work) = measured_work {
+                    if let Some(execution_policy) = execution_policy {
+                        total_work.merge(measured_work.clone());
+                        execution_policy.check_noding_work(
+                            total_work.candidate_pairs,
+                            total_work.exact_intersection_calls,
+                        )?;
+                    }
+                    if let Some(work_stats) = work_stats.as_deref_mut() {
+                        work_stats.merge(measured_work);
+                    }
                 }
                 self.find_splits_simd(&lines)
             } else {
                 // STRATEGY B: Large Input -> Uniform Grid
                 let grid = UniformGrid::new(&lines);
-                if let Some(work_stats) = work_stats.as_deref_mut() {
-                    work_stats.merge(grid.measure_work(&lines));
+                let measured_work = (work_stats.is_some() || execution_policy.is_some())
+                    .then(|| grid.measure_work(&lines));
+                if let Some(measured_work) = measured_work {
+                    if let Some(execution_policy) = execution_policy {
+                        total_work.merge(measured_work.clone());
+                        execution_policy.check_noding_work(
+                            total_work.candidate_pairs,
+                            total_work.exact_intersection_calls,
+                        )?;
+                    }
+                    if let Some(work_stats) = work_stats.as_deref_mut() {
+                        work_stats.merge(measured_work);
+                    }
                 }
                 grid.find_splits(&lines, self)
             };
@@ -297,7 +348,7 @@ impl SnapNoder {
             }
         }
 
-        lines
+        Ok(lines)
     }
 
     fn auto_prefers_simd(&self, lines: &[Line3D]) -> bool {

--- a/crates/geo-polygonize-core/src/options.rs
+++ b/crates/geo-polygonize-core/src/options.rs
@@ -13,6 +13,8 @@ pub struct ExecutionPolicy {
     pub max_input_segments: Option<usize>,
     pub max_input_coordinates: Option<usize>,
     pub max_noded_segments: Option<usize>,
+    pub max_candidate_pairs: Option<usize>,
+    pub max_exact_intersection_calls: Option<usize>,
 }
 
 impl ExecutionPolicy {
@@ -25,6 +27,23 @@ impl ExecutionPolicy {
             });
         }
         Ok(())
+    }
+
+    pub(crate) fn has_noding_work_limits(&self) -> bool {
+        self.max_candidate_pairs.is_some() || self.max_exact_intersection_calls.is_some()
+    }
+
+    pub(crate) fn check_noding_work(
+        &self,
+        candidate_pairs: usize,
+        exact_intersection_calls: usize,
+    ) -> Result<()> {
+        self.check("candidate_pairs", self.max_candidate_pairs, candidate_pairs)?;
+        self.check(
+            "exact_intersection_calls",
+            self.max_exact_intersection_calls,
+            exact_intersection_calls,
+        )
     }
 }
 

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -312,6 +312,7 @@ impl Polygonizer {
         self.graph.clear();
         let grid_size = self.options.precision_model.grid_size();
         let mut segments;
+        let has_noding_work_limits = self.execution_policy.has_noding_work_limits();
 
         if self.options.node_input {
             let mut pre_snap_vertex_candidates = 0;
@@ -364,8 +365,14 @@ impl Polygonizer {
                         let noder =
                             HotPixelNoder::new(grid_size)?.with_z_policy(self.options.z.policy);
                         if let Some(diagnostics) = diagnostics.as_deref_mut() {
-                            let (noded, intersections, mut work_stats) =
-                                noder.node_with_stats(all_segments)?;
+                            let (noded, intersections, mut work_stats) = if has_noding_work_limits {
+                                noder.node_with_stats_and_execution_policy(
+                                    all_segments,
+                                    &self.execution_policy,
+                                )?
+                            } else {
+                                noder.node_with_stats(all_segments)?
+                            };
                             work_stats.pre_snap_vertex_candidates = pre_snap_vertex_candidates;
                             diagnostics.intersection_stats.interpolated_intersections =
                                 work_stats.split_events;
@@ -379,7 +386,14 @@ impl Polygonizer {
                             diagnostics.noding_work_stats = work_stats;
                             segments = noded;
                         } else {
-                            segments = noder.node(all_segments)?;
+                            segments = if has_noding_work_limits {
+                                noder.node_with_execution_policy(
+                                    all_segments,
+                                    &self.execution_policy,
+                                )?
+                            } else {
+                                noder.node(all_segments)?
+                            };
                         }
                     } else {
                         let noder = SnapNoder::new(grid_size)
@@ -391,8 +405,14 @@ impl Polygonizer {
                             matches!(self.options.snap_strategy, SnapStrategy::GeosCompat)
                                 .then(|| restored_coordinates(&noder, &all_segments));
                         if let Some(diagnostics) = diagnostics.as_deref_mut() {
-                            let (noded, stats, mut work_stats) =
-                                noder.node_with_stats(all_segments);
+                            let (noded, stats, mut work_stats) = if has_noding_work_limits {
+                                noder.node_with_stats_and_execution_policy(
+                                    all_segments,
+                                    &self.execution_policy,
+                                )?
+                            } else {
+                                noder.node_with_stats(all_segments)
+                            };
                             work_stats.pre_snap_vertex_candidates = pre_snap_vertex_candidates;
                             diagnostics.intersection_stats.interpolated_intersections = stats
                                 .iter()
@@ -404,7 +424,14 @@ impl Polygonizer {
                             diagnostics.noding_work_stats = work_stats;
                             segments = noded;
                         } else {
-                            segments = noder.node(all_segments);
+                            segments = if has_noding_work_limits {
+                                noder.node_with_execution_policy(
+                                    all_segments,
+                                    &self.execution_policy,
+                                )?
+                            } else {
+                                noder.node(all_segments)
+                            };
                         }
                         if let Some(coordinates) = restore_coordinates {
                             restore_noded_coordinates(&mut segments, &coordinates);
@@ -414,9 +441,15 @@ impl Polygonizer {
                 crate::options::NodingBackend::Advanced => {
                     let noder = AdvancedNoder::new().with_z_policy(self.options.z.policy);
                     if let Some(diagnostics) = diagnostics.as_deref_mut() {
-                        let (noded, stats, mut work_stats) = SnapNoder::new(0.0)
-                            .with_z_policy(self.options.z.policy)
-                            .node_with_stats(all_segments);
+                        let noder = SnapNoder::new(0.0).with_z_policy(self.options.z.policy);
+                        let (noded, stats, mut work_stats) = if has_noding_work_limits {
+                            noder.node_with_stats_and_execution_policy(
+                                all_segments,
+                                &self.execution_policy,
+                            )?
+                        } else {
+                            noder.node_with_stats(all_segments)
+                        };
                         work_stats.pre_snap_vertex_candidates = pre_snap_vertex_candidates;
                         diagnostics.intersection_stats.interpolated_intersections = stats
                             .iter()
@@ -428,7 +461,13 @@ impl Polygonizer {
                         diagnostics.noding_work_stats = work_stats;
                         segments = noded;
                     } else {
-                        segments = noder.node(all_segments);
+                        segments = if has_noding_work_limits {
+                            SnapNoder::new(0.0)
+                                .with_z_policy(self.options.z.policy)
+                                .node_with_execution_policy(all_segments, &self.execution_policy)?
+                        } else {
+                            noder.node(all_segments)
+                        };
                     }
                 }
             }

--- a/crates/geo-polygonize-core/tests/execution_policy.rs
+++ b/crates/geo-polygonize-core/tests/execution_policy.rs
@@ -1,6 +1,7 @@
 use geo_polygonize_core::{
     polygonize_line_strings_with_execution_policy, polygonize_with_execution_policy, Coord3D,
-    ExecutionPolicy, Line3D, PolygonizeError, PolygonizerOptions,
+    ExecutionPolicy, Line3D, NodingGuarantee, NodingOptions, PolygonizeError, PolygonizerOptions,
+    PrecisionModel, SnapStrategy,
 };
 use geo_types::LineString;
 
@@ -92,4 +93,75 @@ fn noded_segment_limit_stops_after_noding() {
             observed,
         }) if stage == "noded_segments" && observed > 0
     ));
+}
+
+#[test]
+fn noding_work_limits_stop_dense_candidates_before_splitting() {
+    let options = PolygonizerOptions {
+        node_input: true,
+        ..Default::default()
+    };
+    let crossing = [
+        Line3D::new(Coord3D::new(0., 0., 0.), Coord3D::new(2., 2., 0.), 0),
+        Line3D::new(Coord3D::new(0., 2., 0.), Coord3D::new(2., 0., 0.), 1),
+    ];
+
+    for (policy, stage) in [
+        (
+            ExecutionPolicy {
+                max_candidate_pairs: Some(0),
+                ..Default::default()
+            },
+            "candidate_pairs",
+        ),
+        (
+            ExecutionPolicy {
+                max_exact_intersection_calls: Some(0),
+                ..Default::default()
+            },
+            "exact_intersection_calls",
+        ),
+    ] {
+        assert!(matches!(
+            polygonize_with_execution_policy(crossing, &options, &policy),
+            Err(PolygonizeError::ResourceLimitExceeded {
+                stage: actual_stage,
+                limit: 0,
+                observed,
+            }) if actual_stage == stage && observed > 0
+        ));
+    }
+}
+
+#[test]
+fn certified_noding_obeys_candidate_limit() {
+    let options = PolygonizerOptions {
+        node_input: true,
+        precision_model: PrecisionModel::FixedGrid { grid_size: 1.0 },
+        snap_strategy: SnapStrategy::Grid,
+        noding: NodingOptions {
+            guarantee: NodingGuarantee::CertifiedFixedPrecision,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let crossing = [
+        Line3D::new(Coord3D::new(0., 0., 0.), Coord3D::new(2., 2., 0.), 0),
+        Line3D::new(Coord3D::new(0., 2., 0.), Coord3D::new(2., 0., 0.), 1),
+    ];
+
+    assert_limit(
+        polygonize_with_execution_policy(
+            crossing,
+            &options,
+            &ExecutionPolicy {
+                max_candidate_pairs: Some(0),
+                ..Default::default()
+            },
+        )
+        .unwrap_err(),
+        "candidate_pairs",
+        0,
+        1,
+    );
 }


### PR DESCRIPTION
## What changed

- add opt-in candidate-pair and exact-intersection-call limits to `ExecutionPolicy`
- stop iterative snap noding before split application when a measured iteration exceeds either cumulative budget
- stop certified hot-pixel noding inline at the same work boundaries
- cover ordinary and certified crossing inputs, and record P0.5 progress

## Why

Candidate enumeration and exact intersection calls dominate hostile crossing-heavy input. These limits bound that work without changing default topology behavior.

## Validation

- `cargo test -p geo-polygonize-core --lib --locked`
- `cargo test -p geo-polygonize-core --test execution_policy --locked`
- `cargo check --workspace --locked`
- `cargo fmt --check`