### PR TITLE
feat(core): add native cancellation checkpoints

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -236,17 +236,22 @@ limit in the core regression suite.
 
 ### P0.6 Cooperative cancellation
 
-- [ ] Add cancellation checkpoints at ingest, candidate enumeration, split
+Progress: Native `CancellationToken` values live in `ExecutionPolicy`, not
+semantic options. Core checkpoints cover ingest, noding, graph construction,
+ring extraction, containment, canonicalization, and output flattening; a
+cancelled workspace run is reusable after resetting its token.
+
+- [x] Add cancellation checkpoints at ingest, candidate enumeration, split
   application, graph construction, ring extraction, containment, canonicalization,
   and output flattening.
-- [ ] Provide a native cancellation token or callback that does not become part
+- [x] Provide a native cancellation token or callback that does not become part
   of semantic options.
 - [ ] Release the Python GIL during pure Rust work where safe and check Python
   signals at bounded intervals.
 - [ ] For Wasm, use a worker-based or genuinely asynchronous/chunked API for
   cancellation. Do not claim `AbortSignal` support for a synchronous main-thread
   Wasm call that cannot yield.
-- [ ] Ensure cancellation unwinds temporary state safely and never poisons a
+- [x] Ensure cancellation unwinds temporary state safely and never poisons a
   reusable workspace.
 
 **Done when:** every long-running phase can be stopped within a documented work

--- a/crates/geo-polygonize-arrow/src/ffi.rs
+++ b/crates/geo-polygonize-arrow/src/ffi.rs
@@ -98,6 +98,7 @@ fn set_polygonize_error(error: &PolygonizeError) -> i32 {
     let status = match error {
         PolygonizeError::InvalidBufferShape { .. } => PolygonizeFfiStatus::InvalidBufferShape,
         PolygonizeError::ResourceLimitExceeded { .. } => PolygonizeFfiStatus::Unknown,
+        PolygonizeError::Cancelled { .. } => PolygonizeFfiStatus::Unknown,
         PolygonizeError::InvalidArgumentType { .. } => PolygonizeFfiStatus::InvalidOption,
         PolygonizeError::InvalidGeometry { .. } => PolygonizeFfiStatus::InvalidGeometry,
         PolygonizeError::TopologyFailure { .. }

--- a/crates/geo-polygonize-core/src/error.rs
+++ b/crates/geo-polygonize-core/src/error.rs
@@ -22,6 +22,9 @@ pub enum PolygonizeError {
         observed: usize,
     },
 
+    #[error("Polygonization cancelled at {stage}")]
+    Cancelled { stage: String },
+
     #[error("Unsupported option combination: {reason}")]
     UnsupportedOptionCombination { reason: String },
 

--- a/crates/geo-polygonize-core/src/fingerprint.rs
+++ b/crates/geo-polygonize-core/src/fingerprint.rs
@@ -247,6 +247,7 @@ pub fn normalize_polygonize_error(error: &PolygonizeError) -> NormalizedPolygoni
             observed: Some(observed.to_string()),
             ..base("resource_limit", "resource_limit_exceeded", stage)
         },
+        PolygonizeError::Cancelled { stage } => base("cancelled", "cancelled", stage),
         PolygonizeError::UnsupportedOptionCombination { .. } => base(
             "invalid_argument",
             "unsupported_option_combination",

--- a/crates/geo-polygonize-core/src/lib.rs
+++ b/crates/geo-polygonize-core/src/lib.rs
@@ -45,9 +45,9 @@ pub use fingerprint::{
     NormalizedPolygonizeErrorV1, TopologyFingerprintV1, TOPOLOGY_FINGERPRINT_V1_SCHEMA_VERSION,
 };
 pub use options::{
-    ContainmentOptions, DeterminismOptions, DiagnosticsOptions, ExecutionPolicy, NodingBackend,
-    NodingGuarantee, NodingOptions, OutputFilterOptions, PolygonizerOptions, PrecisionModel,
-    ProvenanceOptions, SnapStrategy, TouchPolicy, ZOptions, ZPolicy,
+    CancellationToken, ContainmentOptions, DeterminismOptions, DiagnosticsOptions, ExecutionPolicy,
+    NodingBackend, NodingGuarantee, NodingOptions, OutputFilterOptions, PolygonizerOptions,
+    PrecisionModel, ProvenanceOptions, SnapStrategy, TouchPolicy, ZOptions, ZPolicy,
 };
 #[doc(hidden)]
 pub use options::{DedupPolicy, TileOwnershipPolicy};

--- a/crates/geo-polygonize-core/src/noding/hot_pixel.rs
+++ b/crates/geo-polygonize-core/src/noding/hot_pixel.rs
@@ -106,6 +106,7 @@ impl HotPixelNoder {
             for second_index in candidates {
                 work.candidate_pairs += 1;
                 if let Some(execution_policy) = execution_policy {
+                    execution_policy.check_cancelled("candidate_enumeration")?;
                     execution_policy
                         .check_noding_work(work.candidate_pairs, work.exact_intersection_calls)?;
                 }
@@ -143,6 +144,9 @@ impl HotPixelNoder {
         );
         let mut output = Vec::new();
         for line in lines {
+            if let Some(execution_policy) = execution_policy {
+                execution_policy.check_cancelled("split_application")?;
+            }
             let start = self.grid_point(line.start)?;
             let end = self.grid_point(line.end)?;
             let query = AABB::from_corners(

--- a/crates/geo-polygonize-core/src/noding/snap.rs
+++ b/crates/geo-polygonize-core/src/noding/snap.rs
@@ -188,6 +188,7 @@ impl SnapNoder {
         let mut split_events = 0;
         for iteration_index in 0..self.max_iter {
             if let Some(execution_policy) = execution_policy {
+                execution_policy.check_cancelled("candidate_enumeration")?;
                 execution_policy.check_noding_iterations(iteration_index + 1)?;
             }
             let input_segment_count = lines.len();
@@ -262,6 +263,7 @@ impl SnapNoder {
             let split_event_count = events.len();
             split_events += split_event_count;
             if let Some(execution_policy) = execution_policy {
+                execution_policy.check_cancelled("split_application")?;
                 execution_policy.check_split_events(split_events)?;
             }
             if let Some(work_stats) = work_stats.as_deref_mut() {

--- a/crates/geo-polygonize-core/src/options.rs
+++ b/crates/geo-polygonize-core/src/options.rs
@@ -2,6 +2,32 @@ use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
 use crate::error::{PolygonizeError, Result};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+
+/// Cooperative native cancellation handle for an [`ExecutionPolicy`].
+#[derive(Clone, Debug, Default)]
+pub struct CancellationToken(Arc<AtomicBool>);
+
+impl CancellationToken {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn cancel(&self) {
+        self.0.store(true, Ordering::Release);
+    }
+
+    pub fn reset(&self) {
+        self.0.store(false, Ordering::Release);
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.0.load(Ordering::Acquire)
+    }
+}
 
 /// Non-semantic limits applied before polygonization begins.
 ///
@@ -9,6 +35,7 @@ use crate::error::{PolygonizeError, Result};
 /// so equivalent topology options retain identical meaning across callers.
 #[derive(Clone, Debug, Default)]
 pub struct ExecutionPolicy {
+    pub cancellation_token: Option<CancellationToken>,
     pub max_input_line_strings: Option<usize>,
     pub max_input_segments: Option<usize>,
     pub max_input_coordinates: Option<usize>,
@@ -37,7 +64,8 @@ impl ExecutionPolicy {
     }
 
     pub(crate) fn has_noding_work_limits(&self) -> bool {
-        self.max_candidate_pairs.is_some()
+        self.cancellation_token.is_some()
+            || self.max_candidate_pairs.is_some()
             || self.max_exact_intersection_calls.is_some()
             || self.max_split_events.is_some()
             || self.max_noding_iterations.is_some()
@@ -62,6 +90,19 @@ impl ExecutionPolicy {
 
     pub(crate) fn check_noding_iterations(&self, observed: usize) -> Result<()> {
         self.check("noding_iterations", self.max_noding_iterations, observed)
+    }
+
+    pub(crate) fn check_cancelled(&self, stage: &str) -> Result<()> {
+        if self
+            .cancellation_token
+            .as_ref()
+            .is_some_and(CancellationToken::is_cancelled)
+        {
+            return Err(PolygonizeError::Cancelled {
+                stage: stage.to_string(),
+            });
+        }
+        Ok(())
     }
 }
 

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -309,6 +309,8 @@ impl Polygonizer {
         mut all_segments: Vec<Line3D>,
         mut diagnostics: Option<&mut PolygonizerDiagnostics>,
     ) -> Result<()> {
+        self.execution_policy
+            .check_cancelled("graph_construction")?;
         self.graph.clear();
         let grid_size = self.options.precision_model.grid_size();
         let mut segments;
@@ -506,6 +508,8 @@ impl Polygonizer {
 
         // Use bulk load
         self.graph.bulk_load(segments);
+        self.execution_policy
+            .check_cancelled("graph_construction")?;
         self.execution_policy.check(
             "graph_nodes",
             self.execution_policy.max_graph_nodes,
@@ -530,6 +534,7 @@ impl Polygonizer {
 
     fn polygonize_owned(&mut self, input_lines: Vec<Line3D>) -> Result<PolygonizerResult> {
         self.options.validate()?;
+        self.execution_policy.check_cancelled("ingest")?;
         self.execution_policy.check(
             "input_segments",
             self.execution_policy.max_input_segments,
@@ -564,6 +569,8 @@ impl Polygonizer {
         let t_graph_build_start = get_time();
         // 1. Sort edges (Geometry Graph operation)
         self.graph.sort_edges();
+        self.execution_policy
+            .check_cancelled("graph_construction")?;
 
         // 2. Prune dangles
         let mut dangles = self.graph.prune_dangles();
@@ -572,6 +579,7 @@ impl Polygonizer {
         let mut cut_edges = self.graph.delete_cut_edges();
 
         // 4. Find rings (3D)
+        self.execution_policy.check_cancelled("ring_extraction")?;
         let rings_with_ids = self.graph.get_edge_rings_with_graph_ids(
             self.options.node_input,
             self.options.provenance.enabled && self.options.provenance.include_boundary_line_ids,
@@ -609,7 +617,10 @@ impl Polygonizer {
             unassigned_hole_count,
             unassigned_hole_area,
             containment_stats,
-        ) = establish_topology(shells, holes, &self.options);
+        ) = {
+            self.execution_policy.check_cancelled("containment")?;
+            establish_topology(shells, holes, &self.options)
+        };
 
         // 6. Construct Final Polygons
         // Ensure we don't crash on NaNs during processing
@@ -623,6 +634,7 @@ impl Polygonizer {
         let mut result =
             construct_final_polygons(shells, shell_holes, shell_holes_ids, &self.options);
 
+        self.execution_policy.check_cancelled("canonicalization")?;
         result = apply_determinism(
             result,
             &mut dangles,
@@ -635,6 +647,7 @@ impl Polygonizer {
             self.execution_policy.max_output_polygons,
             result.len(),
         )?;
+        self.execution_policy.check_cancelled("output_flattening")?;
         let output_coordinates = result
             .iter()
             .map(|polygon| {

--- a/crates/geo-polygonize-core/tests/cancellation.rs
+++ b/crates/geo-polygonize-core/tests/cancellation.rs
@@ -1,0 +1,44 @@
+use geo_polygonize_core::{
+    polygonize_with_workspace_and_execution_policy, CancellationToken, Coord3D, ExecutionPolicy,
+    Line3D, PolygonizeError, PolygonizerOptions, PolygonizerWorkspace,
+};
+
+fn square() -> [Line3D; 4] {
+    [
+        Line3D::new(Coord3D::new(0., 0., 0.), Coord3D::new(1., 0., 0.), 0),
+        Line3D::new(Coord3D::new(1., 0., 0.), Coord3D::new(1., 1., 0.), 1),
+        Line3D::new(Coord3D::new(1., 1., 0.), Coord3D::new(0., 1., 0.), 2),
+        Line3D::new(Coord3D::new(0., 1., 0.), Coord3D::new(0., 0., 0.), 3),
+    ]
+}
+
+#[test]
+fn cancelled_workspace_run_can_be_reused() {
+    let token = CancellationToken::new();
+    let policy = ExecutionPolicy {
+        cancellation_token: Some(token.clone()),
+        ..Default::default()
+    };
+    let options = PolygonizerOptions::default();
+    let mut workspace = PolygonizerWorkspace::new();
+    token.cancel();
+
+    assert!(matches!(
+        polygonize_with_workspace_and_execution_policy(&square(), &options, &mut workspace, &policy),
+        Err(PolygonizeError::Cancelled { stage }) if stage == "ingest"
+    ));
+
+    token.reset();
+    assert_eq!(
+        polygonize_with_workspace_and_execution_policy(
+            &square(),
+            &options,
+            &mut workspace,
+            &policy
+        )
+        .unwrap()
+        .polygons
+        .len(),
+        1
+    );
+}

--- a/crates/geo-polygonize-python/src/lib.rs
+++ b/crates/geo-polygonize-python/src/lib.rs
@@ -43,6 +43,7 @@ fn to_py_err(err: PolygonizeError) -> PyErr {
         PolygonizeError::InvalidGeometry { reason } => PolygonizeGeometryError::new_err(reason),
         PolygonizeError::InvalidBufferShape { reason } => PolygonizeTypeError::new_err(reason),
         PolygonizeError::ResourceLimitExceeded { .. } => PyRuntimeError::new_err(err.to_string()),
+        PolygonizeError::Cancelled { .. } => PyRuntimeError::new_err(err.to_string()),
         PolygonizeError::UnsupportedOptionCombination { reason } => {
             PolygonizeOptionsError::new_err(reason)
         }

--- a/crates/geo-polygonize-wasm/src/error.rs
+++ b/crates/geo-polygonize-wasm/src/error.rs
@@ -41,6 +41,7 @@ pub fn from_polygonizer_error(e: PolygonizeError) -> JsValue {
         PolygonizeError::InvalidGeometry { .. } => "InvalidGeometry".to_string(),
         PolygonizeError::InvalidBufferShape { .. } => "InvalidBufferShape".to_string(),
         PolygonizeError::ResourceLimitExceeded { .. } => "ResourceLimitExceeded".to_string(),
+        PolygonizeError::Cancelled { .. } => "Cancelled".to_string(),
         PolygonizeError::UnsupportedOptionCombination { .. } => {
             "UnsupportedOptionCombination".to_string()
         }


### PR DESCRIPTION
## What changed

- Add a shared atomic native `CancellationToken` to `ExecutionPolicy`.
- Return typed `Cancelled` errors at core pipeline and noding phase checkpoints.
- Prove a cancelled workspace can run successfully after the token resets.
- Update P0.6 roadmap progress while leaving Python and Wasm binding work open.

## Why

Native callers need a non-semantic way to stop long-running work without leaving reusable workspace state unsafe.

## Validation

- `cargo fmt --check`
- `cargo test -p geo-polygonize-core --test cancellation --locked`
- `cargo test -p geo-polygonize-core --lib --locked`
- `cargo check --workspace --locked`