### PR TITLE
refactor(core): make normalized error codes structural

### DIFF
--- a/crates/geo-polygonize-arrow/src/ffi.rs
+++ b/crates/geo-polygonize-arrow/src/ffi.rs
@@ -100,7 +100,9 @@ fn set_polygonize_error(error: &PolygonizeError) -> i32 {
         PolygonizeError::ResourceLimitExceeded { .. } => PolygonizeFfiStatus::Unknown,
         PolygonizeError::Cancelled { .. } => PolygonizeFfiStatus::Unknown,
         PolygonizeError::InvalidArgumentType { .. } => PolygonizeFfiStatus::InvalidOption,
-        PolygonizeError::InvalidGeometry { .. } => PolygonizeFfiStatus::InvalidGeometry,
+        PolygonizeError::InvalidGeometry { .. } | PolygonizeError::NonFiniteCoordinate { .. } => {
+            PolygonizeFfiStatus::InvalidGeometry
+        }
         PolygonizeError::TopologyFailure { .. }
         | PolygonizeError::ZConflict { .. }
         | PolygonizeError::NodingValidationFailure { .. } => PolygonizeFfiStatus::Topology,
@@ -567,6 +569,7 @@ mod tests {
         set_polygonize_error(&PolygonizeError::NodingValidationFailure {
             first_segment: 3,
             second_segment: 8,
+            kind: geo_polygonize_core::NodingValidationKind::InteriorIntersection,
             reason: "intersection".to_string(),
         });
 

--- a/crates/geo-polygonize-core/src/error.rs
+++ b/crates/geo-polygonize-core/src/error.rs
@@ -1,5 +1,29 @@
 use thiserror::Error;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum NodingValidationKind {
+    ZeroLengthSegment,
+    CollinearOverlap,
+    InteriorIntersection,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PolygonizeErrorKind {
+    InvalidArgumentType,
+    InvalidGeometry,
+    InvalidBufferShape,
+    ResourceLimitExceeded,
+    Cancelled,
+    UnsupportedOptionCombination,
+    TopologyFailure,
+    ZConflict,
+    NodingValidationFailure(NodingValidationKind),
+    InternalInvariantViolation,
+    ArrowError,
+    NullPointer,
+    Panic,
+}
+
 #[derive(Error, Debug)]
 pub enum PolygonizeError {
     #[error("Invalid argument type for {field}: expected {expected}, got {actual}")]
@@ -11,6 +35,9 @@ pub enum PolygonizeError {
 
     #[error("Invalid geometry: {reason}")]
     InvalidGeometry { reason: String },
+
+    #[error("Invalid geometry: {reason}")]
+    NonFiniteCoordinate { reason: String },
 
     #[error("Invalid buffer shape: {reason}")]
     InvalidBufferShape { reason: String },
@@ -40,6 +67,7 @@ pub enum PolygonizeError {
     NodingValidationFailure {
         first_segment: usize,
         second_segment: usize,
+        kind: NodingValidationKind,
         reason: String,
     },
 
@@ -54,6 +82,34 @@ pub enum PolygonizeError {
 
     #[error("Panic occurred across FFI/WASM boundary: {0}")]
     Panic(String),
+}
+
+impl PolygonizeError {
+    pub fn kind(&self) -> PolygonizeErrorKind {
+        match self {
+            Self::InvalidArgumentType { .. } => PolygonizeErrorKind::InvalidArgumentType,
+            Self::InvalidGeometry { .. } | Self::NonFiniteCoordinate { .. } => {
+                PolygonizeErrorKind::InvalidGeometry
+            }
+            Self::InvalidBufferShape { .. } => PolygonizeErrorKind::InvalidBufferShape,
+            Self::ResourceLimitExceeded { .. } => PolygonizeErrorKind::ResourceLimitExceeded,
+            Self::Cancelled { .. } => PolygonizeErrorKind::Cancelled,
+            Self::UnsupportedOptionCombination { .. } => {
+                PolygonizeErrorKind::UnsupportedOptionCombination
+            }
+            Self::TopologyFailure { .. } => PolygonizeErrorKind::TopologyFailure,
+            Self::ZConflict { .. } => PolygonizeErrorKind::ZConflict,
+            Self::NodingValidationFailure { kind, .. } => {
+                PolygonizeErrorKind::NodingValidationFailure(*kind)
+            }
+            Self::InternalInvariantViolation { .. } => {
+                PolygonizeErrorKind::InternalInvariantViolation
+            }
+            Self::ArrowError { .. } => PolygonizeErrorKind::ArrowError,
+            Self::NullPointer { .. } => PolygonizeErrorKind::NullPointer,
+            Self::Panic { .. } => PolygonizeErrorKind::Panic,
+        }
+    }
 }
 
 pub type Result<T> = std::result::Result<T, PolygonizeError>;

--- a/crates/geo-polygonize-core/src/fingerprint.rs
+++ b/crates/geo-polygonize-core/src/fingerprint.rs
@@ -3,7 +3,9 @@
 //! This is intentionally `#[doc(hidden)]`: it is a shared contract for the
 //! repository's adapters, not an additional stable polygonization entrypoint.
 
-use crate::{Coord3D, PolygonizeError, PolygonizerOptions, PolygonizerResult};
+use crate::{
+    Coord3D, NodingValidationKind, PolygonizeError, PolygonizerOptions, PolygonizerResult,
+};
 use serde::Serialize;
 use serde_json::Value;
 use ts_rs::TS;
@@ -227,13 +229,12 @@ pub fn normalize_polygonize_error(error: &PolygonizeError) -> NormalizedPolygoni
             actual: Some(actual.clone()),
             ..base("invalid_argument", "invalid_argument_type", "options")
         },
-        PolygonizeError::InvalidGeometry { reason } => base(
+        PolygonizeError::InvalidGeometry { .. } => {
+            base("invalid_geometry", "invalid_geometry", "input_validation")
+        }
+        PolygonizeError::NonFiniteCoordinate { .. } => base(
             "invalid_geometry",
-            if reason == "line coordinates must be finite" {
-                "non_finite_coordinate"
-            } else {
-                "invalid_geometry"
-            },
+            "non_finite_coordinate",
             "input_validation",
         ),
         PolygonizeError::InvalidBufferShape { .. } => base(
@@ -276,7 +277,8 @@ pub fn normalize_polygonize_error(error: &PolygonizeError) -> NormalizedPolygoni
         PolygonizeError::NodingValidationFailure {
             first_segment,
             second_segment,
-            reason,
+            kind,
+            ..
         } => NormalizedPolygonizeErrorV1 {
             witness: Some(ErrorWitnessV1 {
                 ids: vec![id_usize(*first_segment), id_usize(*second_segment)],
@@ -284,14 +286,10 @@ pub fn normalize_polygonize_error(error: &PolygonizeError) -> NormalizedPolygoni
             }),
             ..base(
                 "topology",
-                if reason.starts_with("zero-length") {
-                    "zero_length_segment"
-                } else if reason.starts_with("collinear overlap") {
-                    "collinear_overlap"
-                } else if reason.starts_with("intersection") {
-                    "interior_intersection"
-                } else {
-                    "noding_validation_failure"
+                match kind {
+                    NodingValidationKind::ZeroLengthSegment => "zero_length_segment",
+                    NodingValidationKind::CollinearOverlap => "collinear_overlap",
+                    NodingValidationKind::InteriorIntersection => "interior_intersection",
                 },
                 "noding_validation",
             )

--- a/crates/geo-polygonize-core/src/lib.rs
+++ b/crates/geo-polygonize-core/src/lib.rs
@@ -38,7 +38,7 @@ pub use diagnostics::{
     PolygonizerDiagnostics, PolygonizerPhaseTimes, SnapStats, ZConflictStats,
     POLYGONIZER_DIAGNOSTICS_V1_SCHEMA_VERSION,
 };
-pub use error::{PolygonizeError, Result};
+pub use error::{NodingValidationKind, PolygonizeError, PolygonizeErrorKind, Result};
 #[doc(hidden)]
 pub use fingerprint::{
     normalize_polygonize_error, CoordinateFingerprintV1, ErrorWitnessV1, FingerprintDiffV1,

--- a/crates/geo-polygonize-core/src/noding/validate.rs
+++ b/crates/geo-polygonize-core/src/noding/validate.rs
@@ -1,4 +1,4 @@
-use crate::error::{PolygonizeError, Result};
+use crate::error::{NodingValidationKind, PolygonizeError, Result};
 use crate::index::{IndexedEnvelope, RStarBackend};
 use crate::options::ExecutionPolicy;
 use crate::types::Line3D;
@@ -55,6 +55,7 @@ impl ValidatingNoder {
                 return failure(
                     first_index,
                     first_index,
+                    NodingValidationKind::ZeroLengthSegment,
                     "zero-length segment is not normalized".to_string(),
                 );
             }
@@ -87,6 +88,7 @@ impl ValidatingNoder {
                         return failure(
                             first_index,
                             second_index,
+                            NodingValidationKind::InteriorIntersection,
                             format!(
                                 "intersection ({}, {}) is not an endpoint of both segments",
                                 intersection.x, intersection.y
@@ -97,6 +99,7 @@ impl ValidatingNoder {
                         return failure(
                             first_index,
                             second_index,
+                            NodingValidationKind::CollinearOverlap,
                             format!(
                                 "collinear overlap from ({}, {}) to ({}, {}) is not normalized",
                                 intersection.start.x,
@@ -134,10 +137,16 @@ fn is_endpoint(line: &Line3D, point: Coord<f64>) -> bool {
         || (line.end.x == point.x && line.end.y == point.y)
 }
 
-fn failure(first_segment: usize, second_segment: usize, reason: String) -> Result<()> {
+fn failure(
+    first_segment: usize,
+    second_segment: usize,
+    kind: NodingValidationKind,
+    reason: String,
+) -> Result<()> {
     Err(PolygonizeError::NodingValidationFailure {
         first_segment,
         second_segment,
+        kind,
         reason,
     })
 }

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -798,7 +798,7 @@ fn validate_lines(lines: &[Line3D], execution_policy: &ExecutionPolicy) -> Resul
             line.end.z,
         ] {
             if !value.is_finite() {
-                return Err(PolygonizeError::InvalidGeometry {
+                return Err(PolygonizeError::NonFiniteCoordinate {
                     reason: "line coordinates must be finite".to_string(),
                 });
             }
@@ -2258,10 +2258,15 @@ mod tests {
             Coord3D::new(1.0, 0.0, 0.0),
             1,
         );
-        assert!(matches!(
-            polygonize([line], &PolygonizerOptions::default()),
-            Err(PolygonizeError::InvalidGeometry { .. })
-        ));
+        let error = polygonize([line], &PolygonizerOptions::default()).unwrap_err();
+        assert_eq!(
+            error.kind(),
+            crate::error::PolygonizeErrorKind::InvalidGeometry
+        );
+        assert_eq!(
+            crate::normalize_polygonize_error(&error).code,
+            "non_finite_coordinate"
+        );
     }
 
     #[test]

--- a/crates/geo-polygonize-core/tests/conformance_fingerprint.rs
+++ b/crates/geo-polygonize-core/tests/conformance_fingerprint.rs
@@ -1,8 +1,8 @@
 use geo_polygonize_core::{
     normalize_polygonize_error, polygonize, polygonize_line_strings, polygonize_with_workspace,
     Coord3D, DeterminismOptions, DiagnosticsOptions, Line3D, NodingGuarantee, NodingOptions,
-    Polygon3D, PolygonizerOptions, PolygonizerResult, PolygonizerWorkspace, ProvenanceOptions,
-    TopologyFingerprintV1,
+    NodingValidationKind, Polygon3D, PolygonizeError, PolygonizerOptions, PolygonizerResult,
+    PolygonizerWorkspace, ProvenanceOptions, TopologyFingerprintV1,
 };
 use geo_types::LineString;
 use serde::Deserialize;
@@ -400,6 +400,28 @@ fn validation_and_option_failures_normalize_deterministically() {
         normalize_polygonize_error(&polygonize(Vec::<Line3D>::new(), &options).unwrap_err());
     assert_eq!(first, second);
     assert_eq!(first.field.as_deref(), Some("pre_snap_tolerance"));
+}
+
+#[test]
+fn normalized_codes_do_not_depend_on_message_wording() {
+    let validation = PolygonizeError::NodingValidationFailure {
+        first_segment: 1,
+        second_segment: 2,
+        kind: NodingValidationKind::CollinearOverlap,
+        reason: "wording may change freely".to_string(),
+    };
+    assert_eq!(
+        normalize_polygonize_error(&validation).code,
+        "collinear_overlap"
+    );
+
+    let non_finite = PolygonizeError::NonFiniteCoordinate {
+        reason: "localized message".to_string(),
+    };
+    assert_eq!(
+        normalize_polygonize_error(&non_finite).code,
+        "non_finite_coordinate"
+    );
 }
 
 #[test]

--- a/crates/geo-polygonize-python/src/lib.rs
+++ b/crates/geo-polygonize-python/src/lib.rs
@@ -47,6 +47,7 @@ fn to_py_err(err: PolygonizeError) -> PyErr {
             "Invalid argument type for {field}: expected {expected}, got {actual}"
         )),
         PolygonizeError::InvalidGeometry { reason } => PolygonizeGeometryError::new_err(reason),
+        PolygonizeError::NonFiniteCoordinate { reason } => PolygonizeGeometryError::new_err(reason),
         PolygonizeError::InvalidBufferShape { reason } => PolygonizeTypeError::new_err(reason),
         PolygonizeError::ResourceLimitExceeded { .. } => PyRuntimeError::new_err(err.to_string()),
         PolygonizeError::Cancelled { .. } => PyRuntimeError::new_err(err.to_string()),

--- a/crates/geo-polygonize-wasm/src/error.rs
+++ b/crates/geo-polygonize-wasm/src/error.rs
@@ -38,7 +38,9 @@ impl PolygonizerWasmError {
 pub fn from_polygonizer_error(e: PolygonizeError) -> JsValue {
     let name = match &e {
         PolygonizeError::InvalidArgumentType { .. } => "InvalidArgumentType".to_string(),
-        PolygonizeError::InvalidGeometry { .. } => "InvalidGeometry".to_string(),
+        PolygonizeError::InvalidGeometry { .. } | PolygonizeError::NonFiniteCoordinate { .. } => {
+            "InvalidGeometry".to_string()
+        }
         PolygonizeError::InvalidBufferShape { .. } => "InvalidBufferShape".to_string(),
         PolygonizeError::ResourceLimitExceeded { .. } => "ResourceLimitExceeded".to_string(),
         PolygonizeError::Cancelled { .. } => "Cancelled".to_string(),


### PR DESCRIPTION
## Stack

Parent:
- none (starts from `main`)

This PR:
- Make normalized error identity structural.

Children:
- #992

## Delivered

- Add exhaustive `PolygonizeErrorKind` and `NodingValidationKind` enums.
- Represent non-finite coordinates and noding failure classes structurally.
- Remove normalized-code comparisons against user-facing reason text.
- Update Rust, Python, Wasm, and C adapters exhaustively.
- Add wording-independence migration tests while preserving existing codes.

## Contract impact

- Serialized normalized V1 family/code/stage values are preserved and no longer depend on message wording.

## Validation

- `cargo check --workspace --all-targets` — passed
- `cargo test -p geo-polygonize-core --test conformance_fingerprint` — 9 passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed

## Agent handoff

Remaining:
- Map resource-limit and cancellation kinds to explicit C ABI statuses.

Next dependency-ready slice:
- `agent/c-abi-execution-statuses`.