### PR TITLE
feat(core): poll graph cancellation checks

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -245,7 +245,8 @@ worker token. Wasm has cancellable GeoJSON and report calls in disposable
 browser workers; aborting terminates the worker rather than claiming that a
 synchronous main-thread Wasm export can yield. SIMD and hot-pixel split scans
 poll every 256 work items; grid polls between cells. Later core phases still
-need equivalent bounded checkpoints.
+need equivalent bounded checkpoints. Graph dangle pruning also polls node
+discovery and its mutable work stack every 256 items.
 
 - [x] Add cancellation checkpoints at ingest, candidate enumeration, split
   application, graph construction, ring extraction, containment, canonicalization,

--- a/crates/geo-polygonize-core/src/graph/planar_graph.rs
+++ b/crates/geo-polygonize-core/src/graph/planar_graph.rs
@@ -1,3 +1,4 @@
+use crate::options::ExecutionPolicy;
 use crate::types::{Coord3D, EdgeSources, Line3D};
 use crate::utils::parallel::{par_flat_map, par_sort_unstable, par_zip_for_each};
 use crate::utils::{compare_angular, z_order_index};
@@ -594,16 +595,38 @@ impl PlanarGraph {
 
     /// Prunes dangles (nodes with degree 1) from the graph iteratively.
     pub fn prune_dangles(&mut self) -> Vec<Vec<Coord3D>> {
-        let mut dangles = Vec::new();
-        let mut to_process: Vec<NodeId> = self
-            .nodes_degree
-            .iter()
-            .enumerate()
-            .filter(|(i, &d)| d == 1 && !self.nodes_marked[*i])
-            .map(|(i, _)| i)
-            .collect();
+        self.prune_dangles_impl(None)
+            .expect("unlimited graph pruning cannot fail")
+    }
 
+    pub(crate) fn prune_dangles_with_execution_policy(
+        &mut self,
+        execution_policy: &ExecutionPolicy,
+    ) -> crate::Result<Vec<Vec<Coord3D>>> {
+        self.prune_dangles_impl(Some(execution_policy))
+    }
+
+    fn prune_dangles_impl(
+        &mut self,
+        execution_policy: Option<&ExecutionPolicy>,
+    ) -> crate::Result<Vec<Vec<Coord3D>>> {
+        let mut dangles = Vec::new();
+        let mut to_process = Vec::new();
+        for (node_idx, &degree) in self.nodes_degree.iter().enumerate() {
+            if let Some(execution_policy) = execution_policy {
+                execution_policy.check_cancelled_every("graph_construction", node_idx)?;
+            }
+            if degree == 1 && !self.nodes_marked[node_idx] {
+                to_process.push(node_idx);
+            }
+        }
+
+        let mut processed = 0;
         while let Some(node_idx) = to_process.pop() {
+            processed += 1;
+            if let Some(execution_policy) = execution_policy {
+                execution_policy.check_cancelled_every("graph_construction", processed)?;
+            }
             if self.nodes_degree[node_idx] != 1 {
                 continue;
             }
@@ -644,7 +667,7 @@ impl PlanarGraph {
                 }
             }
         }
-        dangles
+        Ok(dangles)
     }
 
     /// Finds and removes edges whose two directions belong to the same maximal ring.

--- a/crates/geo-polygonize-core/src/graph/tests.rs
+++ b/crates/geo-polygonize-core/src/graph/tests.rs
@@ -3,6 +3,7 @@
 mod tests {
     use crate::graph::planar_graph::PlanarGraph;
     use crate::types::Line3D;
+    use crate::{CancellationToken, ExecutionPolicy, PolygonizeError};
     use geo_types::{Coord, LineString};
 
     #[test]
@@ -21,6 +22,23 @@ mod tests {
         // Node at (0,0) should have 2 outgoing edges
         let center_node_idx = graph.node_map.get(&Coord::from((0.0, 0.0)).into()).unwrap();
         assert_eq!(graph.nodes_outgoing[*center_node_idx].len(), 2);
+    }
+
+    #[test]
+    fn dangle_pruning_observes_cancellation() {
+        let mut graph = PlanarGraph::new();
+        graph.add_line_string(LineString::from(vec![(0.0, 0.0), (1.0, 0.0)]));
+        let token = CancellationToken::new();
+        token.cancel();
+        let policy = ExecutionPolicy {
+            cancellation_token: Some(token),
+            ..Default::default()
+        };
+
+        assert!(matches!(
+            graph.prune_dangles_with_execution_policy(&policy),
+            Err(PolygonizeError::Cancelled { stage }) if stage == "graph_construction"
+        ));
     }
 
     #[test]

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -573,7 +573,12 @@ impl Polygonizer {
             .check_cancelled("graph_construction")?;
 
         // 2. Prune dangles
-        let mut dangles = self.graph.prune_dangles();
+        let mut dangles = if self.execution_policy.cancellation_token.is_some() {
+            self.graph
+                .prune_dangles_with_execution_policy(&self.execution_policy)?
+        } else {
+            self.graph.prune_dangles()
+        };
 
         // 3. Remove cut edges before extracting minimal rings.
         let mut cut_edges = self.graph.delete_cut_edges();

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -648,15 +648,20 @@ impl Polygonizer {
             result.len(),
         )?;
         self.execution_policy.check_cancelled("output_flattening")?;
-        let output_coordinates = result
-            .iter()
-            .map(|polygon| {
-                polygon.exterior.len() + polygon.interiors.iter().map(Vec::len).sum::<usize>()
-            })
-            .sum::<usize>()
-            + dangles.iter().map(Vec::len).sum::<usize>()
-            + cut_edges.iter().map(Vec::len).sum::<usize>()
-            + invalid_rings.iter().map(Vec::len).sum::<usize>();
+        let mut output_coordinates = 0;
+        for (index, polygon) in result.iter().enumerate() {
+            self.execution_policy
+                .check_cancelled_every("output_flattening", index)?;
+            output_coordinates +=
+                polygon.exterior.len() + polygon.interiors.iter().map(Vec::len).sum::<usize>();
+        }
+        for lines in [&dangles, &cut_edges, &invalid_rings] {
+            for (index, line) in lines.iter().enumerate() {
+                self.execution_policy
+                    .check_cancelled_every("output_flattening", index)?;
+                output_coordinates += line.len();
+            }
+        }
         self.execution_policy.check(
             "output_coordinates",
             self.execution_policy.max_output_coordinates,


### PR DESCRIPTION
## What changed

- Add a policy-aware dangle-pruning path that polls node discovery and work-stack drains every 256 items.
- Keep token-free callers on the existing graph path.
- Add a direct graph cancellation regression and update P0.6 progress.

## Validation

- `cargo test -p geo-polygonize-core graph --lib --locked`
- `cargo clippy --locked -- -D warnings`