### PR TITLE
fix(wasm): preserve runtime selection in cancellable workers

### DIFF
--- a/crates/geo-polygonize-wasm/src/lib.rs
+++ b/crates/geo-polygonize-wasm/src/lib.rs
@@ -664,15 +664,26 @@ fn polygonize_and_flatten(
     let js_cut_edges = serde_wasm_bindgen::to_value(&result.cut_edges).unwrap_or(JsValue::NULL);
     let js_invalid_rings =
         serde_wasm_bindgen::to_value(&result.invalid_rings).unwrap_or(JsValue::NULL);
+    let offset = |value: usize, name: &str| {
+        u32::try_from(value).map_err(|_| {
+            to_js_error(
+                "ResourceLimitExceeded",
+                format!("{name} exceeds the Wasm u32 offset range"),
+            )
+        })
+    };
 
     for poly in result.polygons {
         provenances.push(poly.provenance);
-        polygon_offsets.push(ring_offsets.len() as u32);
+        polygon_offsets.push(offset(ring_offsets.len(), "polygon ring offset")?);
 
         let exterior = poly.exterior;
         let interiors = poly.interiors;
 
-        ring_offsets.push((flat_coords.len() / stride as usize) as u32);
+        ring_offsets.push(offset(
+            flat_coords.len() / stride as usize,
+            "ring coordinate offset",
+        )?);
         for (k, coord) in exterior.iter().enumerate() {
             flat_coords.push(coord.x);
             flat_coords.push(coord.y);
@@ -687,7 +698,10 @@ fn polygonize_and_flatten(
         }
 
         for (h_idx, ring) in interiors.iter().enumerate() {
-            ring_offsets.push((flat_coords.len() / stride as usize) as u32);
+            ring_offsets.push(offset(
+                flat_coords.len() / stride as usize,
+                "ring coordinate offset",
+            )?);
             for (k, coord) in ring.iter().enumerate() {
                 flat_coords.push(coord.x);
                 flat_coords.push(coord.y);

--- a/crates/geo-polygonize-wasm/tests/wasm.test.js
+++ b/crates/geo-polygonize-wasm/tests/wasm.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import init, { polygonize, cfbRobustOptions } from '../../../dist/standard/es/index.js';
+import { selectRuntime } from '../../../pkg-wrapper/runtime.ts';
 
 describe('WASM Polygonizer', () => {
     it('should publish declaration paths referenced by wrapper types', () => {
@@ -16,6 +17,22 @@ describe('WASM Polygonizer', () => {
             await import('../../../dist/standard/es/index.js');
         expect(polygonizeWithOptionsAsync).toBeTypeOf('function');
         expect(polygonizeReportWithOptionsAsync).toBeTypeOf('function');
+    });
+
+    it('should select the same scalar and SIMD variants for direct and worker runtimes', () => {
+        expect(selectRuntime('scalar', 'simd', false)).toEqual({
+            variant: 'scalar',
+            module: 'scalar',
+        });
+        expect(selectRuntime('scalar', 'simd', true)).toEqual({
+            variant: 'simd',
+            module: 'simd',
+        });
+
+        const worker = readFileSync(resolve('dist/standard/es/polygonize_worker.js'), 'utf8');
+        for (const wasm of ['dist/geo_polygonize.wasm', 'dist/geo_polygonize_simd.wasm']) {
+            expect(worker).toContain(readFileSync(resolve(wasm)).toString('base64'));
+        }
     });
 
     it('should initialize slim with module alias options', async () => {

--- a/pkg-wrapper/index.ts
+++ b/pkg-wrapper/index.ts
@@ -2,15 +2,7 @@ import wasmInit, * as exports from "../pkg-scalar/geo_polygonize.js";
 import wasmScalarUrl from "../pkg-scalar/geo_polygonize_bg.wasm";
 import wasmSimdUrl from "../pkg-simd/geo_polygonize_bg.wasm";
 import type { PolygonizerOptions } from "./bindings/PolygonizerOptions";
-
-// Perform SIMD detection once at module load time
-const simdSupported = (() => {
-    try {
-        return WebAssembly.validate(new Uint8Array([0,97,115,109,1,0,0,0,1,5,1,96,0,1,123,3,2,1,0,10,10,1,8,0,65,0,253,15,253,98,11]));
-    } catch (e) {
-        return false;
-    }
-})();
+import { selectRuntime } from "./runtime";
 
 // Cache the initialization promise
 let initPromise: Promise<typeof exports> | undefined;
@@ -128,11 +120,11 @@ export function polygonizeReportWithOptionsAsync(
 export default function init(_input?: any): Promise<typeof exports> {
     if (initPromise) return initPromise;
 
-    const url = simdSupported ? wasmSimdUrl : wasmScalarUrl;
+    const runtime = selectRuntime(wasmScalarUrl, wasmSimdUrl);
 
     // Create the promise and cache it
     initPromise = (async () => {
-        await wasmInit(url);
+        await wasmInit(runtime.module);
         return exports;
     })();
 

--- a/pkg-wrapper/index_slim.ts
+++ b/pkg-wrapper/index_slim.ts
@@ -1,4 +1,5 @@
 import initScalar, * as scalarExports from "../pkg-scalar/geo_polygonize.js";
+import { selectRuntime } from "./runtime";
 
 // We re-export everything. The user is responsible for calling init with the correct module/url.
 export * from "../pkg-scalar/geo_polygonize.js";
@@ -22,9 +23,6 @@ export * from "./bindings/ZPolicy";
 export * from "./cfb";
 
 // We provide a helper to choose based on feature detection if the user wants to use it
-let isSimdSupported: boolean | undefined;
-const SIMD_TEST_BYTES = new Uint8Array([0,97,115,109,1,0,0,0,1,5,1,96,0,1,123,3,2,1,0,10,10,1,8,0,65,0,253,15,253,98,11]);
-
 function normalizeInitInput(input: any) {
     if (input && typeof input === "object" && "module" in input && !("module_or_path" in input)) {
         return { ...input, module_or_path: input.module };
@@ -33,14 +31,7 @@ function normalizeInitInput(input: any) {
 }
 
 export async function initBest(scalarModule: any, simdModule?: any) {
-    if (isSimdSupported === undefined) {
-        try {
-            isSimdSupported = WebAssembly.validate(SIMD_TEST_BYTES);
-        } catch (e) {
-            isSimdSupported = false;
-        }
-    }
-
-    await initScalar(normalizeInitInput(isSimdSupported && simdModule ? simdModule : scalarModule));
+    const runtime = selectRuntime(scalarModule, simdModule ?? scalarModule);
+    await initScalar(normalizeInitInput(runtime.module));
     return scalarExports;
 }

--- a/pkg-wrapper/polygonize_worker.ts
+++ b/pkg-wrapper/polygonize_worker.ts
@@ -2,9 +2,11 @@ import init, {
     polygonizeReportWithOptions,
     polygonizeWithOptions,
 } from "../pkg-scalar/geo_polygonize.js";
-import wasmUrl from "../pkg-scalar/geo_polygonize_bg.wasm";
+import wasmScalarUrl from "../pkg-scalar/geo_polygonize_bg.wasm";
+import wasmSimdUrl from "../pkg-simd/geo_polygonize_bg.wasm";
+import { selectRuntime } from "./runtime";
 
-type Operation = "polygons" | "report";
+type Operation = "initialize" | "polygons" | "report";
 
 type Request = {
     id: number;
@@ -14,18 +16,21 @@ type Request = {
 };
 
 let initialized: Promise<void> | undefined;
+const runtime = selectRuntime(wasmScalarUrl, wasmSimdUrl);
 
 function initialize() {
-    initialized ??= init(wasmUrl).then(() => {});
+    initialized ??= init(runtime.module).then(() => {});
     return initialized;
 }
 
 self.addEventListener("message", async ({ data }: MessageEvent<Request>) => {
     try {
         await initialize();
-        const result = data.operation === "polygons"
-            ? polygonizeWithOptions(data.geojson, data.options)
-            : polygonizeReportWithOptions(data.geojson, data.options);
+        const result = data.operation === "initialize"
+            ? runtime.variant
+            : data.operation === "polygons"
+                ? polygonizeWithOptions(data.geojson, data.options)
+                : polygonizeReportWithOptions(data.geojson, data.options);
         self.postMessage({ id: data.id, result });
     } catch (error) {
         const exception = error instanceof Error ? error : new Error(String(error));

--- a/pkg-wrapper/runtime.ts
+++ b/pkg-wrapper/runtime.ts
@@ -1,0 +1,24 @@
+export type RuntimeVariant = "scalar" | "simd";
+
+const SIMD_TEST_BYTES = new Uint8Array([
+    0, 97, 115, 109, 1, 0, 0, 0, 1, 5, 1, 96, 0, 1, 123, 3, 2, 1, 0, 10, 10, 1, 8,
+    0, 65, 0, 253, 15, 253, 98, 11,
+]);
+
+export function supportsSimd(): boolean {
+    try {
+        return WebAssembly.validate(SIMD_TEST_BYTES);
+    } catch {
+        return false;
+    }
+}
+
+export function selectRuntime<T>(
+    scalar: T,
+    simd: T,
+    simdSupported = supportsSimd(),
+): { variant: RuntimeVariant; module: T } {
+    return simdSupported
+        ? { variant: "simd", module: simd }
+        : { variant: "scalar", module: scalar };
+}

--- a/scripts/benchmark_wasm_worker.mjs
+++ b/scripts/benchmark_wasm_worker.mjs
@@ -1,0 +1,65 @@
+import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+import { extname, resolve } from "node:path";
+import { chromium } from "playwright-core";
+
+const root = process.cwd();
+const server = createServer(async (request, response) => {
+  const pathname = new URL(request.url, "http://localhost").pathname;
+  if (pathname === "/") return response.end("<!doctype html>");
+  const path = resolve(root, `.${pathname}`);
+  if (!path.startsWith(`${root}/`)) return response.writeHead(403).end();
+  response.setHeader(
+    "Content-Type",
+    extname(path) === ".wasm" ? "application/wasm" : "text/javascript",
+  );
+  try {
+    response.end(await readFile(path));
+  } catch {
+    response.writeHead(404).end();
+  }
+});
+
+await new Promise((ready) => server.listen(0, "127.0.0.1", ready));
+const { port } = server.address();
+const browser = await chromium.launch(
+  process.env.CHROME_PATH
+    ? { executablePath: process.env.CHROME_PATH, headless: true }
+    : { channel: "chrome", headless: true },
+);
+
+try {
+  const page = await browser.newPage();
+  await page.goto(`http://127.0.0.1:${port}/`);
+  const result = await page.evaluate(async () => {
+    const input = JSON.stringify({
+      type: "FeatureCollection",
+      features: [{
+        type: "Feature",
+        properties: {},
+        geometry: {
+          type: "LineString",
+          coordinates: [[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]],
+        },
+      }],
+    });
+    const worker = new Worker("/dist/standard/es/polygonize_worker.js", { type: "module" });
+    const request = (operation) => new Promise((resolve, reject) => {
+      worker.onmessage = ({ data }) => data.error ? reject(data.error) : resolve(data.result);
+      worker.onerror = reject;
+      worker.postMessage({ id: 0, operation, geojson: input, options: {} });
+    });
+    const startupStarted = performance.now();
+    const variant = await request("initialize");
+    const startupMs = performance.now() - startupStarted;
+    const polygonizeStarted = performance.now();
+    await request("polygons");
+    const polygonizeMs = performance.now() - polygonizeStarted;
+    worker.terminate();
+    return { variant, coldWorkerStartupMs: startupMs, polygonizeMs };
+  });
+  console.log(JSON.stringify(result, null, 2));
+} finally {
+  await browser.close();
+  await new Promise((closed) => server.close(closed));
+}


### PR DESCRIPTION
## Stack

Parent:
- #992 (merged)

This PR:
- Preserve scalar/SIMD runtime parity in cancellable browser workers.

Children:
- not opened yet

## Delivered

- Share scalar/SIMD feature detection and runtime selection across direct, slim, and worker entry points.
- Bundle both published Wasm variants into the cancellable worker and retain terminate-on-abort behavior.
- Add checked `usize -> u32` output-offset conversion.
- Add a published-asset regression proving the worker contains both scalar and SIMD binaries.
- Add a cold-worker benchmark that reports initialization separately from polygonization.

## Contract impact

- Worker calls now select the same supported runtime variant as direct calls.
- Oversized Wasm output offsets fail explicitly instead of truncating.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo test -p geo-polygonize-wasm` — passed
- `./scripts/build_wasm.sh --variant scalar --no-bundle` — passed
- `./scripts/build_wasm.sh --variant simd --no-bundle` — passed
- `./scripts/build_wasm.sh --bundle-only` — passed
- `npm test` — 19 passed
- `node scripts/benchmark_wasm_worker.mjs` — passed; SIMD selected, cold startup 358.7 ms, polygonization 30.2 ms on this host

## Agent handoff

Remaining:
- Python output-mode child is not opened yet.

Next dependency-ready slice:
- `agent/python-output-boundaries` based on this branch.