### PR TITLE
perf(python): separate polygonization output modes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1115,6 +1115,7 @@ dependencies = [
  "geo-polygonize-core",
  "numpy",
  "pyo3",
+ "serde",
  "serde_json",
 ]
 

--- a/README.md
+++ b/README.md
@@ -160,8 +160,21 @@ coords = np.array([
 # The final closing offset is computed implicitly.
 offsets = np.array([0, 5], dtype=np.uint32)
 
-# Returns a stable dictionary with 'polygons', diagnostics, and provenance.
+# `report` preserves the compatibility result with objects, buffers, fingerprint,
+# diagnostics, and per-binding phase timings.
 result_dict = polygonize(coords=coords, offsets=offsets)
+
+# Request only the representation you need.
+buffers = polygonize(coords=coords, offsets=offsets, output="buffers")
+objects = polygonize(coords=coords, offsets=offsets, output="objects")
+
+# Execution budgets are non-semantic and stay separate from topology options.
+bounded = polygonize(
+    coords=coords,
+    offsets=offsets,
+    output="buffers",
+    execution_limits={"max_output_coordinates": 1_000_000},
+)
 
 # Native-extension probes are cheap and safe for optional integrations.
 ok, error = import_probe()
@@ -181,9 +194,10 @@ result = polygonize_with_options(
 )
 ```
 
-The default return shape is a stable dictionary with `polygons` as
-`SimplePolygon` values. Use `return_polygons=True` only when you want Shapely
-`Polygon` objects.
+The default `report` return shape remains a stable dictionary with `polygons`
+as `SimplePolygon` values. `buffers` omits Python geometry objects and the
+fingerprint; `objects` omits flattened arrays and the fingerprint. Use
+`return_polygons=True` only when you want Shapely `Polygon` objects.
 
 When provenance is enabled, coincident and partially overlapping input lines
 are dissolved into one topology edge while every contributing nonzero

--- a/crates/geo-polygonize-python/Cargo.toml
+++ b/crates/geo-polygonize-python/Cargo.toml
@@ -16,6 +16,7 @@ doctest = false
 polygonize-core = { package = "geo-polygonize-core", path = "../geo-polygonize-core", version = "0.76.1" }
 pyo3 = { version = "0.29", features = ["abi3-py38"] }
 numpy = "0.29"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 [features]

--- a/crates/geo-polygonize-python/src/lib.rs
+++ b/crates/geo-polygonize-python/src/lib.rs
@@ -1,18 +1,110 @@
 use numpy::{PyArray1, PyReadonlyArray1};
 use polygonize_core::{
     normalize_polygonize_error, polygonize_with_execution_policy, CancellationToken, Coord3D,
-    ExecutionPolicy, Line3D, PolygonizeError, PolygonizerOptions, PrecisionModel,
-    TopologyFingerprintV1,
+    ExecutionPolicy, Line3D, PolygonizeError, PolygonizerOptions, PolygonizerResult,
+    PrecisionModel, TopologyFingerprintV1,
 };
 use pyo3::create_exception;
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList, PyTuple};
+use serde::Deserialize;
 use std::sync::mpsc::{sync_channel, RecvTimeoutError};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 const SIGNAL_POLL_INTERVAL: Duration = Duration::from_millis(10);
+const PYTHON_CONVERSION_SIGNAL_INTERVAL: usize = 256;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum OutputMode {
+    Buffers,
+    Objects,
+    Report,
+}
+
+impl OutputMode {
+    fn parse(value: &str) -> PyResult<Self> {
+        match value {
+            "buffers" => Ok(Self::Buffers),
+            "objects" => Ok(Self::Objects),
+            "report" => Ok(Self::Report),
+            _ => Err(PolygonizeOptionsError::new_err(
+                "output must be 'buffers', 'objects', or 'report'",
+            )),
+        }
+    }
+
+    fn needs_buffers(self) -> bool {
+        matches!(self, Self::Buffers | Self::Report)
+    }
+
+    fn needs_objects(self) -> bool {
+        matches!(self, Self::Objects | Self::Report)
+    }
+}
+
+#[derive(Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct PythonExecutionLimits {
+    max_input_line_strings: Option<usize>,
+    max_input_segments: Option<usize>,
+    max_input_coordinates: Option<usize>,
+    max_noded_segments: Option<usize>,
+    max_candidate_pairs: Option<usize>,
+    max_exact_intersection_calls: Option<usize>,
+    max_split_events: Option<usize>,
+    max_noding_iterations: Option<usize>,
+    max_graph_nodes: Option<usize>,
+    max_graph_edges: Option<usize>,
+    max_rings: Option<usize>,
+    max_output_polygons: Option<usize>,
+    max_output_coordinates: Option<usize>,
+}
+
+impl PythonExecutionLimits {
+    fn into_policy(self, cancellation_token: CancellationToken) -> ExecutionPolicy {
+        ExecutionPolicy {
+            cancellation_token: Some(cancellation_token),
+            max_input_line_strings: self.max_input_line_strings,
+            max_input_segments: self.max_input_segments,
+            max_input_coordinates: self.max_input_coordinates,
+            max_noded_segments: self.max_noded_segments,
+            max_candidate_pairs: self.max_candidate_pairs,
+            max_exact_intersection_calls: self.max_exact_intersection_calls,
+            max_split_events: self.max_split_events,
+            max_noding_iterations: self.max_noding_iterations,
+            max_graph_nodes: self.max_graph_nodes,
+            max_graph_edges: self.max_graph_edges,
+            max_rings: self.max_rings,
+            max_output_polygons: self.max_output_polygons,
+            max_output_coordinates: self.max_output_coordinates,
+        }
+    }
+}
+
+#[derive(Default)]
+struct OwnedBuffers {
+    flat_coords: Vec<f64>,
+    ring_offsets: Vec<u32>,
+    polygon_offsets: Vec<u32>,
+    flat_line_ids: Vec<u32>,
+}
+
+#[derive(Default)]
+struct BindingTimings {
+    thread_spawn: Duration,
+    buffer_conversion: Duration,
+    fingerprint: Duration,
+    python_objects: Duration,
+}
+
+struct WorkerOutput {
+    result: PolygonizerResult,
+    fingerprint: Option<TopologyFingerprintV1>,
+    buffers: Option<OwnedBuffers>,
+    timings: BindingTimings,
+}
 
 create_exception!(
     geo_polygonize_core,
@@ -80,19 +172,40 @@ fn polygonize_without_gil(
     py: Python<'_>,
     lines: Vec<Line3D>,
     options: PolygonizerOptions,
-) -> PyResult<(polygonize_core::PolygonizerResult, TopologyFingerprintV1)> {
+    execution_limits: PythonExecutionLimits,
+    output_mode: OutputMode,
+    stride: usize,
+) -> PyResult<WorkerOutput> {
     py.check_signals()?;
     let token = CancellationToken::new();
-    let policy = ExecutionPolicy {
-        cancellation_token: Some(token.clone()),
-        ..Default::default()
-    };
+    let policy = execution_limits.into_policy(token.clone());
     let (sender, receiver) = sync_channel(1);
+    let spawn_started = Instant::now();
     let worker = thread::spawn(move || {
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let result = polygonize_with_execution_policy(lines, &options, &policy)?;
-            let fingerprint = TopologyFingerprintV1::try_from_result(&result, &options)?;
-            Ok((result, fingerprint))
+            let buffer_started = Instant::now();
+            let buffers = output_mode
+                .needs_buffers()
+                .then(|| flatten_result(&result, stride))
+                .transpose()?;
+            let buffer_conversion = buffer_started.elapsed();
+
+            let fingerprint_started = Instant::now();
+            let fingerprint = (output_mode == OutputMode::Report)
+                .then(|| TopologyFingerprintV1::try_from_result(&result, &options))
+                .transpose()?;
+            let fingerprint_duration = fingerprint_started.elapsed();
+            Ok(WorkerOutput {
+                result,
+                fingerprint,
+                buffers,
+                timings: BindingTimings {
+                    buffer_conversion,
+                    fingerprint: fingerprint_duration,
+                    ..Default::default()
+                },
+            })
         }))
         .unwrap_or_else(|_| {
             Err(PolygonizeError::Panic(
@@ -101,6 +214,7 @@ fn polygonize_without_gil(
         });
         let _ = sender.send(result);
     });
+    let thread_spawn = spawn_started.elapsed();
 
     let result = py.detach(move || {
         let result = loop {
@@ -128,11 +242,98 @@ fn polygonize_without_gil(
         result
     });
 
-    result?.map_err(to_py_err)
+    let mut output = result?.map_err(to_py_err)?;
+    output.timings.thread_spawn = thread_spawn;
+    Ok(output)
+}
+
+fn checked_u32(value: usize, field: &str) -> polygonize_core::Result<u32> {
+    u32::try_from(value).map_err(|_| PolygonizeError::ResourceLimitExceeded {
+        stage: field.to_string(),
+        limit: u32::MAX as usize,
+        observed: value,
+    })
+}
+
+fn flatten_result(
+    result: &PolygonizerResult,
+    stride: usize,
+) -> polygonize_core::Result<OwnedBuffers> {
+    let num_points = result.polygons.iter().try_fold(0usize, |count, polygon| {
+        polygon.interiors.iter().try_fold(
+            count.checked_add(polygon.exterior.len()).ok_or_else(|| {
+                PolygonizeError::InternalInvariantViolation {
+                    reason: "Python output point count overflowed usize".to_string(),
+                }
+            })?,
+            |count, ring| {
+                count.checked_add(ring.len()).ok_or_else(|| {
+                    PolygonizeError::InternalInvariantViolation {
+                        reason: "Python output point count overflowed usize".to_string(),
+                    }
+                })
+            },
+        )
+    })?;
+    let num_rings = result.polygons.iter().try_fold(0usize, |count, polygon| {
+        count
+            .checked_add(1 + polygon.interiors.len())
+            .ok_or_else(|| PolygonizeError::InternalInvariantViolation {
+                reason: "Python output ring count overflowed usize".to_string(),
+            })
+    })?;
+    let coordinate_capacity = num_points.checked_mul(stride).ok_or_else(|| {
+        PolygonizeError::InternalInvariantViolation {
+            reason: "Python output coordinate count overflowed usize".to_string(),
+        }
+    })?;
+    let mut buffers = OwnedBuffers {
+        flat_coords: Vec::with_capacity(coordinate_capacity),
+        ring_offsets: Vec::with_capacity(num_rings),
+        polygon_offsets: Vec::with_capacity(result.polygons.len()),
+        flat_line_ids: Vec::with_capacity(num_points),
+    };
+
+    for polygon in &result.polygons {
+        buffers.polygon_offsets.push(checked_u32(
+            buffers.ring_offsets.len(),
+            "python_polygon_offsets",
+        )?);
+        buffers.ring_offsets.push(checked_u32(
+            buffers.flat_coords.len() / stride,
+            "python_ring_offsets",
+        )?);
+        append_ring(
+            &mut buffers,
+            &polygon.exterior,
+            &polygon.exterior_ids,
+            stride,
+        );
+        for (ring, ids) in polygon.interiors.iter().zip(&polygon.interiors_ids) {
+            buffers.ring_offsets.push(checked_u32(
+                buffers.flat_coords.len() / stride,
+                "python_ring_offsets",
+            )?);
+            append_ring(&mut buffers, ring, ids, stride);
+        }
+    }
+    Ok(buffers)
+}
+
+fn append_ring(buffers: &mut OwnedBuffers, ring: &[Coord3D], ids: &[u32], stride: usize) {
+    for (index, coordinate) in ring.iter().enumerate() {
+        buffers.flat_coords.extend([coordinate.x, coordinate.y]);
+        if stride == 3 {
+            buffers.flat_coords.push(coordinate.z);
+        }
+        buffers
+            .flat_line_ids
+            .push(ids.get(index).copied().unwrap_or_default());
+    }
 }
 
 #[pyfunction]
-#[pyo3(signature = (coords, offsets, stride=2, options_json=None, line_ids=None))]
+#[pyo3(signature = (coords, offsets, stride=2, options_json=None, line_ids=None, output="report", execution_json=None))]
 #[allow(clippy::too_many_arguments)]
 fn polygonize_with_options<'py>(
     py: Python<'py>,
@@ -141,6 +342,8 @@ fn polygonize_with_options<'py>(
     stride: u8,
     options_json: Option<&str>,
     line_ids: Option<PyReadonlyArray1<'py, u32>>,
+    output: &str,
+    execution_json: Option<&str>,
 ) -> PyResult<Py<PyAny>> {
     let options: PolygonizerOptions = if let Some(json) = options_json {
         serde_json::from_str(json)
@@ -149,11 +352,20 @@ fn polygonize_with_options<'py>(
         PolygonizerOptions::default()
     };
 
-    polygonize_internal(py, coords, offsets, stride, options, line_ids)
+    polygonize_internal(
+        py,
+        coords,
+        offsets,
+        stride,
+        options,
+        line_ids,
+        OutputMode::parse(output)?,
+        parse_execution_limits(execution_json)?,
+    )
 }
 
 #[pyfunction]
-#[pyo3(signature = (coords, offsets, node=false, snap=1e-10, extract_only_polygonal=false, stride=2, line_ids=None, report_mode=false))]
+#[pyo3(signature = (coords, offsets, node=false, snap=1e-10, extract_only_polygonal=false, stride=2, line_ids=None, report_mode=false, output="report", execution_json=None))]
 #[allow(clippy::too_many_arguments)]
 fn polygonize<'py>(
     py: Python<'py>,
@@ -165,6 +377,8 @@ fn polygonize<'py>(
     stride: u8,
     line_ids: Option<PyReadonlyArray1<'py, u32>>,
     report_mode: bool,
+    output: &str,
+    execution_json: Option<&str>,
 ) -> PyResult<Py<PyAny>> {
     let mut options = PolygonizerOptions::default();
     options.diagnostics.enabled = report_mode;
@@ -177,9 +391,30 @@ fn polygonize<'py>(
     };
     options.extract_only_polygonal = extract_only_polygonal;
 
-    polygonize_internal(py, coords, offsets, stride, options, line_ids)
+    polygonize_internal(
+        py,
+        coords,
+        offsets,
+        stride,
+        options,
+        line_ids,
+        OutputMode::parse(output)?,
+        parse_execution_limits(execution_json)?,
+    )
 }
 
+fn parse_execution_limits(value: Option<&str>) -> PyResult<PythonExecutionLimits> {
+    value.map_or_else(
+        || Ok(PythonExecutionLimits::default()),
+        |json| {
+            serde_json::from_str(json).map_err(|error| {
+                PolygonizeOptionsError::new_err(format!("Invalid execution limits json: {error}"))
+            })
+        },
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
 fn polygonize_internal<'py>(
     py: Python<'py>,
     coords: PyReadonlyArray1<'py, f64>,
@@ -187,6 +422,8 @@ fn polygonize_internal<'py>(
     stride: u8,
     options: PolygonizerOptions,
     line_ids: Option<PyReadonlyArray1<'py, u32>>,
+    output_mode: OutputMode,
+    execution_limits: PythonExecutionLimits,
 ) -> PyResult<Py<PyAny>> {
     let coords_slice = coords.as_slice()?;
     let offsets_slice = offsets.as_slice()?;
@@ -241,11 +478,16 @@ fn polygonize_internal<'py>(
                     ),
                 }));
             }
-            if end * stride_usize > coords_slice.len() {
+            let coordinate_end = end.checked_mul(stride_usize).ok_or_else(|| {
+                to_py_err(PolygonizeError::InvalidBufferShape {
+                    reason: "Invalid offsets: coordinate index overflow".to_string(),
+                })
+            })?;
+            if coordinate_end > coords_slice.len() {
                 return Err(to_py_err(PolygonizeError::InvalidBufferShape {
                     reason: format!(
                         "Invalid offsets: calculated end offset {} exceeds coordinate capacity {} for stride {}",
-                        end * stride_usize, coords_slice.len(), stride_usize
+                        coordinate_end, coords_slice.len(), stride_usize
                     ),
                 }));
             }
@@ -284,130 +526,89 @@ fn polygonize_internal<'py>(
         }
     }
 
-    let (result, topology_fingerprint) = polygonize_without_gil(py, lines, options)?;
+    let mut output = polygonize_without_gil(
+        py,
+        lines,
+        options,
+        execution_limits,
+        output_mode,
+        stride_usize,
+    )?;
+    let result = &output.result;
+    let python_objects_started = Instant::now();
+    let mut converted_items = 0usize;
 
-    // Flatten logic
-    let mut num_points = 0;
-    let mut num_rings = 0;
-    let num_polygons = result.polygons.len();
-
-    for poly in &result.polygons {
-        num_points += poly.exterior.len();
-        num_rings += 1 + poly.interiors.len();
-        for ring in &poly.interiors {
-            num_points += ring.len();
-        }
-    }
-
-    let mut flat_coords = Vec::with_capacity(num_points * stride_usize);
-    let mut ring_offsets = Vec::with_capacity(num_rings);
-    let mut polygon_offsets = Vec::with_capacity(num_polygons);
-    let mut flat_line_ids = Vec::with_capacity(num_points);
-
-    for poly in &result.polygons {
-        polygon_offsets.push(ring_offsets.len() as u32);
-
-        let exterior = &poly.exterior;
-        let interiors = &poly.interiors;
-
-        ring_offsets.push((flat_coords.len() / stride_usize) as u32);
-        for (k, c) in exterior.iter().enumerate() {
-            flat_coords.push(c.x);
-            flat_coords.push(c.y);
-            if stride == 3 {
-                flat_coords.push(c.z);
-            }
-            if k < poly.exterior_ids.len() {
-                flat_line_ids.push(poly.exterior_ids[k]);
-            } else {
-                flat_line_ids.push(0);
-            }
-        }
-
-        for (h_idx, ring) in interiors.iter().enumerate() {
-            ring_offsets.push((flat_coords.len() / stride_usize) as u32);
-            for (k, c) in ring.iter().enumerate() {
-                flat_coords.push(c.x);
-                flat_coords.push(c.y);
-                if stride == 3 {
-                    flat_coords.push(c.z);
-                }
-                if k < poly.interiors_ids[h_idx].len() {
-                    flat_line_ids.push(poly.interiors_ids[h_idx][k]);
-                } else {
-                    flat_line_ids.push(0);
-                }
-            }
-        }
-    }
-
-    // We will build Python polygons via the SimplePolygon class from geo_polygonize.types.
-    // If geo_polygonize.types isn't available, we fallback to a simple dict representation?
-    // The issue asks to "construct and return SimplePolygon objects directly".
     let py_polygons = PyList::empty(py);
-
-    // Attempt to import the Python class `SimplePolygon`
-    let simple_polygon_cls = py
-        .import("geo_polygonize.types")?
-        .getattr("SimplePolygon")?;
-
-    for poly in &result.polygons {
-        // Construct exterior tuples
-        let exterior_pts = PyList::empty(py);
-        for c in &poly.exterior {
-            if stride == 3 {
-                exterior_pts.append(PyTuple::new(py, [c.x, c.y, c.z])?)?;
-            } else {
-                exterior_pts.append(PyTuple::new(py, [c.x, c.y])?)?;
-            }
-        }
-        let shell = PyTuple::new(py, exterior_pts)?;
-
-        let shell_ids = PyTuple::new(py, &poly.exterior_ids)?;
-
-        // Construct interiors
-        let holes = PyList::empty(py);
-        let holes_ids = PyList::empty(py);
-
-        for (h_idx, ring) in poly.interiors.iter().enumerate() {
-            let ring_pts = PyList::empty(py);
-            for c in ring {
+    if output_mode.needs_objects() {
+        let simple_polygon_cls = py
+            .import("geo_polygonize.types")?
+            .getattr("SimplePolygon")?;
+        for poly in &result.polygons {
+            check_python_signal(py, &mut converted_items)?;
+            // Construct exterior tuples
+            let exterior_pts = PyList::empty(py);
+            for c in &poly.exterior {
+                check_python_signal(py, &mut converted_items)?;
                 if stride == 3 {
-                    ring_pts.append(PyTuple::new(py, [c.x, c.y, c.z])?)?;
+                    exterior_pts.append(PyTuple::new(py, [c.x, c.y, c.z])?)?;
                 } else {
-                    ring_pts.append(PyTuple::new(py, [c.x, c.y])?)?;
+                    exterior_pts.append(PyTuple::new(py, [c.x, c.y])?)?;
                 }
             }
-            holes.append(PyTuple::new(py, ring_pts)?)?;
+            let shell = PyTuple::new(py, exterior_pts)?;
 
-            let r_ids = PyTuple::new(py, &poly.interiors_ids[h_idx])?;
-            holes_ids.append(r_ids)?;
-        }
+            let shell_ids = PyTuple::new(py, &poly.exterior_ids)?;
 
-        let py_provenance = if let Some(ref prov) = poly.provenance {
-            let prov_dict = PyDict::new(py);
-            let b_ids = PyTuple::new(py, &prov.boundary_line_ids)?;
-            prov_dict.set_item("boundary_line_ids", b_ids)?;
-            if let Some(ref prof_id) = prov.input_profile_id {
-                prov_dict.set_item("input_profile_id", prof_id)?;
-            } else {
-                prov_dict.set_item("input_profile_id", py.None())?;
+            // Construct interiors
+            let holes = PyList::empty(py);
+            let holes_ids = PyList::empty(py);
+
+            for (h_idx, ring) in poly.interiors.iter().enumerate() {
+                let ring_pts = PyList::empty(py);
+                for c in ring {
+                    check_python_signal(py, &mut converted_items)?;
+                    if stride == 3 {
+                        ring_pts.append(PyTuple::new(py, [c.x, c.y, c.z])?)?;
+                    } else {
+                        ring_pts.append(PyTuple::new(py, [c.x, c.y])?)?;
+                    }
+                }
+                holes.append(PyTuple::new(py, ring_pts)?)?;
+
+                let r_ids = PyTuple::new(py, &poly.interiors_ids[h_idx])?;
+                holes_ids.append(r_ids)?;
             }
-            prov_dict.into_any()
-        } else {
-            py.None().into_bound(py)
-        };
 
-        let py_poly =
-            simple_polygon_cls.call1((shell, holes, shell_ids, holes_ids, py_provenance))?;
-        py_polygons.append(py_poly)?;
+            let py_provenance = if let Some(ref prov) = poly.provenance {
+                let prov_dict = PyDict::new(py);
+                let b_ids = PyTuple::new(py, &prov.boundary_line_ids)?;
+                prov_dict.set_item("boundary_line_ids", b_ids)?;
+                if let Some(ref prof_id) = prov.input_profile_id {
+                    prov_dict.set_item("input_profile_id", prof_id)?;
+                } else {
+                    prov_dict.set_item("input_profile_id", py.None())?;
+                }
+                prov_dict.into_any()
+            } else {
+                py.None().into_bound(py)
+            };
+
+            let py_poly =
+                simple_polygon_cls.call1((shell, holes, shell_ids, holes_ids, py_provenance))?;
+            py_polygons.append(py_poly)?;
+        }
     }
 
     // Construct dangles
     let py_dangles = PyList::empty(py);
-    for dangle in &result.dangles {
+    for dangle in result
+        .dangles
+        .iter()
+        .filter(|_| output_mode.needs_objects())
+    {
         let dangle_pts = PyList::empty(py);
         for c in dangle {
+            check_python_signal(py, &mut converted_items)?;
             if stride == 3 {
                 dangle_pts.append(PyTuple::new(py, [c.x, c.y, c.z])?)?;
             } else {
@@ -419,9 +620,14 @@ fn polygonize_internal<'py>(
 
     // Construct cut edges
     let py_cut_edges = PyList::empty(py);
-    for cut_edge in &result.cut_edges {
+    for cut_edge in result
+        .cut_edges
+        .iter()
+        .filter(|_| output_mode.needs_objects())
+    {
         let cut_edge_pts = PyList::empty(py);
         for c in cut_edge {
+            check_python_signal(py, &mut converted_items)?;
             if stride == 3 {
                 cut_edge_pts.append(PyTuple::new(py, [c.x, c.y, c.z])?)?;
             } else {
@@ -433,9 +639,14 @@ fn polygonize_internal<'py>(
 
     // Construct invalid rings
     let py_invalid_rings = PyList::empty(py);
-    for invalid_ring in &result.invalid_rings {
+    for invalid_ring in result
+        .invalid_rings
+        .iter()
+        .filter(|_| output_mode.needs_objects())
+    {
         let invalid_pts = PyList::empty(py);
         for c in invalid_ring {
+            check_python_signal(py, &mut converted_items)?;
             if stride == 3 {
                 invalid_pts.append(PyTuple::new(py, [c.x, c.y, c.z])?)?;
             } else {
@@ -444,34 +655,75 @@ fn polygonize_internal<'py>(
         }
         py_invalid_rings.append(PyTuple::new(py, invalid_pts)?)?;
     }
+    output.timings.python_objects = python_objects_started.elapsed();
 
     let dict = PyDict::new(py);
-    dict.set_item("flat_coords", PyArray1::from_vec(py, flat_coords))?;
-    dict.set_item("ring_offsets", PyArray1::from_vec(py, ring_offsets))?;
-    dict.set_item("polygon_offsets", PyArray1::from_vec(py, polygon_offsets))?;
-    dict.set_item("flat_line_ids", PyArray1::from_vec(py, flat_line_ids))?;
     dict.set_item("stride", stride)?;
-
-    dict.set_item("polygons", py_polygons)?;
-    dict.set_item("dangles", py_dangles)?;
-    dict.set_item("cut_edges", py_cut_edges)?;
-    dict.set_item("invalid_rings", py_invalid_rings)?;
-    let json_module = py.import("json")?;
-    let loads_func = json_module.getattr("loads")?;
-    dict.set_item(
-        "topology_fingerprint",
-        loads_func.call1((serde_json::to_string(&topology_fingerprint).unwrap(),))?,
-    )?;
-
-    if let Some(ref diag) = result.diagnostics {
-        // Map diagnostics using serde to a Python dict
-        if let Ok(diag_json) = serde_json::to_string(diag) {
-            let py_diag = loads_func.call1((diag_json,))?;
-            dict.set_item("diagnostics", py_diag)?;
+    if let Some(buffers) = output.buffers {
+        dict.set_item("flat_coords", PyArray1::from_vec(py, buffers.flat_coords))?;
+        dict.set_item("ring_offsets", PyArray1::from_vec(py, buffers.ring_offsets))?;
+        dict.set_item(
+            "polygon_offsets",
+            PyArray1::from_vec(py, buffers.polygon_offsets),
+        )?;
+        dict.set_item(
+            "flat_line_ids",
+            PyArray1::from_vec(py, buffers.flat_line_ids),
+        )?;
+    }
+    if output_mode.needs_objects() {
+        dict.set_item("polygons", py_polygons)?;
+        dict.set_item("dangles", py_dangles)?;
+        dict.set_item("cut_edges", py_cut_edges)?;
+        dict.set_item("invalid_rings", py_invalid_rings)?;
+    }
+    if output_mode == OutputMode::Report {
+        let json_module = py.import("json")?;
+        let loads = json_module.getattr("loads")?;
+        if let Some(fingerprint) = output.fingerprint {
+            dict.set_item(
+                "topology_fingerprint",
+                loads.call1((
+                    serde_json::to_string(&fingerprint).expect("fingerprint serializes"),
+                ))?,
+            )?;
         }
+        if let Some(ref diagnostics) = result.diagnostics {
+            dict.set_item(
+                "diagnostics",
+                loads
+                    .call1((serde_json::to_string(diagnostics).expect("diagnostics serialize"),))?,
+            )?;
+        }
+        let timings = PyDict::new(py);
+        timings.set_item(
+            "thread_spawn_ms",
+            output.timings.thread_spawn.as_secs_f64() * 1_000.0,
+        )?;
+        timings.set_item(
+            "buffer_conversion_ms",
+            output.timings.buffer_conversion.as_secs_f64() * 1_000.0,
+        )?;
+        timings.set_item(
+            "fingerprint_ms",
+            output.timings.fingerprint.as_secs_f64() * 1_000.0,
+        )?;
+        timings.set_item(
+            "python_objects_ms",
+            output.timings.python_objects.as_secs_f64() * 1_000.0,
+        )?;
+        dict.set_item("binding_timings", timings)?;
     }
 
     Ok(dict.into())
+}
+
+fn check_python_signal(py: Python<'_>, converted_items: &mut usize) -> PyResult<()> {
+    *converted_items = converted_items.saturating_add(1);
+    if converted_items.is_multiple_of(PYTHON_CONVERSION_SIGNAL_INTERVAL) {
+        py.check_signals()?;
+    }
+    Ok(())
 }
 
 #[pymodule]

--- a/python/geo_polygonize/__init__.py
+++ b/python/geo_polygonize/__init__.py
@@ -45,7 +45,17 @@ def is_available():
     """Return True when a geo_polygonize runtime backend is importable."""
     return import_probe()[0]
 
-def polygonize_with_options(lines=None, coords=None, offsets=None, options=None, stride=None, line_ids=None, return_polygons=False):
+def polygonize_with_options(
+    lines=None,
+    coords=None,
+    offsets=None,
+    options=None,
+    stride=None,
+    line_ids=None,
+    return_polygons=False,
+    output="report",
+    execution_limits=None,
+):
     """
     Polygonize a set of lines with full canonical options.
 
@@ -57,6 +67,8 @@ def polygonize_with_options(lines=None, coords=None, offsets=None, options=None,
         stride: stride of coordinates (2 or 3). If None, defaults to 2 unless coords is (N, 3).
         line_ids: optional uint32 array of line IDs.
         return_polygons: if True, returns Shapely Polygon objects instead of a dictionary.
+        output: one of "buffers", "objects", or "report". "report" preserves the legacy result.
+        execution_limits: optional non-semantic execution budget dictionary.
     """
     if lines is not None:
         flat_coords = []
@@ -114,9 +126,21 @@ def polygonize_with_options(lines=None, coords=None, offsets=None, options=None,
     if line_ids is not None:
         line_ids = np.ascontiguousarray(line_ids, dtype=np.uint32)
 
+    if return_polygons and output == "buffers":
+        raise ValueError("return_polygons=True requires output='objects' or output='report'")
+
     options_json = None if options is None else json.dumps(options)
 
-    result = _polygonize_with_options_impl(coords, offsets, stride=stride, options_json=options_json, line_ids=line_ids)
+    execution_json = None if execution_limits is None else json.dumps(execution_limits)
+    result = _polygonize_with_options_impl(
+        coords,
+        offsets,
+        stride=stride,
+        options_json=options_json,
+        line_ids=line_ids,
+        output=output,
+        execution_json=execution_json,
+    )
 
     if return_polygons:
         try:
@@ -229,7 +253,19 @@ def explain_mismatch(result_a, result_b, tolerance=1e-5):
         "mismatches": mismatches
     }
 
-def polygonize(coords=None, offsets=None, lines=None, node=False, snap=1e-10, extract_only_polygonal=False, stride=None, line_ids=None, return_polygons=False):
+def polygonize(
+    coords=None,
+    offsets=None,
+    lines=None,
+    node=False,
+    snap=1e-10,
+    extract_only_polygonal=False,
+    stride=None,
+    line_ids=None,
+    return_polygons=False,
+    output="report",
+    execution_limits=None,
+):
     """
     Polygonize a set of lines.
 
@@ -243,6 +279,8 @@ def polygonize(coords=None, offsets=None, lines=None, node=False, snap=1e-10, ex
         stride: stride of coordinates (2 or 3). If None, defaults to 2 unless coords is (N, 3).
         line_ids: optional uint32 array of line IDs.
         return_polygons: if True, returns Shapely Polygon objects instead of a dictionary.
+        output: one of "buffers", "objects", or "report". "report" preserves the legacy result.
+        execution_limits: optional non-semantic execution budget dictionary.
 
     Returns:
         Dict with keys 'polygons' (List[SimplePolygon]), 'dangles', 'invalid_rings', and 'flat_line_ids'.
@@ -349,7 +387,15 @@ def polygonize(coords=None, offsets=None, lines=None, node=False, snap=1e-10, ex
         "input_profile_id": None
     }
 
-    result = polygonize_with_options(coords=coords, offsets=offsets, options=options, stride=stride, line_ids=line_ids)
+    result = polygonize_with_options(
+        coords=coords,
+        offsets=offsets,
+        options=options,
+        stride=stride,
+        line_ids=line_ids,
+        output=output,
+        execution_limits=execution_limits,
+    )
 
     if return_polygons:
         try:

--- a/python/test_wrapper.py
+++ b/python/test_wrapper.py
@@ -301,6 +301,48 @@ def test_polygonize_with_options():
 
     print("polygonize_with_options API test passed!")
 
+def test_output_modes_and_execution_limits():
+    from geo_polygonize import polygonize_with_options
+
+    coords = np.array([
+        0.0, 0.0, 1.0, 0.0,
+        1.0, 0.0, 1.0, 1.0,
+        1.0, 1.0, 0.0, 1.0,
+        0.0, 1.0, 0.0, 0.0,
+    ], dtype=np.float64)
+    offsets = np.array([0, 2, 4, 6, 8], dtype=np.uint32)
+
+    buffers = polygonize_with_options(coords=coords, offsets=offsets, output="buffers")
+    assert "flat_coords" in buffers
+    assert "polygons" not in buffers
+    assert "topology_fingerprint" not in buffers
+
+    objects = polygonize_with_options(coords=coords, offsets=offsets, output="objects")
+    assert len(objects["polygons"]) == 1
+    assert "flat_coords" not in objects
+    assert "topology_fingerprint" not in objects
+
+    report = polygonize_with_options(coords=coords, offsets=offsets)
+    assert "flat_coords" in report
+    assert len(report["polygons"]) == 1
+    assert report["topology_fingerprint"]["schema_version"] == 1
+    assert set(report["binding_timings"]) == {
+        "thread_spawn_ms",
+        "buffer_conversion_ms",
+        "fingerprint_ms",
+        "python_objects_ms",
+    }
+
+    with pytest.raises(RuntimeError, match="input_segments"):
+        polygonize_with_options(
+            coords=coords,
+            offsets=offsets,
+            execution_limits={"max_input_segments": 3},
+        )
+
+    with pytest.raises(Exception, match="output must be"):
+        polygonize_with_options(coords=coords, offsets=offsets, output="unknown")
+
 def test_3d_to_2d_slicing():
     print("\nTesting 3D to 2D slicing (stride=2, shape=(N, 3))...")
     # 2D array with 3 columns, but we want 2D polygonization (XY)


### PR DESCRIPTION
## Stack

Parent:
- #998 (merged)

This PR:
- Separate Python `buffers`, `objects`, and compatibility `report` output modes.

Children:
- not opened yet

## Delivered

- Avoids flattened buffers, `SimplePolygon` trees, and topology fingerprints unless the selected mode requires them.
- Performs owned buffer flattening in the detached Rust worker and polls Python signals every 256 object-conversion items.
- Checks every generated `usize -> u32` ring/polygon offset conversion.
- Exposes all execution budgets through a separate `execution_limits` dictionary.
- Reports thread-spawn, buffer-conversion, fingerprint, and Python-object phase timings.
- Preserves `report` as the default compatibility shape.

## Contract impact

- Adds output selection and execution budgets without changing semantic `PolygonizerOptions`.
- `buffers` omits Python objects and fingerprints; `objects` omits flat arrays and fingerprints; `report` preserves both and adds binding timings.
- Canonical topology, provenance, Z behavior, and normalized errors are unchanged.

## Validation

- `cargo fmt --all -- --check` — passed before and after rebase
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `cargo test --workspace` — passed
- `cargo test -p geo-polygonize-core --no-default-features` — passed
- `RUSTDOCFLAGS='-D warnings' cargo doc -p geo-polygonize-core --no-deps` — passed
- `python3 -m maturin build --release --out target/wheels` — passed; abi3 wheel built
- `pytest --import-mode=importlib tests python` from `/tmp` against the installed wheel — 30 passed
- initial `pytest tests python` from the repository root — environment-only failure because the source package shadowed the installed extension; rerun above exercised the wheel
- post-rebase targeted Python suite — 16 passed
- `npm test` — 19 passed
- `npm run docs:build` — passed; existing npm audit reported 5 dependency vulnerabilities
- report timing probe — thread spawn 0.032708 ms; buffer conversion 0.0005 ms; fingerprint 0.110417 ms; Python objects 0.010459 ms

## Agent handoff

Remaining:
- Review whether binding timings should stay in every report or move behind an explicit measurement flag before 1.0.

Next dependency-ready slice:
- none in Stack B