### PR TITLE
feat(core): cap result growth

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -210,7 +210,8 @@ Progress: The core now has an opt-in, non-semantic `ExecutionPolicy` that
 rejects oversized input line-string, segment, coordinate, and noded-segment
 counts before graph construction, plus noding candidate, exact-intersection,
 split-event, and iteration work before split application. Graph node, edge, and
-ring limits now stop before classification.
+ring limits now stop before classification. Final polygon and output-coordinate
+limits stop before a result is returned.
 
 Add opt-in limits for:
 
@@ -219,7 +220,7 @@ Add opt-in limits for:
 - [x] candidate pairs and exact intersection calls;
 - [x] split events and iterative-noding passes;
 - [x] graph nodes, edges, and rings;
-- [ ] polygons and output coordinates;
+- [x] polygons and output coordinates;
 - [ ] per-stage and total trace bytes;
 - [ ] estimated working memory where a reliable bound is available.
 

--- a/crates/geo-polygonize-core/src/options.rs
+++ b/crates/geo-polygonize-core/src/options.rs
@@ -20,6 +20,8 @@ pub struct ExecutionPolicy {
     pub max_graph_nodes: Option<usize>,
     pub max_graph_edges: Option<usize>,
     pub max_rings: Option<usize>,
+    pub max_output_polygons: Option<usize>,
+    pub max_output_coordinates: Option<usize>,
 }
 
 impl ExecutionPolicy {

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -630,6 +630,25 @@ impl Polygonizer {
             &mut invalid_rings,
             &self.options,
         );
+        self.execution_policy.check(
+            "output_polygons",
+            self.execution_policy.max_output_polygons,
+            result.len(),
+        )?;
+        let output_coordinates = result
+            .iter()
+            .map(|polygon| {
+                polygon.exterior.len() + polygon.interiors.iter().map(Vec::len).sum::<usize>()
+            })
+            .sum::<usize>()
+            + dangles.iter().map(Vec::len).sum::<usize>()
+            + cut_edges.iter().map(Vec::len).sum::<usize>()
+            + invalid_rings.iter().map(Vec::len).sum::<usize>();
+        self.execution_policy.check(
+            "output_coordinates",
+            self.execution_policy.max_output_coordinates,
+            output_coordinates,
+        )?;
 
         if let Some(ref mut d) = diag {
             d.phase_times.containment = get_elapsed(t_containment_start);

--- a/crates/geo-polygonize-core/tests/execution_policy.rs
+++ b/crates/geo-polygonize-core/tests/execution_policy.rs
@@ -257,3 +257,45 @@ fn graph_and_ring_limits_stop_after_their_boundary() {
         }) if stage == "rings" && observed > 0
     ));
 }
+
+#[test]
+fn output_limits_stop_before_returning_a_result() {
+    let square = [
+        Line3D::new(Coord3D::new(0., 0., 0.), Coord3D::new(1., 0., 0.), 0),
+        Line3D::new(Coord3D::new(1., 0., 0.), Coord3D::new(1., 1., 0.), 1),
+        Line3D::new(Coord3D::new(1., 1., 0.), Coord3D::new(0., 1., 0.), 2),
+        Line3D::new(Coord3D::new(0., 1., 0.), Coord3D::new(0., 0., 0.), 3),
+    ];
+    let options = PolygonizerOptions::default();
+
+    assert_limit(
+        polygonize_with_execution_policy(
+            square,
+            &options,
+            &ExecutionPolicy {
+                max_output_polygons: Some(0),
+                ..Default::default()
+            },
+        )
+        .unwrap_err(),
+        "output_polygons",
+        0,
+        1,
+    );
+    assert!(matches!(
+        polygonize_with_execution_policy(
+            square,
+            &options,
+            &ExecutionPolicy {
+                max_output_polygons: Some(1),
+                max_output_coordinates: Some(0),
+                ..Default::default()
+            },
+        ),
+        Err(PolygonizeError::ResourceLimitExceeded {
+            stage,
+            limit: 0,
+            observed,
+        }) if stage == "output_coordinates" && observed > 0
+    ));
+}


### PR DESCRIPTION
## What changed

- add opt-in final polygon and total output-coordinate limits
- count every returned coordinate stream after canonicalization and before returning a result
- cover both limits and update P0.5 progress

## Why

Topology can be valid yet still create too much output for a caller to retain. These limits make final result growth explicit and typed.

## Validation

- `cargo test -p geo-polygonize-core --test execution_policy --locked`
- `cargo check --workspace --locked`
- `cargo fmt --check`