### PR TITLE
feat(core): cap graph growth

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -209,7 +209,8 @@ execution policy rather than extending `PolygonizerOptions`.
 Progress: The core now has an opt-in, non-semantic `ExecutionPolicy` that
 rejects oversized input line-string, segment, coordinate, and noded-segment
 counts before graph construction, plus noding candidate, exact-intersection,
-split-event, and iteration work before split application.
+split-event, and iteration work before split application. Graph node, edge, and
+ring limits now stop before classification.
 
 Add opt-in limits for:
 
@@ -217,7 +218,8 @@ Add opt-in limits for:
 - [x] noded segment expansion;
 - [x] candidate pairs and exact intersection calls;
 - [x] split events and iterative-noding passes;
-- [ ] graph nodes, edges, rings, polygons, and output coordinates;
+- [x] graph nodes, edges, and rings;
+- [ ] polygons and output coordinates;
 - [ ] per-stage and total trace bytes;
 - [ ] estimated working memory where a reliable bound is available.
 

--- a/crates/geo-polygonize-core/src/options.rs
+++ b/crates/geo-polygonize-core/src/options.rs
@@ -17,6 +17,9 @@ pub struct ExecutionPolicy {
     pub max_exact_intersection_calls: Option<usize>,
     pub max_split_events: Option<usize>,
     pub max_noding_iterations: Option<usize>,
+    pub max_graph_nodes: Option<usize>,
+    pub max_graph_edges: Option<usize>,
+    pub max_rings: Option<usize>,
 }
 
 impl ExecutionPolicy {

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -506,6 +506,16 @@ impl Polygonizer {
 
         // Use bulk load
         self.graph.bulk_load(segments);
+        self.execution_policy.check(
+            "graph_nodes",
+            self.execution_policy.max_graph_nodes,
+            self.graph.nodes_x.len(),
+        )?;
+        self.execution_policy.check(
+            "graph_edges",
+            self.execution_policy.max_graph_edges,
+            self.graph.edges.len(),
+        )?;
 
         Ok(())
     }
@@ -566,6 +576,11 @@ impl Polygonizer {
             self.options.node_input,
             self.options.provenance.enabled && self.options.provenance.include_boundary_line_ids,
         );
+        self.execution_policy.check(
+            "rings",
+            self.execution_policy.max_rings,
+            rings_with_ids.len(),
+        )?;
 
         if let Some(ref mut d) = diag {
             d.phase_times.graph_build = get_elapsed(t_graph_build_start);

--- a/crates/geo-polygonize-core/tests/execution_policy.rs
+++ b/crates/geo-polygonize-core/tests/execution_policy.rs
@@ -203,3 +203,57 @@ fn split_and_iteration_limits_stop_noding() {
         ));
     }
 }
+
+#[test]
+fn graph_and_ring_limits_stop_after_their_boundary() {
+    let options = PolygonizerOptions::default();
+    let segment = Line3D::new(Coord3D::new(0., 0., 0.), Coord3D::new(1., 0., 0.), 0);
+
+    for (policy, stage, observed) in [
+        (
+            ExecutionPolicy {
+                max_graph_nodes: Some(1),
+                ..Default::default()
+            },
+            "graph_nodes",
+            2,
+        ),
+        (
+            ExecutionPolicy {
+                max_graph_edges: Some(0),
+                ..Default::default()
+            },
+            "graph_edges",
+            1,
+        ),
+    ] {
+        assert_limit(
+            polygonize_with_execution_policy([segment], &options, &policy).unwrap_err(),
+            stage,
+            policy.max_graph_nodes.or(policy.max_graph_edges).unwrap(),
+            observed,
+        );
+    }
+
+    let square = [
+        Line3D::new(Coord3D::new(0., 0., 0.), Coord3D::new(1., 0., 0.), 0),
+        Line3D::new(Coord3D::new(1., 0., 0.), Coord3D::new(1., 1., 0.), 1),
+        Line3D::new(Coord3D::new(1., 1., 0.), Coord3D::new(0., 1., 0.), 2),
+        Line3D::new(Coord3D::new(0., 1., 0.), Coord3D::new(0., 0., 0.), 3),
+    ];
+    assert!(matches!(
+        polygonize_with_execution_policy(
+            square,
+            &options,
+            &ExecutionPolicy {
+                max_rings: Some(0),
+                ..Default::default()
+            },
+        ),
+        Err(PolygonizeError::ResourceLimitExceeded {
+            stage,
+            limit: 0,
+            observed,
+        }) if stage == "rings" && observed > 0
+    ));
+}


### PR DESCRIPTION
## What changed

- add opt-in graph-node, graph-edge, and extracted-ring limits to `ExecutionPolicy`
- check graph counts immediately after load and rings before classification
- cover each boundary and update P0.5 progress

## Why

Noded input can grow the graph and ring set independently of initial input limits. These caps stop later topology stages before they amplify work further.

## Validation

- `cargo test -p geo-polygonize-core --test execution_policy --locked`
- `cargo check --workspace --locked`
- `cargo fmt --check`