### PR TITLE
perf(core): gate benchmark artifact publication

### DIFF
--- a/.github/workflows/benchmark-evidence.yml
+++ b/.github/workflows/benchmark-evidence.yml
@@ -9,6 +9,7 @@ on:
       - "crates/geo-polygonize-core/examples/benchmark_record.rs"
       - "crates/geo-polygonize-core/tests/workloads/**"
       - "tests/test_reference_geos.py"
+      - "tests/test_publish_benchmark.py"
   push:
     branches: [main]
     paths:
@@ -16,6 +17,7 @@ on:
       - "crates/geo-polygonize-core/examples/benchmark_record.rs"
       - "crates/geo-polygonize-core/tests/workloads/**"
       - "tests/test_reference_geos.py"
+      - "tests/test_publish_benchmark.py"
 
 permissions:
   contents: read
@@ -44,7 +46,7 @@ jobs:
 
       - run: cargo build --locked --release -p geo-polygonize-core --example benchmark_record
 
-      - run: pytest -q tests/test_reference_geos.py
+      - run: pytest -q tests/test_reference_geos.py tests/test_publish_benchmark.py
 
       - run: python benchmarks/check_geos_references.py
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -344,7 +344,7 @@ Record:
 ### P1.3 Durable benchmark reporting
 
 - [ ] Publish machine-readable artifacts and a human-readable trend dashboard.
-- [ ] Separate noisy runner samples from decision-quality measurements.
+- [x] Separate noisy runner samples from decision-quality measurements.
 - [ ] Pin GEOS, JTS, Shapely, Rust, and Node versions in comparison jobs.
 - [x] Define the minimum effect size and regression budget before each backend or
   dispatch experiment.
@@ -358,8 +358,10 @@ job publishes timing artifacts. Benchmark decision policy V1 now classifies
 diagnostic results as nonpublishable and requires dedicated-runner repetitions,
 warmup, dispersion, correctness, environment, and commit gates for
 decision-quality evidence. It also predeclares a 5% minimum effect size and 2%
-secondary-metric regression budget. Publication enforcement and durable
-decision records remain separate work.
+secondary-metric regression budget. Publication V1 now bundles only records
+that pass the policy's runner, warmup, repetition, sample, identity, schema, and
+dispersion gates; diagnostic and noisy records cannot enter that artifact.
+A durable trend view and decision records remain separate work.
 
 ### P1.4 Differential minimization
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -46,13 +46,15 @@ python3 benchmarks/reference_geos.py \
 
 The benchmark runner validates that the reference workload, lane, dependency
 versions, payload hash, and topology all match before timing. It also rejects
-any timed sample whose fingerprint changes:
+any timed sample whose fingerprint changes and performs five untimed warmups by
+default:
 
 ```bash
 cargo run -p geo-polygonize-core --release --example benchmark_record -- \
   --lane already-noded \
   --workload already-noded-coverage-v1 \
   --samples 30 \
+  --repetition 1 \
   --peak-rss-bytes <externally-measured-peak> \
   --reference-result target/reference-result.json \
   --output target/benchmark-record.json
@@ -65,6 +67,25 @@ every GEOS-comparable parity workload using `reference-requirements.txt`.
 Peak RSS remains an explicit harness input because the Rust standard library
 does not expose a portable process peak. The runner measures allocations with
 the repository's existing `dhat` allocator.
+
+Run the benchmark in five separate processes with unique `--repetition` values,
+then gate the records before publication:
+
+```bash
+python3 benchmarks/publish_benchmark.py \
+  --runner-class dedicated \
+  --warmup-iterations 5 \
+  --record target/benchmark-record-1.json \
+  --record target/benchmark-record-2.json \
+  --record target/benchmark-record-3.json \
+  --record target/benchmark-record-4.json \
+  --record target/benchmark-record-5.json \
+  --output target/benchmark-publication.json
+```
+
+The publisher rejects shared runners, too few warmups, process repetitions or
+samples, duplicate record IDs, mixed commits/environments/workloads, schema
+failures, and p50 relative median absolute deviation above 3%.
 
 Use `--lane floating` with a parity-class workload that permits the floating
 profile to measure floating noding plus polygonization. The runner performs an

--- a/benchmarks/benchmark-publication-v1.schema.json
+++ b/benchmarks/benchmark-publication-v1.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/graydonpleasants/geo-polygonize/benchmarks/benchmark-publication-v1.schema.json",
+  "title": "geo-polygonize benchmark publication V1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "publication_id",
+    "policy_id",
+    "measurement_class",
+    "runner_class",
+    "warmup_iterations",
+    "process_repetitions",
+    "p50_relative_mad_percent",
+    "records"
+  ],
+  "properties": {
+    "schema_version": {"const": 1},
+    "publication_id": {"type": "string", "minLength": 1},
+    "policy_id": {"const": "benchmark-decision-v1"},
+    "measurement_class": {"const": "decision-quality"},
+    "runner_class": {"const": "dedicated"},
+    "warmup_iterations": {"type": "integer", "minimum": 5},
+    "process_repetitions": {"type": "integer", "minimum": 5},
+    "p50_relative_mad_percent": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 3
+    },
+    "records": {
+      "type": "array",
+      "minItems": 5,
+      "items": {
+        "$ref": "https://github.com/graydonpleasants/geo-polygonize/benchmarks/benchmark-record-v1.schema.json"
+      }
+    }
+  }
+}

--- a/benchmarks/publish_benchmark.py
+++ b/benchmarks/publish_benchmark.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Validate repeated benchmark records before creating a publication artifact."""
+
+import argparse
+import json
+import statistics
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+from referencing import Registry, Resource
+
+ROOT = Path(__file__).parent
+
+
+def load(name):
+    return json.loads((ROOT / name).read_text())
+
+
+def publish(record_paths, runner_class, warmup_iterations):
+    policy = load("benchmark-decision-policy-v1.json")
+    quality = policy["measurement_classes"]["decision_quality"]
+    if runner_class not in quality["allowed_runner_classes"]:
+        raise ValueError(f"{runner_class} is not a decision-quality runner")
+    if warmup_iterations < quality["warmup_iterations"]:
+        raise ValueError("insufficient warmup iterations")
+    if len(record_paths) < quality["minimum_process_repetitions"]:
+        raise ValueError("insufficient process repetitions")
+
+    record_schema = load("benchmark-record-v1.schema.json")
+    record_validator = Draft202012Validator(record_schema)
+    records = [json.loads(Path(path).read_text()) for path in record_paths]
+    for record in records:
+        record_validator.validate(record)
+        if record["measurement"]["samples"] < quality["minimum_samples_per_process"]:
+            raise ValueError("insufficient samples per process")
+
+    if len({record["record_id"] for record in records}) != len(records):
+        raise ValueError("record IDs must be unique")
+    stable_fields = [
+        "workload_id",
+        "lane",
+        "implementation",
+        "correctness_gate",
+        "topology",
+        "work",
+        "environment",
+    ]
+    baseline = records[0]
+    if any(
+        record[field] != baseline[field]
+        for record in records[1:]
+        for field in stable_fields
+    ):
+        raise ValueError("records do not describe one commit, environment, and workload")
+
+    p50_values = [record["measurement"]["p50_ms"] for record in records]
+    median = statistics.median(p50_values)
+    if median <= 0:
+        raise ValueError("decision-quality p50 must be positive")
+    relative_mad = (
+        statistics.median(abs(value - median) for value in p50_values) / median * 100
+    )
+    if relative_mad > quality["maximum_relative_mad_percent"]:
+        raise ValueError("p50 dispersion exceeds the decision-quality limit")
+
+    records.sort(key=lambda record: record["record_id"])
+    publication = {
+        "schema_version": 1,
+        "publication_id": (
+            f"{baseline['workload_id']}-{baseline['environment']['commit_sha'][:12]}-"
+            f"{baseline['lane']}"
+        ),
+        "policy_id": policy["policy_id"],
+        "measurement_class": "decision-quality",
+        "runner_class": runner_class,
+        "warmup_iterations": warmup_iterations,
+        "process_repetitions": len(records),
+        "p50_relative_mad_percent": relative_mad,
+        "records": records,
+    }
+    publication_schema = load("benchmark-publication-v1.schema.json")
+    registry = Registry().with_resource(
+        record_schema["$id"], Resource.from_contents(record_schema)
+    )
+    Draft202012Validator(publication_schema, registry=registry).validate(publication)
+    return publication
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--record", action="append", required=True)
+    parser.add_argument("--runner-class", required=True)
+    parser.add_argument("--warmup-iterations", type=int, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    publication = publish(args.record, args.runner_class, args.warmup_iterations)
+    args.output.write_text(json.dumps(publication, indent=2, allow_nan=False) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/geo-polygonize-core/examples/benchmark_record.rs
+++ b/crates/geo-polygonize-core/examples/benchmark_record.rs
@@ -24,6 +24,10 @@ struct Args {
     workload: String,
     #[arg(long, default_value_t = 30)]
     samples: usize,
+    #[arg(long, default_value_t = 5)]
+    warmup_iterations: usize,
+    #[arg(long)]
+    repetition: Option<usize>,
     #[arg(long)]
     peak_rss_bytes: Option<u64>,
     #[arg(long)]
@@ -169,6 +173,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     if !args.check_only && args.samples == 0 {
         return Err("samples must be greater than zero".into());
     }
+    if args.repetition == Some(0) {
+        return Err("repetition must be greater than zero".into());
+    }
     if !args.check_only && args.peak_rss_bytes.is_none() {
         return Err("peak RSS is required when recording timings".into());
     }
@@ -242,13 +249,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         return Ok(());
     }
 
+    let mut timed_options = options.clone();
+    timed_options.diagnostics.timings = true;
+    for _ in 0..args.warmup_iterations {
+        polygonize(lines.clone(), &timed_options)?;
+    }
     let profile_path = std::env::temp_dir().join(format!(
         "geo-polygonize-benchmark-{}.json",
         std::process::id()
     ));
     let _profiler = dhat::Profiler::builder().file_name(profile_path).build();
-    let mut timed_options = options.clone();
-    timed_options.diagnostics.timings = true;
     let mut samples = Samples::default();
     for _ in 0..args.samples {
         let before = dhat::HeapStats::get();
@@ -282,9 +292,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let dependencies = dependencies(&reference)?;
     let commit = command("git", &["rev-parse", "HEAD"])?;
     let output_coordinates = output_coordinates(&correctness);
+    let record_id = format!("{}-{}-{}", workload.id, &commit[..12], args.lane.profile());
     let record = json!({
         "schema_version": 1,
-        "record_id": format!("{}-{}-{}", workload.id, &commit[..12], args.lane.profile()),
+        "record_id": args.repetition.map_or(record_id.clone(), |repetition| format!("{record_id}-r{repetition}")),
         "workload_id": workload.id,
         "lane": args.lane.record_name(),
         "implementation": {

--- a/tests/test_publish_benchmark.py
+++ b/tests/test_publish_benchmark.py
@@ -1,0 +1,114 @@
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+PATH = Path(__file__).resolve().parents[1] / "benchmarks/publish_benchmark.py"
+SPEC = importlib.util.spec_from_file_location("publish_benchmark", PATH)
+PUBLISHER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(PUBLISHER)
+
+
+def record(index, p50=100.0):
+    return {
+        "schema_version": 1,
+        "record_id": f"coverage-abcdef123456-already-noded-r{index}",
+        "workload_id": "coverage",
+        "lane": "already-noded-polygonization",
+        "implementation": {"name": "core", "version": "1", "features": []},
+        "correctness_gate": {
+            "status": "passed",
+            "validation": {"promised": True, "result": "passed"},
+            "compatibility": {"expected": "parity", "observed": "equal"},
+            "fingerprint": {
+                "outcome": "equal",
+                "actual_sha256": "a" * 64,
+                "reference_sha256": "a" * 64,
+            },
+        },
+        "topology": {
+            "polygons": 1,
+            "rings": 1,
+            "dangles": 0,
+            "cut_edges": 0,
+            "invalid_rings": 0,
+            "provenance_sources": 1,
+        },
+        "measurement": {
+            "p50_ms": p50,
+            "p95_ms": p50 + 1,
+            "throughput": {"value": 10, "unit": "input-segments/second"},
+            "samples": 30,
+            "phase_times_ms": {"polygonize": p50},
+            "allocations": {"count": 1, "bytes": 1},
+            "peak_rss_bytes": 1,
+        },
+        "work": {
+            "input_line_strings": 1,
+            "input_segments": 1,
+            "input_coordinates": 2,
+            "output_polygons": 1,
+            "output_coordinates": 5,
+            "candidate_pairs": 0,
+            "exact_predicate_calls": 0,
+            "split_events": 0,
+            "segment_expansion": {
+                "input_segments": 1,
+                "noded_segments": 1,
+                "ratio": 1,
+            },
+        },
+        "environment": {
+            "architecture": "x86_64",
+            "os": {"name": "Linux", "version": "1"},
+            "compiler": {"name": "rustc", "version": "1"},
+            "dependencies": {"core": "1"},
+            "commit_sha": "b" * 40,
+        },
+    }
+
+
+def write_records(tmp_path, records):
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    paths = []
+    for index, value in enumerate(records):
+        path = tmp_path / f"{index}.json"
+        path.write_text(json.dumps(value))
+        paths.append(path)
+    return paths
+
+
+def test_publication_enforces_decision_quality_policy(tmp_path):
+    paths = write_records(
+        tmp_path,
+        [
+            record(index, p50)
+            for index, p50 in enumerate([100, 101, 99, 100.5, 99.5], 1)
+        ],
+    )
+    publication = PUBLISHER.publish(paths, "dedicated", 5)
+    assert publication["measurement_class"] == "decision-quality"
+    assert publication["process_repetitions"] == 5
+    assert publication["p50_relative_mad_percent"] == 0.5
+
+    with pytest.raises(ValueError, match="runner"):
+        PUBLISHER.publish(paths, "shared-hosted", 5)
+    with pytest.raises(ValueError, match="warmup"):
+        PUBLISHER.publish(paths, "dedicated", 4)
+    with pytest.raises(ValueError, match="process repetitions"):
+        PUBLISHER.publish(paths[:4], "dedicated", 5)
+    with pytest.raises(ValueError, match="record IDs"):
+        PUBLISHER.publish(paths[:-1] + [paths[0]], "dedicated", 5)
+
+    mixed = [record(index) for index in range(1, 6)]
+    mixed[-1]["environment"]["commit_sha"] = "c" * 40
+    with pytest.raises(ValueError, match="one commit"):
+        PUBLISHER.publish(write_records(tmp_path / "mixed", mixed), "dedicated", 5)
+
+    noisy = write_records(
+        tmp_path / "noisy",
+        [record(index, p50) for index, p50 in enumerate([100, 110, 90, 120, 80], 1)],
+    )
+    with pytest.raises(ValueError, match="dispersion"):
+        PUBLISHER.publish(noisy, "dedicated", 5)


### PR DESCRIPTION
## Stack

Parent:
- #1011 (merged)

This PR:
- Enforces decision-quality policy before benchmark records become a publication artifact.

Children:
- not opened yet

## Delivered

- Added benchmark publication V1 and a validator/bundler for repeated benchmark records.
- Rejects shared runners, insufficient warmups/repetitions/samples, duplicate IDs, mixed identities, invalid schemas, and excessive p50 dispersion.
- Added untimed warmups and unique repetition IDs to the existing correctness-gated runner.
- Added focused policy rejection tests and CI coverage.

## Contract impact

- Benchmark record V1 remains unchanged.
- Only dedicated-runner records satisfying decision policy V1 can enter a publication artifact.
- Hosted correctness jobs remain untimed and nonpublishable.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `cargo test --workspace` — passed
- `cargo test -p geo-polygonize-core --no-default-features` — passed
- `RUSTDOCFLAGS="-D warnings" cargo doc -p geo-polygonize-core --no-deps` — passed
- `pytest -q tests/test_reference_geos.py tests/test_publish_benchmark.py` — 4 passed; existing pytest-asyncio deprecation warning
- `python3 -m py_compile benchmarks/publish_benchmark.py tests/test_publish_benchmark.py` — passed
- `npm test` — 19 passed
- `npm run docs:build` — passed; npm audit reported 5 existing findings

## Agent handoff

Remaining:
- Add durable decision records for accepted and rejected experiments.
- Render publication artifacts into a human-readable trend view.
- Pin Node when a Node comparison job exists.

Next dependency-ready slice:
- `agent/p1-benchmark-decision-records`