### PR TITLE
feat(core): poll grid cancellation checkpoints

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -243,9 +243,9 @@ cancelled workspace run is reusable after resetting its token. Python releases
 the GIL for owned Rust work and polls signals every 10 ms before cancelling the
 worker token. Wasm has cancellable GeoJSON and report calls in disposable
 browser workers; aborting terminates the worker rather than claiming that a
-synchronous main-thread Wasm export can yield. SIMD noding polls cancellation
-every 256 candidate comparisons and every 256 split events; grid, hot-pixel,
-and later core phases still need equivalent bounded checkpoints.
+synchronous main-thread Wasm export can yield. SIMD and hot-pixel split scans
+poll every 256 work items; grid polls between cells. Later core phases still
+need equivalent bounded checkpoints.
 
 - [x] Add cancellation checkpoints at ingest, candidate enumeration, split
   application, graph construction, ring extraction, containment, canonicalization,

--- a/crates/geo-polygonize-core/src/noding/grid.rs
+++ b/crates/geo-polygonize-core/src/noding/grid.rs
@@ -1,5 +1,6 @@
 use crate::diagnostics::NodingWorkStats;
 use crate::noding::snap::SnapNoder;
+use crate::options::ExecutionPolicy;
 use crate::types::{Coord3D, Line3D};
 use crate::utils::soa::SoALines;
 use geo::algorithm::line_intersection::{line_intersection, LineIntersection};
@@ -424,6 +425,35 @@ impl UniformGrid {
         splits
     }
 
+    pub(crate) fn find_splits_with_execution_policy(
+        &self,
+        lines: &[Line3D],
+        snap_noder: &SnapNoder,
+        execution_policy: &ExecutionPolicy,
+    ) -> crate::Result<Vec<(usize, Coord3D)>> {
+        let soa = SoALines::new(lines);
+        let mut splits = Vec::new();
+        for idx in 0..self.rows * self.cols {
+            execution_policy.check_cancelled_every("candidate_enumeration", idx)?;
+            let start = self.cell_offsets[idx];
+            let end = self.cell_offsets[idx + 1];
+            self.process_cell(
+                idx / self.cols,
+                idx % self.cols,
+                &self.cell_items[start..end],
+                lines,
+                snap_noder,
+                &soa,
+                &mut splits,
+            );
+        }
+        execution_policy.check_cancelled("candidate_enumeration")?;
+        if !self.global_lines.is_empty() {
+            splits.extend(self.process_global_lines(lines, snap_noder, &soa));
+        }
+        Ok(splits)
+    }
+
     pub(crate) fn measure_work(&self, lines: &[Line3D]) -> NodingWorkStats {
         let mut stats = NodingWorkStats {
             grid_cells: self.rows * self.cols,
@@ -685,6 +715,7 @@ mod tests {
     use super::*;
     use crate::noding::snap::SnapNoder;
     use crate::types::{Coord3D, Line3D};
+    use crate::{CancellationToken, ExecutionPolicy, PolygonizeError};
     use approx::assert_relative_eq;
 
     fn make_line(x1: f64, y1: f64, x2: f64, y2: f64) -> Line3D {
@@ -706,6 +737,25 @@ mod tests {
         let noder = SnapNoder::new(1e-6);
         let splits = grid.find_splits(&[], &noder);
         assert!(splits.is_empty());
+    }
+
+    #[test]
+    fn policy_path_observes_cancellation_before_returning() {
+        let token = CancellationToken::new();
+        token.cancel();
+        let policy = ExecutionPolicy {
+            cancellation_token: Some(token),
+            ..Default::default()
+        };
+
+        assert!(matches!(
+            UniformGrid::new(&[]).find_splits_with_execution_policy(
+                &[],
+                &SnapNoder::new(1.0),
+                &policy,
+            ),
+            Err(PolygonizeError::Cancelled { stage }) if stage == "candidate_enumeration"
+        ));
     }
 
     #[test]

--- a/crates/geo-polygonize-core/src/noding/hot_pixel.rs
+++ b/crates/geo-polygonize-core/src/noding/hot_pixel.rs
@@ -165,7 +165,10 @@ impl HotPixelNoder {
             candidates.sort_unstable();
 
             let mut points = vec![line.start, line.end];
-            for hot_pixel_index in candidates {
+            for (candidate_index, hot_pixel_index) in candidates.into_iter().enumerate() {
+                if let Some(execution_policy) = execution_policy {
+                    execution_policy.check_cancelled_every("split_application", candidate_index)?;
+                }
                 let hot_pixel = hot_pixels[hot_pixel_index];
                 if hot_pixel == start
                     || hot_pixel == end

--- a/crates/geo-polygonize-core/src/noding/snap.rs
+++ b/crates/geo-polygonize-core/src/noding/snap.rs
@@ -239,7 +239,11 @@ impl SnapNoder {
                         work_stats.merge(measured_work);
                     }
                 }
-                grid.find_splits(&lines, self)
+                if let Some(execution_policy) = execution_policy {
+                    grid.find_splits_with_execution_policy(&lines, self, execution_policy)?
+                } else {
+                    grid.find_splits(&lines, self)
+                }
             };
 
             if events.is_empty() {


### PR DESCRIPTION
## What changed

- Poll cancellation between grid cells on execution-policy noding runs.
- Poll hot-pixel split candidate scans every 256 entries.
- Add a grid cancellation regression and update P0.6 progress.

## Validation

- `cargo test -p geo-polygonize-core noding::grid --lib --locked`
- `cargo clippy --locked -- -D warnings`