### PR TITLE
perf(core): add certified fixed-precision benchmark lane

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -316,14 +316,16 @@ Do not mix integrated noding on one side with a bare polygonizer on the other.
 
 Before recording time, require:
 
-- [ ] full-noding validation where the policy claims it;
-- [ ] expected compatibility classification;
-- [ ] canonical topology fingerprint or documented divergence;
-- [ ] polygon, ring, dangle, cut-edge, invalid-ring, and provenance metrics.
+- [x] full-noding validation where the policy claims it;
+- [x] expected compatibility classification;
+- [x] canonical topology fingerprint or documented divergence;
+- [x] polygon, ring, dangle, cut-edge, invalid-ring, and provenance metrics.
 
 Progress: Benchmark record V1 now encodes these gates and all three lanes as a
-strict machine-readable schema. No benchmark result is published by the schema
-change itself.
+strict machine-readable schema. The native runner now enforces them for
+already-noded, floating, and certified fixed-precision workloads before timing,
+and requires external reference and peak-RSS evidence. Cross-implementation
+reference execution and result publication remain separate work.
 
 Record:
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -39,3 +39,8 @@ the repository's existing `dhat` allocator.
 Use `--lane floating` with a parity-class workload that permits the floating
 profile to measure floating noding plus polygonization. The runner performs an
 untimed full-noding validation of that pipeline before collecting samples.
+
+Use `--lane certified-fixed` only with a parity-class `certified-fixed`
+workload. Its untimed gate and timed samples both retain
+`CertifiedFixedPrecision`, so the lane measures hot-pixel snap rounding and
+never substitutes the floating or iterative snap backend.

--- a/crates/geo-polygonize-core/examples/benchmark_record.rs
+++ b/crates/geo-polygonize-core/examples/benchmark_record.rs
@@ -38,6 +38,7 @@ struct Args {
 enum Lane {
     AlreadyNoded,
     Floating,
+    CertifiedFixed,
 }
 
 impl Lane {
@@ -45,6 +46,7 @@ impl Lane {
         match self {
             Self::AlreadyNoded => "already-noded",
             Self::Floating => "floating",
+            Self::CertifiedFixed => "certified-fixed",
         }
     }
 
@@ -52,6 +54,7 @@ impl Lane {
         match self {
             Self::AlreadyNoded => "already-noded-polygonization",
             Self::Floating => "floating-noding-plus-polygonization",
+            Self::CertifiedFixed => "certified-fixed-precision-noding-plus-polygonization",
         }
     }
 
@@ -61,6 +64,21 @@ impl Lane {
             Self::Floating => {
                 options.node_input && matches!(options.precision_model, PrecisionModel::Floating)
             }
+            Self::CertifiedFixed => {
+                options.node_input
+                    && matches!(options.precision_model, PrecisionModel::FixedGrid { .. })
+                    && matches!(
+                        options.noding.guarantee,
+                        NodingGuarantee::CertifiedFixedPrecision
+                    )
+            }
+        }
+    }
+
+    fn validation_guarantee(self) -> NodingGuarantee {
+        match self {
+            Self::CertifiedFixed => NodingGuarantee::CertifiedFixedPrecision,
+            Self::AlreadyNoded | Self::Floating => NodingGuarantee::Validate,
         }
     }
 }
@@ -151,7 +169,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     options.provenance.include_boundary_line_ids = true;
 
     let mut validation_options = options.clone();
-    validation_options.noding.guarantee = NodingGuarantee::Validate;
+    validation_options.noding.guarantee = args.lane.validation_guarantee();
     polygonize(lines.clone(), &validation_options)?;
 
     let mut correctness_options = options.clone();
@@ -455,5 +473,12 @@ mod tests {
         assert!(Lane::Floating.accepts(&options));
         options.precision_model = PrecisionModel::FixedGrid { grid_size: 1.0 };
         assert!(!Lane::Floating.accepts(&options));
+        assert!(!Lane::CertifiedFixed.accepts(&options));
+        options.noding.guarantee = NodingGuarantee::CertifiedFixedPrecision;
+        assert!(Lane::CertifiedFixed.accepts(&options));
+        assert!(matches!(
+            Lane::CertifiedFixed.validation_guarantee(),
+            NodingGuarantee::CertifiedFixedPrecision
+        ));
     }
 }


### PR DESCRIPTION
## Stack

Parent:
- #1004

This PR:
- Add the certified fixed-precision noding plus polygonization lane.

Children:
- not opened yet

## Delivered

- Restricts the certified lane to parity-class `certified-fixed` workloads using fixed-grid precision and `CertifiedFixedPrecision`.
- Retains the hot-pixel certified guarantee for both the untimed correctness gate and timed samples.
- Emits the certified lane name required by benchmark record V1.
- Marks the four pre-timing P1.2 gates complete while leaving reference execution and result publication open.
- Completes broad stack validation across Rust, no-default core, rustdoc, npm, and docs.

## Contract impact

- Never substitutes floating or iterative snap noding into the certified lane.
- Does not alter polygonization output or public options.
- No benchmark result or comparative claim is published.

## Validation

- `cargo fmt --all -- --check` — passed before and after descendant rebase
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `cargo test --workspace` — passed
- `cargo test -p geo-polygonize-core --no-default-features` — passed
- `RUSTDOCFLAGS='-D warnings' cargo doc -p geo-polygonize-core --no-deps` — passed
- post-rebase example/workload tests — 3 passed each
- `npm test` — 19 passed
- `npm run docs:build` — passed; existing npm audit reported 5 dependency vulnerabilities
- mismatched certified fingerprint smoke — rejected before timing
- matching ephemeral certified smoke — emitted one sample and passed JSON Schema V1 validation; record was not published

## Agent handoff

Remaining:
- Execute and pin the GEOS/JTS reference side for each equivalent lane.
- Supply real peak-RSS measurements and publish gated records.

Next dependency-ready slice:
- `agent/p1-reference-fingerprints`