### PR TITLE
perf(core): define benchmark decision records

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -348,7 +348,7 @@ Record:
 - [ ] Pin GEOS, JTS, Shapely, Rust, and Node versions in comparison jobs.
 - [x] Define the minimum effect size and regression budget before each backend or
   dispatch experiment.
-- [ ] Keep rejected experiments and crossover measurements linked from the
+- [x] Keep rejected experiments and crossover measurements linked from the
   relevant decision record.
 
 Progress: The correctness jobs pin Rust, Python, Shapely and its bundled GEOS,
@@ -361,7 +361,9 @@ decision-quality evidence. It also predeclares a 5% minimum effect size and 2%
 secondary-metric regression budget. Publication V1 now bundles only records
 that pass the policy's runner, warmup, repetition, sample, identity, schema, and
 dispersion gates; diagnostic and noisy records cannot enter that artifact.
-A durable trend view and decision records remain separate work.
+Decision record V1 now requires checksum-pinned baseline and candidate evidence,
+preserves the predeclared thresholds, and refuses unlinked rejected experiments
+or measured crossovers. A durable trend view remains separate work.
 
 ### P1.4 Differential minimization
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -87,6 +87,13 @@ The publisher rejects shared runners, too few warmups, process repetitions or
 samples, duplicate record IDs, mixed commits/environments/workloads, schema
 failures, and p50 relative median absolute deviation above 3%.
 
+`benchmark-decision-v1.schema.json` defines the durable decision record for an
+experiment. Store records under `benchmarks/decisions/` when real evidence
+exists. Each record preserves the predeclared policy thresholds and links
+checksum-pinned baseline and candidate publications. Rejected experiments
+require their own publication links; measured crossovers require both linked
+publications and an explicit descriptor, range, and unit.
+
 Use `--lane floating` with a parity-class workload that permits the floating
 profile to measure floating noding plus polygonization. The runner performs an
 untimed full-noding validation of that pipeline before collecting samples.

--- a/benchmarks/benchmark-decision-v1.schema.json
+++ b/benchmarks/benchmark-decision-v1.schema.json
@@ -1,0 +1,144 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/graydonpleasants/geo-polygonize/benchmarks/benchmark-decision-v1.schema.json",
+  "title": "geo-polygonize benchmark decision V1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "decision_id",
+    "title",
+    "policy_id",
+    "hypothesis",
+    "target_workloads",
+    "non_targets",
+    "semantic_invariants",
+    "predeclared_thresholds",
+    "outcome",
+    "rationale",
+    "baseline_publications",
+    "candidate_publications",
+    "rejected_experiments",
+    "crossover"
+  ],
+  "properties": {
+    "schema_version": {"const": 1},
+    "decision_id": {"type": "string", "minLength": 1},
+    "title": {"type": "string", "minLength": 1},
+    "policy_id": {"const": "benchmark-decision-v1"},
+    "hypothesis": {"type": "string", "minLength": 1},
+    "target_workloads": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"type": "string", "minLength": 1}
+    },
+    "non_targets": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {"type": "string", "minLength": 1}
+    },
+    "semantic_invariants": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"type": "string", "minLength": 1}
+    },
+    "predeclared_thresholds": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "primary_metric",
+        "minimum_effect_size_percent",
+        "regression_budget_percent"
+      ],
+      "properties": {
+        "primary_metric": {"const": "p50_ms"},
+        "minimum_effect_size_percent": {"const": 5.0},
+        "regression_budget_percent": {"const": 2.0}
+      }
+    },
+    "outcome": {"enum": ["promoted", "rejected", "retained-research"]},
+    "rationale": {"type": "string", "minLength": 1},
+    "baseline_publications": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"$ref": "#/$defs/artifact"}
+    },
+    "candidate_publications": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"$ref": "#/$defs/artifact"}
+    },
+    "rejected_experiments": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "reason", "publications"],
+        "properties": {
+          "name": {"type": "string", "minLength": 1},
+          "reason": {"type": "string", "minLength": 1},
+          "publications": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {"$ref": "#/$defs/artifact"}
+          }
+        }
+      }
+    },
+    "crossover": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status"],
+      "properties": {
+        "status": {"enum": ["measured", "not-applicable"]},
+        "range": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["descriptor", "lower_bound", "upper_bound", "unit"],
+          "properties": {
+            "descriptor": {"type": "string", "minLength": 1},
+            "lower_bound": {"type": "number", "minimum": 0},
+            "upper_bound": {"type": "number", "minimum": 0},
+            "unit": {"type": "string", "minLength": 1}
+          }
+        },
+        "publications": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/artifact"}
+        },
+        "reason": {"type": "string", "minLength": 1}
+      },
+      "allOf": [
+        {
+          "if": {"properties": {"status": {"const": "measured"}}},
+          "then": {
+            "required": ["range", "publications"],
+            "not": {"required": ["reason"]}
+          },
+          "else": {
+            "required": ["reason"],
+            "not": {"anyOf": [{"required": ["range"]}, {"required": ["publications"]}]}
+          }
+        }
+      ]
+    }
+  },
+  "$defs": {
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["uri", "sha256"],
+      "properties": {
+        "uri": {"type": "string", "minLength": 1},
+        "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+      }
+    }
+  }
+}

--- a/tests/test_publish_benchmark.py
+++ b/tests/test_publish_benchmark.py
@@ -3,6 +3,7 @@ import json
 from pathlib import Path
 
 import pytest
+from jsonschema import Draft202012Validator, ValidationError
 
 PATH = Path(__file__).resolve().parents[1] / "benchmarks/publish_benchmark.py"
 SPEC = importlib.util.spec_from_file_location("publish_benchmark", PATH)
@@ -112,3 +113,61 @@ def test_publication_enforces_decision_quality_policy(tmp_path):
     )
     with pytest.raises(ValueError, match="dispersion"):
         PUBLISHER.publish(noisy, "dedicated", 5)
+
+
+def test_decision_schema_keeps_rejections_and_crossovers_linked():
+    schema = json.loads(
+        (PATH.parent / "benchmark-decision-v1.schema.json").read_text()
+    )
+    Draft202012Validator.check_schema(schema)
+    artifact = {"uri": "artifacts/candidate.json", "sha256": "a" * 64}
+    decision = {
+        "schema_version": 1,
+        "decision_id": "candidate-layout-v1",
+        "title": "Candidate layout experiment",
+        "policy_id": "benchmark-decision-v1",
+        "hypothesis": "The candidate reduces end-to-end p50.",
+        "target_workloads": ["dense-crossings-v1"],
+        "non_targets": ["small sparse inputs"],
+        "semantic_invariants": ["canonical topology remains equal"],
+        "predeclared_thresholds": {
+            "primary_metric": "p50_ms",
+            "minimum_effect_size_percent": 5.0,
+            "regression_budget_percent": 2.0,
+        },
+        "outcome": "rejected",
+        "rationale": "The candidate missed the effect-size threshold.",
+        "baseline_publications": [
+            {"uri": "artifacts/baseline.json", "sha256": "b" * 64}
+        ],
+        "candidate_publications": [artifact],
+        "rejected_experiments": [
+            {
+                "name": "candidate layout",
+                "reason": "End-to-end p50 improved by less than 5%.",
+                "publications": [artifact],
+            }
+        ],
+        "crossover": {
+            "status": "measured",
+            "range": {
+                "descriptor": "input segments",
+                "lower_bound": 1000,
+                "upper_bound": 2000,
+                "unit": "segments",
+            },
+            "publications": [artifact],
+        },
+    }
+    validator = Draft202012Validator(schema)
+    validator.validate(decision)
+    for path in (PATH.parent / "decisions").glob("*.json"):
+        validator.validate(json.loads(path.read_text()))
+
+    decision["rejected_experiments"][0]["publications"] = []
+    with pytest.raises(ValidationError):
+        validator.validate(decision)
+    decision["rejected_experiments"][0]["publications"] = [artifact]
+    decision["crossover"].pop("publications")
+    with pytest.raises(ValidationError):
+        validator.validate(decision)


### PR DESCRIPTION
## Stack

Parent:
- #1012 (merged)

This PR:
- Defines durable, evidence-linked benchmark decision records.

Children:
- not opened yet

## Delivered

- Added a strict benchmark decision V1 JSON Schema.
- Requires checksum-pinned baseline and candidate publication artifacts.
- Requires every listed rejected experiment to retain linked evidence and a reason.
- Requires measured crossovers to retain an explicit descriptor, range, unit, and publication links.
- Validates every future `benchmarks/decisions/*.json` record in CI.

## Contract impact

- No benchmark, fingerprint, or runtime schema was changed.
- Decision records preserve the predeclared 5% effect threshold and 2% regression budget.
- No synthetic decision history was added where real experiment evidence does not exist.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `cargo test --workspace` — passed
- `cargo test -p geo-polygonize-core --no-default-features` — passed
- `RUSTDOCFLAGS="-D warnings" cargo doc -p geo-polygonize-core --no-deps` — passed
- `pytest -q tests/test_reference_geos.py tests/test_publish_benchmark.py` — 5 passed; existing pytest-asyncio deprecation warning
- `python3 -m json.tool benchmarks/benchmark-decision-v1.schema.json` — passed
- `python3 -m py_compile tests/test_publish_benchmark.py` — passed
- `npm test` — 19 passed
- `npm run docs:build` — passed; npm audit reported 5 existing findings

## Agent handoff

Remaining:
- Render publication and decision artifacts into a human-readable trend view.
- Define durable artifact retention/upload when a dedicated benchmark runner exists.
- Pin Node when a Node comparison job exists.

Next dependency-ready slice:
- `agent/p1-benchmark-trend-view`