### PR TITLE
ci(github): improve release and benchmark workflows

### DIFF
--- a/.github/workflows/cross-architecture-benchmarks.yml
+++ b/.github/workflows/cross-architecture-benchmarks.yml
@@ -2,6 +2,10 @@ name: Cross-architecture benchmarks
 
 on:
   workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+      - "geo-polygonize-v*"
   schedule:
     - cron: "0 6 * * 1"
   pull_request:
@@ -114,3 +118,53 @@ jobs:
           name: wasm-crossover-benchmarks
           path: wasm-*.json
           retention-days: 30
+
+  attach-to-release:
+    name: Attach results to release
+    if: always() && startsWith(github.ref, 'refs/tags/')
+    needs: [native, wasm]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download benchmark results
+        if: needs.native.result == 'success' && needs.wasm.result == 'success'
+        uses: actions/download-artifact@v4
+        with:
+          pattern: "*-benchmarks"
+          path: benchmark-results
+
+      - name: Attach benchmark results
+        if: needs.native.result == 'success' && needs.wasm.result == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          zip -qr "benchmark-results-${TAG}.zip" benchmark-results
+          gh release upload "$TAG" "benchmark-results-${TAG}.zip" --clobber
+
+      - name: Add package and benchmark links
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          version="${TAG#geo-polygonize-v}"
+          version="${version#v}"
+          gh release view "$TAG" --json body --jq .body > release-body.md
+          sed '/<!-- release-links:start -->/,/<!-- release-links:end -->/d' release-body.md > release-body.next.md
+          {
+            cat release-body.next.md
+            printf '\n<!-- release-links:start -->\n## Packages\n\n'
+            printf '| Package | Release |\n|---|---|\n'
+            printf '| npm | [geo-polygonize %s](https://www.npmjs.com/package/geo-polygonize/v/%s) |\n' "$version" "$version"
+            printf '| PyPI | [geo-polygonize-py %s](https://pypi.org/project/geo-polygonize-py/%s/) |\n' "$version" "$version"
+            for package in geo-polygonize-core geo-polygonize-arrow geo-polygonize-flatgeobuf geo-polygonize-wasm; do
+              printf '| crates.io | [%s %s](https://crates.io/crates/%s/%s) |\n' "$package" "$version" "$package" "$version"
+            done
+            if [ -f "benchmark-results-${TAG}.zip" ]; then
+              printf '| Benchmarks | [Cross-architecture results](https://github.com/%s/releases/download/%s/benchmark-results-%s.zip) |\n' "$REPOSITORY" "$TAG" "$TAG"
+            fi
+            printf '<!-- release-links:end -->\n'
+          } > release-body.updated.md
+          gh release edit "$TAG" --notes-file release-body.updated.md

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -2,16 +2,6 @@ name: Maintenance
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-      - develop
-    paths:
-      - 'crates/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - 'scripts/**'
-      - '.github/workflows/maintenance.yml'
   pull_request:
     branches:
       - main
@@ -24,16 +14,15 @@ on:
       - '.github/workflows/maintenance.yml'
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
 
 concurrency:
-  group: "${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(main): release') && 'release' || 'code' }}"
+  group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: true
 
 jobs:
   maintenance:
-    if: "${{ github.event_name != 'push' || (!startsWith(github.event.head_commit.message, 'chore(github): update benchmarks') && !startsWith(github.event.head_commit.message, 'chore(main): release')) }}"
     continue-on-error: true
     runs-on: ubuntu-latest
     steps:
@@ -75,28 +64,15 @@ jobs:
             bash crates/geo-polygonize-core/benches/run_comparison.sh
           fi
 
-      - name: Update BENCHMARKS.md
-        if: github.event_name == 'push'
-        run: python3 crates/geo-polygonize-core/benches/compare_results.py --update
-
-      - name: Create Pull Request
-        if: github.event_name == 'push'
-        uses: peter-evans/create-pull-request@v6
-        with:
-          token: ${{ secrets.GH_PAT }}
-          commit-message: "chore(github): update benchmarks"
-          title: "chore(github): update benchmarks"
-          body: "Automated benchmark updates."
-          branch: update-benchmarks
-          base: ${{ github.ref_name }}
-          add-paths: BENCHMARKS.md
-
       - name: Generate Benchmark Report
-        if: github.event_name == 'pull_request'
         run: python3 crates/geo-polygonize-core/benches/compare_results.py > benchmark_report.md
 
       - name: Comment on PR
         if: github.event_name == 'pull_request' && hashFiles('benchmark_report.md') != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr comment ${{ github.event.pull_request.number }} --body-file benchmark_report.md
+        run: gh pr comment ${{ github.event.pull_request.number }} --edit-last --create-if-none --body-file benchmark_report.md
+
+      - name: Add report to workflow summary
+        if: github.event_name == 'workflow_dispatch'
+        run: cat benchmark_report.md >> "$GITHUB_STEP_SUMMARY"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,4 +1,5 @@
 {
+  "draft-pull-request": true,
   "packages": {
     ".": {
       "release-type": "node",


### PR DESCRIPTION
## Summary

- Run cross-architecture benchmarks for version tags.
- Attach benchmark results to GitHub releases and add package links to release notes.
- Simplify maintenance workflow permissions and benchmark reporting.
- Configure release-please to create draft pull requests.

## Testing

- Not run (not requested)