### PR TITLE
fix(core): enforce noding limits inside candidate scans

### DIFF
--- a/crates/geo-polygonize-core/src/diagnostics.rs
+++ b/crates/geo-polygonize-core/src/diagnostics.rs
@@ -91,6 +91,8 @@ pub(crate) struct ExecutionWorkTracker<'a> {
     stats: Option<&'a mut NodingWorkStats>,
     candidate_pairs: usize,
     exact_intersection_calls: usize,
+    #[cfg(test)]
+    cancel_at_candidate: Option<(crate::CancellationToken, usize)>,
 }
 
 impl<'a> ExecutionWorkTracker<'a> {
@@ -107,7 +109,19 @@ impl<'a> ExecutionWorkTracker<'a> {
             stats,
             candidate_pairs,
             exact_intersection_calls,
+            #[cfg(test)]
+            cancel_at_candidate: None,
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn cancel_at_candidate(
+        mut self,
+        token: crate::CancellationToken,
+        candidate: usize,
+    ) -> Self {
+        self.cancel_at_candidate = Some((token, candidate));
+        self
     }
 
     pub(crate) fn grid(&mut self, cells: usize, entries: usize, globals: usize) {
@@ -145,6 +159,12 @@ impl<'a> ExecutionWorkTracker<'a> {
                 stats.exact_intersection_calls = stats.exact_intersection_calls.saturating_add(1);
             } else {
                 stats.aabb_rejections = stats.aabb_rejections.saturating_add(1);
+            }
+        }
+        #[cfg(test)]
+        if let Some((token, candidate)) = &self.cancel_at_candidate {
+            if self.candidate_pairs == *candidate {
+                token.cancel();
             }
         }
         if let Some(policy) = self.policy {

--- a/crates/geo-polygonize-core/src/noding/grid.rs
+++ b/crates/geo-polygonize-core/src/noding/grid.rs
@@ -778,6 +778,63 @@ mod tests {
     }
 
     #[test]
+    fn dense_cell_stops_at_the_first_pair_over_budget() {
+        let lines = (0..40)
+            .map(|index| make_line(-1.0, index as f64 / 100.0, 1.0, 1.0 - index as f64 / 100.0))
+            .collect::<Vec<_>>();
+        let grid = UniformGrid::new(&lines);
+        let policy = ExecutionPolicy {
+            max_candidate_pairs: Some(256),
+            ..Default::default()
+        };
+        let mut stats = crate::NodingWorkStats::default();
+        let result = grid.find_splits_tracked(
+            &lines,
+            &SnapNoder::new(0.0),
+            &mut ExecutionWorkTracker::new(Some(&policy), Some(&mut stats)),
+        );
+
+        assert!(matches!(
+            result,
+            Err(PolygonizeError::ResourceLimitExceeded {
+                stage,
+                limit: 256,
+                observed: 257,
+            }) if stage == "candidate_pairs"
+        ));
+        assert_eq!(stats.candidate_pairs, 257);
+    }
+
+    #[test]
+    fn dense_cell_cancellation_latency_is_bounded_in_work_items() {
+        let lines = (0..40)
+            .map(|index| make_line(-1.0, index as f64 / 100.0, 1.0, 1.0 - index as f64 / 100.0))
+            .collect::<Vec<_>>();
+        let token = CancellationToken::new();
+        let policy = ExecutionPolicy {
+            cancellation_token: Some(token.clone()),
+            ..Default::default()
+        };
+        let mut stats = crate::NodingWorkStats::default();
+        let result = UniformGrid::new(&lines).find_splits_tracked(
+            &lines,
+            &SnapNoder::new(0.0),
+            &mut ExecutionWorkTracker::new(Some(&policy), Some(&mut stats))
+                .cancel_at_candidate(token, 17),
+        );
+
+        assert!(matches!(
+            result,
+            Err(PolygonizeError::Cancelled { stage }) if stage == "candidate_enumeration"
+        ));
+        assert_eq!(
+            stats.candidate_pairs,
+            crate::options::CANCELLATION_CHECK_INTERVAL
+        );
+        assert!(stats.candidate_pairs < lines.len() * (lines.len() - 1) / 2);
+    }
+
+    #[test]
     fn test_new_with_empty_lines() {
         let lines: Vec<Line3D> = Vec::new();
         let grid = UniformGrid::new(&lines);

--- a/crates/geo-polygonize-core/src/noding/hot_pixel.rs
+++ b/crates/geo-polygonize-core/src/noding/hot_pixel.rs
@@ -104,13 +104,22 @@ impl HotPixelNoder {
                 .collect();
             candidates.sort_unstable();
             for second_index in candidates {
-                work.candidate_pairs += 1;
+                work.candidate_pairs = work.candidate_pairs.checked_add(1).ok_or_else(|| {
+                    PolygonizeError::InternalInvariantViolation {
+                        reason: "candidate-pair counter overflow".to_string(),
+                    }
+                })?;
                 if let Some(execution_policy) = execution_policy {
                     execution_policy.check_cancelled("candidate_enumeration")?;
                     execution_policy
                         .check_noding_work(work.candidate_pairs, work.exact_intersection_calls)?;
                 }
-                work.exact_intersection_calls += 1;
+                work.exact_intersection_calls = work
+                    .exact_intersection_calls
+                    .checked_add(1)
+                    .ok_or_else(|| PolygonizeError::InternalInvariantViolation {
+                        reason: "exact-intersection counter overflow".to_string(),
+                    })?;
                 if let Some(execution_policy) = execution_policy {
                     execution_policy
                         .check_noding_work(work.candidate_pairs, work.exact_intersection_calls)?;
@@ -195,17 +204,24 @@ impl HotPixelNoder {
                 projection(left_grid).cmp(&projection(right_grid))
             });
             points.dedup_by(|left, right| left.x == right.x && left.y == right.y);
-            work.split_events += points.len().saturating_sub(2);
+            work.split_events = work
+                .split_events
+                .checked_add(points.len().saturating_sub(2))
+                .ok_or_else(|| PolygonizeError::InternalInvariantViolation {
+                    reason: "split-event counter overflow".to_string(),
+                })?;
             if let Some(execution_policy) = execution_policy {
                 execution_policy.check_split_events(work.split_events)?;
             }
-            output.extend(points.windows(2).filter_map(|pair| {
-                (pair[0].x != pair[1].x || pair[0].y != pair[1].y).then_some(Line3D::new(
-                    pair[0],
-                    pair[1],
-                    line.line_id,
-                ))
-            }));
+            for (replacement_index, pair) in points.windows(2).enumerate() {
+                if let Some(execution_policy) = execution_policy {
+                    execution_policy
+                        .check_cancelled_every("split_application", replacement_index)?;
+                }
+                if pair[0].x != pair[1].x || pair[0].y != pair[1].y {
+                    output.push(Line3D::new(pair[0], pair[1], line.line_id));
+                }
+            }
         }
 
         snapper.normalize_and_dedup(&mut output);

--- a/crates/geo-polygonize-core/src/noding/snap.rs
+++ b/crates/geo-polygonize-core/src/noding/snap.rs
@@ -311,7 +311,11 @@ impl SnapNoder {
                 points.dedup_by(|a, b| a.x == b.x && a.y == b.y);
 
                 // Create replacement segments for the split line.
-                for w in points.windows(2) {
+                for (replacement_index, w) in points.windows(2).enumerate() {
+                    if let Some(execution_policy) = execution_policy {
+                        execution_policy
+                            .check_cancelled_every("split_application", replacement_index)?;
+                    }
                     let p0 = w[0];
                     let p1 = w[1];
                     // Check 2D equality
@@ -987,6 +991,34 @@ mod tests {
             ),
             Err(PolygonizeError::Cancelled { stage }) if stage == "candidate_enumeration"
         ));
+    }
+
+    #[test]
+    fn simd_midflight_cancellation_latency_is_bounded_in_work_items() {
+        let token = CancellationToken::new();
+        let policy = ExecutionPolicy {
+            cancellation_token: Some(token.clone()),
+            ..Default::default()
+        };
+        let lines = (0..300)
+            .map(|y| make_line(0.0, y as f64, 1.0, y as f64))
+            .collect::<Vec<_>>();
+        let mut stats = NodingWorkStats::default();
+        let result = SnapNoder::new(1.0).find_splits_simd_tracked(
+            &lines,
+            &mut ExecutionWorkTracker::new(Some(&policy), Some(&mut stats))
+                .cancel_at_candidate(token, 17),
+        );
+
+        assert!(matches!(
+            result,
+            Err(PolygonizeError::Cancelled { stage }) if stage == "candidate_enumeration"
+        ));
+        assert_eq!(
+            stats.candidate_pairs,
+            crate::options::CANCELLATION_CHECK_INTERVAL
+        );
+        assert!(stats.candidate_pairs < lines.len() * (lines.len() - 1) / 2);
     }
 
     #[test]


### PR DESCRIPTION
## Stack

Parent:
- #987

This PR:
- Enforce noding limits and cancellation inline in dense candidate and split scans.

Children:
- #989

## Delivered

- Stop dense grid scans at deterministic `limit + 1`.
- Check counter arithmetic in certified hot-pixel candidate scans.
- Poll cancellation during floating and hot-pixel replacement-segment emission.
- Add deterministic mid-flight cancellation injection for SIMD and dense single-cell scans.
- Prove both scans stop at the documented 256-work-item polling boundary.

## Contract impact

- Resource failures expose deterministic first-over-limit observations; no partial output is returned.
- Dense cancellation latency is measured in work items rather than wall-clock time.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo test -p geo-polygonize-core dense_cell_cancellation_latency_is_bounded_in_work_items` — passed
- `cargo test -p geo-polygonize-core simd_midflight_cancellation_latency_is_bounded_in_work_items` — passed
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings` — passed

## Agent handoff

Remaining:
- none in this slice

Next dependency-ready slice:
- #989 `agent/core-preemptive-growth-limits`
