### PR TITLE
test(wasm): fuzz ingestion boundaries

### DIFF
--- a/crates/geo-polygonize-core/fuzz/Cargo.lock
+++ b/crates/geo-polygonize-core/fuzz/Cargo.lock
@@ -3,10 +3,42 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "const-random",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "approx"
@@ -27,10 +59,270 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bd47f2a6ddc39244bd722a27ee5da66c03369d087b9e024eafdb03e98b98ea7"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-csv",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-json",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c7bbd679c5418b8639b92be01f361d60013c4906574b578b77b63c78356594c"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8a4ab47b3f3eac60f7fd31b81e9028fda018607bcc63451aca4f2b755269862"
+dependencies = [
+ "ahash",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "hashbrown 0.16.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d18b89b4c4f4811d0858175e79541fe98e33e18db3b011708bc287b1240593f"
+dependencies = [
+ "bytes",
+ "half",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "722b5c41dd1d14d0a879a1bce92c6fe33f546101bb2acce57a209825edd075b3"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "atoi",
+ "base64",
+ "chrono",
+ "half",
+ "lexical-core",
+ "num-traits",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-csv"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27ddb80a4848e03b1655af496d5ac2563a779e5742fcb48f2ca2e089c9cd2197"
+dependencies = [
+ "arrow-array",
+ "arrow-cast",
+ "arrow-schema",
+ "chrono",
+ "csv",
+ "csv-core",
+ "regex",
+]
+
+[[package]]
+name = "arrow-data"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1683705c63dcf0d18972759eda48489028cbbff67af7d6bef2c6b7b74ab778a"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf72d04c07229fbf4dbebe7145cac37d7cf7ec582fe705c6b92cb314af096ab"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "flatbuffers",
+]
+
+[[package]]
+name = "arrow-json"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84a905f41fedfcd7679813c89a61dc369c0f932b27aa8dcc6aa051cc781a97d"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "indexmap",
+ "itoa",
+ "lexical-core",
+ "memchr",
+ "num-traits",
+ "ryu",
+ "serde_core",
+ "serde_json",
+ "simdutf8",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "082342947d4e5a2bcccf029a0a0397e21cb3bb8421edd9571d34fb5dd2670256"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+]
+
+[[package]]
+name = "arrow-row"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a931b520a2a5e22033e01a6f2486b4cdc26f9106b759abeebc320f125e94d7"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "half",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4cf0d4a6609679e03002167a61074a21d7b1ad9ea65e462b2c0a97f8a3b2bc6"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "arrow-select"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b320d86a9806923663bb0fd9baa65ecaba81cb0cd77ff8c1768b9716b4ef891"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-string"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b493e99162e5764077e7823e50ba284858d365922631c7aaefe9487b1abd02c2"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "memchr",
+ "num-traits",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "as-slice"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45403b49e3954a4b8428a0ac21a4b7afadccf92bfd96273f1a58cd4812496ae0"
+dependencies = [
+ "generic-array 0.12.4",
+ "generic-array 0.13.3",
+ "generic-array 0.14.9",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bumpalo"
@@ -51,6 +343,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
 name = "cc"
 version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,6 +365,49 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-deque"
@@ -92,6 +433,33 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "derive_arbitrary"
@@ -133,6 +501,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
+dependencies = [
+ "bitflags",
+ "rustc_version",
+]
+
+[[package]]
 name = "float_next_after"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,6 +521,34 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "generic-array"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f797e67af32588215eaaab8327027ee8e71b9dd0b2b26996aedf20c030fce309"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "geo"
@@ -159,9 +565,21 @@ dependencies = [
  "num-traits",
  "rand",
  "robust",
- "rstar",
+ "rstar 0.12.2",
  "sif-itree",
  "spade",
+]
+
+[[package]]
+name = "geo-polygonize-arrow"
+version = "0.76.2"
+dependencies = [
+ "arrow",
+ "geo",
+ "geo-polygonize-core",
+ "geo-traits",
+ "geoarrow",
+ "serde_json",
 ]
 
 [[package]]
@@ -178,7 +596,7 @@ dependencies = [
  "multiversion",
  "rayon",
  "robust",
- "rstar",
+ "rstar 0.12.2",
  "serde",
  "serde_json",
  "smallvec",
@@ -193,8 +611,32 @@ name = "geo-polygonize-core-fuzz"
 version = "0.0.0"
 dependencies = [
  "arbitrary",
+ "arrow",
+ "geo",
+ "geo-polygonize-arrow",
  "geo-polygonize-core",
+ "geo-polygonize-wasm",
+ "geoarrow",
  "libfuzzer-sys",
+]
+
+[[package]]
+name = "geo-polygonize-wasm"
+version = "0.76.2"
+dependencies = [
+ "arrow",
+ "arrow-ipc",
+ "geo",
+ "geo-polygonize-arrow",
+ "geo-polygonize-core",
+ "geo-traits",
+ "geoarrow",
+ "geojson",
+ "getrandom 0.2.17",
+ "js-sys",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -215,8 +657,51 @@ dependencies = [
  "approx",
  "num-traits",
  "rayon",
- "rstar",
+ "rstar 0.10.0",
+ "rstar 0.11.0",
+ "rstar 0.12.2",
+ "rstar 0.8.4",
+ "rstar 0.9.3",
  "serde",
+]
+
+[[package]]
+name = "geoarrow"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd02b95a09c124fdf0c5e4480e4cf0a508d31a88837d89a4107e24efb1a6f3f8"
+dependencies = [
+ "geoarrow-array",
+ "geoarrow-schema",
+]
+
+[[package]]
+name = "geoarrow-array"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1cc4106ac0a0a512c398961ce95d8150475c84a84e17c4511c3643fa120a17"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-schema",
+ "geo-traits",
+ "geoarrow-schema",
+ "num-traits",
+ "wkb",
+ "wkt",
+]
+
+[[package]]
+name = "geoarrow-schema"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e97be4e9f523f92bd6a0e0458323f4b783d073d011664decd8dbf05651704f34"
+dependencies = [
+ "arrow-schema",
+ "geo-traits",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -226,6 +711,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5a7f08910fd98737a6eda7568e7c5e645093e073328eeef49758cfe8b0489c7"
 dependencies = [
  "libm",
+]
+
+[[package]]
+name = "geojson"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e26f3c45b36fccc9cf2805e61d4da6bc4bbd5a3a9589b01afa3a40eff703bd79"
+dependencies = [
+ "geo-types",
+ "log",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -254,6 +752,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+ "zerocopy",
+]
+
+[[package]]
+name = "hash32"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4041af86e63ac4298ce40e5cca669066e75b6f1aa3390fe2561ffa5e1d9f4cc"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,12 +802,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heapless"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634bd4d29cbf24424d0a4bfcbf80c6960129dc24424752a7d1d1390607023422"
+dependencies = [
+ "as-slice",
+ "generic-array 0.14.9",
+ "hash32 0.1.1",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32 0.2.1",
+ "rustc_version",
+ "spin",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "heapless"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
- "hash32",
+ "hash32 0.3.1",
  "stable_deref_trait",
 ]
 
@@ -343,6 +908,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35e6d558e6d4c7b82bc51d9c771e7a927862a161a7d87bf2b0541450e0e20915"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+]
+
+[[package]]
 name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,6 +977,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "lexical-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,6 +1054,15 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -434,6 +1099,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,10 +1137,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "pdqselect"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec91767ecc0a0bbe558ce8c9da33c068066c57ecc8bb8477ef8c1ad3ef77c27"
 
 [[package]]
 name = "ppv-lite86"
@@ -456,6 +1177,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -533,6 +1263,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
 name = "robust"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -540,13 +1299,72 @@ checksum = "4e27ee8bb91ca0adcf0ecb116293afa12d393f9c2b9b9cd54d33e8078fe19839"
 
 [[package]]
 name = "rstar"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a45c0e8804d37e4d97e55c6f258bc9ad9c5ee7b07437009dd152d764949a27c"
+dependencies = [
+ "heapless 0.6.1",
+ "num-traits",
+ "pdqselect",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
+name = "rstar"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b40f1bfe5acdab44bc63e6699c28b74f75ec43afb59f3eda01e145aff86a25fa"
+dependencies = [
+ "heapless 0.7.17",
+ "num-traits",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
+name = "rstar"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f39465655a1e3d8ae79c6d9e007f4953bfc5d55297602df9dc38f9ae9f1359a"
+dependencies = [
+ "heapless 0.7.17",
+ "num-traits",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
+name = "rstar"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73111312eb7a2287d229f06c00ff35b51ddee180f017ab6dec1f69d62ac098d6"
+dependencies = [
+ "heapless 0.7.17",
+ "num-traits",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
+name = "rstar"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "421400d13ccfd26dfa5858199c30a5d76f9c54e0dba7575273025b43c5175dbb"
 dependencies = [
- "heapless",
+ "heapless 0.8.0",
  "num-traits",
+ "serde",
  "smallvec",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -554,6 +1372,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "safe_arch"
@@ -565,6 +1389,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -572,6 +1408,17 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -620,6 +1467,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7f45b8998ced5134fb1d75732c77842a3e888f19c1ff98481822e8fbfbf930b"
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -631,10 +1484,19 @@ version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb313e1c8afee5b5647e00ee0fe6855e3d529eb863a0fdae1d60006c4d1e9990"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.5",
  "num-traits",
  "robust",
  "smallvec",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -710,6 +1572,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
 name = "ts-rs"
 version = "12.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,10 +1633,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
@@ -827,10 +1740,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -842,10 +1808,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
+name = "wkb"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a120b336c7ad17749026d50427c23d838ecb50cd64aaea6254b5030152f890a9"
+dependencies = [
+ "byteorder",
+ "geo-traits",
+ "num_enum",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "wkt"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efb2b923ccc882312e559ffaa832a055ba9d1ac0cc8e86b3e25453247e4b81d7"
+dependencies = [
+ "geo-traits",
+ "geo-types",
+ "log",
+ "num-traits",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "zerocopy"

--- a/crates/geo-polygonize-core/fuzz/Cargo.toml
+++ b/crates/geo-polygonize-core/fuzz/Cargo.toml
@@ -10,9 +10,19 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 arbitrary = { version = "1", features = ["derive"] }
+arrow = { version = "57", features = ["ffi"] }
+geo = "0.32"
+geoarrow = "0.7"
 
 [dependencies.geo-polygonize-core]
 path = ".."
+
+[dependencies.geo-polygonize-arrow]
+path = "../../geo-polygonize-arrow"
+
+[dependencies.geo-polygonize-wasm]
+path = "../../geo-polygonize-wasm"
+default-features = false
 
 [[bin]]
 name = "core_pipeline"

--- a/crates/geo-polygonize-core/fuzz/fuzz_targets/arrow_ffi_ingestion.rs
+++ b/crates/geo-polygonize-core/fuzz/fuzz_targets/arrow_ffi_ingestion.rs
@@ -1,36 +1,61 @@
 #![no_main]
 
-use geo_polygonize_core::{Coord3D, Line3D};
+use arrow::ffi::{FFI_ArrowArray, FFI_ArrowSchema};
+use geo_polygonize_arrow::ffi::{polygonize_ffi, PolygonizerOptions};
+use geoarrow::array::{GeoArrowArray, LineStringBuilder};
+use geoarrow::datatypes::{Dimension, LineStringType};
 use libfuzzer_sys::fuzz_target;
+use std::sync::Arc;
 
 fuzz_target!(|data: &[u8]| {
-    // Arrow FFI ingestion is mainly interacting with pointers.
-    // Fuzzing it directly from raw bytes is unsafe and unreliable without a valid Arrow structure.
-    // Instead, we fuzz the extraction logic given fuzzed coordinate arrays mimicking Arrow buffers.
-
-    if data.len() % (8 * 2) != 0 || data.len() > 100 * 8 * 2 {
-        return;
+    let flags = data.first().copied().unwrap_or_default();
+    let snap_grid_size = data
+        .get(1..9)
+        .map(|bytes| f64::from_le_bytes(bytes.try_into().unwrap()))
+        .unwrap_or_default();
+    let options = PolygonizerOptions {
+        node_input: flags & 1,
+        snap_grid_size,
+        extract_only_polygonal: (flags >> 1) & 1,
+        report_mode: (flags >> 2) & 1,
+    };
+    let mut builder = LineStringBuilder::new(LineStringType::new(
+        Dimension::XY,
+        Arc::new(Default::default()),
+    ));
+    let coords = data
+        .get(9..)
+        .unwrap_or_default()
+        .as_chunks::<16>()
+        .0
+        .iter()
+        .map(|chunk| {
+            (
+                f64::from_le_bytes(chunk[..8].try_into().unwrap()),
+                f64::from_le_bytes(chunk[8..].try_into().unwrap()),
+            )
+        })
+        .collect::<Vec<_>>();
+    for coords in coords.chunks(usize::from(flags >> 4) + 1) {
+        let line = geo::LineString::from(coords.to_vec());
+        builder.push_line_string(Some(&line)).unwrap();
     }
 
-    let mut coords = Vec::new();
-    for chunk in data.chunks_exact(8 * 2) {
-        let x = f64::from_le_bytes(chunk[0..8].try_into().unwrap());
-        let y = f64::from_le_bytes(chunk[8..16].try_into().unwrap());
-        if x.is_nan() || y.is_nan() {
-            return;
-        }
-        coords.push(Coord3D { x, y, z: 0.0 });
-    }
+    let input = builder.finish();
+    let field = input.data_type().to_field("geometry", true);
+    let array = input.into_array_ref();
+    let (mut input_array, _) = arrow::ffi::to_ffi(&array.to_data()).unwrap();
+    let mut input_schema = FFI_ArrowSchema::try_from(&field).unwrap();
+    let mut output_array = FFI_ArrowArray::empty();
+    let mut output_schema = FFI_ArrowSchema::empty();
 
-    let mut lines = Vec::new();
-    for i in 0..coords.len().saturating_sub(1) {
-        lines.push(Line3D {
-            start: coords[i],
-            end: coords[i + 1],
-            line_id: i as u32,
-        });
+    unsafe {
+        polygonize_ffi(
+            &mut input_array,
+            &mut input_schema,
+            &mut output_array,
+            &mut output_schema,
+            &options,
+        );
     }
-
-    let options = geo_polygonize_core::PolygonizerOptions::default();
-    let _ = geo_polygonize_core::polygonize(lines.iter().copied(), &options);
 });

--- a/crates/geo-polygonize-core/fuzz/fuzz_targets/wasm_typed_buffer_ingestion.rs
+++ b/crates/geo-polygonize-core/fuzz/fuzz_targets/wasm_typed_buffer_ingestion.rs
@@ -1,35 +1,49 @@
 #![no_main]
 
-use geo_polygonize_core::{Coord3D, Line3D};
+use geo_polygonize_core::{polygonize, PolygonizerOptions};
+use geo_polygonize_wasm::parse_buffer_lines;
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
-    // This is a placeholder since we can't easily fuzz the exact JS typed buffer API
-    // from native Rust, but we can fuzz the parsing logic.
-    if data.len() % (8 * 3) != 0 || data.len() > 100 * 8 * 3 {
-        return;
-    }
+    let flags = data.first().copied().unwrap_or_default();
+    let stride = match flags & 3 {
+        0 => 2,
+        1 => 3,
+        invalid => invalid - 2,
+    };
+    let coords = data
+        .get(1..)
+        .unwrap_or_default()
+        .as_chunks::<8>()
+        .0
+        .iter()
+        .map(|chunk| f64::from_le_bytes(*chunk))
+        .collect::<Vec<_>>();
+    let offsets = data
+        .get(1..)
+        .unwrap_or_default()
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .take(16)
+        .map(|chunk| u16::from_le_bytes(*chunk) as u32)
+        .collect::<Vec<_>>();
+    let line_ids = (flags & 4 != 0).then(|| {
+        data.get(1..)
+            .unwrap_or_default()
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .take(if flags & 8 == 0 {
+                offsets.len()
+            } else {
+                offsets.len().saturating_sub(1)
+            })
+            .map(|chunk| u32::from_le_bytes(*chunk))
+            .collect::<Vec<_>>()
+    });
 
-    let mut coords = Vec::new();
-    for chunk in data.chunks_exact(8 * 3) {
-        let x = f64::from_le_bytes(chunk[0..8].try_into().unwrap());
-        let y = f64::from_le_bytes(chunk[8..16].try_into().unwrap());
-        let z = f64::from_le_bytes(chunk[16..24].try_into().unwrap());
-        if x.is_nan() || y.is_nan() || z.is_nan() {
-            return;
-        }
-        coords.push(Coord3D { x, y, z });
+    if let Ok(lines) = parse_buffer_lines(&coords, &offsets, stride, line_ids.as_deref()) {
+        let _ = polygonize(lines, &PolygonizerOptions::default());
     }
-
-    let mut lines = Vec::new();
-    for i in 0..coords.len().saturating_sub(1) {
-        lines.push(Line3D {
-            start: coords[i],
-            end: coords[i + 1],
-            line_id: i as u32,
-        });
-    }
-
-    let options = geo_polygonize_core::PolygonizerOptions::default();
-    let _ = geo_polygonize_core::polygonize(lines.iter().copied(), &options);
 });

--- a/crates/geo-polygonize-wasm/Cargo.toml
+++ b/crates/geo-polygonize-wasm/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 readme = "../../README.md"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 geo-polygonize-core = { path = "../geo-polygonize-core", version = "0.76.2" }

--- a/crates/geo-polygonize-wasm/src/buffer.rs
+++ b/crates/geo-polygonize-wasm/src/buffer.rs
@@ -1,0 +1,84 @@
+use geo_polygonize_core::{Coord3D, Line3D};
+
+pub struct BufferError {
+    pub name: &'static str,
+    pub message: String,
+}
+
+#[doc(hidden)]
+pub fn parse_buffer_lines(
+    coords: &[f64],
+    offsets: &[u32],
+    stride: u8,
+    line_ids: Option<&[u32]>,
+) -> Result<Vec<Line3D>, BufferError> {
+    if stride != 2 && stride != 3 {
+        return Err(BufferError {
+            name: "InvalidArgumentType",
+            message: "stride must be 2 or 3".to_string(),
+        });
+    }
+    if let Some(ids) = line_ids {
+        if !offsets.is_empty() && ids.len() != offsets.len() {
+            return Err(BufferError {
+                name: "InvalidBufferShape",
+                message: format!(
+                    "line_ids length {} does not match line count {}",
+                    ids.len(),
+                    offsets.len()
+                ),
+            });
+        }
+    }
+
+    let stride = usize::from(stride);
+    let mut lines = Vec::new();
+    for (i, &start) in offsets.iter().enumerate() {
+        let start = start as usize;
+        let end = offsets
+            .get(i + 1)
+            .map_or(coords.len() / stride, |&offset| offset as usize);
+        if start > end {
+            return Err(BufferError {
+                name: "InvalidInput",
+                message: format!(
+                    "Invalid offsets: start offset ({start}) is greater than end offset ({end}) at index {i}"
+                ),
+            });
+        }
+        let coordinate_end = end.checked_mul(stride).ok_or_else(|| BufferError {
+            name: "InvalidArgumentType",
+            message: "Invalid offsets: calculated end offset exceeds coordinate capacity"
+                .to_string(),
+        })?;
+        if coordinate_end > coords.len() {
+            return Err(BufferError {
+                name: "InvalidArgumentType",
+                message: format!(
+                    "Invalid offsets: calculated end offset {coordinate_end} exceeds coordinate capacity {} for stride {stride}",
+                    coords.len()
+                ),
+            });
+        }
+
+        let line_id = line_ids.map_or(0, |ids| ids[i]);
+        for j in start..end.saturating_sub(1) {
+            let index = j * stride;
+            let next = (j + 1) * stride;
+            lines.push(Line3D::new(
+                Coord3D::new(
+                    coords[index],
+                    coords[index + 1],
+                    if stride == 3 { coords[index + 2] } else { 0.0 },
+                ),
+                Coord3D::new(
+                    coords[next],
+                    coords[next + 1],
+                    if stride == 3 { coords[next + 2] } else { 0.0 },
+                ),
+                line_id,
+            ));
+        }
+    }
+    Ok(lines)
+}

--- a/crates/geo-polygonize-wasm/src/lib.rs
+++ b/crates/geo-polygonize-wasm/src/lib.rs
@@ -1,11 +1,12 @@
+mod buffer;
 mod error;
 
 use arrow::compute::concat;
 use arrow_ipc::reader::StreamReader;
+pub use buffer::parse_buffer_lines;
 use geo_polygonize_arrow::{polygonize_arrow, PolygonizerOptions};
 use geo_polygonize_core::{
-    polygonize as polygonize_lines, Coord3D, Line3D, Polygonizer, PolygonizerResult,
-    TopologyFingerprintV1,
+    polygonize as polygonize_lines, Line3D, Polygonizer, PolygonizerResult, TopologyFingerprintV1,
 };
 use geoarrow::array::GeoArrowArray;
 use geojson::{GeoJson, Geometry, Value};
@@ -334,72 +335,8 @@ pub fn polygonize_with_options_buffer_js(
             )
         })?;
 
-    if stride != 2 && stride != 3 {
-        return Err(to_js_error("InvalidArgumentType", "stride must be 2 or 3"));
-    }
-
-    if let Some(ref ids) = line_ids {
-        if !offsets.is_empty() && ids.len() != offsets.len() {
-            return Err(to_js_error(
-                "InvalidBufferShape",
-                format!(
-                    "line_ids length {} does not match line count {}",
-                    ids.len(),
-                    offsets.len()
-                ),
-            ));
-        }
-    }
-
-    let mut lines = Vec::new();
-
-    for i in 0..offsets.len() {
-        let start = offsets[i] as usize;
-        let end = if i + 1 < offsets.len() {
-            offsets[i + 1] as usize
-        } else {
-            coords.len() / stride as usize
-        };
-
-        if start > end {
-            return Err(to_js_error(
-                "InvalidInput",
-                format!(
-                "Invalid offsets: start offset ({}) is greater than end offset ({}) at index {}",
-                start, end, i
-            ),
-            ));
-        }
-
-        let line_id = if let Some(ref ids) = line_ids {
-            if i < ids.len() {
-                ids[i]
-            } else {
-                0
-            }
-        } else {
-            0
-        };
-        if end * stride as usize > coords.len() {
-            return Err(to_js_error("InvalidArgumentType", format!(
-                "Invalid offsets: calculated end offset {} exceeds coordinate capacity {} for stride {}",
-                end * stride as usize, coords.len(), stride
-            )));
-        }
-
-        for j in start..end.saturating_sub(1) {
-            let idx = j * stride as usize;
-            let jdx = (j + 1) * stride as usize;
-            let z1 = if stride == 3 { coords[idx + 2] } else { 0.0 };
-            let z2 = if stride == 3 { coords[jdx + 2] } else { 0.0 };
-
-            lines.push(Line3D::new(
-                Coord3D::new(coords[idx], coords[idx + 1], z1),
-                Coord3D::new(coords[jdx], coords[jdx + 1], z2),
-                line_id,
-            ));
-        }
-    }
+    let lines = parse_buffer_lines(coords, offsets, stride, line_ids.as_deref())
+        .map_err(|error| to_js_error(error.name, error.message))?;
 
     polygonize_and_flatten(lines, options, stride)
 }
@@ -416,10 +353,6 @@ pub fn polygonize_buffers(
     #[cfg(feature = "console_error_panic_hook")]
     console_error_panic_hook::set_once();
 
-    if stride != 2 && stride != 3 {
-        return Err(to_js_error("InvalidArgumentType", "stride must be 2 or 3"));
-    }
-
     let options = geo_polygonize_core::PolygonizerOptions {
         node_input,
         precision_model: if node_input {
@@ -429,68 +362,8 @@ pub fn polygonize_buffers(
         },
         ..Default::default()
     };
-    if let Some(ref ids) = line_ids {
-        if !offsets.is_empty() && ids.len() != offsets.len() {
-            return Err(to_js_error(
-                "InvalidBufferShape",
-                format!(
-                    "line_ids length {} does not match line count {}",
-                    ids.len(),
-                    offsets.len()
-                ),
-            ));
-        }
-    }
-
-    let mut lines = Vec::new();
-
-    for i in 0..offsets.len() {
-        let start = offsets[i] as usize;
-        let end = if i + 1 < offsets.len() {
-            offsets[i + 1] as usize
-        } else {
-            coords.len() / stride as usize
-        };
-
-        if start > end {
-            return Err(to_js_error(
-                "InvalidInput",
-                format!(
-                "Invalid offsets: start offset ({}) is greater than end offset ({}) at index {}",
-                start, end, i
-            ),
-            ));
-        }
-
-        let line_id = if let Some(ref ids) = line_ids {
-            if i < ids.len() {
-                ids[i]
-            } else {
-                0
-            }
-        } else {
-            0
-        };
-        if end * stride as usize > coords.len() {
-            return Err(to_js_error("InvalidArgumentType", format!(
-                "Invalid offsets: calculated end offset {} exceeds coordinate capacity {} for stride {}",
-                end * stride as usize, coords.len(), stride
-            )));
-        }
-
-        for j in start..end.saturating_sub(1) {
-            let idx = j * stride as usize;
-            let jdx = (j + 1) * stride as usize;
-            let z1 = if stride == 3 { coords[idx + 2] } else { 0.0 };
-            let z2 = if stride == 3 { coords[jdx + 2] } else { 0.0 };
-
-            lines.push(Line3D::new(
-                Coord3D::new(coords[idx], coords[idx + 1], z1),
-                Coord3D::new(coords[jdx], coords[jdx + 1], z2),
-                line_id,
-            ));
-        }
-    }
+    let lines = parse_buffer_lines(coords, offsets, stride, line_ids.as_deref())
+        .map_err(|error| to_js_error(error.name, error.message))?;
 
     polygonize_and_flatten(lines, options, stride)
 }


### PR DESCRIPTION
## What changed

- replace the placeholder Arrow fuzz target with a harness that exports valid GeoArrow data through the Arrow C Data Interface and invokes `polygonize_ffi`
- extract the duplicated WASM typed-buffer parser and fuzz the same production implementation used by both buffer exports
- use checked offset multiplication so oversized offsets cannot wrap on 32-bit WASM
- refresh the nested fuzz lockfile with the real Arrow and WASM dependencies

## Why

The existing targets only reconstructed core `Line3D` values, so they never exercised either named ingestion boundary. The WASM buffer parser was also duplicated across two exports, which made fixes easy to apply inconsistently.

## Impact

Scheduled fuzzing now covers the actual Arrow FFI and WASM typed-buffer parsing paths. Public JavaScript behavior is unchanged except malformed oversized offsets now return an error instead of risking wrapped arithmetic.

## Validation

- `cargo clippy --locked -p geo-polygonize-wasm --all-targets -- -D warnings`
- `cargo +nightly clippy --locked --manifest-path crates/geo-polygonize-core/fuzz/Cargo.toml --bins -- -D warnings`
- `cargo test --locked -p geo-polygonize-wasm`
- `cargo check --locked -p geo-polygonize-wasm --target wasm32-unknown-unknown`
- 1,000-iteration smoke runs for both fuzz targets, followed by 100-iteration runs on current `main`