### PR TITLE
perf(core): render benchmark trend evidence

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -363,7 +363,10 @@ that pass the policy's runner, warmup, repetition, sample, identity, schema, and
 dispersion gates; diagnostic and noisy records cannot enter that artifact.
 Decision record V1 now requires checksum-pinned baseline and candidate evidence,
 preserves the predeclared thresholds, and refuses unlinked rejected experiments
-or measured crossovers. A durable trend view remains separate work.
+or measured crossovers. A deterministic Markdown renderer now turns valid
+publication and decision artifacts into a human-readable trend view. Durable
+artifact upload and retention remain separate work; no timing rows are
+fabricated in their absence.
 
 ### P1.4 Differential minimization
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -94,6 +94,19 @@ checksum-pinned baseline and candidate publications. Rejected experiments
 require their own publication links; measured crossovers require both linked
 publications and an explicit descriptor, range, and unit.
 
+Render schema-valid publications and decisions as a deterministic Markdown
+trend view:
+
+```bash
+python3 benchmarks/render_benchmark_trends.py \
+  --publication artifacts/benchmark-publication.json \
+  --decision benchmarks/decisions/candidate-layout-v1.json \
+  --output artifacts/benchmark-trends.md
+```
+
+The renderer refuses invalid or diagnostic artifacts and emits no fabricated
+rows when one evidence class is absent.
+
 Use `--lane floating` with a parity-class workload that permits the floating
 profile to measure floating noding plus polygonization. The runner performs an
 untimed full-noding validation of that pipeline before collecting samples.

--- a/benchmarks/render_benchmark_trends.py
+++ b/benchmarks/render_benchmark_trends.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Render schema-valid benchmark publications and decisions as Markdown."""
+
+import argparse
+import html
+import json
+import statistics
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+from referencing import Registry, Resource
+
+ROOT = Path(__file__).parent
+
+
+def load(path):
+    return json.loads(Path(path).read_text())
+
+
+def cell(value):
+    return html.escape(str(value)).replace("|", r"\|").replace("\n", " ")
+
+
+def render(publication_paths, decision_paths):
+    record_schema = load(ROOT / "benchmark-record-v1.schema.json")
+    publication_schema = load(ROOT / "benchmark-publication-v1.schema.json")
+    registry = Registry().with_resource(
+        record_schema["$id"], Resource.from_contents(record_schema)
+    )
+    publication_validator = Draft202012Validator(
+        publication_schema, registry=registry
+    )
+    publications = [load(path) for path in publication_paths]
+    for publication in publications:
+        publication_validator.validate(publication)
+
+    decision_validator = Draft202012Validator(
+        load(ROOT / "benchmark-decision-v1.schema.json")
+    )
+    decisions = [load(path) for path in decision_paths]
+    for decision in decisions:
+        decision_validator.validate(decision)
+
+    lines = [
+        "# Benchmark trends",
+        "",
+        "Generated from schema-valid decision-quality artifacts.",
+        "",
+        "## Publications",
+        "",
+    ]
+    if publications:
+        lines.extend(
+            [
+                "| Workload | Lane | Architecture | Commit | p50 ms | p95 ms | Throughput | Allocated bytes | Peak RSS bytes | Processes | MAD % |",
+                "| --- | --- | --- | --- | ---: | ---: | --- | ---: | ---: | ---: | ---: |",
+            ]
+        )
+        for publication in sorted(
+            publications,
+            key=lambda value: (
+                value["records"][0]["workload_id"],
+                value["records"][0]["lane"],
+                value["records"][0]["environment"]["commit_sha"],
+            ),
+        ):
+            records = publication["records"]
+            identities = {
+                (
+                    record["workload_id"],
+                    record["lane"],
+                    json.dumps(record["environment"], sort_keys=True),
+                )
+                for record in records
+            }
+            throughput_units = {
+                record["measurement"]["throughput"]["unit"] for record in records
+            }
+            if len(identities) != 1 or len(throughput_units) != 1:
+                raise ValueError("publication records mix identities or throughput units")
+            measurement = [record["measurement"] for record in records]
+            throughput = [value["throughput"]["value"] for value in measurement]
+            lines.append(
+                "| "
+                + " | ".join(
+                    map(
+                        cell,
+                        [
+                            records[0]["workload_id"],
+                            records[0]["lane"],
+                            records[0]["environment"]["architecture"],
+                            records[0]["environment"]["commit_sha"][:12],
+                            f"{statistics.median(value['p50_ms'] for value in measurement):.3f}",
+                            f"{statistics.median(value['p95_ms'] for value in measurement):.3f}",
+                            (
+                                f"{statistics.median(throughput):.3f} "
+                                f"{measurement[0]['throughput']['unit']}"
+                            ),
+                            round(
+                                statistics.median(
+                                    value["allocations"]["bytes"]
+                                    for value in measurement
+                                )
+                            ),
+                            round(
+                                statistics.median(
+                                    value["peak_rss_bytes"] for value in measurement
+                                )
+                            ),
+                            publication["process_repetitions"],
+                            f"{publication['p50_relative_mad_percent']:.3f}",
+                        ],
+                    )
+                )
+                + " |"
+            )
+    else:
+        lines.append("No decision-quality publications.")
+
+    lines.extend(["", "## Decisions", ""])
+    if decisions:
+        lines.extend(
+            [
+                "| Decision | Outcome | Targets | Crossover |",
+                "| --- | --- | --- | --- |",
+            ]
+        )
+        for decision in sorted(decisions, key=lambda value: value["decision_id"]):
+            crossover = decision["crossover"]
+            if crossover["status"] == "measured":
+                measured = crossover["range"]
+                summary = (
+                    f"{measured['lower_bound']}–{measured['upper_bound']} "
+                    f"{measured['unit']} ({measured['descriptor']})"
+                )
+            else:
+                summary = f"not applicable: {crossover['reason']}"
+            lines.append(
+                "| "
+                + " | ".join(
+                    map(
+                        cell,
+                        [
+                            decision["decision_id"],
+                            decision["outcome"],
+                            ", ".join(decision["target_workloads"]),
+                            summary,
+                        ],
+                    )
+                )
+                + " |"
+            )
+    else:
+        lines.append("No decision records.")
+    return "\n".join(lines) + "\n"
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--publication", action="append", default=[])
+    parser.add_argument("--decision", action="append", default=[])
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    if not args.publication and not args.decision:
+        parser.error("at least one publication or decision is required")
+    args.output.write_text(render(args.publication, args.decision))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_publish_benchmark.py
+++ b/tests/test_publish_benchmark.py
@@ -9,6 +9,12 @@ PATH = Path(__file__).resolve().parents[1] / "benchmarks/publish_benchmark.py"
 SPEC = importlib.util.spec_from_file_location("publish_benchmark", PATH)
 PUBLISHER = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(PUBLISHER)
+TREND_PATH = PATH.parent / "render_benchmark_trends.py"
+TREND_SPEC = importlib.util.spec_from_file_location(
+    "render_benchmark_trends", TREND_PATH
+)
+TREND_RENDERER = importlib.util.module_from_spec(TREND_SPEC)
+TREND_SPEC.loader.exec_module(TREND_RENDERER)
 
 
 def record(index, p50=100.0):
@@ -80,6 +86,48 @@ def write_records(tmp_path, records):
     return paths
 
 
+def decision_record():
+    artifact = {"uri": "artifacts/candidate.json", "sha256": "a" * 64}
+    return {
+        "schema_version": 1,
+        "decision_id": "candidate-layout-v1",
+        "title": "Candidate layout experiment",
+        "policy_id": "benchmark-decision-v1",
+        "hypothesis": "The candidate reduces end-to-end p50.",
+        "target_workloads": ["dense-crossings-v1"],
+        "non_targets": ["small sparse inputs"],
+        "semantic_invariants": ["canonical topology remains equal"],
+        "predeclared_thresholds": {
+            "primary_metric": "p50_ms",
+            "minimum_effect_size_percent": 5.0,
+            "regression_budget_percent": 2.0,
+        },
+        "outcome": "rejected",
+        "rationale": "The candidate missed the effect-size threshold.",
+        "baseline_publications": [
+            {"uri": "artifacts/baseline.json", "sha256": "b" * 64}
+        ],
+        "candidate_publications": [artifact],
+        "rejected_experiments": [
+            {
+                "name": "candidate layout",
+                "reason": "End-to-end p50 improved by less than 5%.",
+                "publications": [artifact],
+            }
+        ],
+        "crossover": {
+            "status": "measured",
+            "range": {
+                "descriptor": "input segments",
+                "lower_bound": 1000,
+                "upper_bound": 2000,
+                "unit": "segments",
+            },
+            "publications": [artifact],
+        },
+    }
+
+
 def test_publication_enforces_decision_quality_policy(tmp_path):
     paths = write_records(
         tmp_path,
@@ -120,45 +168,7 @@ def test_decision_schema_keeps_rejections_and_crossovers_linked():
         (PATH.parent / "benchmark-decision-v1.schema.json").read_text()
     )
     Draft202012Validator.check_schema(schema)
-    artifact = {"uri": "artifacts/candidate.json", "sha256": "a" * 64}
-    decision = {
-        "schema_version": 1,
-        "decision_id": "candidate-layout-v1",
-        "title": "Candidate layout experiment",
-        "policy_id": "benchmark-decision-v1",
-        "hypothesis": "The candidate reduces end-to-end p50.",
-        "target_workloads": ["dense-crossings-v1"],
-        "non_targets": ["small sparse inputs"],
-        "semantic_invariants": ["canonical topology remains equal"],
-        "predeclared_thresholds": {
-            "primary_metric": "p50_ms",
-            "minimum_effect_size_percent": 5.0,
-            "regression_budget_percent": 2.0,
-        },
-        "outcome": "rejected",
-        "rationale": "The candidate missed the effect-size threshold.",
-        "baseline_publications": [
-            {"uri": "artifacts/baseline.json", "sha256": "b" * 64}
-        ],
-        "candidate_publications": [artifact],
-        "rejected_experiments": [
-            {
-                "name": "candidate layout",
-                "reason": "End-to-end p50 improved by less than 5%.",
-                "publications": [artifact],
-            }
-        ],
-        "crossover": {
-            "status": "measured",
-            "range": {
-                "descriptor": "input segments",
-                "lower_bound": 1000,
-                "upper_bound": 2000,
-                "unit": "segments",
-            },
-            "publications": [artifact],
-        },
-    }
+    decision = decision_record()
     validator = Draft202012Validator(schema)
     validator.validate(decision)
     for path in (PATH.parent / "decisions").glob("*.json"):
@@ -167,7 +177,43 @@ def test_decision_schema_keeps_rejections_and_crossovers_linked():
     decision["rejected_experiments"][0]["publications"] = []
     with pytest.raises(ValidationError):
         validator.validate(decision)
-    decision["rejected_experiments"][0]["publications"] = [artifact]
+    decision["rejected_experiments"][0]["publications"] = decision[
+        "candidate_publications"
+    ]
     decision["crossover"].pop("publications")
     with pytest.raises(ValidationError):
         validator.validate(decision)
+
+
+def test_trend_renderer_uses_only_schema_valid_evidence(tmp_path):
+    record_paths = write_records(
+        tmp_path / "records",
+        [
+            record(index, p50)
+            for index, p50 in enumerate([100, 101, 99, 100.5, 99.5], 1)
+        ],
+    )
+    publication_path = tmp_path / "publication.json"
+    publication_path.write_text(
+        json.dumps(PUBLISHER.publish(record_paths, "dedicated", 5))
+    )
+    decision = decision_record()
+    decision["target_workloads"] = ["dense|crossings"]
+    decision_path = tmp_path / "decision.json"
+    decision_path.write_text(json.dumps(decision))
+
+    dashboard = TREND_RENDERER.render([publication_path], [decision_path])
+    assert "| coverage | already-noded-polygonization | x86_64 |" in dashboard
+    assert "| candidate-layout-v1 | rejected | dense\\|crossings |" in dashboard
+    assert "1000–2000 segments (input segments)" in dashboard
+
+    publication = json.loads(publication_path.read_text())
+    publication["measurement_class"] = "diagnostic"
+    publication_path.write_text(json.dumps(publication))
+    with pytest.raises(ValidationError):
+        TREND_RENDERER.render([publication_path], [decision_path])
+    publication["measurement_class"] = "decision-quality"
+    publication["records"][-1]["measurement"]["throughput"]["unit"] = "items/second"
+    publication_path.write_text(json.dumps(publication))
+    with pytest.raises(ValueError, match="throughput units"):
+        TREND_RENDERER.render([publication_path], [decision_path])


### PR DESCRIPTION
## Stack

Parent:
- #1013 (merged)

This PR:
- Renders validated benchmark publications and decisions as a human-readable trend view.

Children:
- not opened yet

## Delivered

- Added a deterministic Markdown trend renderer using the existing publication and decision schemas.
- Summarizes workload, lane, architecture, commit, timing, throughput units, allocations, RSS, repetitions, and dispersion.
- Summarizes decision outcomes, target workloads, and measured crossover ranges.
- Escapes artifact text and rejects diagnostic, schema-invalid, mixed-identity, or mixed-unit evidence.
- Emits explicit empty-state text rather than fabricated rows.

## Contract impact

- No benchmark, decision, fingerprint, or runtime schema changed.
- Only decision-quality publication artifacts can appear in timing rows.
- The durable publication roadmap item remains open until genuine artifacts have upload and retention.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `cargo test --workspace` — passed
- `cargo test -p geo-polygonize-core --no-default-features` — passed
- `RUSTDOCFLAGS="-D warnings" cargo doc -p geo-polygonize-core --no-deps` — passed
- `pytest -q tests/test_reference_geos.py tests/test_publish_benchmark.py` — 6 passed; existing pytest-asyncio deprecation warning
- `python3 -m py_compile benchmarks/render_benchmark_trends.py tests/test_publish_benchmark.py` — passed
- `npm test` — 19 passed
- `npm run docs:build` — passed; npm audit reported 5 existing findings

## Agent handoff

Remaining:
- Upload and retain real machine-readable publications from a dedicated runner.
- Pin Node when a Node comparison job exists.
- Begin P1.4 differential minimization and reproducible failure bundles.

Next dependency-ready slice:
- `agent/p1-differential-minimizer`