### PR TITLE
refactor(core): account noding work during candidate enumeration

### DIFF
--- a/crates/geo-polygonize-core/src/diagnostics.rs
+++ b/crates/geo-polygonize-core/src/diagnostics.rs
@@ -86,16 +86,72 @@ pub struct NodingWorkStats {
     pub pre_snap_vertex_candidates: usize,
 }
 
-impl NodingWorkStats {
-    pub(crate) fn merge(&mut self, other: Self) {
-        self.grid_cells += other.grid_cells;
-        self.grid_cell_entries += other.grid_cell_entries;
-        self.global_lines += other.global_lines;
-        self.candidate_pairs += other.candidate_pairs;
-        self.aabb_rejections += other.aabb_rejections;
-        self.exact_intersection_calls += other.exact_intersection_calls;
-        self.split_events += other.split_events;
-        self.pre_snap_vertex_candidates += other.pre_snap_vertex_candidates;
+pub(crate) struct ExecutionWorkTracker<'a> {
+    policy: Option<&'a crate::ExecutionPolicy>,
+    stats: Option<&'a mut NodingWorkStats>,
+    candidate_pairs: usize,
+    exact_intersection_calls: usize,
+}
+
+impl<'a> ExecutionWorkTracker<'a> {
+    pub(crate) fn new(
+        policy: Option<&'a crate::ExecutionPolicy>,
+        stats: Option<&'a mut NodingWorkStats>,
+    ) -> Self {
+        let candidate_pairs = stats.as_deref().map_or(0, |stats| stats.candidate_pairs);
+        let exact_intersection_calls = stats
+            .as_deref()
+            .map_or(0, |stats| stats.exact_intersection_calls);
+        Self {
+            policy,
+            stats,
+            candidate_pairs,
+            exact_intersection_calls,
+        }
+    }
+
+    pub(crate) fn grid(&mut self, cells: usize, entries: usize, globals: usize) {
+        if let Some(stats) = self.stats.as_deref_mut() {
+            stats.grid_cells = stats.grid_cells.saturating_add(cells);
+            stats.grid_cell_entries = stats.grid_cell_entries.saturating_add(entries);
+            stats.global_lines = stats.global_lines.saturating_add(globals);
+        }
+    }
+
+    pub(crate) fn check_cancelled(&self) -> crate::Result<()> {
+        if let Some(policy) = self.policy {
+            policy.check_cancelled("candidate_enumeration")?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn candidate(&mut self, overlaps: bool) -> crate::Result<()> {
+        self.candidate_pairs = self.candidate_pairs.checked_add(1).ok_or_else(|| {
+            crate::PolygonizeError::InternalInvariantViolation {
+                reason: "candidate-pair counter overflow".to_string(),
+            }
+        })?;
+        if overlaps {
+            self.exact_intersection_calls = self
+                .exact_intersection_calls
+                .checked_add(1)
+                .ok_or_else(|| crate::PolygonizeError::InternalInvariantViolation {
+                    reason: "exact-intersection counter overflow".to_string(),
+                })?;
+        }
+        if let Some(stats) = self.stats.as_deref_mut() {
+            stats.candidate_pairs = stats.candidate_pairs.saturating_add(1);
+            if overlaps {
+                stats.exact_intersection_calls = stats.exact_intersection_calls.saturating_add(1);
+            } else {
+                stats.aabb_rejections = stats.aabb_rejections.saturating_add(1);
+            }
+        }
+        if let Some(policy) = self.policy {
+            policy.check_cancelled_every("candidate_enumeration", self.candidate_pairs)?;
+            policy.check_noding_work(self.candidate_pairs, self.exact_intersection_calls)?;
+        }
+        Ok(())
     }
 }
 

--- a/crates/geo-polygonize-core/src/noding/grid.rs
+++ b/crates/geo-polygonize-core/src/noding/grid.rs
@@ -1,6 +1,5 @@
-use crate::diagnostics::NodingWorkStats;
+use crate::diagnostics::ExecutionWorkTracker;
 use crate::noding::snap::SnapNoder;
-use crate::options::ExecutionPolicy;
 use crate::types::{Coord3D, Line3D};
 use crate::utils::soa::SoALines;
 use geo::algorithm::line_intersection::{line_intersection, LineIntersection};
@@ -387,7 +386,17 @@ impl UniformGrid {
                     if cell_indices.len() >= 2 {
                         let r = idx / self.cols;
                         let c = idx % self.cols;
-                        self.process_cell(r, c, cell_indices, lines, snap_noder, &soa, &mut acc);
+                        self.process_cell(
+                            r,
+                            c,
+                            cell_indices,
+                            lines,
+                            snap_noder,
+                            &soa,
+                            &mut acc,
+                            None,
+                        )
+                        .expect("unlimited noding cannot fail");
                     }
                     acc
                 })
@@ -410,7 +419,17 @@ impl UniformGrid {
                     let end = self.cell_offsets[idx + 1];
                     let cell_indices = &self.cell_items[start..end];
 
-                    self.process_cell(r, c, cell_indices, lines, snap_noder, &soa, &mut splits);
+                    self.process_cell(
+                        r,
+                        c,
+                        cell_indices,
+                        lines,
+                        snap_noder,
+                        &soa,
+                        &mut splits,
+                        None,
+                    )
+                    .expect("unlimited noding cannot fail");
                 }
             }
             splits
@@ -425,16 +444,21 @@ impl UniformGrid {
         splits
     }
 
-    pub(crate) fn find_splits_with_execution_policy(
+    pub(crate) fn find_splits_tracked(
         &self,
         lines: &[Line3D],
         snap_noder: &SnapNoder,
-        execution_policy: &ExecutionPolicy,
+        tracker: &mut ExecutionWorkTracker<'_>,
     ) -> crate::Result<Vec<(usize, Coord3D)>> {
         let soa = SoALines::new(lines);
         let mut splits = Vec::new();
+        tracker.check_cancelled()?;
+        tracker.grid(
+            self.rows.saturating_mul(self.cols),
+            self.cell_items.len(),
+            self.global_lines.len(),
+        );
         for idx in 0..self.rows * self.cols {
-            execution_policy.check_cancelled_every("candidate_enumeration", idx)?;
             let start = self.cell_offsets[idx];
             let end = self.cell_offsets[idx + 1];
             self.process_cell(
@@ -445,60 +469,14 @@ impl UniformGrid {
                 snap_noder,
                 &soa,
                 &mut splits,
-            );
+                Some(tracker),
+            )?;
         }
-        execution_policy.check_cancelled("candidate_enumeration")?;
         if !self.global_lines.is_empty() {
-            splits.extend(self.process_global_lines(lines, snap_noder, &soa));
+            splits.extend(self.process_global_lines_tracked(lines, snap_noder, tracker)?);
         }
+        tracker.check_cancelled()?;
         Ok(splits)
-    }
-
-    pub(crate) fn measure_work(&self, lines: &[Line3D]) -> NodingWorkStats {
-        let mut stats = NodingWorkStats {
-            grid_cells: self.rows * self.cols,
-            grid_cell_entries: self.cell_items.len(),
-            global_lines: self.global_lines.len(),
-            ..Default::default()
-        };
-        let overlaps = |left: &Line3D, right: &Line3D| {
-            left.start.x.max(left.end.x) >= right.start.x.min(right.end.x)
-                && left.start.x.min(left.end.x) <= right.start.x.max(right.end.x)
-                && left.start.y.max(left.end.y) >= right.start.y.min(right.end.y)
-                && left.start.y.min(left.end.y) <= right.start.y.max(right.end.y)
-        };
-
-        for cell in self.cell_offsets.windows(2) {
-            let indices = &self.cell_items[cell[0]..cell[1]];
-            for (i, &left_idx) in indices.iter().enumerate() {
-                for &right_idx in &indices[i + 1..] {
-                    stats.candidate_pairs += 1;
-                    if overlaps(&lines[left_idx as usize], &lines[right_idx as usize]) {
-                        stats.exact_intersection_calls += 1;
-                    } else {
-                        stats.aabb_rejections += 1;
-                    }
-                }
-            }
-        }
-
-        for &left_idx in &self.global_lines {
-            for (right_idx, right) in lines.iter().enumerate() {
-                if right_idx == left_idx
-                    || (right_idx < left_idx && self.global_lines.binary_search(&right_idx).is_ok())
-                {
-                    continue;
-                }
-                stats.candidate_pairs += 1;
-                if overlaps(&lines[left_idx], right) {
-                    stats.exact_intersection_calls += 1;
-                } else {
-                    stats.aabb_rejections += 1;
-                }
-            }
-        }
-
-        stats
     }
 
     fn process_global_lines(
@@ -581,6 +559,40 @@ impl UniformGrid {
         }
     }
 
+    fn process_global_lines_tracked(
+        &self,
+        lines: &[Line3D],
+        snap_noder: &SnapNoder,
+        tracker: &mut ExecutionWorkTracker<'_>,
+    ) -> crate::Result<Vec<(usize, Coord3D)>> {
+        let mut events = Vec::new();
+        for &left_idx in &self.global_lines {
+            for (right_idx, right) in lines.iter().enumerate() {
+                if right_idx == left_idx
+                    || (right_idx < left_idx && self.global_lines.binary_search(&right_idx).is_ok())
+                {
+                    continue;
+                }
+                let left = &lines[left_idx];
+                let overlaps = left.start.x.max(left.end.x) >= right.start.x.min(right.end.x)
+                    && left.start.x.min(left.end.x) <= right.start.x.max(right.end.x)
+                    && left.start.y.max(left.end.y) >= right.start.y.min(right.end.y)
+                    && left.start.y.min(left.end.y) <= right.start.y.max(right.end.y);
+                tracker.candidate(overlaps)?;
+                if overlaps {
+                    snap_noder.process_intersection(
+                        *left,
+                        *right,
+                        left_idx,
+                        right_idx,
+                        |idx, point| events.push((idx, point)),
+                    );
+                }
+            }
+        }
+        Ok(events)
+    }
+
     #[inline]
     #[allow(clippy::too_many_arguments)]
     fn handle_collinear(
@@ -627,9 +639,10 @@ impl UniformGrid {
         snap_noder: &SnapNoder,
         soa: &SoALines,
         splits: &mut Vec<(usize, Coord3D)>,
-    ) {
+        mut tracker: Option<&mut ExecutionWorkTracker<'_>>,
+    ) -> crate::Result<()> {
         if cell_indices.len() < 2 {
-            return;
+            return Ok(());
         }
 
         // Define current cell bounds
@@ -660,7 +673,12 @@ impl UniformGrid {
                 let max_y2 = soa.max_y[idx2];
 
                 // Scalar overlap check
-                if max_x1 >= min_x2 && min_x1 <= max_x2 && max_y1 >= min_y2 && min_y1 <= max_y2 {
+                let overlaps =
+                    max_x1 >= min_x2 && min_x1 <= max_x2 && max_y1 >= min_y2 && min_y1 <= max_y2;
+                if let Some(tracker) = tracker.as_deref_mut() {
+                    tracker.candidate(overlaps)?;
+                }
+                if overlaps {
                     let l1 = lines[idx1];
                     let l2 = lines[idx2];
 
@@ -707,6 +725,7 @@ impl UniformGrid {
                 }
             }
         }
+        Ok(())
     }
 }
 
@@ -749,10 +768,10 @@ mod tests {
         };
 
         assert!(matches!(
-            UniformGrid::new(&[]).find_splits_with_execution_policy(
+            UniformGrid::new(&[]).find_splits_tracked(
                 &[],
                 &SnapNoder::new(1.0),
-                &policy,
+                &mut ExecutionWorkTracker::new(Some(&policy), None),
             ),
             Err(PolygonizeError::Cancelled { stage }) if stage == "candidate_enumeration"
         ));

--- a/crates/geo-polygonize-core/src/noding/snap.rs
+++ b/crates/geo-polygonize-core/src/noding/snap.rs
@@ -1,4 +1,4 @@
-use crate::diagnostics::{NodingIterationStats, NodingWorkStats};
+use crate::diagnostics::{ExecutionWorkTracker, NodingIterationStats, NodingWorkStats};
 use crate::index::{IndexedEnvelope, RStarBackend};
 use crate::noding::grid::UniformGrid;
 use crate::options::{ExecutionPolicy, SnapStrategy, ZPolicy};
@@ -184,7 +184,6 @@ impl SnapNoder {
         let auto_prefers_simd =
             self.strategy == NodingStrategy::Auto && self.auto_prefers_simd(&lines);
         let mut new_lines = Vec::new();
-        let mut total_work = NodingWorkStats::default();
         let mut split_events = 0;
         for iteration_index in 0..self.max_iter {
             if let Some(execution_policy) = execution_policy {
@@ -203,44 +202,20 @@ impl SnapNoder {
 
             let mut events = if !use_grid {
                 // STRATEGY A: Small Input -> SIMD Brute Force
-                let measured_work = (work_stats.is_some() || execution_policy.is_some())
-                    .then(|| Self::measure_simd_work(&lines));
-                if let Some(measured_work) = measured_work {
-                    if let Some(execution_policy) = execution_policy {
-                        total_work.merge(measured_work.clone());
-                        execution_policy.check_noding_work(
-                            total_work.candidate_pairs,
-                            total_work.exact_intersection_calls,
-                        )?;
-                    }
-                    if let Some(work_stats) = work_stats.as_deref_mut() {
-                        work_stats.merge(measured_work);
-                    }
-                }
-                if let Some(execution_policy) = execution_policy {
-                    self.find_splits_simd_with_execution_policy(&lines, execution_policy)?
+                if execution_policy.is_some() || work_stats.is_some() {
+                    let mut tracker =
+                        ExecutionWorkTracker::new(execution_policy, work_stats.as_deref_mut());
+                    self.find_splits_simd_tracked(&lines, &mut tracker)?
                 } else {
                     self.find_splits_simd(&lines)
                 }
             } else {
                 // STRATEGY B: Large Input -> Uniform Grid
                 let grid = UniformGrid::new(&lines);
-                let measured_work = (work_stats.is_some() || execution_policy.is_some())
-                    .then(|| grid.measure_work(&lines));
-                if let Some(measured_work) = measured_work {
-                    if let Some(execution_policy) = execution_policy {
-                        total_work.merge(measured_work.clone());
-                        execution_policy.check_noding_work(
-                            total_work.candidate_pairs,
-                            total_work.exact_intersection_calls,
-                        )?;
-                    }
-                    if let Some(work_stats) = work_stats.as_deref_mut() {
-                        work_stats.merge(measured_work);
-                    }
-                }
-                if let Some(execution_policy) = execution_policy {
-                    grid.find_splits_with_execution_policy(&lines, self, execution_policy)?
+                if execution_policy.is_some() || work_stats.is_some() {
+                    let mut tracker =
+                        ExecutionWorkTracker::new(execution_policy, work_stats.as_deref_mut());
+                    grid.find_splits_tracked(&lines, self, &mut tracker)?
                 } else {
                     grid.find_splits(&lines, self)
                 }
@@ -398,25 +373,6 @@ impl SnapNoder {
         }
 
         split_pairs * 4 >= pairs
-    }
-
-    fn measure_simd_work(lines: &[Line3D]) -> NodingWorkStats {
-        let mut stats = NodingWorkStats::default();
-        for (i, left) in lines.iter().enumerate() {
-            for right in &lines[i + 1..] {
-                stats.candidate_pairs += 1;
-                let overlaps = left.start.x.max(left.end.x) >= right.start.x.min(right.end.x)
-                    && left.start.x.min(left.end.x) <= right.start.x.max(right.end.x)
-                    && left.start.y.max(left.end.y) >= right.start.y.min(right.end.y)
-                    && left.start.y.min(left.end.y) <= right.start.y.max(right.end.y);
-                if overlaps {
-                    stats.exact_intersection_calls += 1;
-                } else {
-                    stats.aabb_rejections += 1;
-                }
-            }
-        }
-        stats
     }
 
     pub fn pre_snap_to_reference_vertices(lines: &[Line3D], tolerance: f64) -> Vec<Line3D> {
@@ -808,22 +764,24 @@ impl SnapNoder {
         }
     }
 
-    fn find_splits_simd_with_execution_policy(
+    fn find_splits_simd_tracked(
         &self,
         lines: &[Line3D],
-        execution_policy: &ExecutionPolicy,
+        tracker: &mut ExecutionWorkTracker<'_>,
     ) -> crate::Result<Vec<(usize, Coord3D)>> {
         let soa = SoALines::new(lines);
         let mut splits = Vec::new();
+        tracker.check_cancelled()?;
         for (i, &query_line) in lines.iter().enumerate() {
             splits.extend(self.check_intersection_simd(
                 query_line,
                 i,
                 lines,
                 &soa,
-                Some(execution_policy),
+                Some(tracker),
             )?);
         }
+        tracker.check_cancelled()?;
         Ok(splits)
     }
 
@@ -855,10 +813,9 @@ impl SnapNoder {
         i: usize,
         lines: &[Line3D],
         soa: &SoALines,
-        execution_policy: Option<&ExecutionPolicy>,
+        mut tracker: Option<&mut ExecutionWorkTracker<'_>>,
     ) -> crate::Result<Vec<(usize, Coord3D)>> {
         let mut events = Vec::new();
-        let mut checked = 0;
         // Start block to avoid duplicate checks (j > i)
         // We start checking at index i+1.
         // The SoA batching index `j` steps by 4.
@@ -870,10 +827,6 @@ impl SnapNoder {
         // Handling unaligned start to be absolutely safe and avoid self-check artifacts
         #[allow(clippy::needless_range_loop)]
         for j in (i + 1)..start_block.min(lines.len()) {
-            checked += 1;
-            if let Some(execution_policy) = execution_policy {
-                execution_policy.check_cancelled_every("candidate_enumeration", checked)?;
-            }
             let target_line = lines[j];
             // Standard BBox check
             let q_min_x = query_line.start.x.min(query_line.end.x);
@@ -886,8 +839,14 @@ impl SnapNoder {
             let t_min_y = target_line.start.y.min(target_line.end.y);
             let t_max_y = target_line.start.y.max(target_line.end.y);
 
-            if q_max_x >= t_min_x && q_min_x <= t_max_x && q_max_y >= t_min_y && q_min_y <= t_max_y
-            {
+            let overlaps = q_max_x >= t_min_x
+                && q_min_x <= t_max_x
+                && q_max_y >= t_min_y
+                && q_min_y <= t_max_y;
+            if let Some(tracker) = tracker.as_deref_mut() {
+                tracker.candidate(overlaps)?;
+            }
+            if overlaps {
                 self.process_intersection(query_line, target_line, i, j, |idx, pt| {
                     events.push((idx, pt))
                 });
@@ -901,32 +860,22 @@ impl SnapNoder {
         let q_max_y = f64x4::splat(query_line.start.y.max(query_line.end.y));
 
         for j in (start_block..soa.len()).step_by(4) {
-            checked += 4;
-            if let Some(execution_policy) = execution_policy {
-                execution_policy.check_cancelled_every("candidate_enumeration", checked)?;
-            }
             let mask = soa.intersects_bbox_batch_splatted(q_min_x, q_max_x, q_min_y, q_max_y, j);
 
-            if mask != 0 {
-                for k in 0..4 {
-                    if (mask & (1 << k)) != 0 {
-                        let target_idx = j + k;
-                        if target_idx >= lines.len() {
-                            continue;
-                        }
-                        if target_idx <= i {
-                            continue;
-                        } // Enforce i < j
-
-                        let target_line = lines[target_idx];
-                        self.process_intersection(
-                            query_line,
-                            target_line,
-                            i,
-                            target_idx,
-                            |idx, pt| events.push((idx, pt)),
-                        );
-                    }
+            for k in 0..4 {
+                let target_idx = j + k;
+                if target_idx >= lines.len() || target_idx <= i {
+                    continue;
+                }
+                let overlaps = (mask & (1 << k)) != 0;
+                if let Some(tracker) = tracker.as_deref_mut() {
+                    tracker.candidate(overlaps)?;
+                }
+                if overlaps {
+                    let target_line = lines[target_idx];
+                    self.process_intersection(query_line, target_line, i, target_idx, |idx, pt| {
+                        events.push((idx, pt))
+                    });
                 }
             }
         }
@@ -1032,9 +981,41 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert!(matches!(
-            SnapNoder::new(1.0).find_splits_simd_with_execution_policy(&lines, &policy),
+            SnapNoder::new(1.0).find_splits_simd_tracked(
+                &lines,
+                &mut ExecutionWorkTracker::new(Some(&policy), None),
+            ),
             Err(PolygonizeError::Cancelled { stage }) if stage == "candidate_enumeration"
         ));
+    }
+
+    #[test]
+    fn live_scan_supplies_diagnostics_and_budget_enforcement() {
+        let lines = vec![
+            make_line(0.0, 0.0, 2.0, 2.0),
+            make_line(0.0, 2.0, 2.0, 0.0),
+            make_line(1.0, -1.0, 1.0, 3.0),
+        ];
+        let policy = ExecutionPolicy {
+            max_candidate_pairs: Some(1),
+            ..Default::default()
+        };
+        let mut stats = NodingWorkStats::default();
+        let result = SnapNoder::new(0.0).find_splits_simd_tracked(
+            &lines,
+            &mut ExecutionWorkTracker::new(Some(&policy), Some(&mut stats)),
+        );
+
+        assert!(matches!(
+            result,
+            Err(PolygonizeError::ResourceLimitExceeded {
+                stage,
+                limit: 1,
+                observed: 2,
+            }) if stage == "candidate_pairs"
+        ));
+        assert_eq!(stats.candidate_pairs, 2);
+        assert_eq!(stats.exact_intersection_calls, 2);
     }
 
     #[test]

--- a/crates/geo-polygonize-core/src/options.rs
+++ b/crates/geo-polygonize-core/src/options.rs
@@ -66,12 +66,15 @@ impl ExecutionPolicy {
         Ok(())
     }
 
-    pub(crate) fn has_noding_work_limits(&self) -> bool {
-        self.cancellation_token.is_some()
-            || self.max_candidate_pairs.is_some()
+    pub(crate) fn has_noding_work_budgets(&self) -> bool {
+        self.max_candidate_pairs.is_some()
             || self.max_exact_intersection_calls.is_some()
             || self.max_split_events.is_some()
             || self.max_noding_iterations.is_some()
+    }
+
+    pub(crate) fn has_cancellation(&self) -> bool {
+        self.cancellation_token.is_some()
     }
 
     pub(crate) fn check_noding_work(

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -318,7 +318,8 @@ impl Polygonizer {
         self.graph.clear();
         let grid_size = self.options.precision_model.grid_size();
         let mut segments;
-        let has_noding_work_limits = self.execution_policy.has_noding_work_limits();
+        let has_execution_controls = self.execution_policy.has_noding_work_budgets()
+            || self.execution_policy.has_cancellation();
 
         if self.options.node_input {
             let mut pre_snap_vertex_candidates = 0;
@@ -371,7 +372,7 @@ impl Polygonizer {
                         let noder =
                             HotPixelNoder::new(grid_size)?.with_z_policy(self.options.z.policy);
                         if let Some(diagnostics) = diagnostics.as_deref_mut() {
-                            let (noded, intersections, mut work_stats) = if has_noding_work_limits {
+                            let (noded, intersections, mut work_stats) = if has_execution_controls {
                                 noder.node_with_stats_and_execution_policy(
                                     all_segments,
                                     &self.execution_policy,
@@ -392,7 +393,7 @@ impl Polygonizer {
                             diagnostics.noding_work_stats = work_stats;
                             segments = noded;
                         } else {
-                            segments = if has_noding_work_limits {
+                            segments = if has_execution_controls {
                                 noder.node_with_execution_policy(
                                     all_segments,
                                     &self.execution_policy,
@@ -418,7 +419,7 @@ impl Polygonizer {
                                 None
                             };
                         if let Some(diagnostics) = diagnostics.as_deref_mut() {
-                            let (noded, stats, mut work_stats) = if has_noding_work_limits {
+                            let (noded, stats, mut work_stats) = if has_execution_controls {
                                 noder.node_with_stats_and_execution_policy(
                                     all_segments,
                                     &self.execution_policy,
@@ -437,7 +438,7 @@ impl Polygonizer {
                             diagnostics.noding_work_stats = work_stats;
                             segments = noded;
                         } else {
-                            segments = if has_noding_work_limits {
+                            segments = if has_execution_controls {
                                 noder.node_with_execution_policy(
                                     all_segments,
                                     &self.execution_policy,
@@ -459,7 +460,7 @@ impl Polygonizer {
                     let noder = AdvancedNoder::new().with_z_policy(self.options.z.policy);
                     if let Some(diagnostics) = diagnostics.as_deref_mut() {
                         let noder = SnapNoder::new(0.0).with_z_policy(self.options.z.policy);
-                        let (noded, stats, mut work_stats) = if has_noding_work_limits {
+                        let (noded, stats, mut work_stats) = if has_execution_controls {
                             noder.node_with_stats_and_execution_policy(
                                 all_segments,
                                 &self.execution_policy,
@@ -478,7 +479,7 @@ impl Polygonizer {
                         diagnostics.noding_work_stats = work_stats;
                         segments = noded;
                     } else {
-                        segments = if has_noding_work_limits {
+                        segments = if has_execution_controls {
                             SnapNoder::new(0.0)
                                 .with_z_policy(self.options.z.policy)
                                 .node_with_execution_policy(all_segments, &self.execution_policy)?

--- a/crates/geo-polygonize-core/tests/execution_policy.rs
+++ b/crates/geo-polygonize-core/tests/execution_policy.rs
@@ -70,7 +70,7 @@ fn input_limits_stop_before_polygonization() {
     let segment = Line3D::new(Coord3D::new(0., 0., 0.), Coord3D::new(1., 0., 0.), 0);
     assert_limit(
         polygonize_with_execution_policy(
-            [segment.clone(), segment],
+            [segment, segment],
             &options,
             &ExecutionPolicy {
                 max_input_segments: Some(1),
@@ -334,7 +334,7 @@ fn adversarial_inputs_hit_their_declared_budget() {
             &ExecutionPolicy { max_candidate_pairs: Some(0), ..Default::default() },
         ),
         Err(PolygonizeError::ResourceLimitExceeded { stage, observed, .. })
-            if stage == "candidate_pairs" && observed >= 45
+            if stage == "candidate_pairs" && observed == 1
     ));
 
     let overlaps = (0..8)
@@ -353,7 +353,7 @@ fn adversarial_inputs_hit_their_declared_budget() {
             &ExecutionPolicy { max_exact_intersection_calls: Some(0), ..Default::default() },
         ),
         Err(PolygonizeError::ResourceLimitExceeded { stage, observed, .. })
-            if stage == "exact_intersection_calls" && observed >= 28
+            if stage == "exact_intersection_calls" && observed == 1
     ));
 
     let duplicate = Line3D::new(Coord3D::new(0., 0., 0.), Coord3D::new(1., 0., 0.), 0);


### PR DESCRIPTION
## Stack

Parent:
- #986

This PR:
- Account noding diagnostics and budgets in the physical candidate scan.

Children:
- #988

## Delivered

- Add one live execution work tracker for policy enforcement and diagnostics.
- Remove runtime SIMD/grid measurement passes.
- Separate cancellation presence from numeric noding budgets.
- Preserve the parallel unlimited path.
- Use checked live counters and saturating diagnostic accumulation.
- Prove one candidate scan supplies both diagnostics and limit enforcement.

## Contract impact

- Cancellation no longer causes a duplicate candidate enumeration; limit failures now report the first item beyond the budget.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo test -p geo-polygonize-core` — passed (167 unit tests plus integration suites)
- `cargo test -p geo-polygonize-core --no-default-features` — passed
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings` — passed

## Agent handoff

Remaining:
- Extend inline cancellation/limit coverage through dense grid, global-line, hot-pixel, and split replacement loops.

Next dependency-ready slice:
- `agent/core-inline-execution-limits`.