### PR TITLE
test(core): define public workload corpus manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,6 +449,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array 0.14.9",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,6 +648,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "criterion"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -719,6 +737,16 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array 0.14.9",
+ "typenum",
+]
 
 [[package]]
 name = "csv"
@@ -820,6 +848,16 @@ dependencies = [
  "serde",
  "serde_json",
  "thousands",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -1049,6 +1087,7 @@ dependencies = [
  "rstar 0.12.2",
  "serde",
  "serde_json",
+ "sha2",
  "smallvec",
  "thiserror 1.0.69",
  "ts-rs",
@@ -2523,6 +2562,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]

--- a/crates/geo-polygonize-core/Cargo.toml
+++ b/crates/geo-polygonize-core/Cargo.toml
@@ -37,6 +37,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 walkdir = "2.5.0"
 dhat = "0.3.3"
+sha2 = "0.10"
 
 [features]
 default = ["parallel"]

--- a/crates/geo-polygonize-core/tests/workload_manifest.rs
+++ b/crates/geo-polygonize-core/tests/workload_manifest.rs
@@ -1,0 +1,204 @@
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Manifest {
+    schema_version: u32,
+    workloads: Vec<Workload>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Workload {
+    id: String,
+    description: String,
+    domain: String,
+    source_url: String,
+    license: String,
+    attribution: String,
+    artifact: Artifact,
+    coordinate_reference: String,
+    units: String,
+    compatibility_class: CompatibilityClass,
+    permitted_profiles: Vec<Profile>,
+    retained_result_families: Vec<ResultFamily>,
+    size: Size,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Artifact {
+    clip_path: Option<String>,
+    download_url: Option<String>,
+    sha256: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "kebab-case")]
+enum CompatibilityClass {
+    Parity,
+    ExpectedDivergence,
+    Invalid,
+    Ambiguous,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "kebab-case")]
+enum Profile {
+    AlreadyNoded,
+    Floating,
+    IterativeGrid,
+    CertifiedFixed,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "kebab-case")]
+enum ResultFamily {
+    Polygons,
+    Dangles,
+    CutEdges,
+    InvalidRings,
+    Provenance,
+    Diagnostics,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "kebab-case")]
+enum CandidateClass {
+    Sparse,
+    Moderate,
+    Dense,
+    Pathological,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Size {
+    line_strings: usize,
+    segments: usize,
+    coordinates: usize,
+    expected_candidate_class: Option<CandidateClass>,
+}
+
+fn workload_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/workloads")
+}
+
+fn validate(manifest: &Manifest) -> Result<(), String> {
+    if manifest.schema_version != 1 {
+        return Err("unsupported manifest schema".into());
+    }
+    let mut ids = HashSet::new();
+    for workload in &manifest.workloads {
+        if !ids.insert(&workload.id) {
+            return Err(format!("duplicate workload ID: {}", workload.id));
+        }
+        for (name, value) in [
+            ("description", &workload.description),
+            ("domain", &workload.domain),
+            ("source_url", &workload.source_url),
+            ("license", &workload.license),
+            ("attribution", &workload.attribution),
+            ("coordinate_reference", &workload.coordinate_reference),
+            ("units", &workload.units),
+        ] {
+            if value.trim().is_empty() {
+                return Err(format!("{} has empty {name}", workload.id));
+            }
+        }
+        if !workload.source_url.starts_with("https://") {
+            return Err(format!("{} source URL must use HTTPS", workload.id));
+        }
+        if workload.permitted_profiles.is_empty() || workload.retained_result_families.is_empty() {
+            return Err(format!("{} has an empty contract list", workload.id));
+        }
+        let _ = (
+            &workload.compatibility_class,
+            workload.size.line_strings,
+            workload.size.segments,
+            workload.size.coordinates,
+            &workload.size.expected_candidate_class,
+        );
+        if workload.artifact.sha256.len() != 64
+            || !workload
+                .artifact
+                .sha256
+                .bytes()
+                .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+        {
+            return Err(format!("{} has an invalid SHA-256", workload.id));
+        }
+        match (
+            workload.artifact.clip_path.as_deref(),
+            workload.artifact.download_url.as_deref(),
+        ) {
+            (Some(path), None) => {
+                let bytes = std::fs::read(workload_root().join(path))
+                    .map_err(|error| format!("{} clip: {error}", workload.id))?;
+                let actual = format!("{:x}", Sha256::digest(bytes));
+                if actual != workload.artifact.sha256 {
+                    return Err(format!("{} checksum mismatch", workload.id));
+                }
+            }
+            (None, Some(url)) if url.starts_with("https://") => {}
+            _ => return Err(format!("{} must select one artifact source", workload.id)),
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn public_workload_manifest_is_valid() {
+    let root = workload_root();
+    let schema: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(root.join("manifest-v1.schema.json")).unwrap())
+            .unwrap();
+    assert_eq!(
+        schema["$schema"],
+        "https://json-schema.org/draft/2020-12/schema"
+    );
+
+    let manifest: Manifest =
+        serde_json::from_slice(&std::fs::read(root.join("manifest-v1.json")).unwrap()).unwrap();
+    validate(&manifest).unwrap();
+}
+
+#[test]
+fn validator_rejects_duplicate_ids_missing_licenses_bad_checksums_and_profiles() {
+    let workload = |id: &str, license: &str, sha256: &str, profile: &str| {
+        format!(
+            r#"{{"id":"{id}","description":"clip","domain":"test","source_url":"https://example.com","license":"{license}","attribution":"test","artifact":{{"download_url":"https://example.com/clip","sha256":"{sha256}"}},"coordinate_reference":"EPSG:4326","units":"degrees","compatibility_class":"parity","permitted_profiles":["{profile}"],"retained_result_families":["polygons"],"size":{{"line_strings":1,"segments":1,"coordinates":2}}}}"#
+        )
+    };
+    let hash = "0".repeat(64);
+    let duplicate: Manifest = serde_json::from_str(&format!(
+        r#"{{"schema_version":1,"workloads":[{},{}]}}"#,
+        workload("same", "MIT", &hash, "floating"),
+        workload("same", "MIT", &hash, "floating")
+    ))
+    .unwrap();
+    assert!(validate(&duplicate).unwrap_err().contains("duplicate"));
+
+    let missing_license: Manifest = serde_json::from_str(&format!(
+        r#"{{"schema_version":1,"workloads":[{}]}}"#,
+        workload("missing-license", "", &hash, "floating")
+    ))
+    .unwrap();
+    assert!(validate(&missing_license).unwrap_err().contains("license"));
+
+    let bad_checksum: Manifest = serde_json::from_str(&format!(
+        r#"{{"schema_version":1,"workloads":[{}]}}"#,
+        workload("bad-hash", "MIT", "xyz", "floating")
+    ))
+    .unwrap();
+    assert!(validate(&bad_checksum).unwrap_err().contains("SHA-256"));
+
+    let unsupported = format!(
+        r#"{{"schema_version":1,"workloads":[{}]}}"#,
+        workload("bad-profile", "MIT", &hash, "gpu")
+    );
+    assert!(serde_json::from_str::<Manifest>(&unsupported).is_err());
+}

--- a/crates/geo-polygonize-core/tests/workloads/manifest-v1.json
+++ b/crates/geo-polygonize-core/tests/workloads/manifest-v1.json
@@ -1,0 +1,4 @@
+{
+  "schema_version": 1,
+  "workloads": [ ]
+}

--- a/crates/geo-polygonize-core/tests/workloads/manifest-v1.schema.json
+++ b/crates/geo-polygonize-core/tests/workloads/manifest-v1.schema.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/graydonpleasants/geo-polygonize/tests/workloads/manifest-v1.schema.json",
+  "title": "geo-polygonize public workload manifest v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "workloads"],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "workloads": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/workload" }
+    }
+  },
+  "$defs": {
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sha256"],
+      "properties": {
+        "clip_path": { "type": "string", "minLength": 1 },
+        "download_url": { "type": "string", "format": "uri" },
+        "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+      },
+      "oneOf": [
+        { "required": ["clip_path"], "not": { "required": ["download_url"] } },
+        { "required": ["download_url"], "not": { "required": ["clip_path"] } }
+      ]
+    },
+    "size": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["line_strings", "segments", "coordinates"],
+      "properties": {
+        "line_strings": { "type": "integer", "minimum": 0 },
+        "segments": { "type": "integer", "minimum": 0 },
+        "coordinates": { "type": "integer", "minimum": 0 },
+        "expected_candidate_class": {
+          "enum": ["sparse", "moderate", "dense", "pathological"]
+        }
+      }
+    },
+    "workload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id", "description", "domain", "source_url", "license", "attribution",
+        "artifact", "coordinate_reference", "units", "compatibility_class",
+        "permitted_profiles", "retained_result_families", "size"
+      ],
+      "properties": {
+        "id": { "type": "string", "pattern": "^[a-z0-9][a-z0-9._-]*$" },
+        "description": { "type": "string", "minLength": 1 },
+        "domain": { "type": "string", "minLength": 1 },
+        "source_url": { "type": "string", "format": "uri" },
+        "license": { "type": "string", "minLength": 1 },
+        "attribution": { "type": "string", "minLength": 1 },
+        "artifact": { "$ref": "#/$defs/artifact" },
+        "coordinate_reference": { "type": "string", "minLength": 1 },
+        "units": { "type": "string", "minLength": 1 },
+        "compatibility_class": {
+          "enum": ["parity", "expected-divergence", "invalid", "ambiguous"]
+        },
+        "permitted_profiles": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "enum": ["already-noded", "floating", "iterative-grid", "certified-fixed"]
+          }
+        },
+        "retained_result_families": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "enum": ["polygons", "dangles", "cut-edges", "invalid-rings", "provenance", "diagnostics"]
+          }
+        },
+        "size": { "$ref": "#/$defs/size" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Stack

Parent:
- none (starts from `main`)

This PR:
- Define the public workload corpus manifest contract.

Children:
- not opened yet

## Delivered

- Add JSON Schema v1 for provenance, licensing, artifacts, CRS/units, compatibility, profiles, retained families, and size/work descriptors.
- Add a checked-in manifest ready for C2 seeds.
- Validate duplicate IDs, required license metadata, profile enums, artifact selection, and SHA-256 syntax/content.
- Add negative CI tests for duplicate IDs, missing licenses, bad checksums, and unsupported profiles.

## Contract impact

- Establishes an additive test-data schema only; no polygonization API or semantic output changes.

## Validation

- `cargo test -p geo-polygonize-core --test workload_manifest` — 2 passed
- `cargo clippy -p geo-polygonize-core --test workload_manifest -- -D warnings` — passed
- `git diff --check` — passed

## Agent handoff

Remaining:
- Populate redistributable clips with real provenance and checksums.

Next dependency-ready slice:
- `agent/p1-corpus-seed`.