### PR TITLE
perf(core): validate external topology references

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -324,8 +324,11 @@ Before recording time, require:
 Progress: Benchmark record V1 now encodes these gates and all three lanes as a
 strict machine-readable schema. The native runner now enforces them for
 already-noded, floating, and certified fixed-precision workloads before timing,
-and requires external reference and peak-RSS evidence. Cross-implementation
-reference execution and result publication remain separate work.
+and requires external reference and peak-RSS evidence. A versioned
+cross-implementation topology fingerprint and GEOS/Shapely reference runner now
+cover the already-noded and floating lanes without pretending Rust-only
+provenance or diagnostics are external equality evidence. Equivalent JTS
+certified-fixed reference execution and result publication remain separate work.
 
 Record:
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -17,18 +17,32 @@ features, and dependency versions. Phase names and throughput units are explicit
 strings so different runners can report their native phases without pretending
 unlike pipelines are equivalent.
 
-The already-noded runner requires an externally established fingerprint and
-reference dependency version, validates that the input is fully noded before
-timing, and rejects any timed sample whose fingerprint changes:
+`reference-result-v1.schema.json` defines the external correctness evidence.
+Its topology fingerprint compares only fields both implementations can produce:
+canonical XY polygon rings, dangles, cut edges, and invalid rings. Rust-only
+edge IDs, provenance, options, and diagnostics remain in the benchmark record
+but cannot be used as cross-implementation equality evidence.
+
+Generate a GEOS/Shapely reference for the already-noded or floating lane:
+
+```bash
+python3 benchmarks/reference_geos.py \
+  --lane already-noded \
+  --workload already-noded-coverage-v1 \
+  --output target/reference-result.json
+```
+
+The benchmark runner validates that the reference workload, lane, dependency
+versions, payload hash, and topology all match before timing. It also rejects
+any timed sample whose fingerprint changes:
 
 ```bash
 cargo run -p geo-polygonize-core --release --example benchmark_record -- \
   --lane already-noded \
   --workload already-noded-coverage-v1 \
   --samples 30 \
-  --expected-fingerprint-sha256 <64-lowercase-hex-digits> \
   --peak-rss-bytes <externally-measured-peak> \
-  --reference-dependency geos=3.13.1 \
+  --reference-result target/reference-result.json \
   --output target/benchmark-record.json
 ```
 
@@ -39,8 +53,11 @@ the repository's existing `dhat` allocator.
 Use `--lane floating` with a parity-class workload that permits the floating
 profile to measure floating noding plus polygonization. The runner performs an
 untimed full-noding validation of that pipeline before collecting samples.
+Generate its reference with `reference_geos.py --lane floating`.
 
 Use `--lane certified-fixed` only with a parity-class `certified-fixed`
 workload. Its untimed gate and timed samples both retain
 `CertifiedFixedPrecision`, so the lane measures hot-pixel snap rounding and
-never substitutes the floating or iterative snap backend.
+never substitutes the floating or iterative snap backend. GEOS/Shapely does not
+provide the equivalent certified JTS pipeline, so the GEOS reference generator
+deliberately rejects that lane.

--- a/benchmarks/reference-result-v1.schema.json
+++ b/benchmarks/reference-result-v1.schema.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/graydonpleasants/geo-polygonize/benchmarks/reference-result-v1.schema.json",
+  "title": "geo-polygonize external topology reference V1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "workload_id",
+    "lane",
+    "implementation",
+    "fingerprint_sha256",
+    "topology"
+  ],
+  "properties": {
+    "schema_version": {"const": 1},
+    "workload_id": {"type": "string", "minLength": 1},
+    "lane": {
+      "enum": [
+        "already-noded-polygonization",
+        "floating-noding-plus-polygonization",
+        "certified-fixed-precision-noding-plus-polygonization"
+      ]
+    },
+    "implementation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "version", "dependencies"],
+      "properties": {
+        "name": {"type": "string", "minLength": 1},
+        "version": {"type": "string", "minLength": 1},
+        "dependencies": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": {"type": "string", "minLength": 1}
+        }
+      }
+    },
+    "fingerprint_sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "topology": {"$ref": "#/$defs/topology"}
+  },
+  "$defs": {
+    "coordinate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["x", "y"],
+      "properties": {
+        "x": {"type": "string", "pattern": "^0x[0-9a-f]{16}$"},
+        "y": {"type": "string", "pattern": "^0x[0-9a-f]{16}$"}
+      }
+    },
+    "line": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/coordinate"}
+    },
+    "polygon": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["exterior", "interiors"],
+      "properties": {
+        "exterior": {"$ref": "#/$defs/line"},
+        "interiors": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/line"}
+        }
+      }
+    },
+    "topology": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["polygons", "dangles", "cut_edges", "invalid_rings"],
+      "properties": {
+        "polygons": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/polygon"}
+        },
+        "dangles": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/line"}
+        },
+        "cut_edges": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/line"}
+        },
+        "invalid_rings": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/line"}
+        }
+      }
+    }
+  }
+}

--- a/benchmarks/reference_geos.py
+++ b/benchmarks/reference_geos.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Emit a GEOS/Shapely topology reference for one public workload."""
+
+import argparse
+import hashlib
+import json
+import struct
+from pathlib import Path
+
+import shapely
+from shapely.geometry import LineString, shape
+from shapely.ops import polygonize_full, unary_union
+
+
+LANES = {
+    "already-noded": "already-noded-polygonization",
+    "floating": "floating-noding-plus-polygonization",
+}
+
+
+def bits(value):
+    if value == 0:
+        value = 0.0
+    return f"0x{struct.unpack('>Q', struct.pack('>d', value))[0]:016x}"
+
+
+def coordinate(value):
+    return {"x": bits(value[0]), "y": bits(value[1])}
+
+
+def coordinate_key(value):
+    return value["x"], value["y"]
+
+
+def minimum_rotation(values):
+    size = len(values)
+    if size < 2:
+        return values
+    left, right, offset = 0, 1, 0
+    while left < size and right < size and offset < size:
+        first = coordinate_key(values[(left + offset) % size])
+        second = coordinate_key(values[(right + offset) % size])
+        if first == second:
+            offset += 1
+        elif first < second:
+            right += offset + 1
+            if right == left:
+                right += 1
+            offset = 0
+        else:
+            left += offset + 1
+            if left == right:
+                left += 1
+            offset = 0
+    start = min(left, right)
+    return values[start:] + values[:start]
+
+
+def canonical_ring(values):
+    values = [coordinate(value) for value in values]
+    if len(values) > 1 and values[0] == values[-1]:
+        values.pop()
+    if not values:
+        return []
+    forward = minimum_rotation(values)
+    backward = minimum_rotation(list(reversed(values)))
+    result = min(forward, backward, key=canonical_json)
+    return result + [result[0]]
+
+
+def canonical_line(values):
+    values = [coordinate(value) for value in values]
+    backward = list(reversed(values))
+    return min(values, backward, key=canonical_json)
+
+
+def canonical_json(value):
+    return json.dumps(value, separators=(",", ":"), sort_keys=False)
+
+
+def geometries(collection):
+    return list(collection.geoms)
+
+
+def canonical_topology(lines, lane):
+    source = lines if lane == "already-noded" else unary_union(lines)
+    polygons, cuts, dangles, invalid = polygonize_full(source)
+    polygon_values = []
+    for polygon in geometries(polygons):
+        interiors = [canonical_ring(ring.coords) for ring in polygon.interiors]
+        interiors.sort(key=canonical_json)
+        polygon_values.append(
+            {
+                "exterior": canonical_ring(polygon.exterior.coords),
+                "interiors": interiors,
+            }
+        )
+    polygon_values.sort(key=canonical_json)
+
+    def linestrings(collection, ring=False):
+        canonicalize = canonical_ring if ring else canonical_line
+        result = [canonicalize(line.coords) for line in geometries(collection)]
+        result.sort(key=canonical_json)
+        return result
+
+    return {
+        "polygons": polygon_values,
+        "dangles": linestrings(dangles),
+        "cut_edges": linestrings(cuts),
+        "invalid_rings": linestrings(invalid, ring=True),
+    }
+
+
+def load_workload(root, workload_id):
+    manifest_path = root / "crates/geo-polygonize-core/tests/workloads/manifest-v1.json"
+    manifest = json.loads(manifest_path.read_text())
+    workload = next(
+        (value for value in manifest["workloads"] if value["id"] == workload_id), None
+    )
+    if workload is None:
+        raise ValueError(f"unknown workload {workload_id}")
+    clip = manifest_path.parent / workload["artifact"]["clip_path"]
+    collection = json.loads(clip.read_text())
+    lines = []
+    for feature in collection["features"]:
+        geometry = shape(feature["geometry"])
+        if geometry.geom_type == "LineString":
+            source_lines = [geometry]
+        elif geometry.geom_type == "MultiLineString":
+            source_lines = geometry.geoms
+        else:
+            raise ValueError("workload geometry must contain line strings")
+        for line in source_lines:
+            coordinates = list(line.coords)
+            lines.extend(
+                LineString(coordinates[index : index + 2])
+                for index in range(len(coordinates) - 1)
+            )
+    return workload, lines
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--lane", choices=LANES, required=True)
+    parser.add_argument("--workload", required=True)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    root = Path(__file__).resolve().parents[1]
+    workload, lines = load_workload(root, args.workload)
+    if workload["compatibility_class"] != "parity":
+        raise ValueError(f"{args.workload} is not a parity-class workload")
+    if args.lane not in workload["permitted_profiles"]:
+        raise ValueError(f"{args.workload} does not permit {args.lane}")
+
+    topology = canonical_topology(lines, args.lane)
+    result = {
+        "schema_version": 1,
+        "workload_id": args.workload,
+        "lane": LANES[args.lane],
+        "implementation": {
+            "name": "shapely",
+            "version": shapely.__version__,
+            "dependencies": {"geos": shapely.geos_version_string},
+        },
+        "fingerprint_sha256": hashlib.sha256(
+            canonical_json(topology).encode()
+        ).hexdigest(),
+        "topology": topology,
+    }
+    output = json.dumps(result, indent=2) + "\n"
+    if args.output:
+        args.output.write_text(output)
+    else:
+        print(output, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/geo-polygonize-core/examples/benchmark_record.rs
+++ b/crates/geo-polygonize-core/examples/benchmark_record.rs
@@ -7,7 +7,7 @@ use geo_polygonize_core::{
     PrecisionModel, TopologyFingerprintV1,
 };
 use geojson::{GeoJson, Value as GeoJsonValue};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
@@ -25,11 +25,9 @@ struct Args {
     #[arg(long)]
     samples: usize,
     #[arg(long)]
-    expected_fingerprint_sha256: String,
-    #[arg(long)]
     peak_rss_bytes: u64,
-    #[arg(long = "reference-dependency", required = true)]
-    reference_dependencies: Vec<String>,
+    #[arg(long)]
+    reference_result: PathBuf,
     #[arg(long)]
     output: Option<PathBuf>,
 }
@@ -110,6 +108,48 @@ struct WorkloadSize {
     coordinates: usize,
 }
 
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ReferenceResult {
+    schema_version: u32,
+    workload_id: String,
+    lane: String,
+    implementation: ReferenceImplementation,
+    fingerprint_sha256: String,
+    topology: BenchmarkTopologyFingerprintV1,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ReferenceImplementation {
+    name: String,
+    version: String,
+    dependencies: BTreeMap<String, String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+struct BenchmarkTopologyFingerprintV1 {
+    polygons: Vec<BenchmarkPolygonV1>,
+    dangles: Vec<Vec<BenchmarkCoordinateV1>>,
+    cut_edges: Vec<Vec<BenchmarkCoordinateV1>>,
+    invalid_rings: Vec<Vec<BenchmarkCoordinateV1>>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(deny_unknown_fields)]
+struct BenchmarkCoordinateV1 {
+    x: String,
+    y: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(deny_unknown_fields)]
+struct BenchmarkPolygonV1 {
+    exterior: Vec<BenchmarkCoordinateV1>,
+    interiors: Vec<Vec<BenchmarkCoordinateV1>>,
+}
+
 #[derive(Default)]
 struct Samples {
     elapsed: Vec<Duration>,
@@ -175,13 +215,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut correctness_options = options.clone();
     correctness_options.diagnostics.enabled = true;
     let correctness = polygonize(lines.clone(), &correctness_options)?;
-    let expected = parse_sha256(&args.expected_fingerprint_sha256)?;
-    let actual = fingerprint_sha256(&correctness, &options)?;
-    if actual != expected {
+    let reference: ReferenceResult =
+        serde_json::from_slice(&std::fs::read(&args.reference_result)?)?;
+    validate_reference(&reference, &workload.id, args.lane)?;
+    let expected = parse_sha256(&reference.fingerprint_sha256)?;
+    let reference_hash = benchmark_fingerprint_sha256(&reference.topology);
+    if reference_hash != expected {
+        return Err("reference result fingerprint does not match its topology payload".into());
+    }
+    let actual_topology = benchmark_topology(&correctness, &options)?;
+    let actual = benchmark_fingerprint_sha256(&actual_topology);
+    if actual_topology != reference.topology {
         return Err(format!(
             "correctness gate failed: expected {}, observed {}",
             hex(&expected),
-            hex(&actual)
+            hex(&actual),
         )
         .into());
     }
@@ -202,7 +250,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let after = dhat::HeapStats::get();
         samples.allocations += after.total_blocks - before.total_blocks;
         samples.allocated_bytes += after.total_bytes - before.total_bytes;
-        if fingerprint_sha256(&result, &options)? != expected {
+        if benchmark_fingerprint_sha256(&benchmark_topology(&result, &options)?) != expected {
             return Err("timed sample fingerprint diverged after correctness gate".into());
         }
         let phase = &result
@@ -223,7 +271,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .ok_or("correctness run omitted diagnostics")?;
     let p50 = percentile(&samples.elapsed, 50);
     let p95 = percentile(&samples.elapsed, 95);
-    let dependencies = dependencies(&args.reference_dependencies)?;
+    let dependencies = dependencies(&reference)?;
     let commit = command("git", &["rev-parse", "HEAD"])?;
     let output_coordinates = output_coordinates(&correctness);
     let record = json!({
@@ -353,12 +401,95 @@ fn coordinate(position: &[f64]) -> Result<Coord3D, Box<dyn std::error::Error>> {
     ))
 }
 
-fn fingerprint_sha256(
+fn benchmark_topology(
     result: &PolygonizerResult,
     options: &PolygonizerOptions,
-) -> geo_polygonize_core::Result<[u8; 32]> {
+) -> geo_polygonize_core::Result<BenchmarkTopologyFingerprintV1> {
     let fingerprint = TopologyFingerprintV1::try_from_result(result, options)?;
-    Ok(Sha256::digest(serde_json::to_vec(&fingerprint).expect("fingerprint serializes")).into())
+    let mut polygons: Vec<_> = fingerprint
+        .polygons
+        .into_iter()
+        .map(|polygon| {
+            let mut interiors: Vec<_> = polygon
+                .interiors
+                .into_iter()
+                .map(|ring| canonical_benchmark_ring(xy(ring.coordinates)))
+                .collect();
+            interiors.sort();
+            BenchmarkPolygonV1 {
+                exterior: canonical_benchmark_ring(xy(polygon.exterior)),
+                interiors,
+            }
+        })
+        .collect();
+    polygons.sort();
+    Ok(BenchmarkTopologyFingerprintV1 {
+        polygons,
+        dangles: fingerprint.dangles.into_iter().map(xy).collect(),
+        cut_edges: fingerprint.cut_edges.into_iter().map(xy).collect(),
+        invalid_rings: fingerprint.invalid_rings.into_iter().map(xy).collect(),
+    })
+}
+
+fn xy(
+    coordinates: Vec<geo_polygonize_core::CoordinateFingerprintV1>,
+) -> Vec<BenchmarkCoordinateV1> {
+    coordinates
+        .into_iter()
+        .map(|coordinate| BenchmarkCoordinateV1 {
+            x: coordinate.x,
+            y: coordinate.y,
+        })
+        .collect()
+}
+
+fn canonical_benchmark_ring(mut ring: Vec<BenchmarkCoordinateV1>) -> Vec<BenchmarkCoordinateV1> {
+    if ring.len() > 1 && ring.first() == ring.last() {
+        ring.pop();
+    }
+    if ring.is_empty() {
+        return ring;
+    }
+    let forward = rotate_benchmark_ring(&ring);
+    ring.reverse();
+    let backward = rotate_benchmark_ring(&ring);
+    let mut result = forward.min(backward);
+    result.push(result[0].clone());
+    result
+}
+
+fn rotate_benchmark_ring(ring: &[BenchmarkCoordinateV1]) -> Vec<BenchmarkCoordinateV1> {
+    let size = ring.len();
+    let (mut left, mut right, mut offset) = (0, 1, 0);
+    while left < size && right < size && offset < size {
+        match ring[(left + offset) % size].cmp(&ring[(right + offset) % size]) {
+            std::cmp::Ordering::Equal => offset += 1,
+            std::cmp::Ordering::Less => {
+                right += offset + 1;
+                if right == left {
+                    right += 1;
+                }
+                offset = 0;
+            }
+            std::cmp::Ordering::Greater => {
+                left += offset + 1;
+                if left == right {
+                    left += 1;
+                }
+                offset = 0;
+            }
+        }
+    }
+    let start = left.min(right);
+    ring[start..]
+        .iter()
+        .chain(&ring[..start])
+        .cloned()
+        .collect()
+}
+
+fn benchmark_fingerprint_sha256(topology: &BenchmarkTopologyFingerprintV1) -> [u8; 32] {
+    Sha256::digest(serde_json::to_vec(topology).expect("benchmark topology serializes")).into()
 }
 
 fn parse_sha256(value: &str) -> Result<[u8; 32], Box<dyn std::error::Error>> {
@@ -412,24 +543,66 @@ fn output_coordinates(result: &PolygonizerResult) -> usize {
 }
 
 fn dependencies(
-    reference_dependencies: &[String],
+    reference: &ReferenceResult,
 ) -> Result<BTreeMap<String, String>, Box<dyn std::error::Error>> {
     let mut dependencies = BTreeMap::from([(
         "geo-polygonize-core".to_string(),
         env!("CARGO_PKG_VERSION").to_string(),
     )]);
-    for dependency in reference_dependencies {
-        let (name, version) = dependency
-            .split_once('=')
-            .ok_or("reference dependencies must use name=version")?;
+    if dependencies
+        .insert(
+            reference.implementation.name.clone(),
+            reference.implementation.version.clone(),
+        )
+        .is_some()
+    {
+        return Err("reference implementation duplicates a dependency name".into());
+    }
+    if reference.implementation.dependencies.is_empty() {
+        return Err("reference dependencies are required".into());
+    }
+    for (name, version) in &reference.implementation.dependencies {
         if name.is_empty()
             || version.is_empty()
-            || dependencies.insert(name.into(), version.into()).is_some()
+            || dependencies.insert(name.clone(), version.clone()).is_some()
         {
-            return Err(format!("invalid or duplicate reference dependency {dependency}").into());
+            return Err(format!("invalid or duplicate reference dependency {name}").into());
         }
     }
     Ok(dependencies)
+}
+
+fn validate_reference(
+    reference: &ReferenceResult,
+    workload_id: &str,
+    lane: Lane,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if reference.schema_version != 1 {
+        return Err(format!(
+            "unsupported reference result schema {}",
+            reference.schema_version
+        )
+        .into());
+    }
+    if reference.workload_id != workload_id {
+        return Err(format!(
+            "reference workload {} does not match {workload_id}",
+            reference.workload_id
+        )
+        .into());
+    }
+    if reference.lane != lane.record_name() {
+        return Err(format!(
+            "reference lane {} does not match {}",
+            reference.lane,
+            lane.record_name()
+        )
+        .into());
+    }
+    if reference.implementation.name.is_empty() || reference.implementation.version.is_empty() {
+        return Err("reference implementation name and version are required".into());
+    }
+    Ok(())
 }
 
 fn command(program: &str, args: &[&str]) -> Result<String, Box<dyn std::error::Error>> {
@@ -461,6 +634,35 @@ mod tests {
         let hash = "00".repeat(32);
         assert_eq!(parse_sha256(&hash).unwrap(), [0; 32]);
         assert!(parse_sha256(&"AA".repeat(32)).is_err());
+    }
+
+    #[test]
+    fn benchmark_fingerprint_omits_rust_only_edge_identity() {
+        let mut options = PolygonizerOptions::default();
+        options.provenance.enabled = true;
+        options.provenance.include_boundary_line_ids = true;
+        let first = polygonize(
+            [
+                Line3D::new(Coord3D::new(0.0, 0.0, 0.0), Coord3D::new(1.0, 0.0, 0.0), 1),
+                Line3D::new(Coord3D::new(1.0, 0.0, 0.0), Coord3D::new(0.0, 1.0, 0.0), 2),
+                Line3D::new(Coord3D::new(0.0, 1.0, 0.0), Coord3D::new(0.0, 0.0, 0.0), 3),
+            ],
+            &options,
+        )
+        .unwrap();
+        let second = polygonize(
+            [
+                Line3D::new(Coord3D::new(0.0, 0.0, 9.0), Coord3D::new(1.0, 0.0, 9.0), 10),
+                Line3D::new(Coord3D::new(1.0, 0.0, 9.0), Coord3D::new(0.0, 1.0, 9.0), 20),
+                Line3D::new(Coord3D::new(0.0, 1.0, 9.0), Coord3D::new(0.0, 0.0, 9.0), 30),
+            ],
+            &options,
+        )
+        .unwrap();
+        assert_eq!(
+            benchmark_topology(&first, &options).unwrap(),
+            benchmark_topology(&second, &options).unwrap()
+        );
     }
 
     #[test]

--- a/tests/test_reference_geos.py
+++ b/tests/test_reference_geos.py
@@ -1,0 +1,38 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+PATH = Path(__file__).resolve().parents[1] / "benchmarks/reference_geos.py"
+SPEC = importlib.util.spec_from_file_location("reference_geos", PATH)
+REFERENCE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(REFERENCE)
+
+
+def test_ring_and_line_canonicalization_preserve_negative_zero_contract():
+    ring = [(1.0, -0.0), (0.0, 1.0), (-0.0, 0.0), (1.0, -0.0)]
+    assert REFERENCE.canonical_ring(ring) == [
+        {"x": "0x0000000000000000", "y": "0x0000000000000000"},
+        {"x": "0x0000000000000000", "y": "0x3ff0000000000000"},
+        {"x": "0x3ff0000000000000", "y": "0x0000000000000000"},
+        {"x": "0x0000000000000000", "y": "0x0000000000000000"},
+    ]
+    assert REFERENCE.canonical_line([(1.0, 0.0), (0.0, 0.0)])[0]["x"] == (
+        "0x0000000000000000"
+    )
+
+
+@pytest.mark.parametrize(
+    ("workload", "lane"),
+    [
+        ("already-noded-coverage-v1", "already-noded"),
+        ("network-linework-v1", "floating"),
+    ],
+)
+def test_reference_generation_is_deterministic(workload, lane):
+    root = PATH.parents[1]
+    _, lines = REFERENCE.load_workload(root, workload)
+    first = REFERENCE.canonical_topology(lines, lane)
+    second = REFERENCE.canonical_topology(list(reversed(lines)), lane)
+    assert REFERENCE.canonical_json(first) == REFERENCE.canonical_json(second)


### PR DESCRIPTION
## Stack

Parent:
- #1005 (merged)

This PR:
- Defines the cross-implementation topology fingerprint and generates GEOS/Shapely references for already-noded and floating lanes.

Children:
- #1007

## Delivered

- Added a strict external-reference result schema with canonical XY polygons, dangles, cut edges, and invalid rings.
- Added a GEOS/Shapely reference generator that feeds the same constituent segments as the Rust runner.
- Replaced opaque externally supplied hashes with validated reference payloads and pinned dependency metadata.
- Kept Rust-only edge IDs, provenance, options, and diagnostics out of cross-engine equality while retaining them in benchmark records.

## Contract impact

- Benchmark correctness now compares only topology fields both implementations can produce.
- No public polygonization API or semantic option changed.
- Certified fixed precision remains blocked on an equivalent JTS reference executor.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo test -p geo-polygonize-core --example benchmark_record` — 4 passed
- `cargo clippy -p geo-polygonize-core --example benchmark_record -- -D warnings` — passed
- `pytest -q tests/test_reference_geos.py` — 3 passed
- reference schema validation — generated already-noded and floating references passed
- all parity GEOS lanes smoke gate — 10 workload/lane combinations passed before timing

## Agent handoff

Remaining:
- Add the equivalent JTS certified fixed-precision reference executor.
- Pin comparison-job dependencies and publish only schema-valid artifacts.

Next dependency-ready slice:
- `agent/p1-reference-environment` (#1007)
