### PR TITLE
fix(core): bound cancellation across preprocessing and grid construction

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -243,26 +243,25 @@ cancelled workspace run is reusable after resetting its token. Python releases
 the GIL for owned Rust work and polls signals every 10 ms before cancelling the
 worker token. Wasm has cancellable GeoJSON and report calls in disposable
 browser workers; aborting terminates the worker rather than claiming that a
-synchronous main-thread Wasm export can yield. SIMD and hot-pixel split scans
-poll every 256 work items; grid polls between cells. Later core phases still
-need equivalent bounded checkpoints. Graph dangle pruning also polls node
+synchronous main-thread Wasm export can yield. SIMD, grid, and hot-pixel split
+scans poll every 256 work items. Uniform-grid bounds, counting, and population
+passes also poll every 256 input segments. Graph dangle pruning also polls node
 discovery and its mutable work stack every 256 items; token-aware containment
 polls every 256 hole assignments while token-free runs retain the parallel path.
 Cut-edge removal and minimal-ring extraction also poll every 256 graph-traversal
 work items. Ring classification and invalid-ring filtering poll every 256
 ring, coordinate, and containment-comparison work items.
 Final polygon assembly and deterministic-ordering preprocessing also poll every
-256 items; their standard-library sort calls remain phase-boundary-only.
+256 items. Standard-library sorts cannot be interrupted, so cancellation-enabled
+runs reject every audited sort above 1,000,000 items before sorting begins.
 Token-aware graph bulk loading and node-star preparation also poll every 256
-nodes or edges; their internal sorting remains phase-boundary-only.
-Input validation and Z-conflict reconciliation also poll every 256 lines or
-endpoints; Z reconciliation sorting remains phase-boundary-only.
+nodes or edges. Input validation and Z-conflict reconciliation also poll every
+256 lines or endpoints.
 Line-string conversion and fixed-grid snapping also poll every 256 input
 coordinates or segments.
 GeoCompat coordinate restoration also polls every 256 snapped coordinates or
 noded segments.
-Token-aware noding validation also polls every 256 segments or candidate pairs;
-candidate sorting remains phase-boundary-only.
+Token-aware noding validation also polls every 256 segments or candidate pairs.
 
 - [x] Add cancellation checkpoints at ingest, candidate enumeration, split
   application, graph construction, ring extraction, containment, canonicalization,

--- a/crates/geo-polygonize-core/src/graph/planar_graph.rs
+++ b/crates/geo-polygonize-core/src/graph/planar_graph.rs
@@ -280,6 +280,9 @@ impl PlanarGraph {
         let mut entries: Vec<NodeEntry> = par_flat_map(&lines, to_entries);
 
         // 2. Sort using precomputed Z-order
+        if let Some(execution_policy) = execution_policy {
+            execution_policy.check_uncancellable_sort("graph_node_sort", entries.len())?;
+        }
         par_sort_unstable(&mut entries);
 
         // Dedup using exact equality on X,Y. Z is ignored for dedup key but carried.
@@ -364,6 +367,9 @@ impl PlanarGraph {
             }
         }
 
+        if let Some(execution_policy) = execution_policy {
+            execution_policy.check_uncancellable_sort("graph_edge_sort", valid_edges.len())?;
+        }
         valid_edges.sort_unstable_by(|(u1, v1, l1), (u2, v2, l2)| {
             let key1 = ((*u1).min(*v1), (*u1).max(*v1));
             let key2 = ((*u2).min(*v2), (*u2).max(*v2));
@@ -665,6 +671,7 @@ impl PlanarGraph {
         for (src_idx, adj) in self.nodes_outgoing.iter_mut().enumerate() {
             execution_policy.check_cancelled_every("graph_construction", src_idx)?;
             adj.retain(|&idx| !self.edges[self.directed_edges[idx].edge_idx].deleted);
+            execution_policy.check_uncancellable_sort("graph_node_star_sort", adj.len())?;
 
             let center = Coord {
                 x: nodes_x[src_idx],

--- a/crates/geo-polygonize-core/src/noding/grid.rs
+++ b/crates/geo-polygonize-core/src/noding/grid.rs
@@ -1,5 +1,6 @@
 use crate::diagnostics::ExecutionWorkTracker;
 use crate::noding::snap::SnapNoder;
+use crate::options::ExecutionPolicy;
 use crate::types::{Coord3D, Line3D};
 use crate::utils::soa::SoALines;
 use geo::algorithm::line_intersection::{line_intersection, LineIntersection};
@@ -143,6 +144,61 @@ fn segment_cells(
     cells
 }
 
+fn serial_bounds(
+    lines: &[Line3D],
+    execution_policy: Option<&ExecutionPolicy>,
+) -> crate::Result<(f64, f64, f64, f64)> {
+    let mut bounds = (f64::MAX, f64::MAX, f64::MIN, f64::MIN);
+    for (index, line) in lines.iter().enumerate() {
+        if let Some(execution_policy) = execution_policy {
+            execution_policy.check_cancelled_every("grid_construction", index)?;
+        }
+        bounds.0 = bounds.0.min(line.start.x.min(line.end.x));
+        bounds.1 = bounds.1.min(line.start.y.min(line.end.y));
+        bounds.2 = bounds.2.max(line.start.x.max(line.end.x));
+        bounds.3 = bounds.3.max(line.start.y.max(line.end.y));
+    }
+    Ok(bounds)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn count_cells(
+    lines: &[Line3D],
+    min_x: f64,
+    min_y: f64,
+    cell_size: f64,
+    cols: usize,
+    rows: usize,
+    execution_policy: Option<&ExecutionPolicy>,
+    max_cells_per_line: usize,
+) -> crate::Result<(Vec<usize>, Vec<usize>)> {
+    let cell_count = cols.checked_mul(rows).ok_or_else(|| {
+        crate::PolygonizeError::InternalInvariantViolation {
+            reason: "uniform-grid cell count overflow".to_string(),
+        }
+    })?;
+    let mut counts = vec![0usize; cell_count];
+    let mut global_lines = Vec::new();
+    for (index, line) in lines.iter().enumerate() {
+        if let Some(execution_policy) = execution_policy {
+            execution_policy.check_cancelled_every("grid_construction", index)?;
+        }
+        let cells = segment_cells(line, min_x, min_y, cell_size, cols, rows);
+        if cells.len() > max_cells_per_line {
+            global_lines.push(index);
+            continue;
+        }
+        for cell in cells {
+            counts[cell] = counts[cell].checked_add(1).ok_or_else(|| {
+                crate::PolygonizeError::InternalInvariantViolation {
+                    reason: "uniform-grid cell population overflow".to_string(),
+                }
+            })?;
+        }
+    }
+    Ok((counts, global_lines))
+}
+
 pub struct UniformGrid {
     /// Compressed Sparse Row (CSR) storage
     /// cell_offsets[i]..cell_offsets[i+1] gives the range in cell_items for cell i
@@ -159,45 +215,53 @@ pub struct UniformGrid {
 
 impl UniformGrid {
     pub fn new(lines: &[Line3D]) -> Self {
+        Self::new_impl(lines, None).expect("unlimited grid construction cannot fail")
+    }
+
+    pub(crate) fn new_with_execution_policy(
+        lines: &[Line3D],
+        execution_policy: &ExecutionPolicy,
+    ) -> crate::Result<Self> {
+        Self::new_impl(lines, Some(execution_policy))
+    }
+
+    fn new_impl(
+        lines: &[Line3D],
+        execution_policy: Option<&ExecutionPolicy>,
+    ) -> crate::Result<Self> {
+        if let Some(execution_policy) = execution_policy {
+            execution_policy.check_cancelled("grid_construction")?;
+        }
         if lines.is_empty() {
-            return Self::empty();
+            return Ok(Self::empty());
         }
 
         // 1. Calculate Bounds & Heuristics
         #[cfg(feature = "parallel")]
-        let (min_x, min_y, max_x, max_y) = lines
-            .par_iter()
-            .fold(
-                || (f64::MAX, f64::MAX, f64::MIN, f64::MIN),
-                |acc, line| {
-                    (
-                        acc.0.min(line.start.x.min(line.end.x)),
-                        acc.1.min(line.start.y.min(line.end.y)),
-                        acc.2.max(line.start.x.max(line.end.x)),
-                        acc.3.max(line.start.y.max(line.end.y)),
-                    )
-                },
-            )
-            .reduce(
-                || (f64::MAX, f64::MAX, f64::MIN, f64::MIN),
-                |a, b| (a.0.min(b.0), a.1.min(b.1), a.2.max(b.2), a.3.max(b.3)),
-            );
+        let (min_x, min_y, max_x, max_y) = if execution_policy.is_some() {
+            serial_bounds(lines, execution_policy)?
+        } else {
+            lines
+                .par_iter()
+                .fold(
+                    || (f64::MAX, f64::MAX, f64::MIN, f64::MIN),
+                    |acc, line| {
+                        (
+                            acc.0.min(line.start.x.min(line.end.x)),
+                            acc.1.min(line.start.y.min(line.end.y)),
+                            acc.2.max(line.start.x.max(line.end.x)),
+                            acc.3.max(line.start.y.max(line.end.y)),
+                        )
+                    },
+                )
+                .reduce(
+                    || (f64::MAX, f64::MAX, f64::MIN, f64::MIN),
+                    |a, b| (a.0.min(b.0), a.1.min(b.1), a.2.max(b.2), a.3.max(b.3)),
+                )
+        };
 
         #[cfg(not(feature = "parallel"))]
-        let (min_x, min_y, max_x, max_y) = {
-            let mut min_x = f64::MAX;
-            let mut min_y = f64::MAX;
-            let mut max_x = f64::MIN;
-            let mut max_y = f64::MIN;
-
-            for line in lines {
-                min_x = min_x.min(line.start.x.min(line.end.x));
-                min_y = min_y.min(line.start.y.min(line.end.y));
-                max_x = max_x.max(line.start.x.max(line.end.x));
-                max_y = max_y.max(line.start.y.max(line.end.y));
-            }
-            (min_x, min_y, max_x, max_y)
-        };
+        let (min_x, min_y, max_x, max_y) = serial_bounds(lines, execution_policy)?;
 
         let width = max_x - min_x;
         let height = max_y - min_y;
@@ -234,16 +298,32 @@ impl UniformGrid {
             // Add small epsilon to ensure max boundary falls into a valid cell
             cols = ((width + 1e-9) / cell_size).ceil() as usize;
             rows = ((height + 1e-9) / cell_size).ceil() as usize;
+            let cell_count = cols.checked_mul(rows).ok_or_else(|| {
+                crate::PolygonizeError::InternalInvariantViolation {
+                    reason: "uniform-grid cell count overflow".to_string(),
+                }
+            })?;
 
             // Pass 1: Count entries per cell & Identify Global Lines
             #[cfg(feature = "parallel")]
-            let (pass_counts, pass_globals) = {
+            let (pass_counts, pass_globals) = if execution_policy.is_some() {
+                count_cells(
+                    lines,
+                    min_x,
+                    min_y,
+                    cell_size,
+                    cols,
+                    rows,
+                    execution_policy,
+                    MAX_CELLS_PER_LINE,
+                )?
+            } else {
                 let chunk_size = (lines.len() / rayon::current_num_threads()).max(1);
                 let results: Vec<_> = lines
                     .par_chunks(chunk_size)
                     .enumerate()
                     .map(|(chunk_idx, chunk)| {
-                        let mut local_counts = vec![0usize; cols * rows];
+                        let mut local_counts = vec![0usize; cell_count];
                         let mut local_global = Vec::new();
                         let start_i = chunk_idx * chunk_size;
 
@@ -255,18 +335,18 @@ impl UniformGrid {
                                 continue;
                             }
                             for cell in cells {
-                                local_counts[cell] += 1;
+                                local_counts[cell] = local_counts[cell].saturating_add(1);
                             }
                         }
                         (local_counts, local_global)
                     })
                     .collect();
 
-                let mut final_counts = vec![0usize; cols * rows];
+                let mut final_counts = vec![0usize; cell_count];
                 let mut final_globals = Vec::new();
                 for (local_counts, local_global) in results {
                     for i in 0..final_counts.len() {
-                        final_counts[i] += local_counts[i];
+                        final_counts[i] = final_counts[i].saturating_add(local_counts[i]);
                     }
                     final_globals.extend(local_global);
                 }
@@ -274,22 +354,16 @@ impl UniformGrid {
             };
 
             #[cfg(not(feature = "parallel"))]
-            let (pass_counts, pass_globals) = {
-                let mut local_counts = vec![0usize; cols * rows];
-                let mut local_global = Vec::new();
-
-                for (i, line) in lines.iter().enumerate() {
-                    let cells = segment_cells(line, min_x, min_y, cell_size, cols, rows);
-                    if cells.len() > MAX_CELLS_PER_LINE {
-                        local_global.push(i);
-                        continue;
-                    }
-                    for cell in cells {
-                        local_counts[cell] += 1;
-                    }
-                }
-                (local_counts, local_global)
-            };
+            let (pass_counts, pass_globals) = count_cells(
+                lines,
+                min_x,
+                min_y,
+                cell_size,
+                cols,
+                rows,
+                execution_policy,
+                MAX_CELLS_PER_LINE,
+            )?;
 
             counts = pass_counts;
             global_lines = pass_globals;
@@ -300,7 +374,7 @@ impl UniformGrid {
                 // Skew detected: too many lines in a single cell.
                 // Refine grid by halving cell size, unless we have too many cells.
                 // We limit total cells to avoid memory explosion.
-                if (cols * 2) * (rows * 2) < 1_000_000 {
+                if cell_count.saturating_mul(4) < 1_000_000 {
                     cell_size /= 2.0;
                     continue; // Retry with finer grid
                 }
@@ -311,11 +385,24 @@ impl UniformGrid {
         }
 
         // Prefix Sum to create offsets
-        let mut cell_offsets = Vec::with_capacity(cols * rows + 1);
-        let mut sum = 0;
+        let cell_count = cols.checked_mul(rows).ok_or_else(|| {
+            crate::PolygonizeError::InternalInvariantViolation {
+                reason: "uniform-grid cell count overflow".to_string(),
+            }
+        })?;
+        let mut cell_offsets = Vec::with_capacity(cell_count.checked_add(1).ok_or_else(|| {
+            crate::PolygonizeError::InternalInvariantViolation {
+                reason: "uniform-grid offset count overflow".to_string(),
+            }
+        })?);
+        let mut sum = 0usize;
         cell_offsets.push(0);
         for count in counts {
-            sum += count;
+            sum = sum.checked_add(count).ok_or_else(|| {
+                crate::PolygonizeError::InternalInvariantViolation {
+                    reason: "uniform-grid item count overflow".to_string(),
+                }
+            })?;
             cell_offsets.push(sum);
         }
 
@@ -323,12 +410,15 @@ impl UniformGrid {
         let mut cell_items = vec![0u32; sum];
         // We need a running tracker of where to insert in each cell.
         // Copy the start offsets to use as current write pointers.
-        let mut current_offsets = cell_offsets[0..cols * rows].to_vec();
+        let mut current_offsets = cell_offsets[0..cell_count].to_vec();
 
         // Use peekable iterator to skip global lines efficiently
         let mut global_iter = global_lines.iter().peekable();
 
         for (i, line) in lines.iter().enumerate() {
+            if let Some(execution_policy) = execution_policy {
+                execution_policy.check_cancelled_every("grid_construction", i)?;
+            }
             // Check if this line is global
             if let Some(&&global_idx) = global_iter.peek() {
                 if i == global_idx {
@@ -339,12 +429,20 @@ impl UniformGrid {
 
             for cell in segment_cells(line, min_x, min_y, cell_size, cols, rows) {
                 let write_pos = current_offsets[cell];
-                cell_items[write_pos] = i as u32;
-                current_offsets[cell] += 1;
+                cell_items[write_pos] = u32::try_from(i).map_err(|_| {
+                    crate::PolygonizeError::InternalInvariantViolation {
+                        reason: "uniform-grid line index exceeds u32".to_string(),
+                    }
+                })?;
+                current_offsets[cell] = current_offsets[cell].checked_add(1).ok_or_else(|| {
+                    crate::PolygonizeError::InternalInvariantViolation {
+                        reason: "uniform-grid write offset overflow".to_string(),
+                    }
+                })?;
             }
         }
 
-        Self {
+        Ok(Self {
             cell_offsets,
             cell_items,
             global_lines,
@@ -352,7 +450,7 @@ impl UniformGrid {
             cols,
             rows,
             bounds_min: Coord { x: min_x, y: min_y },
-        }
+        })
     }
 
     fn empty() -> Self {
@@ -774,6 +872,24 @@ mod tests {
                 &mut ExecutionWorkTracker::new(Some(&policy), None),
             ),
             Err(PolygonizeError::Cancelled { stage }) if stage == "candidate_enumeration"
+        ));
+    }
+
+    #[test]
+    fn grid_construction_polls_during_input_passes() {
+        let lines = (0..512)
+            .map(|index| make_line(0.0, index as f64, 1.0, index as f64 + 0.5))
+            .collect::<Vec<_>>();
+        let token = CancellationToken::new();
+        let policy = ExecutionPolicy {
+            cancellation_token: Some(token.clone()),
+            cancel_at_work_item: Some((token, 17)),
+            ..Default::default()
+        };
+
+        assert!(matches!(
+            UniformGrid::new_with_execution_policy(&lines, &policy),
+            Err(PolygonizeError::Cancelled { stage }) if stage == "grid_construction"
         ));
     }
 

--- a/crates/geo-polygonize-core/src/noding/hot_pixel.rs
+++ b/crates/geo-polygonize-core/src/noding/hot_pixel.rs
@@ -79,7 +79,12 @@ impl HotPixelNoder {
         let snapper = SnapNoder::new(self.grid_size).with_z_policy(self.z_policy);
         snapper.normalize_and_dedup(&mut lines);
 
-        let mut hot_pixels = Vec::with_capacity(lines.len() * 2);
+        let hot_pixel_capacity = lines.len().checked_mul(2).ok_or_else(|| {
+            PolygonizeError::InternalInvariantViolation {
+                reason: "hot-pixel endpoint count overflow".to_string(),
+            }
+        })?;
+        let mut hot_pixels = Vec::with_capacity(hot_pixel_capacity);
         for line in &lines {
             hot_pixels.push(self.grid_point(line.start)?);
             hot_pixels.push(self.grid_point(line.end)?);
@@ -102,6 +107,10 @@ impl HotPixelNoder {
                 .locate_in_envelope_intersecting(&line_envelope(first))
                 .filter(|second_index| *second_index > first_index)
                 .collect();
+            if let Some(execution_policy) = execution_policy {
+                execution_policy
+                    .check_uncancellable_sort("hot_pixel_candidate_sort", candidates.len())?;
+            }
             candidates.sort_unstable();
             for second_index in candidates {
                 work.candidate_pairs = work.candidate_pairs.checked_add(1).ok_or_else(|| {
@@ -138,6 +147,9 @@ impl HotPixelNoder {
                 }
             }
         }
+        if let Some(execution_policy) = execution_policy {
+            execution_policy.check_uncancellable_sort("hot_pixel_sort", hot_pixels.len())?;
+        }
         hot_pixels.sort_unstable();
         hot_pixels.dedup();
 
@@ -171,6 +183,10 @@ impl HotPixelNoder {
             let mut candidates: Vec<_> = hot_pixel_index
                 .locate_in_envelope_intersecting(&query)
                 .collect();
+            if let Some(execution_policy) = execution_policy {
+                execution_policy
+                    .check_uncancellable_sort("hot_pixel_candidate_sort", candidates.len())?;
+            }
             candidates.sort_unstable();
 
             let mut points = vec![line.start, line.end];
@@ -194,6 +210,9 @@ impl HotPixelNoder {
 
             let dx = end.x - start.x;
             let dy = end.y - start.y;
+            if let Some(execution_policy) = execution_policy {
+                execution_policy.check_uncancellable_sort("split_point_sort", points.len())?;
+            }
             points.sort_unstable_by(|left, right| {
                 let left_grid = self.grid_point(*left).expect("validated grid coordinate");
                 let right_grid = self.grid_point(*right).expect("validated grid coordinate");

--- a/crates/geo-polygonize-core/src/noding/snap.rs
+++ b/crates/geo-polygonize-core/src/noding/snap.rs
@@ -212,7 +212,11 @@ impl SnapNoder {
                 }
             } else {
                 // STRATEGY B: Large Input -> Uniform Grid
-                let grid = UniformGrid::new(&lines);
+                let grid = if let Some(execution_policy) = execution_policy {
+                    UniformGrid::new_with_execution_policy(&lines, execution_policy)?
+                } else {
+                    UniformGrid::new(&lines)
+                };
                 if execution_policy.is_some() || work_stats.is_some() {
                     let mut tracker =
                         ExecutionWorkTracker::new(execution_policy, work_stats.as_deref_mut());
@@ -234,6 +238,9 @@ impl SnapNoder {
             }
 
             // Sort and dedup events by (line_index, split_point) to stabilize near-equal repeats.
+            if let Some(execution_policy) = execution_policy {
+                execution_policy.check_uncancellable_sort("noding_candidate_sort", events.len())?;
+            }
             events.sort_unstable_by(|a, b| {
                 a.0.cmp(&b.0)
                     .then(a.1.x.total_cmp(&b.1.x))
@@ -319,6 +326,10 @@ impl SnapNoder {
                 let len_sq = dx * dx + dy * dy;
 
                 if len_sq > 0.0 {
+                    if let Some(execution_policy) = execution_policy {
+                        execution_policy
+                            .check_uncancellable_sort("split_point_sort", points.len())?;
+                    }
                     points.sort_unstable_by(|a, b| {
                         let ta = ((a.x - start.x) * dx + (a.y - start.y) * dy) / len_sq;
                         let tb = ((b.x - start.x) * dx + (b.y - start.y) * dy) / len_sq;
@@ -326,6 +337,10 @@ impl SnapNoder {
                     });
                 } else {
                     // Fallback to sort by X, then Y if segment is a zero-length point
+                    if let Some(execution_policy) = execution_policy {
+                        execution_policy
+                            .check_uncancellable_sort("split_point_sort", points.len())?;
+                    }
                     points.sort_unstable_by(|a, b| a.x.total_cmp(&b.x).then(a.y.total_cmp(&b.y)));
                 }
 
@@ -425,15 +440,18 @@ impl SnapNoder {
     }
 
     pub fn pre_snap_to_reference_vertices(lines: &[Line3D], tolerance: f64) -> Vec<Line3D> {
-        Self::pre_snap_impl(lines, tolerance, true, ZPolicy::InterpolateAlongEdge).0
+        Self::pre_snap_impl(lines, tolerance, true, ZPolicy::InterpolateAlongEdge, None)
+            .expect("unlimited pre-snap cannot fail")
+            .0
     }
 
     pub(crate) fn pre_snap_to_reference_vertices_with_stats(
         lines: &[Line3D],
         tolerance: f64,
         z_policy: ZPolicy,
-    ) -> (Vec<Line3D>, usize) {
-        Self::pre_snap_impl(lines, tolerance, true, z_policy)
+        execution_policy: &ExecutionPolicy,
+    ) -> crate::Result<(Vec<Line3D>, usize)> {
+        Self::pre_snap_impl(lines, tolerance, true, z_policy, Some(execution_policy))
     }
 
     fn pre_snap_impl(
@@ -441,17 +459,31 @@ impl SnapNoder {
         tolerance: f64,
         use_index: bool,
         z_policy: ZPolicy,
-    ) -> (Vec<Line3D>, usize) {
+        execution_policy: Option<&ExecutionPolicy>,
+    ) -> crate::Result<(Vec<Line3D>, usize)> {
+        if let Some(policy) = execution_policy {
+            policy.check_cancelled("pre_snap")?;
+        }
         if lines.is_empty() || tolerance <= 0.0 {
-            return (lines.to_vec(), 0);
+            return Ok((lines.to_vec(), 0));
         }
 
-        let mut reference_vertices: Vec<Coord3D> = SnapNoder::new(0.0)
-            .node(lines.to_vec())
-            .into_iter()
-            .flat_map(|line| [line.start, line.end])
-            .collect();
+        let exact_noded = if let Some(policy) = execution_policy {
+            SnapNoder::new(0.0).node_with_execution_policy(lines.to_vec(), policy)?
+        } else {
+            SnapNoder::new(0.0).node(lines.to_vec())
+        };
+        let mut reference_vertices = Vec::with_capacity(exact_noded.len().saturating_mul(2));
+        for (index, line) in exact_noded.into_iter().enumerate() {
+            if let Some(policy) = execution_policy {
+                policy.check_cancelled_every("pre_snap", index)?;
+            }
+            reference_vertices.extend([line.start, line.end]);
+        }
 
+        if let Some(policy) = execution_policy {
+            policy.check_cancelled("pre_snap")?;
+        }
         reference_vertices.sort_unstable_by(|a, b| {
             a.x.total_cmp(&b.x)
                 .then(a.y.total_cmp(&b.y))
@@ -459,18 +491,21 @@ impl SnapNoder {
         });
         reference_vertices.dedup_by(|a, b| a.x == b.x && a.y == b.y);
 
-        let vertex_index = use_index.then(|| {
-            RStarBackend::new(
-                reference_vertices
-                    .iter()
-                    .enumerate()
-                    .map(|(index, vertex)| IndexedEnvelope {
-                        aabb: AABB::from_corners([vertex.x, vertex.y], [vertex.x, vertex.y]),
-                        index,
-                    })
-                    .collect(),
-            )
-        });
+        let vertex_index = if use_index {
+            let mut entries = Vec::with_capacity(reference_vertices.len());
+            for (index, vertex) in reference_vertices.iter().enumerate() {
+                if let Some(policy) = execution_policy {
+                    policy.check_cancelled_every("pre_snap", index)?;
+                }
+                entries.push(IndexedEnvelope {
+                    aabb: AABB::from_corners([vertex.x, vertex.y], [vertex.x, vertex.y]),
+                    index,
+                });
+            }
+            Some(RStarBackend::new(entries))
+        } else {
+            None
+        };
 
         let tolerance_sq = tolerance * tolerance;
         let mut snapped = Vec::with_capacity(lines.len());
@@ -478,7 +513,10 @@ impl SnapNoder {
         let mut vertex_candidates = 0;
         let z_resolver = SnapNoder::new(0.0).with_z_policy(z_policy);
 
-        for &line in lines {
+        for (line_index, &line) in lines.iter().enumerate() {
+            if let Some(policy) = execution_policy {
+                policy.check_cancelled_every("pre_snap", line_index)?;
+            }
             let (mut start, start_candidates) = if let Some(index) = vertex_index.as_ref() {
                 nearest_reference_vertex_indexed(line.start, &reference_vertices, index, tolerance)
             } else {
@@ -518,13 +556,20 @@ impl SnapNoder {
             points.push((1.0, end));
 
             {
-                let mut consider_vertex = |vertex: Coord3D| {
-                    vertex_candidates += 1;
+                let mut consider_vertex = |vertex: Coord3D| -> crate::Result<()> {
+                    vertex_candidates = vertex_candidates.checked_add(1).ok_or_else(|| {
+                        PolygonizeError::InternalInvariantViolation {
+                            reason: "pre-snap candidate counter overflow".to_string(),
+                        }
+                    })?;
+                    if let Some(policy) = execution_policy {
+                        policy.check_cancelled_every("pre_snap", vertex_candidates)?;
+                    }
                     let vx = vertex.x - start.x;
                     let vy = vertex.y - start.y;
                     let t = (vx * dx + vy * dy) / len_sq;
                     if !(0.0..=1.0).contains(&t) {
-                        return;
+                        return Ok(());
                     }
 
                     let nearest_x = start.x + t * dx;
@@ -541,6 +586,7 @@ impl SnapNoder {
                             ),
                         ));
                     }
+                    Ok(())
                 };
 
                 if let Some(index) = vertex_index.as_ref().filter(|_| {
@@ -561,11 +607,11 @@ impl SnapNoder {
                         ],
                     );
                     for idx in index.locate_in_envelope_intersecting(&query) {
-                        consider_vertex(reference_vertices[idx]);
+                        consider_vertex(reference_vertices[idx])?;
                     }
                 } else {
                     for &vertex in &reference_vertices {
-                        consider_vertex(vertex);
+                        consider_vertex(vertex)?;
                     }
                 }
             }
@@ -590,7 +636,10 @@ impl SnapNoder {
             }
         }
 
-        (snapped, vertex_candidates)
+        if let Some(policy) = execution_policy {
+            policy.check_cancelled("pre_snap")?;
+        }
+        Ok((snapped, vertex_candidates))
     }
 
     pub(crate) fn normalize_and_dedup(&self, lines: &mut Vec<Line3D>) {
@@ -1258,9 +1307,11 @@ mod tests {
             .collect();
 
         let (linear, linear_candidates) =
-            SnapNoder::pre_snap_impl(&lines, 0.5, false, ZPolicy::InterpolateAlongEdge);
+            SnapNoder::pre_snap_impl(&lines, 0.5, false, ZPolicy::InterpolateAlongEdge, None)
+                .unwrap();
         let (indexed, indexed_candidates) =
-            SnapNoder::pre_snap_impl(&lines, 0.5, true, ZPolicy::InterpolateAlongEdge);
+            SnapNoder::pre_snap_impl(&lines, 0.5, true, ZPolicy::InterpolateAlongEdge, None)
+                .unwrap();
 
         assert_eq!(indexed.len(), linear.len());
         for (actual, expected) in indexed.iter().zip(linear) {
@@ -1270,6 +1321,31 @@ mod tests {
         }
         assert_eq!(linear_candidates, 240_000);
         assert_eq!(indexed_candidates, 1_100);
+    }
+
+    #[test]
+    fn pre_snap_reference_work_observes_cancellation() {
+        let token = CancellationToken::new();
+        token.cancel();
+        let policy = ExecutionPolicy {
+            cancellation_token: Some(token),
+            ..Default::default()
+        };
+        let lines = vec![
+            make_line(0.0, 0.0, 10.0, 0.0),
+            make_line(5.0, 0.1, 5.0, 1.0),
+        ];
+
+        assert!(matches!(
+            SnapNoder::pre_snap_impl(
+                &lines,
+                0.5,
+                true,
+                ZPolicy::InterpolateAlongEdge,
+                Some(&policy),
+            ),
+            Err(PolygonizeError::Cancelled { stage }) if stage == "pre_snap"
+        ));
     }
 
     #[test]

--- a/crates/geo-polygonize-core/src/noding/validate.rs
+++ b/crates/geo-polygonize-core/src/noding/validate.rs
@@ -63,6 +63,10 @@ impl ValidatingNoder {
                 .locate_in_envelope_intersecting(&envelope(first))
                 .filter(|second_index| *second_index > first_index)
                 .collect();
+            if let Some(execution_policy) = execution_policy {
+                execution_policy
+                    .check_uncancellable_sort("noding_validation_sort", candidates.len())?;
+            }
             candidates.sort_unstable();
             for (candidate_index, second_index) in candidates.into_iter().enumerate() {
                 if let Some(execution_policy) = execution_policy {

--- a/crates/geo-polygonize-core/src/options.rs
+++ b/crates/geo-polygonize-core/src/options.rs
@@ -9,6 +9,9 @@ use std::sync::{
 
 /// Maximum noding work items between cooperative cancellation checks.
 pub(crate) const CANCELLATION_CHECK_INTERVAL: usize = 256;
+/// Maximum items accepted by an uninterruptible standard-library sort when
+/// cooperative cancellation is enabled.
+pub(crate) const MAX_UNCANCELLABLE_SORT_ITEMS: usize = 1_000_000;
 
 /// Cooperative native cancellation handle for an [`ExecutionPolicy`].
 #[derive(Clone, Debug, Default)]
@@ -39,6 +42,8 @@ impl CancellationToken {
 #[derive(Clone, Debug, Default)]
 pub struct ExecutionPolicy {
     pub cancellation_token: Option<CancellationToken>,
+    #[cfg(test)]
+    pub(crate) cancel_at_work_item: Option<(CancellationToken, usize)>,
     pub max_input_line_strings: Option<usize>,
     pub max_input_segments: Option<usize>,
     pub max_input_coordinates: Option<usize>,
@@ -112,8 +117,22 @@ impl ExecutionPolicy {
     }
 
     pub(crate) fn check_cancelled_every(&self, stage: &str, work_items: usize) -> Result<()> {
+        #[cfg(test)]
+        if let Some((token, cancel_at)) = &self.cancel_at_work_item {
+            if work_items == *cancel_at {
+                token.cancel();
+            }
+        }
         if work_items.is_multiple_of(CANCELLATION_CHECK_INTERVAL) {
             self.check_cancelled(stage)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn check_uncancellable_sort(&self, stage: &str, items: usize) -> Result<()> {
+        self.check_cancelled(stage)?;
+        if self.has_cancellation() {
+            self.check(stage, Some(MAX_UNCANCELLABLE_SORT_ITEMS), items)?;
         }
         Ok(())
     }
@@ -644,5 +663,27 @@ mod tests {
         .is_err());
 
         assert!(PolygonizerOptions::default().validate().is_ok());
+    }
+
+    #[test]
+    fn cancellation_enabled_sorts_have_a_fixed_item_ceiling() {
+        let policy = ExecutionPolicy {
+            cancellation_token: Some(CancellationToken::new()),
+            ..Default::default()
+        };
+        assert!(policy
+            .check_uncancellable_sort("test_sort", MAX_UNCANCELLABLE_SORT_ITEMS)
+            .is_ok());
+        assert!(matches!(
+            policy.check_uncancellable_sort(
+                "test_sort",
+                MAX_UNCANCELLABLE_SORT_ITEMS + 1
+            ),
+            Err(PolygonizeError::ResourceLimitExceeded {
+                stage,
+                limit: MAX_UNCANCELLABLE_SORT_ITEMS,
+                observed,
+            }) if stage == "test_sort" && observed == MAX_UNCANCELLABLE_SORT_ITEMS + 1
+        ));
     }
 }

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -361,7 +361,8 @@ impl Polygonizer {
                     &all_segments,
                     self.options.pre_snap_tolerance,
                     self.options.z.policy,
-                );
+                    &self.execution_policy,
+                )?;
                 all_segments = snapped;
                 pre_snap_vertex_candidates = candidates;
             }
@@ -831,7 +832,12 @@ fn reconcile_segment_z(
         return Ok(ZConflictStats::default());
     }
 
-    let mut endpoints = Vec::with_capacity(segments.len() * 2);
+    let endpoint_capacity = segments.len().checked_mul(2).ok_or_else(|| {
+        PolygonizeError::InternalInvariantViolation {
+            reason: "Z-reconciliation endpoint count overflow".to_string(),
+        }
+    })?;
+    let mut endpoints = Vec::with_capacity(endpoint_capacity);
     for (segment, line) in segments.iter().enumerate() {
         execution_policy.check_cancelled_every("graph_construction", segment)?;
         endpoints.push(SegmentEndpoint {
@@ -847,6 +853,7 @@ fn reconcile_segment_z(
             line_id: line.line_id,
         });
     }
+    execution_policy.check_uncancellable_sort("z_reconciliation_sort", endpoints.len())?;
     endpoints.sort_unstable_by(|a, b| {
         a.coordinate
             .x
@@ -1249,6 +1256,8 @@ pub(crate) fn construct_final_polygons(
                 .collect();
 
             let use_stable_tie_breaks = options.determinism.stable_tie_breaks;
+            execution_policy
+                .check_uncancellable_sort("canonical_hole_sort", combined_holes.len())?;
             if use_stable_tie_breaks {
                 let mut combined_holes_with_bbox: Vec<_> = combined_holes
                     .into_iter()
@@ -1545,6 +1554,7 @@ pub(crate) fn apply_determinism(
                 sort_keys.push((index, area, bbox, polygon.interiors.len()));
             }
 
+            execution_policy.check_uncancellable_sort("canonical_polygon_sort", sort_keys.len())?;
             sort_keys.sort_unstable_by(|(_, area1, b1, holes1), (_, area2, b2, holes2)| {
                 area2.total_cmp(area1).then_with(|| {
                     b1.min()
@@ -1566,6 +1576,7 @@ pub(crate) fn apply_determinism(
                 sort_keys.push((index, polygon.exterior_unsigned_area_2d()));
             }
 
+            execution_policy.check_uncancellable_sort("canonical_polygon_sort", sort_keys.len())?;
             sort_keys.sort_unstable_by(|(_, area1), (_, area2)| area2.total_cmp(area1));
 
             reorder_polygons(&mut result, sort_keys.into_iter().map(|(index, _)| index));
@@ -1600,6 +1611,8 @@ pub(crate) fn apply_determinism(
                 dangles_with_cache.push((std::mem::take(line), bbox));
             }
 
+            execution_policy
+                .check_uncancellable_sort("canonical_line_sort", dangles_with_cache.len())?;
             dangles_with_cache.sort_unstable_by(|(l1, b1), (l2, b2)| {
                 b1.min()
                     .x
@@ -1612,6 +1625,7 @@ pub(crate) fn apply_determinism(
                 execution_policy.check_cancelled_every("canonicalization", i)?;
                 dangles[i] = l;
             }
+            execution_policy.check_uncancellable_sort("canonical_line_sort", cut_edges.len())?;
             sort_open_lines(cut_edges);
         }
 
@@ -1633,6 +1647,8 @@ pub(crate) fn apply_determinism(
                 invalid_with_bbox.push((ring, area, bbox));
             }
 
+            execution_policy
+                .check_uncancellable_sort("canonical_invalid_ring_sort", invalid_with_bbox.len())?;
             invalid_with_bbox.sort_unstable_by(|(r1, area1, b1), (r2, area2, b2)| {
                 area2.total_cmp(area1).then_with(|| {
                     b1.min()
@@ -1647,6 +1663,8 @@ pub(crate) fn apply_determinism(
                 invalid_rings.push(ring);
             }
         } else {
+            execution_policy
+                .check_uncancellable_sort("canonical_invalid_ring_sort", combined_invalid.len())?;
             combined_invalid.sort_unstable_by(|(_, area1), (_, area2)| area2.total_cmp(area1));
             for (index, (ring, _)) in combined_invalid.into_iter().enumerate() {
                 execution_policy.check_cancelled_every("canonicalization", index)?;


### PR DESCRIPTION
## Stack

Parent:
- #989

This PR:
- Close cancellation gaps in preprocessing, grid construction, validation, graph preparation, and canonical sorting.

Children:
- none

## Delivered

- Pass `ExecutionPolicy` through the pre-snap exact-noding and reference-vertex paths.
- Poll UniformGrid bounds, cell counting, and population every 256 input segments.
- Preserve the unlimited parallel grid-construction path.
- Add checked grid dimensions, counts, offsets, and `usize -> u32` line-index conversion.
- Bound audited standard-library sorts to 1,000,000 items when cancellation is enabled.
- Cover candidate, split-point, hot-pixel, graph, Z-reconciliation, and canonical-result sorts.
- Update the P0.6 cancellation contract and add deterministic grid-construction and sort-ceiling tests.

## Contract impact

- Every named long-running region now has either 256-work-item polling or a documented pre-sort ceiling.
- Cancellation-enabled calls may return a resource-limit error before an audited sort exceeding 1,000,000 items.
- Token-free paths retain their parallel behavior and have no new implicit sort ceiling.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `cargo test --workspace` — passed
- `cargo test -p geo-polygonize-core --no-default-features` — passed
- `RUSTDOCFLAGS='-D warnings' cargo doc -p geo-polygonize-core --no-deps` — passed
- `npm test` — 18 passed
- `npm run docs:build` — passed with existing Vite/MUI chunk and directive warnings

## Agent handoff

Remaining:
- none for Stack A's stated A3-A5 risks

Next dependency-ready slice:
- review and merge #988, then rebase/retarget #989 according to the stack procedure
