### PR TITLE
perf(core): add floating noding benchmark lane

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -23,6 +23,7 @@ timing, and rejects any timed sample whose fingerprint changes:
 
 ```bash
 cargo run -p geo-polygonize-core --release --example benchmark_record -- \
+  --lane already-noded \
   --workload already-noded-coverage-v1 \
   --samples 30 \
   --expected-fingerprint-sha256 <64-lowercase-hex-digits> \
@@ -34,3 +35,7 @@ cargo run -p geo-polygonize-core --release --example benchmark_record -- \
 Peak RSS remains an explicit harness input because the Rust standard library
 does not expose a portable process peak. The runner measures allocations with
 the repository's existing `dhat` allocator.
+
+Use `--lane floating` with a parity-class workload that permits the floating
+profile to measure floating noding plus polygonization. The runner performs an
+untimed full-noding validation of that pipeline before collecting samples.

--- a/crates/geo-polygonize-core/examples/benchmark_record.rs
+++ b/crates/geo-polygonize-core/examples/benchmark_record.rs
@@ -1,10 +1,10 @@
 #[global_allocator]
 static ALLOC: dhat::Alloc = dhat::Alloc;
 
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use geo_polygonize_core::{
     polygonize, Coord3D, Line3D, NodingGuarantee, PolygonizerOptions, PolygonizerResult,
-    TopologyFingerprintV1,
+    PrecisionModel, TopologyFingerprintV1,
 };
 use geojson::{GeoJson, Value as GeoJsonValue};
 use serde::Deserialize;
@@ -16,8 +16,10 @@ use std::process::Command;
 use std::time::{Duration, Instant};
 
 #[derive(Parser)]
-#[command(about = "Emit one correctness-gated already-noded benchmark record")]
+#[command(about = "Emit one correctness-gated benchmark record")]
 struct Args {
+    #[arg(long, value_enum)]
+    lane: Lane,
     #[arg(long)]
     workload: String,
     #[arg(long)]
@@ -30,6 +32,37 @@ struct Args {
     reference_dependencies: Vec<String>,
     #[arg(long)]
     output: Option<PathBuf>,
+}
+
+#[derive(Clone, Copy, ValueEnum)]
+enum Lane {
+    AlreadyNoded,
+    Floating,
+}
+
+impl Lane {
+    fn profile(self) -> &'static str {
+        match self {
+            Self::AlreadyNoded => "already-noded",
+            Self::Floating => "floating",
+        }
+    }
+
+    fn record_name(self) -> &'static str {
+        match self {
+            Self::AlreadyNoded => "already-noded-polygonization",
+            Self::Floating => "floating-noding-plus-polygonization",
+        }
+    }
+
+    fn accepts(self, options: &PolygonizerOptions) -> bool {
+        match self {
+            Self::AlreadyNoded => !options.node_input,
+            Self::Floating => {
+                options.node_input && matches!(options.precision_model, PrecisionModel::Floating)
+            }
+        }
+    }
 }
 
 #[derive(Deserialize)]
@@ -89,11 +122,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         || !workload
             .permitted_profiles
             .iter()
-            .any(|profile| profile == "already-noded")
+            .any(|profile| profile == args.lane.profile())
     {
         return Err(format!(
-            "{} is not a parity-class already-noded workload",
-            workload.id
+            "{} is not a parity-class {} workload",
+            workload.id,
+            args.lane.profile()
         )
         .into());
     }
@@ -111,8 +145,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut options = workload
         .options
         .into_iter()
-        .find(|options| !options.node_input)
-        .ok_or("workload has no already-noded options")?;
+        .find(|options| args.lane.accepts(options))
+        .ok_or_else(|| format!("workload has no {} options", args.lane.profile()))?;
     options.provenance.enabled = true;
     options.provenance.include_boundary_line_ids = true;
 
@@ -176,9 +210,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let output_coordinates = output_coordinates(&correctness);
     let record = json!({
         "schema_version": 1,
-        "record_id": format!("{}-{}-already-noded", workload.id, &commit[..12]),
+        "record_id": format!("{}-{}-{}", workload.id, &commit[..12], args.lane.profile()),
         "workload_id": workload.id,
-        "lane": "already-noded-polygonization",
+        "lane": args.lane.record_name(),
         "implementation": {
             "name": "geo-polygonize-core",
             "version": env!("CARGO_PKG_VERSION"),
@@ -409,5 +443,17 @@ mod tests {
         let hash = "00".repeat(32);
         assert_eq!(parse_sha256(&hash).unwrap(), [0; 32]);
         assert!(parse_sha256(&"AA".repeat(32)).is_err());
+    }
+
+    #[test]
+    fn lanes_select_only_equivalent_options() {
+        let mut options = PolygonizerOptions::default();
+        assert!(Lane::AlreadyNoded.accepts(&options));
+        assert!(!Lane::Floating.accepts(&options));
+        options.node_input = true;
+        assert!(!Lane::AlreadyNoded.accepts(&options));
+        assert!(Lane::Floating.accepts(&options));
+        options.precision_model = PrecisionModel::FixedGrid { grid_size: 1.0 };
+        assert!(!Lane::Floating.accepts(&options));
     }
 }


### PR DESCRIPTION
## Stack

Parent:
- #1003 (merged)

This PR:
- Add the equivalent floating-noding-plus-polygonization lane.

Children:
- #1005

## Delivered

- Adds explicit `already-noded` and `floating` lane selection.
- Restricts floating runs to parity-class workloads and floating precision options with integrated noding enabled.
- Runs full-noding validation outside the timed region.
- Applies the same reference fingerprint gate to every timed sample.
- Emits the distinct floating lane name required by benchmark record V1.

## Contract impact

- Does not mix floating integrated noding with bare polygonization.
- Does not alter semantic options or core output.
- Expected-divergence workloads remain rejected until a reviewed divergence contract exists.

## Validation

- `cargo fmt --all -- --check` — passed before and after parent-merge rebase
- `cargo test -p geo-polygonize-core --example benchmark_record` — 3 passed
- `cargo test -p geo-polygonize-core --test workload_manifest` — 3 passed after rebase
- `cargo clippy -p geo-polygonize-core --example benchmark_record -- -D warnings` — passed
- mismatched floating fingerprint smoke — rejected before timing
- matching ephemeral floating smoke — emitted one sample and passed JSON Schema V1 validation; record was not published

## Agent handoff

Remaining:
- Add the certified fixed-precision lane.
- Establish reviewed external reference fingerprints and real peak-RSS measurements.

Next dependency-ready slice:
- #1005