### PR TITLE
feat(core): cap split and noding passes

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -208,15 +208,15 @@ execution policy rather than extending `PolygonizerOptions`.
 
 Progress: The core now has an opt-in, non-semantic `ExecutionPolicy` that
 rejects oversized input line-string, segment, coordinate, and noded-segment
-counts before graph construction, plus noding candidate and exact-intersection
-work before splitting.
+counts before graph construction, plus noding candidate, exact-intersection,
+split-event, and iteration work before split application.
 
 Add opt-in limits for:
 
 - [x] input line strings, segments, and coordinates;
 - [x] noded segment expansion;
 - [x] candidate pairs and exact intersection calls;
-- [ ] split events and iterative-noding passes;
+- [x] split events and iterative-noding passes;
 - [ ] graph nodes, edges, rings, polygons, and output coordinates;
 - [ ] per-stage and total trace bytes;
 - [ ] estimated working memory where a reliable bound is available.

--- a/crates/geo-polygonize-core/src/noding/hot_pixel.rs
+++ b/crates/geo-polygonize-core/src/noding/hot_pixel.rs
@@ -189,6 +189,9 @@ impl HotPixelNoder {
             });
             points.dedup_by(|left, right| left.x == right.x && left.y == right.y);
             work.split_events += points.len().saturating_sub(2);
+            if let Some(execution_policy) = execution_policy {
+                execution_policy.check_split_events(work.split_events)?;
+            }
             output.extend(points.windows(2).filter_map(|pair| {
                 (pair[0].x != pair[1].x || pair[0].y != pair[1].y).then_some(Line3D::new(
                     pair[0],

--- a/crates/geo-polygonize-core/src/noding/snap.rs
+++ b/crates/geo-polygonize-core/src/noding/snap.rs
@@ -185,7 +185,11 @@ impl SnapNoder {
             self.strategy == NodingStrategy::Auto && self.auto_prefers_simd(&lines);
         let mut new_lines = Vec::new();
         let mut total_work = NodingWorkStats::default();
+        let mut split_events = 0;
         for iteration_index in 0..self.max_iter {
+            if let Some(execution_policy) = execution_policy {
+                execution_policy.check_noding_iterations(iteration_index + 1)?;
+            }
             let input_segment_count = lines.len();
             let use_grid = match self.strategy {
                 NodingStrategy::Auto => {
@@ -256,6 +260,10 @@ impl SnapNoder {
                 // Z should be consistent (interpolated from the same line).
             });
             let split_event_count = events.len();
+            split_events += split_event_count;
+            if let Some(execution_policy) = execution_policy {
+                execution_policy.check_split_events(split_events)?;
+            }
             if let Some(work_stats) = work_stats.as_deref_mut() {
                 work_stats.split_events += split_event_count;
             }

--- a/crates/geo-polygonize-core/src/options.rs
+++ b/crates/geo-polygonize-core/src/options.rs
@@ -15,6 +15,8 @@ pub struct ExecutionPolicy {
     pub max_noded_segments: Option<usize>,
     pub max_candidate_pairs: Option<usize>,
     pub max_exact_intersection_calls: Option<usize>,
+    pub max_split_events: Option<usize>,
+    pub max_noding_iterations: Option<usize>,
 }
 
 impl ExecutionPolicy {
@@ -30,7 +32,10 @@ impl ExecutionPolicy {
     }
 
     pub(crate) fn has_noding_work_limits(&self) -> bool {
-        self.max_candidate_pairs.is_some() || self.max_exact_intersection_calls.is_some()
+        self.max_candidate_pairs.is_some()
+            || self.max_exact_intersection_calls.is_some()
+            || self.max_split_events.is_some()
+            || self.max_noding_iterations.is_some()
     }
 
     pub(crate) fn check_noding_work(
@@ -44,6 +49,14 @@ impl ExecutionPolicy {
             self.max_exact_intersection_calls,
             exact_intersection_calls,
         )
+    }
+
+    pub(crate) fn check_split_events(&self, observed: usize) -> Result<()> {
+        self.check("split_events", self.max_split_events, observed)
+    }
+
+    pub(crate) fn check_noding_iterations(&self, observed: usize) -> Result<()> {
+        self.check("noding_iterations", self.max_noding_iterations, observed)
     }
 }
 

--- a/crates/geo-polygonize-core/tests/execution_policy.rs
+++ b/crates/geo-polygonize-core/tests/execution_policy.rs
@@ -165,3 +165,41 @@ fn certified_noding_obeys_candidate_limit() {
         1,
     );
 }
+
+#[test]
+fn split_and_iteration_limits_stop_noding() {
+    let options = PolygonizerOptions {
+        node_input: true,
+        ..Default::default()
+    };
+    let crossing = [
+        Line3D::new(Coord3D::new(0., 0., 0.), Coord3D::new(2., 2., 0.), 0),
+        Line3D::new(Coord3D::new(0., 2., 0.), Coord3D::new(2., 0., 0.), 1),
+    ];
+
+    for (policy, stage) in [
+        (
+            ExecutionPolicy {
+                max_split_events: Some(0),
+                ..Default::default()
+            },
+            "split_events",
+        ),
+        (
+            ExecutionPolicy {
+                max_noding_iterations: Some(0),
+                ..Default::default()
+            },
+            "noding_iterations",
+        ),
+    ] {
+        assert!(matches!(
+            polygonize_with_execution_policy(crossing, &options, &policy),
+            Err(PolygonizeError::ResourceLimitExceeded {
+                stage: actual_stage,
+                limit: 0,
+                observed,
+            }) if actual_stage == stage && observed > 0
+        ));
+    }
+}


### PR DESCRIPTION
## What changed

- add opt-in split-event and noding-iteration limits to `ExecutionPolicy`
- stop iterative snap noding before a pass or before applying split replacements
- apply the split-event limit to certified hot-pixel noding
- cover both limits and record P0.5 progress

## Why

Iterative noding can amplify difficult inputs even after pair-work limits. These caps keep the remaining split loop bounded without changing default behavior.

## Validation

- `cargo test -p geo-polygonize-core --lib --locked`
- `cargo test -p geo-polygonize-core --test execution_policy --locked`
- `cargo check --workspace --locked`
- `cargo fmt --check`