### PR TITLE
perf(core): publish correctness-gated benchmark records

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -321,6 +321,10 @@ Before recording time, require:
 - [ ] canonical topology fingerprint or documented divergence;
 - [ ] polygon, ring, dangle, cut-edge, invalid-ring, and provenance metrics.
 
+Progress: Benchmark record V1 now encodes these gates and all three lanes as a
+strict machine-readable schema. No benchmark result is published by the schema
+change itself.
+
 Record:
 
 - p50, p95, throughput, and sample count;

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,18 @@
+# Correctness-gated benchmark records
+
+`benchmark-record-v1.schema.json` defines the only publishable timing record.
+It keeps three lanes separate:
+
+1. already-noded polygonization;
+2. floating noding plus polygonization;
+3. certified fixed-precision noding plus polygonization.
+
+A runner must validate its promised noding postcondition and compare the
+topology fingerprint before serializing a record. Expected divergence requires
+both the manifest classification and a reason. Failed or unexplained runs are
+test artifacts, not timing records.
+
+Records pin the commit, compiler, operating system, architecture, implementation,
+features, and dependency versions. Phase names and throughput units are explicit
+strings so different runners can report their native phases without pretending
+unlike pipelines are equivalent.

--- a/benchmarks/benchmark-record-v1.schema.json
+++ b/benchmarks/benchmark-record-v1.schema.json
@@ -1,0 +1,251 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/graydonpleasants/geo-polygonize/benchmarks/benchmark-record-v1.schema.json",
+  "title": "geo-polygonize correctness-gated benchmark record V1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "record_id",
+    "workload_id",
+    "lane",
+    "implementation",
+    "correctness_gate",
+    "topology",
+    "measurement",
+    "work",
+    "environment"
+  ],
+  "properties": {
+    "schema_version": {"const": 1},
+    "record_id": {"type": "string", "minLength": 1},
+    "workload_id": {"type": "string", "minLength": 1},
+    "lane": {
+      "enum": [
+        "already-noded-polygonization",
+        "floating-noding-plus-polygonization",
+        "certified-fixed-precision-noding-plus-polygonization"
+      ]
+    },
+    "implementation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "version", "features"],
+      "properties": {
+        "name": {"type": "string", "minLength": 1},
+        "version": {"type": "string", "minLength": 1},
+        "features": {
+          "type": "array",
+          "items": {"type": "string"},
+          "uniqueItems": true
+        }
+      }
+    },
+    "correctness_gate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "validation", "compatibility", "fingerprint"],
+      "properties": {
+        "status": {"const": "passed"},
+        "validation": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["promised", "result"],
+          "properties": {
+            "promised": {"type": "boolean"},
+            "result": {"enum": ["passed", "not-promised"]}
+          },
+          "allOf": [
+            {
+              "if": {"properties": {"promised": {"const": true}}},
+              "then": {"properties": {"result": {"const": "passed"}}},
+              "else": {"properties": {"result": {"const": "not-promised"}}}
+            }
+          ]
+        },
+        "compatibility": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["expected", "observed"],
+          "properties": {
+            "expected": {"enum": ["parity", "expected-divergence"]},
+            "observed": {"enum": ["equal", "expected-divergence"]}
+          },
+          "allOf": [
+            {
+              "if": {"properties": {"expected": {"const": "parity"}}},
+              "then": {"properties": {"observed": {"const": "equal"}}},
+              "else": {
+                "properties": {"observed": {"const": "expected-divergence"}}
+              }
+            }
+          ]
+        },
+        "fingerprint": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["outcome", "actual_sha256"],
+          "properties": {
+            "outcome": {"enum": ["equal", "expected-divergence"]},
+            "actual_sha256": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "reference_sha256": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
+            },
+            "divergence_reason": {"type": "string", "minLength": 1}
+          },
+          "allOf": [
+            {
+              "if": {
+                "properties": {"outcome": {"const": "expected-divergence"}}
+              },
+              "then": {"required": ["divergence_reason"]},
+              "else": {"required": ["reference_sha256"]}
+            }
+          ]
+        }
+      }
+    },
+    "topology": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "polygons",
+        "rings",
+        "dangles",
+        "cut_edges",
+        "invalid_rings",
+        "provenance_sources"
+      ],
+      "properties": {
+        "polygons": {"type": "integer", "minimum": 0},
+        "rings": {"type": "integer", "minimum": 0},
+        "dangles": {"type": "integer", "minimum": 0},
+        "cut_edges": {"type": "integer", "minimum": 0},
+        "invalid_rings": {"type": "integer", "minimum": 0},
+        "provenance_sources": {"type": "integer", "minimum": 0}
+      }
+    },
+    "measurement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "p50_ms",
+        "p95_ms",
+        "throughput",
+        "samples",
+        "phase_times_ms",
+        "allocations",
+        "peak_rss_bytes"
+      ],
+      "properties": {
+        "p50_ms": {"type": "number", "minimum": 0},
+        "p95_ms": {"type": "number", "minimum": 0},
+        "throughput": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["value", "unit"],
+          "properties": {
+            "value": {"type": "number", "minimum": 0},
+            "unit": {"type": "string", "minLength": 1}
+          }
+        },
+        "samples": {"type": "integer", "minimum": 1},
+        "phase_times_ms": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": {"type": "number", "minimum": 0}
+        },
+        "allocations": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["count", "bytes"],
+          "properties": {
+            "count": {"type": "integer", "minimum": 0},
+            "bytes": {"type": "integer", "minimum": 0}
+          }
+        },
+        "peak_rss_bytes": {"type": "integer", "minimum": 0}
+      }
+    },
+    "work": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "input_line_strings",
+        "input_segments",
+        "input_coordinates",
+        "output_polygons",
+        "output_coordinates",
+        "candidate_pairs",
+        "exact_predicate_calls",
+        "split_events",
+        "segment_expansion"
+      ],
+      "properties": {
+        "input_line_strings": {"type": "integer", "minimum": 0},
+        "input_segments": {"type": "integer", "minimum": 0},
+        "input_coordinates": {"type": "integer", "minimum": 0},
+        "output_polygons": {"type": "integer", "minimum": 0},
+        "output_coordinates": {"type": "integer", "minimum": 0},
+        "candidate_pairs": {"type": "integer", "minimum": 0},
+        "exact_predicate_calls": {"type": "integer", "minimum": 0},
+        "split_events": {"type": "integer", "minimum": 0},
+        "segment_expansion": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["input_segments", "noded_segments", "ratio"],
+          "properties": {
+            "input_segments": {"type": "integer", "minimum": 0},
+            "noded_segments": {"type": "integer", "minimum": 0},
+            "ratio": {"type": "number", "minimum": 0}
+          }
+        }
+      }
+    },
+    "environment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "architecture",
+        "os",
+        "compiler",
+        "dependencies",
+        "commit_sha"
+      ],
+      "properties": {
+        "architecture": {"type": "string", "minLength": 1},
+        "os": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["name", "version"],
+          "properties": {
+            "name": {"type": "string", "minLength": 1},
+            "version": {"type": "string", "minLength": 1}
+          }
+        },
+        "compiler": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["name", "version"],
+          "properties": {
+            "name": {"type": "string", "minLength": 1},
+            "version": {"type": "string", "minLength": 1}
+          }
+        },
+        "dependencies": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": {"type": "string", "minLength": 1}
+        },
+        "commit_sha": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        }
+      }
+    }
+  }
+}

--- a/crates/geo-polygonize-core/tests/benchmark_record_schema.rs
+++ b/crates/geo-polygonize-core/tests/benchmark_record_schema.rs
@@ -1,0 +1,104 @@
+use serde_json::Value;
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+fn schema() -> Value {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../benchmarks/benchmark-record-v1.schema.json");
+    serde_json::from_slice(&std::fs::read(path).unwrap()).unwrap()
+}
+
+fn required(value: &Value) -> HashSet<&str> {
+    value["required"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|field| field.as_str().unwrap())
+        .collect()
+}
+
+fn enum_values<'a>(value: &'a Value, path: &[&str]) -> HashSet<&'a str> {
+    let value = path.iter().fold(value, |value, key| &value[*key]);
+    value["enum"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|variant| variant.as_str().unwrap())
+        .collect()
+}
+
+#[test]
+fn benchmark_schema_requires_correctness_before_timings() {
+    let schema = schema();
+    assert_eq!(schema["properties"]["schema_version"]["const"], 1);
+    assert_eq!(
+        enum_values(&schema, &["properties", "lane"]),
+        HashSet::from([
+            "already-noded-polygonization",
+            "floating-noding-plus-polygonization",
+            "certified-fixed-precision-noding-plus-polygonization",
+        ])
+    );
+
+    let gate = &schema["properties"]["correctness_gate"];
+    assert_eq!(gate["properties"]["status"]["const"], "passed");
+    assert_eq!(
+        enum_values(gate, &["properties", "validation", "properties", "result"]),
+        HashSet::from(["passed", "not-promised"])
+    );
+    assert_eq!(
+        enum_values(
+            gate,
+            &["properties", "fingerprint", "properties", "outcome"]
+        ),
+        HashSet::from(["equal", "expected-divergence"])
+    );
+    assert!(required(gate).is_superset(&HashSet::from([
+        "status",
+        "validation",
+        "compatibility",
+        "fingerprint",
+    ])));
+}
+
+#[test]
+fn benchmark_schema_requires_measurement_work_and_environment_evidence() {
+    let schema = schema();
+    let properties = &schema["properties"];
+    assert!(
+        required(&properties["topology"]).is_superset(&HashSet::from([
+            "polygons",
+            "rings",
+            "dangles",
+            "cut_edges",
+            "invalid_rings",
+            "provenance_sources",
+        ]))
+    );
+    assert!(
+        required(&properties["measurement"]).is_superset(&HashSet::from([
+            "p50_ms",
+            "p95_ms",
+            "throughput",
+            "samples",
+            "phase_times_ms",
+            "allocations",
+            "peak_rss_bytes",
+        ]))
+    );
+    assert!(required(&properties["work"]).is_superset(&HashSet::from([
+        "candidate_pairs",
+        "exact_predicate_calls",
+        "split_events",
+        "segment_expansion",
+    ])));
+    assert!(
+        required(&properties["environment"]).is_superset(&HashSet::from([
+            "architecture",
+            "os",
+            "compiler",
+            "dependencies",
+            "commit_sha",
+        ]))
+    );
+}


### PR DESCRIPTION
## Stack

Parent:
- #999 (merged)

This PR:
- Define strict correctness-gated benchmark record V1.

Children:
- not opened yet

## Delivered

- Defines separate already-noded, floating-noding, and certified fixed-precision lanes.
- Requires successful promised validation, expected compatibility, fingerprint equality or explained divergence, and full topology metrics before a timing record is valid.
- Records p50, p95, throughput, samples, phase times, allocations, peak RSS, input/output sizes, noding work, and segment expansion.
- Pins implementation, features, architecture, OS/compiler versions, dependencies, commit SHA, and workload ID.
- Adds contract tests and reproduction guidance without publishing synthetic performance results.

## Contract impact

- Adds benchmark record schema V1 only; it does not alter polygonization or existing serialized schemas.
- Failed or unexplained runs cannot satisfy the publishable timing schema.
- No performance comparison is emitted by this PR.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `cargo test --workspace` — passed, including 2 benchmark schema contract tests
- `cargo test -p geo-polygonize-core --no-default-features` — passed
- `RUSTDOCFLAGS='-D warnings' cargo doc -p geo-polygonize-core --no-deps` — passed
- `npm test` — 19 passed
- `npm run docs:build` — passed; existing npm audit reported 5 dependency vulnerabilities

## Agent handoff

Remaining:
- Build runners that populate V1 only after executing the encoded correctness gate.
- Publish result artifacts and a trend view after runner methodology is reviewed.

Next dependency-ready slice:
- implement one correctness-gated runner for the already-noded lane