### PR TITLE
fix(core): expose resource and cancellation FFI statuses

### DIFF
--- a/crates/geo-polygonize-arrow/src/ffi.rs
+++ b/crates/geo-polygonize-arrow/src/ffi.rs
@@ -27,6 +27,8 @@ pub enum PolygonizeFfiStatus {
     InternalInvariant = 10,
     Arrow = 11,
     Unknown = 12,
+    ResourceLimitExceeded = 13,
+    Cancelled = 14,
     Panic = 99,
 }
 
@@ -97,8 +99,8 @@ fn set_polygonize_error(error: &PolygonizeError) -> i32 {
     let normalized = normalize_polygonize_error(error);
     let status = match error {
         PolygonizeError::InvalidBufferShape { .. } => PolygonizeFfiStatus::InvalidBufferShape,
-        PolygonizeError::ResourceLimitExceeded { .. } => PolygonizeFfiStatus::Unknown,
-        PolygonizeError::Cancelled { .. } => PolygonizeFfiStatus::Unknown,
+        PolygonizeError::ResourceLimitExceeded { .. } => PolygonizeFfiStatus::ResourceLimitExceeded,
+        PolygonizeError::Cancelled { .. } => PolygonizeFfiStatus::Cancelled,
         PolygonizeError::InvalidArgumentType { .. } => PolygonizeFfiStatus::InvalidOption,
         PolygonizeError::InvalidGeometry { .. } | PolygonizeError::NonFiniteCoordinate { .. } => {
             PolygonizeFfiStatus::InvalidGeometry
@@ -583,5 +585,41 @@ mod tests {
             unsafe { CStr::from_ptr(error.witness) }.to_str().unwrap(),
             r#"{"ids":["0x0000000000000003","0x0000000000000008"],"coordinate":null}"#
         );
+    }
+
+    #[test]
+    fn test_ffi_execution_errors_have_explicit_statuses() {
+        for (error, expected_status, expected_family, expected_stage) in [
+            (
+                PolygonizeError::ResourceLimitExceeded {
+                    stage: "candidate_pairs".to_string(),
+                    limit: 10,
+                    observed: 11,
+                },
+                PolygonizeFfiStatus::ResourceLimitExceeded,
+                "resource_limit",
+                "candidate_pairs",
+            ),
+            (
+                PolygonizeError::Cancelled {
+                    stage: "containment".to_string(),
+                },
+                PolygonizeFfiStatus::Cancelled,
+                "cancelled",
+                "containment",
+            ),
+        ] {
+            assert_eq!(set_polygonize_error(&error), expected_status as i32);
+            let stored = unsafe { &*polygonize_ffi_last_error() };
+            assert_eq!(stored.status, expected_status as i32);
+            assert_eq!(
+                unsafe { CStr::from_ptr(stored.family) }.to_str().unwrap(),
+                expected_family
+            );
+            assert_eq!(
+                unsafe { CStr::from_ptr(stored.stage) }.to_str().unwrap(),
+                expected_stage
+            );
+        }
     }
 }

--- a/docs/C_ABI.md
+++ b/docs/C_ABI.md
@@ -27,7 +27,12 @@ The returned `int32_t` values are ABI-stable: `0` success, `1` invalid
 argument, `2` invalid Arrow C input, `4` output schema export failure, `5`
 invalid buffer shape, `6` invalid option, `7` invalid geometry, `8` topology
 failure, `9` unsupported option combination, `10` internal invariant failure,
-`11` Arrow adapter failure, `12` unknown failure, and `99` contained panic.
+`11` Arrow adapter failure, `12` unknown failure, `13` resource limit exceeded,
+`14` cancellation, and `99` contained panic.
+
+Statuses `13` and `14` are additive ABI v1 behavior: existing numeric values and
+request layouts are unchanged, so consumers may handle unknown future nonzero
+statuses conservatively without requiring an ABI v2 request.
 
 On a nonzero result, `polygonize_ffi_last_error()` returns a thread-local
 `PolygonizeFfiLastError` with the matching status plus NUL-terminated `family`,


### PR DESCRIPTION
## Stack

Parent:
- #991

This PR:
- Expose resource-limit and cancellation C statuses.

Children:
- not opened yet

## Delivered

- Add ABI-stable status 13 for resource limits and 14 for cancellation.
- Preserve thread-local family, stage, message, and witness retrieval.
- Document the change as additive ABI v1 behavior.
- Test both mappings and last-error metadata.

## Contract impact

- C consumers no longer receive `Unknown` for operational execution failures; existing status values and layouts are unchanged.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo test -p geo-polygonize-arrow test_ffi_execution_errors_have_explicit_statuses` — passed
- `cargo clippy -p geo-polygonize-arrow --all-targets -- -D warnings` — passed
- `git diff --check` — passed

## Agent handoff

Remaining:
- Continue Wasm worker runtime parity after this contract lands.

Next dependency-ready slice:
- `agent/wasm-worker-runtime-parity`.