### PR TITLE
perf(core): define benchmark decision policy

### DIFF
--- a/.github/workflows/benchmark-evidence.yml
+++ b/.github/workflows/benchmark-evidence.yml
@@ -38,6 +38,10 @@ jobs:
 
       - run: python -m pip install -r benchmarks/reference-requirements.txt
 
+      - name: Validate benchmark decision policy
+        run: |
+          python -c 'import json; from jsonschema import validate; validate(json.load(open("benchmarks/benchmark-decision-policy-v1.json")), json.load(open("benchmarks/benchmark-decision-policy-v1.schema.json")))'
+
       - run: cargo build --locked --release -p geo-polygonize-core --example benchmark_record
 
       - run: pytest -q tests/test_reference_geos.py

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -346,7 +346,7 @@ Record:
 - [ ] Publish machine-readable artifacts and a human-readable trend dashboard.
 - [ ] Separate noisy runner samples from decision-quality measurements.
 - [ ] Pin GEOS, JTS, Shapely, Rust, and Node versions in comparison jobs.
-- [ ] Define the minimum effect size and regression budget before each backend or
+- [x] Define the minimum effect size and regression budget before each backend or
   dispatch experiment.
 - [ ] Keep rejected experiments and crossover measurements linked from the
   relevant decision record.
@@ -354,7 +354,12 @@ Record:
 Progress: The correctness jobs pin Rust, Python, Shapely and its bundled GEOS,
 plus the Maven/Java image, JTS, and JSON adapter used by the certified lane.
 Node remains to be pinned when a Node comparison job exists; neither correctness
-job publishes timing artifacts.
+job publishes timing artifacts. Benchmark decision policy V1 now classifies
+diagnostic results as nonpublishable and requires dedicated-runner repetitions,
+warmup, dispersion, correctness, environment, and commit gates for
+decision-quality evidence. It also predeclares a 5% minimum effect size and 2%
+secondary-metric regression budget. Publication enforcement and durable
+decision records remain separate work.
 
 ### P1.4 Differential minimization
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -17,6 +17,18 @@ features, and dependency versions. Phase names and throughput units are explicit
 strings so different runners can report their native phases without pretending
 unlike pipelines are equivalent.
 
+`benchmark-decision-policy-v1.json` separates diagnostic runs from evidence
+that can support a performance decision. Shared or smoke-test measurements are
+diagnostic and nonpublishable. Decision-quality measurements require a
+dedicated runner, five independent processes with at least 30 samples each,
+warmup, no more than 3% relative median absolute deviation, a passed correctness
+gate, a pinned environment, and the same commit.
+
+Before an experiment starts, its primary claim must meet the policy's 5%
+minimum effect size while every secondary metric stays within the 2% regression
+budget. The current hosted correctness jobs collect no timings and therefore
+remain diagnostic.
+
 `reference-result-v1.schema.json` defines the external correctness evidence.
 Its topology fingerprint compares only fields both implementations can produce:
 canonical XY polygon rings, dangles, cut edges, and invalid rings. Rust-only

--- a/benchmarks/benchmark-decision-policy-v1.json
+++ b/benchmarks/benchmark-decision-policy-v1.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "policy_id": "benchmark-decision-v1",
+  "measurement_classes": {
+    "diagnostic": {
+      "publishable": false,
+      "purpose": "correctness and benchmark-harness smoke checks",
+      "minimum_samples": 1
+    },
+    "decision_quality": {
+      "publishable": true,
+      "allowed_runner_classes": ["dedicated"],
+      "minimum_samples_per_process": 30,
+      "minimum_process_repetitions": 5,
+      "warmup_iterations": 5,
+      "maximum_relative_mad_percent": 3.0,
+      "require_correctness_gate": true,
+      "require_pinned_environment": true,
+      "require_same_commit": true
+    }
+  },
+  "promotion": {
+    "primary_metric": "p50_ms",
+    "minimum_effect_size_percent": 5.0,
+    "regression_budget_percent": 2.0,
+    "secondary_metrics": [
+      "p95_ms",
+      "allocated_bytes",
+      "peak_rss_bytes"
+    ],
+    "require_no_secondary_regression_over_budget": true,
+    "require_predeclared_experiment": true
+  }
+}

--- a/benchmarks/benchmark-decision-policy-v1.schema.json
+++ b/benchmarks/benchmark-decision-policy-v1.schema.json
@@ -1,0 +1,107 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/graydonpleasants/geo-polygonize/benchmarks/benchmark-decision-policy-v1.schema.json",
+  "title": "geo-polygonize benchmark decision policy V1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "policy_id",
+    "measurement_classes",
+    "promotion"
+  ],
+  "properties": {
+    "schema_version": {"const": 1},
+    "policy_id": {"type": "string", "minLength": 1},
+    "measurement_classes": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["diagnostic", "decision_quality"],
+      "properties": {
+        "diagnostic": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["publishable", "purpose", "minimum_samples"],
+          "properties": {
+            "publishable": {"const": false},
+            "purpose": {"type": "string", "minLength": 1},
+            "minimum_samples": {"type": "integer", "minimum": 1}
+          }
+        },
+        "decision_quality": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "publishable",
+            "allowed_runner_classes",
+            "minimum_samples_per_process",
+            "minimum_process_repetitions",
+            "warmup_iterations",
+            "maximum_relative_mad_percent",
+            "require_correctness_gate",
+            "require_pinned_environment",
+            "require_same_commit"
+          ],
+          "properties": {
+            "publishable": {"const": true},
+            "allowed_runner_classes": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {"enum": ["dedicated"]}
+            },
+            "minimum_samples_per_process": {
+              "type": "integer",
+              "minimum": 2
+            },
+            "minimum_process_repetitions": {
+              "type": "integer",
+              "minimum": 2
+            },
+            "warmup_iterations": {"type": "integer", "minimum": 1},
+            "maximum_relative_mad_percent": {
+              "type": "number",
+              "exclusiveMinimum": 0
+            },
+            "require_correctness_gate": {"const": true},
+            "require_pinned_environment": {"const": true},
+            "require_same_commit": {"const": true}
+          }
+        }
+      }
+    },
+    "promotion": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "primary_metric",
+        "minimum_effect_size_percent",
+        "regression_budget_percent",
+        "secondary_metrics",
+        "require_no_secondary_regression_over_budget",
+        "require_predeclared_experiment"
+      ],
+      "properties": {
+        "primary_metric": {"const": "p50_ms"},
+        "minimum_effect_size_percent": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "regression_budget_percent": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "secondary_metrics": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "enum": ["p95_ms", "allocated_bytes", "peak_rss_bytes"]
+          }
+        },
+        "require_no_secondary_regression_over_budget": {"const": true},
+        "require_predeclared_experiment": {"const": true}
+      }
+    }
+  }
+}

--- a/crates/geo-polygonize-core/tests/benchmark_record_schema.rs
+++ b/crates/geo-polygonize-core/tests/benchmark_record_schema.rs
@@ -8,6 +8,13 @@ fn schema() -> Value {
     serde_json::from_slice(&std::fs::read(path).unwrap()).unwrap()
 }
 
+fn benchmark_file(name: &str) -> Value {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../benchmarks")
+        .join(name);
+    serde_json::from_slice(&std::fs::read(path).unwrap()).unwrap()
+}
+
 fn required(value: &Value) -> HashSet<&str> {
     value["required"]
         .as_array()
@@ -100,5 +107,56 @@ fn benchmark_schema_requires_measurement_work_and_environment_evidence() {
             "dependencies",
             "commit_sha",
         ]))
+    );
+}
+
+#[test]
+fn decision_policy_separates_diagnostics_from_publishable_evidence() {
+    let policy = benchmark_file("benchmark-decision-policy-v1.json");
+    let classes = &policy["measurement_classes"];
+    assert_eq!(policy["schema_version"], 1);
+    assert_eq!(classes["diagnostic"]["publishable"], false);
+    assert_eq!(classes["decision_quality"]["publishable"], true);
+    assert_eq!(
+        classes["decision_quality"]["allowed_runner_classes"],
+        serde_json::json!(["dedicated"])
+    );
+    assert!(
+        classes["decision_quality"]["minimum_samples_per_process"]
+            .as_u64()
+            .unwrap()
+            > classes["diagnostic"]["minimum_samples"].as_u64().unwrap()
+    );
+    assert!(
+        classes["decision_quality"]["minimum_process_repetitions"]
+            .as_u64()
+            .unwrap()
+            > 1
+    );
+
+    let promotion = &policy["promotion"];
+    assert!(
+        promotion["minimum_effect_size_percent"].as_f64().unwrap()
+            > promotion["regression_budget_percent"].as_f64().unwrap()
+    );
+    for requirement in [
+        "require_correctness_gate",
+        "require_pinned_environment",
+        "require_same_commit",
+    ] {
+        assert_eq!(classes["decision_quality"][requirement], true);
+    }
+
+    let policy_schema = benchmark_file("benchmark-decision-policy-v1.schema.json");
+    assert_eq!(policy_schema["properties"]["schema_version"]["const"], 1);
+    assert_eq!(
+        policy_schema["properties"]["measurement_classes"]["properties"]["diagnostic"]
+            ["properties"]["publishable"]["const"],
+        false
+    );
+    assert_eq!(
+        policy_schema["properties"]["measurement_classes"]["properties"]["decision_quality"]
+            ["properties"]["publishable"]["const"],
+        true
     );
 }


### PR DESCRIPTION
## Stack

Parent:
- #1010 (merged)

This PR:
- Defines the versioned policy for diagnostic and decision-quality benchmark evidence.

Children:
- not opened yet

## Delivered

- Added a strict machine-readable benchmark decision policy and JSON Schema.
- Classified diagnostic measurements as nonpublishable and restricted decision evidence to dedicated runners.
- Required five independent processes, 30 samples per process, warmup, and at most 3% relative MAD.
- Predeclared a 5% minimum primary effect and 2% secondary-metric regression budget.
- Added CI schema validation and Rust contract assertions.

## Contract impact

- Benchmark record V1 is unchanged.
- Hosted correctness jobs remain untimed diagnostic checks.
- Publication enforcement remains a child slice, so the noisy-sample separation roadmap item remains open.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `cargo test --workspace` — passed
- `cargo test -p geo-polygonize-core --no-default-features` — passed
- `RUSTDOCFLAGS="-D warnings" cargo doc -p geo-polygonize-core --no-deps` — passed
- `cargo test -p geo-polygonize-core --test benchmark_record_schema` — 3 passed
- JSON Schema validation — passed
- `npm test` — 19 passed
- `npm run docs:build` — passed; npm audit reported 5 existing findings

## Agent handoff

Remaining:
- Enforce measurement classification when publishing benchmark artifacts.
- Publish durable decision records and a human-readable trend view.
- Link rejected experiments and crossover measurements from their decisions.

Next dependency-ready slice:
- `agent/p1-benchmark-artifact-publication`