### PR TITLE
perf(core): run correctness-gated already-noded benchmarks

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -16,3 +16,21 @@ Records pin the commit, compiler, operating system, architecture, implementation
 features, and dependency versions. Phase names and throughput units are explicit
 strings so different runners can report their native phases without pretending
 unlike pipelines are equivalent.
+
+The already-noded runner requires an externally established fingerprint and
+reference dependency version, validates that the input is fully noded before
+timing, and rejects any timed sample whose fingerprint changes:
+
+```bash
+cargo run -p geo-polygonize-core --release --example benchmark_record -- \
+  --workload already-noded-coverage-v1 \
+  --samples 30 \
+  --expected-fingerprint-sha256 <64-lowercase-hex-digits> \
+  --peak-rss-bytes <externally-measured-peak> \
+  --reference-dependency geos=3.13.1 \
+  --output target/benchmark-record.json
+```
+
+Peak RSS remains an explicit harness input because the Rust standard library
+does not expose a portable process peak. The runner measures allocations with
+the repository's existing `dhat` allocator.

--- a/crates/geo-polygonize-core/examples/benchmark_record.rs
+++ b/crates/geo-polygonize-core/examples/benchmark_record.rs
@@ -1,0 +1,413 @@
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
+use clap::Parser;
+use geo_polygonize_core::{
+    polygonize, Coord3D, Line3D, NodingGuarantee, PolygonizerOptions, PolygonizerResult,
+    TopologyFingerprintV1,
+};
+use geojson::{GeoJson, Value as GeoJsonValue};
+use serde::Deserialize;
+use serde_json::json;
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+#[derive(Parser)]
+#[command(about = "Emit one correctness-gated already-noded benchmark record")]
+struct Args {
+    #[arg(long)]
+    workload: String,
+    #[arg(long)]
+    samples: usize,
+    #[arg(long)]
+    expected_fingerprint_sha256: String,
+    #[arg(long)]
+    peak_rss_bytes: u64,
+    #[arg(long = "reference-dependency", required = true)]
+    reference_dependencies: Vec<String>,
+    #[arg(long)]
+    output: Option<PathBuf>,
+}
+
+#[derive(Deserialize)]
+struct Manifest {
+    workloads: Vec<Workload>,
+}
+
+#[derive(Deserialize)]
+struct Workload {
+    id: String,
+    compatibility_class: String,
+    permitted_profiles: Vec<String>,
+    artifact: Artifact,
+    options: Vec<PolygonizerOptions>,
+    size: WorkloadSize,
+}
+
+#[derive(Deserialize)]
+struct Artifact {
+    clip_path: String,
+}
+
+#[derive(Deserialize)]
+struct WorkloadSize {
+    line_strings: usize,
+    segments: usize,
+    coordinates: usize,
+}
+
+#[derive(Default)]
+struct Samples {
+    elapsed: Vec<Duration>,
+    ingest_and_node: Vec<Duration>,
+    graph_build: Vec<Duration>,
+    ring_extraction: Vec<Duration>,
+    containment: Vec<Duration>,
+    output_flatten: Vec<Duration>,
+    allocations: u64,
+    allocated_bytes: u64,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+    if args.samples == 0 {
+        return Err("samples must be greater than zero".into());
+    }
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let manifest_dir = root.join("tests/workloads");
+    let manifest: Manifest =
+        serde_json::from_slice(&std::fs::read(manifest_dir.join("manifest-v1.json"))?)?;
+    let workload = manifest
+        .workloads
+        .into_iter()
+        .find(|workload| workload.id == args.workload)
+        .ok_or_else(|| format!("unknown workload {}", args.workload))?;
+    if workload.compatibility_class != "parity"
+        || !workload
+            .permitted_profiles
+            .iter()
+            .any(|profile| profile == "already-noded")
+    {
+        return Err(format!(
+            "{} is not a parity-class already-noded workload",
+            workload.id
+        )
+        .into());
+    }
+
+    let lines = load_lines(&manifest_dir.join(&workload.artifact.clip_path))?;
+    if lines.len() != workload.size.segments {
+        return Err(format!(
+            "{} declares {} segments but contains {}",
+            workload.id,
+            workload.size.segments,
+            lines.len()
+        )
+        .into());
+    }
+    let mut options = workload
+        .options
+        .into_iter()
+        .find(|options| !options.node_input)
+        .ok_or("workload has no already-noded options")?;
+    options.provenance.enabled = true;
+    options.provenance.include_boundary_line_ids = true;
+
+    let mut validation_options = options.clone();
+    validation_options.noding.guarantee = NodingGuarantee::Validate;
+    polygonize(lines.clone(), &validation_options)?;
+
+    let mut correctness_options = options.clone();
+    correctness_options.diagnostics.enabled = true;
+    let correctness = polygonize(lines.clone(), &correctness_options)?;
+    let expected = parse_sha256(&args.expected_fingerprint_sha256)?;
+    let actual = fingerprint_sha256(&correctness, &options)?;
+    if actual != expected {
+        return Err(format!(
+            "correctness gate failed: expected {}, observed {}",
+            hex(&expected),
+            hex(&actual)
+        )
+        .into());
+    }
+
+    let profile_path = std::env::temp_dir().join(format!(
+        "geo-polygonize-benchmark-{}.json",
+        std::process::id()
+    ));
+    let _profiler = dhat::Profiler::builder().file_name(profile_path).build();
+    let mut timed_options = options.clone();
+    timed_options.diagnostics.timings = true;
+    let mut samples = Samples::default();
+    for _ in 0..args.samples {
+        let before = dhat::HeapStats::get();
+        let started = Instant::now();
+        let result = polygonize(lines.clone(), &timed_options)?;
+        samples.elapsed.push(started.elapsed());
+        let after = dhat::HeapStats::get();
+        samples.allocations += after.total_blocks - before.total_blocks;
+        samples.allocated_bytes += after.total_bytes - before.total_bytes;
+        if fingerprint_sha256(&result, &options)? != expected {
+            return Err("timed sample fingerprint diverged after correctness gate".into());
+        }
+        let phase = &result
+            .diagnostics
+            .as_ref()
+            .ok_or("timed sample omitted phase diagnostics")?
+            .phase_times;
+        samples.ingest_and_node.push(phase.ingest_and_node);
+        samples.graph_build.push(phase.graph_build);
+        samples.ring_extraction.push(phase.ring_extraction);
+        samples.containment.push(phase.containment);
+        samples.output_flatten.push(phase.output_flatten);
+    }
+
+    let diagnostics = correctness
+        .diagnostics
+        .as_ref()
+        .ok_or("correctness run omitted diagnostics")?;
+    let p50 = percentile(&samples.elapsed, 50);
+    let p95 = percentile(&samples.elapsed, 95);
+    let dependencies = dependencies(&args.reference_dependencies)?;
+    let commit = command("git", &["rev-parse", "HEAD"])?;
+    let output_coordinates = output_coordinates(&correctness);
+    let record = json!({
+        "schema_version": 1,
+        "record_id": format!("{}-{}-already-noded", workload.id, &commit[..12]),
+        "workload_id": workload.id,
+        "lane": "already-noded-polygonization",
+        "implementation": {
+            "name": "geo-polygonize-core",
+            "version": env!("CARGO_PKG_VERSION"),
+            "features": if cfg!(feature = "parallel") { vec!["parallel"] } else { Vec::<&str>::new() },
+        },
+        "correctness_gate": {
+            "status": "passed",
+            "validation": {"promised": true, "result": "passed"},
+            "compatibility": {"expected": "parity", "observed": "equal"},
+            "fingerprint": {
+                "outcome": "equal",
+                "actual_sha256": hex(&actual),
+                "reference_sha256": hex(&expected),
+            },
+        },
+        "topology": {
+            "polygons": correctness.polygons.len(),
+            "rings": correctness.polygons.iter().map(|polygon| 1 + polygon.interiors.len()).sum::<usize>(),
+            "dangles": correctness.dangles.len(),
+            "cut_edges": correctness.cut_edges.len(),
+            "invalid_rings": correctness.invalid_rings.len(),
+            "provenance_sources": provenance_sources(&correctness),
+        },
+        "measurement": {
+            "p50_ms": milliseconds(p50),
+            "p95_ms": milliseconds(p95),
+            "throughput": {
+                "value": if p50.is_zero() { 0.0 } else { lines.len() as f64 / p50.as_secs_f64() },
+                "unit": "input-segments/second",
+            },
+            "samples": args.samples,
+            "phase_times_ms": {
+                "ingest_and_node": milliseconds(percentile(&samples.ingest_and_node, 50)),
+                "graph_build": milliseconds(percentile(&samples.graph_build, 50)),
+                "ring_extraction": milliseconds(percentile(&samples.ring_extraction, 50)),
+                "containment": milliseconds(percentile(&samples.containment, 50)),
+                "output_flatten": milliseconds(percentile(&samples.output_flatten, 50)),
+            },
+            "allocations": {
+                "count": samples.allocations / args.samples as u64,
+                "bytes": samples.allocated_bytes / args.samples as u64,
+            },
+            "peak_rss_bytes": args.peak_rss_bytes,
+        },
+        "work": {
+            "input_line_strings": workload.size.line_strings,
+            "input_segments": lines.len(),
+            "input_coordinates": workload.size.coordinates,
+            "output_polygons": correctness.polygons.len(),
+            "output_coordinates": output_coordinates,
+            "candidate_pairs": diagnostics.noding_work_stats.candidate_pairs,
+            "exact_predicate_calls": diagnostics.noding_work_stats.exact_intersection_calls,
+            "split_events": diagnostics.noding_work_stats.split_events,
+            "segment_expansion": {
+                "input_segments": diagnostics.input_segment_count,
+                "noded_segments": diagnostics.noded_segment_count,
+                "ratio": diagnostics.noded_segment_count as f64 / diagnostics.input_segment_count.max(1) as f64,
+            },
+        },
+        "environment": {
+            "architecture": std::env::consts::ARCH,
+            "os": {
+                "name": command("uname", &["-s"])?,
+                "version": command("uname", &["-r"])?,
+            },
+            "compiler": {
+                "name": "rustc",
+                "version": command("rustc", &["--version"])?,
+            },
+            "dependencies": dependencies,
+            "commit_sha": commit,
+        },
+    });
+    let bytes = serde_json::to_vec_pretty(&record)?;
+    if let Some(path) = args.output {
+        std::fs::write(path, bytes)?;
+    } else {
+        println!("{}", String::from_utf8(bytes)?);
+    }
+    Ok(())
+}
+
+fn load_lines(path: &Path) -> Result<Vec<Line3D>, Box<dyn std::error::Error>> {
+    let geojson: GeoJson = std::fs::read_to_string(path)?.parse()?;
+    let features = match geojson {
+        GeoJson::FeatureCollection(collection) => collection.features,
+        _ => return Err("workload clip must be a FeatureCollection".into()),
+    };
+    let mut line_strings = Vec::new();
+    for feature in features {
+        let geometry = feature.geometry.ok_or("workload feature has no geometry")?;
+        match geometry.value {
+            GeoJsonValue::LineString(line) => line_strings.push(line),
+            GeoJsonValue::MultiLineString(lines) => line_strings.extend(lines),
+            _ => return Err("workload geometry must contain line strings".into()),
+        }
+    }
+    let mut segments = Vec::new();
+    for (index, line) in line_strings.into_iter().enumerate() {
+        let line_id = u32::try_from(index + 1)?;
+        for pair in line.windows(2) {
+            segments.push(Line3D::new(
+                coordinate(&pair[0])?,
+                coordinate(&pair[1])?,
+                line_id,
+            ));
+        }
+    }
+    Ok(segments)
+}
+
+fn coordinate(position: &[f64]) -> Result<Coord3D, Box<dyn std::error::Error>> {
+    if position.len() < 2 {
+        return Err("GeoJSON position must contain x and y".into());
+    }
+    Ok(Coord3D::new(
+        position[0],
+        position[1],
+        position.get(2).copied().unwrap_or_default(),
+    ))
+}
+
+fn fingerprint_sha256(
+    result: &PolygonizerResult,
+    options: &PolygonizerOptions,
+) -> geo_polygonize_core::Result<[u8; 32]> {
+    let fingerprint = TopologyFingerprintV1::try_from_result(result, options)?;
+    Ok(Sha256::digest(serde_json::to_vec(&fingerprint).expect("fingerprint serializes")).into())
+}
+
+fn parse_sha256(value: &str) -> Result<[u8; 32], Box<dyn std::error::Error>> {
+    if value.len() != 64 {
+        return Err("expected fingerprint SHA-256 must contain 64 lowercase hex digits".into());
+    }
+    let mut result = [0; 32];
+    for (index, byte) in result.iter_mut().enumerate() {
+        *byte = u8::from_str_radix(&value[index * 2..index * 2 + 2], 16)?;
+    }
+    if hex(&result) != value {
+        return Err("expected fingerprint SHA-256 must use lowercase hex".into());
+    }
+    Ok(result)
+}
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn percentile(samples: &[Duration], percentile: usize) -> Duration {
+    let mut samples = samples.to_vec();
+    samples.sort_unstable();
+    samples[(samples.len() * percentile).div_ceil(100).saturating_sub(1)]
+}
+
+fn milliseconds(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1_000.0
+}
+
+fn provenance_sources(result: &PolygonizerResult) -> usize {
+    result
+        .polygons
+        .iter()
+        .filter_map(|polygon| polygon.provenance.as_ref())
+        .flat_map(|provenance| &provenance.boundary_line_ids)
+        .copied()
+        .collect::<BTreeSet<_>>()
+        .len()
+}
+
+fn output_coordinates(result: &PolygonizerResult) -> usize {
+    let polygon_coordinates = result.polygons.iter().map(|polygon| {
+        polygon.exterior.len() + polygon.interiors.iter().map(Vec::len).sum::<usize>()
+    });
+    polygon_coordinates
+        .chain(result.dangles.iter().map(Vec::len))
+        .chain(result.cut_edges.iter().map(Vec::len))
+        .chain(result.invalid_rings.iter().map(Vec::len))
+        .sum()
+}
+
+fn dependencies(
+    reference_dependencies: &[String],
+) -> Result<BTreeMap<String, String>, Box<dyn std::error::Error>> {
+    let mut dependencies = BTreeMap::from([(
+        "geo-polygonize-core".to_string(),
+        env!("CARGO_PKG_VERSION").to_string(),
+    )]);
+    for dependency in reference_dependencies {
+        let (name, version) = dependency
+            .split_once('=')
+            .ok_or("reference dependencies must use name=version")?;
+        if name.is_empty()
+            || version.is_empty()
+            || dependencies.insert(name.into(), version.into()).is_some()
+        {
+            return Err(format!("invalid or duplicate reference dependency {dependency}").into());
+        }
+    }
+    Ok(dependencies)
+}
+
+fn command(program: &str, args: &[&str]) -> Result<String, Box<dyn std::error::Error>> {
+    let output = Command::new(program).args(args).output()?;
+    if !output.status.success() {
+        return Err(format!("{program} exited with {}", output.status).into());
+    }
+    Ok(String::from_utf8(output.stdout)?.trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn percentile_uses_nearest_rank() {
+        let values = [
+            Duration::from_millis(4),
+            Duration::from_millis(1),
+            Duration::from_millis(3),
+            Duration::from_millis(2),
+        ];
+        assert_eq!(percentile(&values, 50), Duration::from_millis(2));
+        assert_eq!(percentile(&values, 95), Duration::from_millis(4));
+    }
+
+    #[test]
+    fn sha256_parser_is_strict() {
+        let hash = "00".repeat(32);
+        assert_eq!(parse_sha256(&hash).unwrap(), [0; 32]);
+        assert!(parse_sha256(&"AA".repeat(32)).is_err());
+    }
+}

--- a/crates/geo-polygonize-core/tests/workload_manifest.rs
+++ b/crates/geo-polygonize-core/tests/workload_manifest.rs
@@ -1,4 +1,5 @@
-use geo_polygonize_core::PolygonizerOptions;
+use geo_polygonize_core::{polygonize, Coord3D, Line3D, NodingGuarantee, PolygonizerOptions};
+use geojson::{GeoJson, Value as GeoJsonValue};
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use std::collections::HashSet;
@@ -174,6 +175,67 @@ fn public_workload_manifest_is_valid() {
     let manifest: Manifest =
         serde_json::from_slice(&std::fs::read(root.join("manifest-v1.json")).unwrap()).unwrap();
     validate(&manifest).unwrap();
+}
+
+#[test]
+fn already_noded_workloads_pass_full_noding_validation() {
+    let root = workload_root();
+    let manifest: Manifest =
+        serde_json::from_slice(&std::fs::read(root.join("manifest-v1.json")).unwrap()).unwrap();
+    for workload in manifest.workloads.iter().filter(|workload| {
+        workload
+            .permitted_profiles
+            .iter()
+            .any(|profile| matches!(profile, Profile::AlreadyNoded))
+    }) {
+        let path = workload.artifact.clip_path.as_ref().unwrap();
+        let mut options = workload
+            .options
+            .iter()
+            .find(|options| !options.node_input)
+            .unwrap()
+            .clone();
+        options.noding.guarantee = NodingGuarantee::Validate;
+        polygonize(load_segments(&root.join(path)), &options)
+            .unwrap_or_else(|error| panic!("{} is not fully noded: {error}", workload.id));
+    }
+}
+
+fn load_segments(path: &Path) -> Vec<Line3D> {
+    let geojson: GeoJson = std::fs::read_to_string(path).unwrap().parse().unwrap();
+    let GeoJson::FeatureCollection(collection) = geojson else {
+        panic!("workload must be a FeatureCollection");
+    };
+    let mut lines = Vec::new();
+    for feature in collection.features {
+        match feature.geometry.unwrap().value {
+            GeoJsonValue::LineString(line) => lines.push(line),
+            GeoJsonValue::MultiLineString(feature_lines) => lines.extend(feature_lines),
+            _ => panic!("workload must contain line strings"),
+        }
+    }
+    lines
+        .into_iter()
+        .enumerate()
+        .flat_map(|(index, line)| {
+            line.windows(2)
+                .map(move |pair| {
+                    let coordinate = |position: &[f64]| {
+                        Coord3D::new(
+                            position[0],
+                            position[1],
+                            position.get(2).copied().unwrap_or_default(),
+                        )
+                    };
+                    Line3D::new(
+                        coordinate(&pair[0]),
+                        coordinate(&pair[1]),
+                        u32::try_from(index + 1).unwrap(),
+                    )
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect()
 }
 
 #[test]

--- a/crates/geo-polygonize-core/tests/workloads/clips/already-noded-coverage.geojson
+++ b/crates/geo-polygonize-core/tests/workloads/clips/already-noded-coverage.geojson
@@ -1,1 +1,1 @@
-{"type":"FeatureCollection","features":[{"type":"Feature","properties":{"id":"coverage"},"geometry":{"type":"MultiLineString","coordinates":[[[0,0],[2,0]],[[2,0],[2,2]],[[2,2],[0,2]],[[0,2],[0,0]],[[1,0],[1,2]],[[0,1],[2,1]]]}}]}
+{"type":"FeatureCollection","features":[{"type":"Feature","properties":{"id":"coverage"},"geometry":{"type":"MultiLineString","coordinates":[[[0,0],[1,0]],[[1,0],[2,0]],[[0,1],[1,1]],[[1,1],[2,1]],[[0,2],[1,2]],[[1,2],[2,2]],[[0,0],[0,1]],[[0,1],[0,2]],[[1,0],[1,1]],[[1,1],[1,2]],[[2,0],[2,1]],[[2,1],[2,2]]]}}]}

--- a/crates/geo-polygonize-core/tests/workloads/manifest-v1.json
+++ b/crates/geo-polygonize-core/tests/workloads/manifest-v1.json
@@ -10,7 +10,7 @@
       "attribution": "geo-polygonize contributors; synthetic fixture",
       "artifact": {
         "clip_path": "clips/already-noded-coverage.geojson",
-        "sha256": "bc8a7f64903c50fd6da5619926e80f23c5672b945dedf63db1ac8f330a72a89e"
+        "sha256": "e4cb8fdf539707c898cb690b4ea0abbe5823b2cbc46505b9db7c3a8e06efaac5"
       },
       "coordinate_reference": "local Cartesian",
       "units": "units",
@@ -18,7 +18,7 @@
       "permitted_profiles": ["already-noded"],
       "options": [{"node_input": false}],
       "retained_result_families": ["polygons", "provenance", "diagnostics"],
-      "size": {"line_strings": 6, "segments": 6, "coordinates": 12, "expected_candidate_class": "sparse"}
+      "size": {"line_strings": 12, "segments": 12, "coordinates": 24, "expected_candidate_class": "sparse"}
     },
     {
       "id": "network-linework-v1",


### PR DESCRIPTION
## Stack

Parent:
- #1001 (merged)

This PR:
- Add the correctness-gated already-noded benchmark runner.

Children:
- #1004

## Delivered

- Validates every declared already-noded corpus workload with the independent noding validator.
- Fixes `already-noded-coverage-v1`, whose center lines previously terminated inside unsplit boundary segments.
- Requires an external reference fingerprint and dependency version before timing.
- Rejects any timed sample whose canonical fingerprint diverges.
- Emits schema-V1 p50/p95, phase, allocation, work, topology, provenance, environment, and commit evidence.
- Requires externally measured peak RSS rather than fabricating a portable process peak.

## Contract impact

- Corrects one corpus clip and its checksum/size descriptors without changing public polygonization APIs.
- The runner cannot publish a record before full-noding validation and fingerprint equality pass.
- No comparative performance result is checked in or claimed.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo test -p geo-polygonize-core --test workload_manifest` — 3 passed
- `cargo test -p geo-polygonize-core --example benchmark_record` — 2 passed
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings` — passed
- mismatched fingerprint smoke — rejected before timing and reported the observed hash
- matching ephemeral smoke record — emitted one sample and passed JSON Schema V1 validation; record was not published

## Agent handoff

Remaining:
- Establish reviewed external reference fingerprints and real peak-RSS measurements.
- Add equivalent floating and certified fixed-precision lanes.

Next dependency-ready slice:
- #1004