### PR TITLE
perf(core): add certified JTS reference

### DIFF
--- a/.github/workflows/benchmark-evidence.yml
+++ b/.github/workflows/benchmark-evidence.yml
@@ -43,3 +43,42 @@ jobs:
       - run: pytest -q tests/test_reference_geos.py
 
       - run: python benchmarks/check_geos_references.py
+
+  jts-reference:
+    runs-on: ubuntu-24.04
+    env:
+      MAVEN_IMAGE: maven:3.9.11-eclipse-temurin-21@sha256:6fdc855a6ed81d288ca7ca37ac6ff5e9308b612485c0801d70b25a858c83d237
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.96.1"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12.11"
+
+      - run: python -m pip install jsonschema==4.26.0
+
+      - run: cargo build --locked --release -p geo-polygonize-core --example benchmark_record
+
+      - name: Build pinned JTS reference
+        run: |
+          docker run --rm -v "$PWD:/workspace" -w /workspace "$MAVEN_IMAGE" \
+            mvn -q -f benchmarks/jts-reference/pom.xml package
+
+      - name: Check certified fixed-precision parity
+        run: |
+          mkdir -p target/jts-reference
+          for workload in dense-crossings-v1 overlaps-duplicates-v1; do
+            reference="target/jts-reference/${workload}.json"
+            docker run --rm -v "$PWD:/workspace" -w /workspace "$MAVEN_IMAGE" \
+              java -jar benchmarks/jts-reference/target/geo-polygonize-jts-reference-1.0.0.jar \
+              --root /workspace --workload "$workload" --output "/workspace/$reference"
+            python -c 'import json,sys; from jsonschema import validate; validate(json.load(open(sys.argv[1])), json.load(open(sys.argv[2])))' \
+              "$reference" benchmarks/reference-result-v1.schema.json
+            target/release/examples/benchmark_record \
+              --lane certified-fixed --workload "$workload" \
+              --reference-result "$reference" --check-only
+          done

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -327,8 +327,10 @@ already-noded, floating, and certified fixed-precision workloads before timing,
 and requires external reference and peak-RSS evidence. A versioned
 cross-implementation topology fingerprint and GEOS/Shapely reference runner now
 cover the already-noded and floating lanes without pretending Rust-only
-provenance or diagnostics are external equality evidence. Equivalent JTS
-certified-fixed reference execution and result publication remain separate work.
+provenance or diagnostics are external equality evidence. A pinned JTS
+snap-rounding, validation, deduplication, and polygonization reference now
+covers every certified-fixed parity workload. Result publication remains
+separate work.
 
 Record:
 
@@ -349,10 +351,10 @@ Record:
 - [ ] Keep rejected experiments and crossover measurements linked from the
   relevant decision record.
 
-Progress: The GEOS reference correctness job pins Rust, Python, Shapely, and
-therefore its bundled GEOS version. JTS and Node remain to be pinned when their
-comparison jobs exist; no timing artifact is published by this correctness-only
-job.
+Progress: The correctness jobs pin Rust, Python, Shapely and its bundled GEOS,
+plus the Maven/Java image, JTS, and JSON adapter used by the certified lane.
+Node remains to be pinned when a Node comparison job exists; neither correctness
+job publishes timing artifacts.
 
 ### P1.4 Differential minimization
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -63,5 +63,21 @@ Use `--lane certified-fixed` only with a parity-class `certified-fixed`
 workload. Its untimed gate and timed samples both retain
 `CertifiedFixedPrecision`, so the lane measures hot-pixel snap rounding and
 never substitutes the floating or iterative snap backend. GEOS/Shapely does not
-provide the equivalent certified JTS pipeline, so the GEOS reference generator
+provide the equivalent certified pipeline, so the GEOS reference generator
 deliberately rejects that lane.
+
+The certified reference uses pinned JTS `1.20.0`
+`GeometryNoder` snap rounding with validation, deduplicates the resulting
+segments, and feeds them to JTS `Polygonizer`:
+
+```bash
+mvn -q -f benchmarks/jts-reference/pom.xml package
+java -jar benchmarks/jts-reference/target/geo-polygonize-jts-reference-1.0.0.jar \
+  --root "$PWD" \
+  --workload dense-crossings-v1 \
+  --output target/jts-reference.json
+```
+
+Pass that result to `benchmark_record --lane certified-fixed
+--reference-result target/jts-reference.json`. CI runs this correctness-only
+gate for every certified-fixed parity workload before any timings are allowed.

--- a/benchmarks/jts-reference/pom.xml
+++ b/benchmarks/jts-reference/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>io.github.graydonpleasants</groupId>
+  <artifactId>geo-polygonize-jts-reference</artifactId>
+  <version>1.0.0</version>
+
+  <properties>
+    <maven.compiler.release>21</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <jts.version>1.20.0</jts.version>
+    <jackson.version>2.19.2</jackson.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.locationtech.jts</groupId>
+      <artifactId>jts-core</artifactId>
+      <version>${jts.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.14.1</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.6.1</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals><goal>shade</goal></goals>
+            <configuration>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>io.github.graydonpleasants.JtsReference</mainClass>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/benchmarks/jts-reference/src/main/java/io/github/graydonpleasants/JtsReference.java
+++ b/benchmarks/jts-reference/src/main/java/io/github/graydonpleasants/JtsReference.java
@@ -1,0 +1,351 @@
+package io.github.graydonpleasants;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.Polygon;
+import org.locationtech.jts.geom.PrecisionModel;
+import org.locationtech.jts.noding.snapround.GeometryNoder;
+import org.locationtech.jts.operation.polygonize.Polygonizer;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HexFormat;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+public final class JtsReference {
+    private static final String JTS_VERSION = "1.20.0";
+    private static final String JACKSON_VERSION = "2.19.2";
+    private static final String LANE =
+            "certified-fixed-precision-noding-plus-polygonization";
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    private JtsReference() {}
+
+    public static void main(String[] arguments) throws Exception {
+        Map<String, String> args = arguments(arguments);
+        Path root = Path.of(args.getOrDefault("--root", ".")).toAbsolutePath();
+        String workloadId = required(args, "--workload");
+        Path output = Path.of(required(args, "--output"));
+        Path workloads = root.resolve("crates/geo-polygonize-core/tests/workloads");
+        JsonNode workload = workload(
+                JSON.readTree(workloads.resolve("manifest-v1.json").toFile()), workloadId);
+        double gridSize = certifiedGridSize(workload);
+        List<LineString> input = inputSegments(
+                JSON.readTree(workloads.resolve(workload.at("/artifact/clip_path").asText()).toFile()),
+                new GeometryFactory());
+
+        PrecisionModel precision = new PrecisionModel(1.0 / gridSize);
+        GeometryNoder noder = new GeometryNoder(precision);
+        noder.setValidate(true);
+        @SuppressWarnings("unchecked")
+        List<LineString> noded = noder.node(input);
+        List<LineString> unique = uniqueSegments(noded, new GeometryFactory(precision));
+
+        Polygonizer polygonizer = new Polygonizer();
+        polygonizer.add(unique);
+        Map<String, Object> topology = topology(polygonizer);
+        String fingerprint = HexFormat.of().formatHex(
+                MessageDigest.getInstance("SHA-256").digest(JSON.writeValueAsBytes(topology)));
+
+        Map<String, Object> implementation = new LinkedHashMap<>();
+        implementation.put("name", "jts");
+        implementation.put("version", JTS_VERSION);
+        implementation.put("dependencies", Map.of("jackson-databind", JACKSON_VERSION));
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("schema_version", 1);
+        result.put("workload_id", workloadId);
+        result.put("lane", LANE);
+        result.put("implementation", implementation);
+        result.put("fingerprint_sha256", fingerprint);
+        result.put("topology", topology);
+        JSON.writerWithDefaultPrettyPrinter().writeValue(output.toFile(), result);
+    }
+
+    private static Map<String, String> arguments(String[] values) {
+        if (values.length % 2 != 0) {
+            throw new IllegalArgumentException("arguments must use --name value pairs");
+        }
+        Map<String, String> result = new LinkedHashMap<>();
+        for (int index = 0; index < values.length; index += 2) {
+            if (!values[index].startsWith("--")
+                    || result.put(values[index], values[index + 1]) != null) {
+                throw new IllegalArgumentException("invalid or duplicate argument " + values[index]);
+            }
+        }
+        return result;
+    }
+
+    private static String required(Map<String, String> args, String name) {
+        String value = args.get(name);
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(name + " is required");
+        }
+        return value;
+    }
+
+    private static JsonNode workload(JsonNode manifest, String id) {
+        for (JsonNode workload : manifest.path("workloads")) {
+            if (id.equals(workload.path("id").asText())) {
+                if (!"parity".equals(workload.path("compatibility_class").asText())
+                        || !contains(workload.path("permitted_profiles"), "certified-fixed")) {
+                    throw new IllegalArgumentException(id + " is not a certified-fixed parity workload");
+                }
+                return workload;
+            }
+        }
+        throw new IllegalArgumentException("unknown workload " + id);
+    }
+
+    private static boolean contains(JsonNode values, String expected) {
+        for (JsonNode value : values) {
+            if (expected.equals(value.asText())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static double certifiedGridSize(JsonNode workload) {
+        for (JsonNode options : workload.path("options")) {
+            JsonNode precision = options.path("precision_model");
+            if ("fixed_grid".equals(precision.path("type").asText())
+                    && "CertifiedFixedPrecision".equals(
+                            options.at("/noding/guarantee").asText())) {
+                double gridSize = precision.path("grid_size").asDouble();
+                if (Double.isFinite(gridSize) && gridSize > 0.0) {
+                    return gridSize;
+                }
+            }
+        }
+        throw new IllegalArgumentException("workload has no certified fixed-precision options");
+    }
+
+    private static List<LineString> inputSegments(JsonNode collection, GeometryFactory factory) {
+        List<LineString> result = new ArrayList<>();
+        for (JsonNode feature : collection.path("features")) {
+            JsonNode geometry = feature.path("geometry");
+            String type = geometry.path("type").asText();
+            JsonNode coordinates = geometry.path("coordinates");
+            if ("LineString".equals(type)) {
+                addSegments(coordinates, factory, result);
+            } else if ("MultiLineString".equals(type)) {
+                for (JsonNode line : coordinates) {
+                    addSegments(line, factory, result);
+                }
+            } else {
+                throw new IllegalArgumentException("workload geometry must contain line strings");
+            }
+        }
+        return result;
+    }
+
+    private static void addSegments(
+            JsonNode coordinates, GeometryFactory factory, List<LineString> result) {
+        for (int index = 1; index < coordinates.size(); index++) {
+            result.add(factory.createLineString(new Coordinate[] {
+                    coordinate(coordinates.get(index - 1)), coordinate(coordinates.get(index))
+            }));
+        }
+    }
+
+    private static Coordinate coordinate(JsonNode value) {
+        if (value.size() < 2) {
+            throw new IllegalArgumentException("GeoJSON position must contain x and y");
+        }
+        double x = value.get(0).asDouble();
+        double y = value.get(1).asDouble();
+        if (!Double.isFinite(x) || !Double.isFinite(y)) {
+            throw new IllegalArgumentException("GeoJSON coordinates must be finite");
+        }
+        return new Coordinate(x, y);
+    }
+
+    private static List<LineString> uniqueSegments(
+            List<LineString> lines, GeometryFactory factory) {
+        Map<String, LineString> unique = new TreeMap<>();
+        for (LineString line : lines) {
+            Coordinate[] coordinates = line.getCoordinates();
+            for (int index = 1; index < coordinates.length; index++) {
+                Coordinate first = coordinates[index - 1];
+                Coordinate second = coordinates[index];
+                CoordinateBits left = CoordinateBits.of(first);
+                CoordinateBits right = CoordinateBits.of(second);
+                if (left.equals(right)) {
+                    continue;
+                }
+                String key = left.compareTo(right) <= 0
+                        ? left + "|" + right
+                        : right + "|" + left;
+                unique.putIfAbsent(
+                        key,
+                        factory.createLineString(new Coordinate[] {
+                                new Coordinate(first.x, first.y),
+                                new Coordinate(second.x, second.y)
+                        }));
+            }
+        }
+        return new ArrayList<>(unique.values());
+    }
+
+    private static Map<String, Object> topology(Polygonizer polygonizer) throws Exception {
+        List<Object> polygons = new ArrayList<>();
+        for (Object value : polygonizer.getPolygons()) {
+            Polygon polygon = (Polygon) value;
+            List<Object> interiors = new ArrayList<>();
+            for (int index = 0; index < polygon.getNumInteriorRing(); index++) {
+                interiors.add(canonicalRing(polygon.getInteriorRingN(index).getCoordinates()));
+            }
+            interiors.sort(Comparator.comparing(JtsReference::compactUnchecked));
+            Map<String, Object> result = new LinkedHashMap<>();
+            result.put("exterior", canonicalRing(polygon.getExteriorRing().getCoordinates()));
+            result.put("interiors", interiors);
+            polygons.add(result);
+        }
+        polygons.sort(Comparator.comparing(JtsReference::compactUnchecked));
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("polygons", polygons);
+        result.put("dangles", canonicalLines(polygonizer.getDangles(), false));
+        result.put("cut_edges", canonicalLines(polygonizer.getCutEdges(), false));
+        result.put("invalid_rings", canonicalLines(polygonizer.getInvalidRingLines(), true));
+        return result;
+    }
+
+    private static List<Object> canonicalLines(Collection<?> values, boolean rings)
+            throws Exception {
+        Map<String, Object> result = new TreeMap<>();
+        for (Object value : values) {
+            Coordinate[] coordinates = ((LineString) value).getCoordinates();
+            Object line = rings ? canonicalRing(coordinates) : canonicalLine(coordinates);
+            result.putIfAbsent(JSON.writeValueAsString(line), line);
+        }
+        return new ArrayList<>(result.values());
+    }
+
+    private static List<Map<String, String>> canonicalLine(Coordinate[] coordinates) {
+        List<CoordinateBits> forward = coordinateBits(coordinates);
+        List<CoordinateBits> reverse = new ArrayList<>(forward.reversed());
+        return maps(compare(forward, reverse) <= 0 ? forward : reverse);
+    }
+
+    private static List<Map<String, String>> canonicalRing(Coordinate[] coordinates) {
+        List<CoordinateBits> ring = coordinateBits(coordinates);
+        if (ring.size() > 1 && ring.getFirst().equals(ring.getLast())) {
+            ring.removeLast();
+        }
+        if (ring.isEmpty()) {
+            return List.of();
+        }
+        List<CoordinateBits> forward = rotateMinimum(ring);
+        List<CoordinateBits> reverse = rotateMinimum(new ArrayList<>(ring.reversed()));
+        List<CoordinateBits> result = new ArrayList<>(
+                compare(forward, reverse) <= 0 ? forward : reverse);
+        result.add(result.getFirst());
+        return maps(result);
+    }
+
+    private static List<CoordinateBits> coordinateBits(Coordinate[] coordinates) {
+        List<CoordinateBits> result = new ArrayList<>(coordinates.length);
+        for (Coordinate coordinate : coordinates) {
+            result.add(CoordinateBits.of(coordinate));
+        }
+        return result;
+    }
+
+    private static List<CoordinateBits> rotateMinimum(List<CoordinateBits> values) {
+        int size = values.size();
+        if (size < 2) {
+            return new ArrayList<>(values);
+        }
+        int left = 0;
+        int right = 1;
+        int offset = 0;
+        while (left < size && right < size && offset < size) {
+            int comparison = values.get((left + offset) % size)
+                    .compareTo(values.get((right + offset) % size));
+            if (comparison == 0) {
+                offset++;
+            } else if (comparison < 0) {
+                right += offset + 1;
+                if (right == left) {
+                    right++;
+                }
+                offset = 0;
+            } else {
+                left += offset + 1;
+                if (left == right) {
+                    left++;
+                }
+                offset = 0;
+            }
+        }
+        int start = Math.min(left, right);
+        List<CoordinateBits> result = new ArrayList<>(size);
+        result.addAll(values.subList(start, size));
+        result.addAll(values.subList(0, start));
+        return result;
+    }
+
+    private static int compare(List<CoordinateBits> left, List<CoordinateBits> right) {
+        int size = Math.min(left.size(), right.size());
+        for (int index = 0; index < size; index++) {
+            int comparison = left.get(index).compareTo(right.get(index));
+            if (comparison != 0) {
+                return comparison;
+            }
+        }
+        return Integer.compare(left.size(), right.size());
+    }
+
+    private static List<Map<String, String>> maps(List<CoordinateBits> values) {
+        List<Map<String, String>> result = new ArrayList<>(values.size());
+        for (CoordinateBits value : values) {
+            Map<String, String> coordinate = new LinkedHashMap<>();
+            coordinate.put("x", value.x());
+            coordinate.put("y", value.y());
+            result.add(coordinate);
+        }
+        return result;
+    }
+
+    private static String compactUnchecked(Object value) {
+        try {
+            return JSON.writeValueAsString(value);
+        } catch (Exception error) {
+            throw new IllegalStateException(error);
+        }
+    }
+
+    private record CoordinateBits(String x, String y) implements Comparable<CoordinateBits> {
+        private static CoordinateBits of(Coordinate coordinate) {
+            return new CoordinateBits(bits(coordinate.x), bits(coordinate.y));
+        }
+
+        private static String bits(double value) {
+            long bits = Double.doubleToRawLongBits(value == 0.0 ? 0.0 : value);
+            return "0x" + HexFormat.of().toHexDigits(bits);
+        }
+
+        @Override
+        public int compareTo(CoordinateBits other) {
+            int comparison = x.compareTo(other.x);
+            return comparison != 0 ? comparison : y.compareTo(other.y);
+        }
+
+        @Override
+        public String toString() {
+            return x + "," + y;
+        }
+    }
+}


### PR DESCRIPTION
## Stack

Parent:
- #1007 (merged)

This PR:
- Adds the independent JTS correctness reference for certified fixed-precision benchmarks.

Children:
- not opened yet

## Delivered

- Added a pinned Java 21, Maven 3.9.11, JTS 1.20.0, and Jackson 2.19.2 reference CLI.
- Runs JTS snap rounding with built-in noding validation before deduplicated segment polygonization.
- Emits the existing `reference-result-v1` canonical topology and dependency evidence.
- Checks both certified parity workloads against the Rust hot-pixel lane in correctness-only CI.

## Contract impact

- All three benchmark lanes now have independent, equivalent correctness reference execution.
- Certified JTS and Rust runs consume the same constituent input segments and fixed grid.
- No timing result is emitted or published by the correctness job.

## Validation

- `mvn -q -f benchmarks/jts-reference/pom.xml verify` — passed in pinned Maven/Java image
- reference schema validation — 2 certified results passed
- Rust/JTS correctness gate — `dense-crossings-v1` and `overlaps-duplicates-v1` passed
- `cargo fmt --all -- --check` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `cargo test --workspace` — passed
- `cargo test -p geo-polygonize-core --no-default-features` — passed
- `RUSTDOCFLAGS='-D warnings' cargo doc -p geo-polygonize-core --no-deps` — passed
- `npm test` — 19 passed
- `npm run docs:build` — passed; npm audit reported 5 existing findings

## Agent handoff

Remaining:
- Separate noisy samples from decision-quality measurements.
- Define effect-size and regression budgets before publishing comparisons.
- Publish schema-valid benchmark artifacts and a human-readable trend view.

Next dependency-ready slice:
- `agent/p1-benchmark-decision-policy`
