### PR TITLE
fix(core): enforce execution limits before allocation growth

### DIFF
--- a/crates/geo-polygonize-core/src/graph/planar_graph.rs
+++ b/crates/geo-polygonize-core/src/graph/planar_graph.rs
@@ -290,6 +290,14 @@ impl PlanarGraph {
 
         // 3. Build Nodes
         let start_node_idx = self.nodes_x.len();
+        if let Some(execution_policy) = execution_policy {
+            let observed = start_node_idx.checked_add(entries.len()).ok_or_else(|| {
+                crate::PolygonizeError::InternalInvariantViolation {
+                    reason: "graph node count overflow".to_string(),
+                }
+            })?;
+            execution_policy.check("graph_nodes", execution_policy.max_graph_nodes, observed)?;
+        }
         self.nodes_x.reserve(entries.len());
         self.nodes_y.reserve(entries.len());
         self.nodes_z.reserve(entries.len());
@@ -387,6 +395,17 @@ impl PlanarGraph {
             degrees[*v] += 1;
         }
 
+        if let Some(execution_policy) = execution_policy {
+            let observed = self
+                .edges
+                .len()
+                .checked_add(dissolved.len())
+                .ok_or_else(|| crate::PolygonizeError::InternalInvariantViolation {
+                    reason: "graph edge count overflow".to_string(),
+                })?;
+            execution_policy.check("graph_edges", execution_policy.max_graph_edges, observed)?;
+        }
+
         // Reserve exact capacity
         par_zip_for_each(
             &mut self.nodes_outgoing,
@@ -398,7 +417,12 @@ impl PlanarGraph {
 
         // 5. Build Edges
         self.edges.reserve(dissolved.len());
-        self.directed_edges.reserve(dissolved.len() * 2);
+        let directed_edge_count = dissolved.len().checked_mul(2).ok_or_else(|| {
+            crate::PolygonizeError::InternalInvariantViolation {
+                reason: "directed edge count overflow".to_string(),
+            }
+        })?;
+        self.directed_edges.reserve(directed_edge_count);
 
         let edges_start_len = self.edges.len();
         let directed_edges_start_len = self.directed_edges.len();

--- a/crates/geo-polygonize-core/src/graph/tests.rs
+++ b/crates/geo-polygonize-core/src/graph/tests.rs
@@ -2,7 +2,7 @@
 #[allow(clippy::module_inception)]
 mod tests {
     use crate::graph::planar_graph::PlanarGraph;
-    use crate::types::Line3D;
+    use crate::types::{Coord3D, Line3D};
     use crate::{CancellationToken, ExecutionPolicy, PolygonizeError};
     use geo_types::{Coord, LineString};
 
@@ -80,6 +80,56 @@ mod tests {
             graph.sort_edges_with_execution_policy(&policy),
             Err(PolygonizeError::Cancelled { stage }) if stage == "graph_construction"
         ));
+    }
+
+    #[test]
+    fn graph_limits_are_checked_before_graph_capacity_growth() {
+        let lines = vec![Line3D::new(
+            Coord3D::new(0.0, 0.0, 0.0),
+            Coord3D::new(1.0, 0.0, 0.0),
+            1,
+        )];
+
+        let mut graph = PlanarGraph::new();
+        let error = graph
+            .bulk_load_with_execution_policy(
+                lines.clone(),
+                &ExecutionPolicy {
+                    max_graph_nodes: Some(1),
+                    ..Default::default()
+                },
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            PolygonizeError::ResourceLimitExceeded {
+                stage,
+                limit: 1,
+                observed: 2,
+            } if stage == "graph_nodes"
+        ));
+        assert_eq!(graph.nodes_x.capacity(), 0);
+
+        let mut graph = PlanarGraph::new();
+        let error = graph
+            .bulk_load_with_execution_policy(
+                lines,
+                &ExecutionPolicy {
+                    max_graph_edges: Some(0),
+                    ..Default::default()
+                },
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            PolygonizeError::ResourceLimitExceeded {
+                stage,
+                limit: 0,
+                observed: 1,
+            } if stage == "graph_edges"
+        ));
+        assert_eq!(graph.edges.capacity(), 0);
+        assert_eq!(graph.directed_edges.capacity(), 0);
     }
 
     #[test]

--- a/crates/geo-polygonize-core/src/noding/hot_pixel.rs
+++ b/crates/geo-polygonize-core/src/noding/hot_pixel.rs
@@ -219,6 +219,17 @@ impl HotPixelNoder {
                         .check_cancelled_every("split_application", replacement_index)?;
                 }
                 if pair[0].x != pair[1].x || pair[0].y != pair[1].y {
+                    if let Some(execution_policy) = execution_policy {
+                        execution_policy.check(
+                            "noded_segments",
+                            execution_policy.max_noded_segments,
+                            output.len().checked_add(1).ok_or_else(|| {
+                                PolygonizeError::InternalInvariantViolation {
+                                    reason: "noded segment count overflow".to_string(),
+                                }
+                            })?,
+                        )?;
+                    }
                     output.push(Line3D::new(pair[0], pair[1], line.line_id));
                 }
             }

--- a/crates/geo-polygonize-core/src/noding/snap.rs
+++ b/crates/geo-polygonize-core/src/noding/snap.rs
@@ -1,4 +1,5 @@
 use crate::diagnostics::{ExecutionWorkTracker, NodingIterationStats, NodingWorkStats};
+use crate::error::PolygonizeError;
 use crate::index::{IndexedEnvelope, RStarBackend};
 use crate::noding::grid::UniformGrid;
 use crate::options::{ExecutionPolicy, SnapStrategy, ZPolicy};
@@ -259,7 +260,16 @@ impl SnapNoder {
 
             // Apply splits. Copy untouched line ranges in bulk and only rebuild lines with split events.
             new_lines.clear();
-            new_lines.reserve(lines.len() + events.len());
+            let estimated_len = lines.len().checked_add(events.len()).ok_or_else(|| {
+                PolygonizeError::InternalInvariantViolation {
+                    reason: "noded segment capacity overflow".to_string(),
+                }
+            })?;
+            new_lines.reserve(
+                execution_policy
+                    .and_then(|policy| policy.max_noded_segments)
+                    .map_or(estimated_len, |limit| estimated_len.min(limit)),
+            );
 
             let mut event_idx = 0;
             let mut src_idx = 0;
@@ -271,6 +281,18 @@ impl SnapNoder {
 
                 // Copy untouched lines directly.
                 if src_idx < line_idx {
+                    if let Some(execution_policy) = execution_policy {
+                        execution_policy.check(
+                            "noded_segments",
+                            execution_policy.max_noded_segments,
+                            new_lines
+                                .len()
+                                .checked_add(line_idx - src_idx)
+                                .ok_or_else(|| PolygonizeError::InternalInvariantViolation {
+                                    reason: "noded segment count overflow".to_string(),
+                                })?,
+                        )?;
+                    }
                     new_lines.extend_from_slice(&lines[src_idx..line_idx]);
                 }
 
@@ -320,6 +342,17 @@ impl SnapNoder {
                     let p1 = w[1];
                     // Check 2D equality
                     if p0.x != p1.x || p0.y != p1.y {
+                        if let Some(execution_policy) = execution_policy {
+                            execution_policy.check(
+                                "noded_segments",
+                                execution_policy.max_noded_segments,
+                                new_lines.len().checked_add(1).ok_or_else(|| {
+                                    PolygonizeError::InternalInvariantViolation {
+                                        reason: "noded segment count overflow".to_string(),
+                                    }
+                                })?,
+                            )?;
+                        }
                         new_lines.push(Line3D::new(p0, p1, line.line_id));
                     }
                 }
@@ -329,6 +362,18 @@ impl SnapNoder {
 
             // Copy any untouched trailing lines.
             if src_idx < lines.len() {
+                if let Some(execution_policy) = execution_policy {
+                    execution_policy.check(
+                        "noded_segments",
+                        execution_policy.max_noded_segments,
+                        new_lines
+                            .len()
+                            .checked_add(lines.len() - src_idx)
+                            .ok_or_else(|| PolygonizeError::InternalInvariantViolation {
+                                reason: "noded segment count overflow".to_string(),
+                            })?,
+                    )?;
+                }
                 new_lines.extend_from_slice(&lines[src_idx..]);
             }
 

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -99,20 +99,36 @@ pub fn polygonize_with_execution_policy(
     options: &PolygonizerOptions,
     execution_policy: &ExecutionPolicy,
 ) -> Result<PolygonizerResult> {
-    let lines: Vec<_> = lines.into_iter().collect();
-    execution_policy.check(
-        "input_segments",
-        execution_policy.max_input_segments,
-        lines.len(),
-    )?;
-    execution_policy.check(
-        "input_coordinates",
-        execution_policy.max_input_coordinates,
-        lines.len().saturating_mul(2),
-    )?;
+    execution_policy.check_cancelled("ingest")?;
+    let mut collected = Vec::new();
+    for line in lines {
+        let observed = collected.len().checked_add(1).ok_or_else(|| {
+            PolygonizeError::InternalInvariantViolation {
+                reason: "input-segment counter overflow".to_string(),
+            }
+        })?;
+        execution_policy.check(
+            "input_segments",
+            execution_policy.max_input_segments,
+            observed,
+        )?;
+        let coordinates =
+            observed
+                .checked_mul(2)
+                .ok_or_else(|| PolygonizeError::InternalInvariantViolation {
+                    reason: "input-coordinate counter overflow".to_string(),
+                })?;
+        execution_policy.check(
+            "input_coordinates",
+            execution_policy.max_input_coordinates,
+            coordinates,
+        )?;
+        execution_policy.check_cancelled_every("ingest", observed)?;
+        collected.push(line);
+    }
     Polygonizer::with_options(options.clone())
         .with_execution_policy(execution_policy.clone())
-        .polygonize_owned(lines)
+        .polygonize_owned(collected)
 }
 
 /// Polygonize borrowed or owned GeoRust line strings without first building [`Line3D`] values.
@@ -146,7 +162,7 @@ where
 {
     execution_policy.check_cancelled("ingest")?;
     let mut segments = Vec::new();
-    let mut coordinate_count = 0;
+    let mut coordinate_count: usize = 0;
     for (line_id, line_string) in line_strings.into_iter().enumerate() {
         execution_policy.check_cancelled_every("ingest", line_id)?;
         execution_policy.check(
@@ -161,7 +177,11 @@ where
         let Some(first) = coordinates.next() else {
             continue;
         };
-        coordinate_count += 1;
+        coordinate_count = coordinate_count.checked_add(1).ok_or_else(|| {
+            PolygonizeError::InternalInvariantViolation {
+                reason: "input-coordinate counter overflow".to_string(),
+            }
+        })?;
         execution_policy.check_cancelled_every("ingest", coordinate_count)?;
         execution_policy.check(
             "input_coordinates",
@@ -170,7 +190,11 @@ where
         )?;
         let mut previous = Coord3D::new(first.x(), first.y(), 0.0);
         for coordinate in coordinates {
-            coordinate_count += 1;
+            coordinate_count = coordinate_count.checked_add(1).ok_or_else(|| {
+                PolygonizeError::InternalInvariantViolation {
+                    reason: "input-coordinate counter overflow".to_string(),
+                }
+            })?;
             execution_policy.check_cancelled_every("ingest", coordinate_count)?;
             execution_policy.check(
                 "input_coordinates",
@@ -180,7 +204,11 @@ where
             execution_policy.check(
                 "input_segments",
                 execution_policy.max_input_segments,
-                segments.len() + 1,
+                segments.len().checked_add(1).ok_or_else(|| {
+                    PolygonizeError::InternalInvariantViolation {
+                        reason: "input-segment counter overflow".to_string(),
+                    }
+                })?,
             )?;
             let current = Coord3D::new(coordinate.x(), coordinate.y(), 0.0);
             segments.push(Line3D::new(previous, current, line_id));
@@ -229,7 +257,12 @@ pub fn polygonize_with_workspace_and_execution_policy(
     execution_policy.check(
         "input_coordinates",
         execution_policy.max_input_coordinates,
-        lines.len().saturating_mul(2),
+        lines
+            .len()
+            .checked_mul(2)
+            .ok_or_else(|| PolygonizeError::InternalInvariantViolation {
+                reason: "input-coordinate counter overflow".to_string(),
+            })?,
     )?;
     let mut runner = Polygonizer {
         graph: std::mem::take(&mut workspace.graph),
@@ -531,7 +564,10 @@ impl Polygonizer {
         }
 
         // Use bulk load
-        if self.execution_policy.cancellation_token.is_some() {
+        if self.execution_policy.cancellation_token.is_some()
+            || self.execution_policy.max_graph_nodes.is_some()
+            || self.execution_policy.max_graph_edges.is_some()
+        {
             self.graph
                 .bulk_load_with_execution_policy(segments, &self.execution_policy)?;
         } else {
@@ -696,18 +732,32 @@ impl Polygonizer {
             result.len(),
         )?;
         self.execution_policy.check_cancelled("output_flattening")?;
-        let mut output_coordinates = 0;
+        let mut output_coordinates = 0usize;
         for (index, polygon) in result.iter().enumerate() {
             self.execution_policy
                 .check_cancelled_every("output_flattening", index)?;
-            output_coordinates +=
-                polygon.exterior.len() + polygon.interiors.iter().map(Vec::len).sum::<usize>();
+            output_coordinates = output_coordinates
+                .checked_add(polygon.exterior.len())
+                .and_then(|count| {
+                    polygon
+                        .interiors
+                        .iter()
+                        .try_fold(count, |count, ring| count.checked_add(ring.len()))
+                })
+                .ok_or_else(|| PolygonizeError::InternalInvariantViolation {
+                    reason: "output coordinate count overflow".to_string(),
+                })?;
         }
         for lines in [&dangles, &cut_edges, &invalid_rings] {
             for (index, line) in lines.iter().enumerate() {
                 self.execution_policy
                     .check_cancelled_every("output_flattening", index)?;
-                output_coordinates += line.len();
+                output_coordinates =
+                    output_coordinates.checked_add(line.len()).ok_or_else(|| {
+                        PolygonizeError::InternalInvariantViolation {
+                            reason: "output coordinate count overflow".to_string(),
+                        }
+                    })?;
             }
         }
         self.execution_policy.check(
@@ -1164,7 +1214,11 @@ pub(crate) fn construct_final_polygons(
     execution_policy: &ExecutionPolicy,
 ) -> Result<Vec<Polygon3D>> {
     execution_policy.check_cancelled("canonicalization")?;
-    let mut result = Vec::with_capacity(shells.len());
+    let capacity = execution_policy
+        .max_output_polygons
+        .map_or(shells.len(), |limit| shells.len().min(limit));
+    let mut result = Vec::with_capacity(capacity);
+    let mut output_coordinates = 0usize;
     for (shell_index, ((shell, mut holes), mut holes_ids)) in shells
         .into_iter()
         .zip(shell_holes)
@@ -1271,6 +1325,30 @@ pub(crate) fn construct_final_polygons(
                 .minimum_face_area
                 .is_none_or(|minimum| area >= minimum)
         {
+            execution_policy.check(
+                "output_polygons",
+                execution_policy.max_output_polygons,
+                result.len().checked_add(1).ok_or_else(|| {
+                    PolygonizeError::InternalInvariantViolation {
+                        reason: "output polygon count overflow".to_string(),
+                    }
+                })?,
+            )?;
+            output_coordinates = output_coordinates
+                .checked_add(p.exterior.len())
+                .and_then(|count| {
+                    p.interiors
+                        .iter()
+                        .try_fold(count, |count, ring| count.checked_add(ring.len()))
+                })
+                .ok_or_else(|| PolygonizeError::InternalInvariantViolation {
+                    reason: "output coordinate count overflow".to_string(),
+                })?;
+            execution_policy.check(
+                "output_coordinates",
+                execution_policy.max_output_coordinates,
+                output_coordinates,
+            )?;
             result.push(p);
         }
     }

--- a/crates/geo-polygonize-core/tests/execution_policy.rs
+++ b/crates/geo-polygonize-core/tests/execution_policy.rs
@@ -85,6 +85,33 @@ fn input_limits_stop_before_polygonization() {
 }
 
 #[test]
+fn owned_iterator_stops_after_limit_plus_one_items() {
+    let segment = Line3D::new(Coord3D::new(0., 0., 0.), Coord3D::new(1., 0., 0.), 0);
+    let mut yielded = 0;
+    let guarded = std::iter::from_fn(|| {
+        assert!(yielded < 2, "iterator consumed beyond limit + 1");
+        yielded += 1;
+        Some(segment)
+    });
+
+    assert_limit(
+        polygonize_with_execution_policy(
+            guarded,
+            &PolygonizerOptions::default(),
+            &ExecutionPolicy {
+                max_input_segments: Some(1),
+                ..Default::default()
+            },
+        )
+        .unwrap_err(),
+        "input_segments",
+        1,
+        2,
+    );
+    assert_eq!(yielded, 2);
+}
+
+#[test]
 fn noded_segment_limit_stops_after_noding() {
     let options = PolygonizerOptions {
         node_input: true,
@@ -369,7 +396,7 @@ fn adversarial_inputs_hit_their_declared_budget() {
         .unwrap_err(),
         "input_segments",
         32,
-        128,
+        33,
     );
 
     let mut nested = Vec::new();
@@ -404,6 +431,6 @@ fn adversarial_inputs_hit_their_declared_budget() {
             &ExecutionPolicy { max_output_polygons: Some(0), ..Default::default() },
         ),
         Err(PolygonizeError::ResourceLimitExceeded { stage, observed, .. })
-            if stage == "output_polygons" && observed >= 8
+            if stage == "output_polygons" && observed == 1
     ));
 }


### PR DESCRIPTION
## Stack

Parent:
- #988

This PR:
- Enforce execution limits before owned-input, noded-output, graph, and polygon-result growth.

Children:
- #990

## Delivered

- Collect owned segment iterators incrementally and stop at `limit + 1`.
- Check coordinate and capacity arithmetic.
- Enforce `max_noded_segments` before replacement and hot-pixel output pushes.
- Check graph node and dissolved-edge counts before graph capacity growth.
- Enforce polygon and output-coordinate limits during final materialization.
- Add iterator-consumption and graph-capacity regressions.

## Contract impact

- Configured growth limits now prevent the corresponding result or graph allocation rather than rejecting only after construction.
- Output polygon failures report the deterministic first item beyond the limit.

## Validation

- `cargo test -p geo-polygonize-core --test execution_policy` — 9 passed
- `cargo test -p geo-polygonize-core graph::tests` — 15 passed
- `cargo test -p geo-polygonize-core` — passed
- `cargo test -p geo-polygonize-core --no-default-features` — passed
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings` — passed
- `git diff --check` — passed

## Agent handoff

Remaining:
- none in this slice

Next dependency-ready slice:
- #990 `agent/core-bounded-cancellation`
