### PR TITLE
feat(core): define bounded trace schema

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -376,7 +376,7 @@ fabricated in their absence.
 - [x] Preserve source IDs and Z conflicts during minimization.
 - [ ] Persist every minimized novel failure as a strict golden and compatibility
   classification.
-- [ ] Export a standalone repro bundle containing input, options, versions,
+- [x] Export a standalone repro bundle containing input, options, versions,
   fingerprint, reference metrics, and witness.
 
 **Done when:** a fuzz or production mismatch can become a checked-in, human-sized
@@ -387,7 +387,8 @@ caller's exact mismatch predicate, allowing each adapter to retain its selected
 options and recompute both sides for every candidate. Retained segments are
 copied unchanged. Shared X/Y values can then be simplified atomically while
 source IDs and Z conflicts remain untouched; persisted fixtures and standalone
-repro bundles remain separate work.
+repro bundles use an exact, versioned JSON representation. Persisting novel
+minimized failures as strict golden/compatibility cases remains separate work.
 
 ### P1.5 Trace schema
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -412,6 +412,12 @@ Candidate events and snapshots:
 Trace output must include byte limits, truncation metadata, schema version,
 library version, and canonical options.
 
+Progress: Trace V1 now has explicit summary, noding, graph, ring, and full
+levels plus deterministic event sequencing. Its recorder bounds serialized
+event bytes, reports truncation, includes version/options metadata, and is not
+constructed when tracing is disabled. Pipeline event wiring remains incremental
+work and no event-family checkbox is complete yet.
+
 ### P1.6 Turn the playground into a topology debugger
 
 - [ ] Add the playground prominently to the docs navigation.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -372,8 +372,8 @@ fabricated in their absence.
 
 - [x] Build a line-set delta debugger that minimizes failures while preserving
   the selected options and observed mismatch.
-- [ ] Minimize coordinate complexity after feature/segment minimization.
-- [ ] Preserve source IDs and Z conflicts during minimization.
+- [x] Minimize coordinate complexity after feature/segment minimization.
+- [x] Preserve source IDs and Z conflicts during minimization.
 - [ ] Persist every minimized novel failure as a strict golden and compatibility
   classification.
 - [ ] Export a standalone repro bundle containing input, options, versions,
@@ -385,7 +385,8 @@ fixture without manually rewriting the geometry.
 Progress: A deterministic, doc-hidden line-set ddmin kernel now accepts the
 caller's exact mismatch predicate, allowing each adapter to retain its selected
 options and recompute both sides for every candidate. Retained segments are
-copied unchanged; coordinate minimization, persisted fixtures, and standalone
+copied unchanged. Shared X/Y values can then be simplified atomically while
+source IDs and Z conflicts remain untouched; persisted fixtures and standalone
 repro bundles remain separate work.
 
 ### P1.5 Trace schema

--- a/crates/geo-polygonize-core/src/differential.rs
+++ b/crates/geo-polygonize-core/src/differential.rs
@@ -46,6 +46,75 @@ where
     Some(current)
 }
 
+/// Simplify shared X/Y values while the caller's exact mismatch predicate holds.
+///
+/// Every occurrence of a coordinate value is replaced together so connected
+/// endpoints stay connected. Source IDs and Z values are never changed.
+#[doc(hidden)]
+pub fn minimize_xy_coordinates<F>(lines: Vec<Line3D>, mut reproduces: F) -> Option<Vec<Line3D>>
+where
+    F: FnMut(&[Line3D]) -> bool,
+{
+    if !reproduces(&lines) {
+        return None;
+    }
+
+    let mut current = lines;
+    for axis in [Axis::X, Axis::Y] {
+        let mut values = Vec::new();
+        for line in &current {
+            values.push(axis.get(line.start).to_bits());
+            values.push(axis.get(line.end).to_bits());
+        }
+        values.sort_unstable();
+        values.dedup();
+
+        for bits in values {
+            let value = f64::from_bits(bits);
+            for replacement in [0.0, value.signum(), value.trunc()] {
+                if !replacement.is_finite() || replacement.to_bits() == bits {
+                    continue;
+                }
+                let mut candidate = current.clone();
+                for line in &mut candidate {
+                    axis.replace(&mut line.start, bits, replacement);
+                    axis.replace(&mut line.end, bits, replacement);
+                }
+                if reproduces(&candidate) {
+                    current = candidate;
+                    break;
+                }
+            }
+        }
+    }
+    Some(current)
+}
+
+#[derive(Clone, Copy)]
+enum Axis {
+    X,
+    Y,
+}
+
+impl Axis {
+    fn get(self, coord: crate::Coord3D) -> f64 {
+        match self {
+            Self::X => coord.x,
+            Self::Y => coord.y,
+        }
+    }
+
+    fn replace(self, coord: &mut crate::Coord3D, expected: u64, replacement: f64) {
+        let value = match self {
+            Self::X => &mut coord.x,
+            Self::Y => &mut coord.y,
+        };
+        if value.to_bits() == expected {
+            *value = replacement;
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -93,6 +162,51 @@ mod tests {
         assert_eq!(
             minimize_line_set(lines, |_| true).unwrap(),
             Vec::<Line3D>::new()
+        );
+    }
+
+    #[test]
+    fn simplifies_shared_xy_without_changing_ids_or_z_conflicts() {
+        let lines = vec![
+            Line3D::new(
+                Coord3D::new(123.5, 456.75, 10.0),
+                Coord3D::new(789.25, 456.75, 20.0),
+                7,
+            ),
+            Line3D::new(
+                Coord3D::new(789.25, 456.75, 30.0),
+                Coord3D::new(789.25, 999.5, 40.0),
+                9,
+            ),
+        ];
+        let original_z: Vec<_> = lines
+            .iter()
+            .flat_map(|line| [line.start.z, line.end.z])
+            .collect();
+
+        let minimized = minimize_xy_coordinates(lines, |candidate| {
+            candidate.len() == 2
+                && candidate[0].line_id == 7
+                && candidate[1].line_id == 9
+                && candidate[0].end.x == candidate[1].start.x
+                && candidate[0].end.y == candidate[1].start.y
+                && candidate
+                    .iter()
+                    .all(|line| line.start.to_coord_2d() != line.end.to_coord_2d())
+                && candidate[0].end.z != candidate[1].start.z
+        })
+        .unwrap();
+
+        assert_eq!(minimized[0].start.to_coord_2d(), (0.0, 0.0).into());
+        assert_eq!(minimized[0].end.to_coord_2d(), (1.0, 0.0).into());
+        assert_eq!(minimized[1].start.to_coord_2d(), (1.0, 0.0).into());
+        assert_eq!(minimized[1].end.to_coord_2d(), (1.0, 1.0).into());
+        assert_eq!(
+            minimized
+                .iter()
+                .flat_map(|line| [line.start.z, line.end.z])
+                .collect::<Vec<_>>(),
+            original_z
         );
     }
 }

--- a/crates/geo-polygonize-core/src/differential.rs
+++ b/crates/geo-polygonize-core/src/differential.rs
@@ -1,6 +1,119 @@
 //! Internal differential-test minimization helpers.
 
-use crate::Line3D;
+use crate::{
+    CoordinateFingerprintV1, FingerprintDiffV1, Line3D, PolygonizeError, PolygonizerOptions,
+    TopologyFingerprintV1,
+};
+use serde::Serialize;
+use std::collections::BTreeMap;
+
+/// The standalone differential reproduction bundle schema version.
+pub const REPRO_BUNDLE_V1_SCHEMA_VERSION: u32 = 1;
+
+/// Exact, portable input segment for a differential reproduction bundle.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ReproLineV1 {
+    pub start: CoordinateFingerprintV1,
+    pub end: CoordinateFingerprintV1,
+    pub line_id: String,
+}
+
+/// Reference topology metrics recorded with a differential mismatch.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ReferenceMetricsV1 {
+    pub polygon_count: usize,
+    pub dangle_count: usize,
+    pub cut_edge_count: usize,
+    pub invalid_ring_count: usize,
+    pub total_area: String,
+}
+
+impl ReferenceMetricsV1 {
+    pub fn new(
+        polygon_count: usize,
+        dangle_count: usize,
+        cut_edge_count: usize,
+        invalid_ring_count: usize,
+        total_area: f64,
+    ) -> crate::Result<Self> {
+        Ok(Self {
+            polygon_count,
+            dangle_count,
+            cut_edge_count,
+            invalid_ring_count,
+            total_area: exact_float(total_area)?,
+        })
+    }
+}
+
+/// Versioned, standalone evidence needed to reproduce a differential mismatch.
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct ReproBundleV1 {
+    pub schema_version: u32,
+    pub input: Vec<ReproLineV1>,
+    pub options: serde_json::Value,
+    pub versions: BTreeMap<String, String>,
+    pub fingerprint: TopologyFingerprintV1,
+    pub reference_metrics: ReferenceMetricsV1,
+    pub witness: FingerprintDiffV1,
+}
+
+impl ReproBundleV1 {
+    pub fn new(
+        input: &[Line3D],
+        options: &PolygonizerOptions,
+        mut versions: BTreeMap<String, String>,
+        fingerprint: TopologyFingerprintV1,
+        reference_metrics: ReferenceMetricsV1,
+        witness: FingerprintDiffV1,
+    ) -> crate::Result<Self> {
+        versions
+            .entry("geo-polygonize-core".to_string())
+            .or_insert_with(|| env!("CARGO_PKG_VERSION").to_string());
+        Ok(Self {
+            schema_version: REPRO_BUNDLE_V1_SCHEMA_VERSION,
+            input: input
+                .iter()
+                .map(|line| {
+                    Ok(ReproLineV1 {
+                        start: exact_coordinate(line.start)?,
+                        end: exact_coordinate(line.end)?,
+                        line_id: format!("0x{:08x}", line.line_id),
+                    })
+                })
+                .collect::<crate::Result<_>>()?,
+            options: serde_json::to_value(options).expect("validated options serialize"),
+            versions,
+            fingerprint,
+            reference_metrics,
+            witness,
+        })
+    }
+
+    pub fn to_pretty_json(&self) -> serde_json::Result<String> {
+        serde_json::to_string_pretty(self)
+    }
+}
+
+fn exact_coordinate(coord: crate::Coord3D) -> crate::Result<CoordinateFingerprintV1> {
+    Ok(CoordinateFingerprintV1 {
+        x: exact_float(coord.x)?,
+        y: exact_float(coord.y)?,
+        z: exact_float(coord.z)?,
+    })
+}
+
+fn exact_float(value: f64) -> crate::Result<String> {
+    if !value.is_finite() {
+        return Err(PolygonizeError::InvalidGeometry {
+            reason: "repro bundle values must be finite".to_string(),
+        });
+    }
+    Ok(format!(
+        "0x{:016x}",
+        if value == 0.0 { 0 } else { value.to_bits() }
+    ))
+}
 
 /// Delta-debug a line set while the caller's exact mismatch predicate holds.
 ///
@@ -118,7 +231,8 @@ impl Axis {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Coord3D, PolygonizerOptions};
+    use crate::{polygonize, Coord3D};
+    use serde_json::json;
 
     fn line(id: u32, z: f64) -> Line3D {
         Line3D::new(
@@ -208,5 +322,56 @@ mod tests {
                 .collect::<Vec<_>>(),
             original_z
         );
+    }
+
+    #[test]
+    fn exports_an_exact_standalone_repro_bundle() {
+        let lines = vec![
+            Line3D::new(
+                Coord3D::new(-0.0, 0.0, 10.0),
+                Coord3D::new(1.0, 0.0, 20.0),
+                7,
+            ),
+            Line3D::new(
+                Coord3D::new(1.0, 0.0, 30.0),
+                Coord3D::new(0.0, 1.0, 40.0),
+                9,
+            ),
+        ];
+        let options = PolygonizerOptions::default();
+        let result = polygonize(lines.iter().copied(), &options).unwrap();
+        let fingerprint = TopologyFingerprintV1::try_from_result(&result, &options).unwrap();
+        let witness = FingerprintDiffV1 {
+            path: "$.polygons".to_string(),
+            expected: json!(1),
+            actual: json!(0),
+        };
+        let bundle = ReproBundleV1::new(
+            &lines,
+            &options,
+            BTreeMap::from([("reference".to_string(), "GEOS 3.13.1".to_string())]),
+            fingerprint,
+            ReferenceMetricsV1::new(1, 0, 0, 0, 0.5).unwrap(),
+            witness,
+        )
+        .unwrap();
+        let json: serde_json::Value =
+            serde_json::from_str(&bundle.to_pretty_json().unwrap()).unwrap();
+
+        assert_eq!(json["schema_version"], 1);
+        assert_eq!(
+            json["versions"]["geo-polygonize-core"],
+            env!("CARGO_PKG_VERSION")
+        );
+        assert_eq!(json["versions"]["reference"], "GEOS 3.13.1");
+        assert_eq!(json["input"][0]["start"]["x"], "0x0000000000000000");
+        assert_eq!(json["input"][0]["line_id"], "0x00000007");
+        assert_eq!(
+            json["reference_metrics"]["total_area"],
+            "0x3fe0000000000000"
+        );
+        assert_eq!(json["witness"]["path"], "$.polygons");
+        assert!(json["options"].is_object());
+        assert!(json["fingerprint"].is_object());
     }
 }

--- a/crates/geo-polygonize-core/src/lib.rs
+++ b/crates/geo-polygonize-core/src/lib.rs
@@ -27,6 +27,8 @@ mod options;
 mod polygonizer;
 #[doc(hidden)]
 pub mod tiling;
+#[doc(hidden)]
+pub mod trace;
 mod types;
 // Kept compiler-public for the repository's microbenchmarks; not a supported API.
 #[doc(hidden)]

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -1,0 +1,156 @@
+//! Internal bounded topology trace schema.
+
+use crate::PolygonizerOptions;
+use serde::Serialize;
+
+pub const TOPOLOGY_TRACE_V1_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TraceLevelV1 {
+    Summary,
+    Noding,
+    Graph,
+    Rings,
+    Full,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TraceStageV1 {
+    Summary,
+    Noding,
+    Graph,
+    Rings,
+    Output,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct TraceEventV1 {
+    pub sequence: usize,
+    pub stage: TraceStageV1,
+    pub kind: String,
+    pub payload: serde_json::Value,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct TopologyTraceV1 {
+    pub schema_version: u32,
+    pub library_version: String,
+    pub level: TraceLevelV1,
+    pub byte_limit: usize,
+    pub bytes_used: usize,
+    pub truncated: bool,
+    pub options: serde_json::Value,
+    pub events: Vec<TraceEventV1>,
+}
+
+/// Collects serialized trace events up to an exact byte budget.
+///
+/// Callers hold this as an `Option`; `None` is the disabled fast path.
+pub struct TraceRecorderV1 {
+    trace: TopologyTraceV1,
+}
+
+impl TraceRecorderV1 {
+    pub fn new(
+        level: Option<TraceLevelV1>,
+        byte_limit: usize,
+        options: &PolygonizerOptions,
+    ) -> Option<Self> {
+        level.map(|level| Self {
+            trace: TopologyTraceV1 {
+                schema_version: TOPOLOGY_TRACE_V1_SCHEMA_VERSION,
+                library_version: env!("CARGO_PKG_VERSION").to_string(),
+                level,
+                byte_limit,
+                bytes_used: 0,
+                truncated: false,
+                options: serde_json::to_value(options).expect("validated options serialize"),
+                events: Vec::new(),
+            },
+        })
+    }
+
+    /// Records an allowed event, returning false when the byte budget is exhausted.
+    pub fn record(
+        &mut self,
+        stage: TraceStageV1,
+        kind: impl Into<String>,
+        payload: serde_json::Value,
+    ) -> bool {
+        if self.trace.truncated || !self.trace.level.allows(stage) {
+            return !self.trace.truncated;
+        }
+        let event = TraceEventV1 {
+            sequence: self.trace.events.len(),
+            stage,
+            kind: kind.into(),
+            payload,
+        };
+        let event_bytes = serde_json::to_vec(&event)
+            .expect("trace event serializes")
+            .len();
+        let Some(bytes_used) = self.trace.bytes_used.checked_add(event_bytes) else {
+            self.trace.truncated = true;
+            return false;
+        };
+        if bytes_used > self.trace.byte_limit {
+            self.trace.truncated = true;
+            return false;
+        }
+        self.trace.bytes_used = bytes_used;
+        self.trace.events.push(event);
+        true
+    }
+
+    pub fn finish(self) -> TopologyTraceV1 {
+        self.trace
+    }
+}
+
+impl TraceLevelV1 {
+    fn allows(self, stage: TraceStageV1) -> bool {
+        stage == TraceStageV1::Summary
+            || matches!(
+                (self, stage),
+                (Self::Noding, TraceStageV1::Noding)
+                    | (Self::Graph, TraceStageV1::Graph)
+                    | (Self::Rings, TraceStageV1::Rings)
+                    | (Self::Full, _)
+            )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn disabled_trace_allocates_no_recorder_and_enabled_trace_is_bounded() {
+        let options = PolygonizerOptions::default();
+        assert!(TraceRecorderV1::new(None, 1024, &options).is_none());
+
+        let mut recorder = TraceRecorderV1::new(Some(TraceLevelV1::Noding), 120, &options).unwrap();
+        assert!(recorder.record(
+            TraceStageV1::Graph,
+            "ignored",
+            json!({"large": "x".repeat(500)})
+        ));
+        assert!(recorder.record(TraceStageV1::Noding, "candidate", json!({"pair": [1, 2]})));
+        assert!(!recorder.record(
+            TraceStageV1::Noding,
+            "oversized",
+            json!({"large": "x".repeat(500)})
+        ));
+
+        let trace = recorder.finish();
+        assert_eq!(trace.schema_version, TOPOLOGY_TRACE_V1_SCHEMA_VERSION);
+        assert_eq!(trace.events.len(), 1);
+        assert_eq!(trace.events[0].sequence, 0);
+        assert!(trace.bytes_used <= trace.byte_limit);
+        assert!(trace.truncated);
+        assert!(trace.options.is_object());
+    }
+}


### PR DESCRIPTION
## Stack

Parent:
- #1017

This PR:
- Defines the versioned, selectable, byte-bounded topology trace foundation.

Children:
- #1019

## Delivered

- Added Trace V1 metadata, deterministic event sequencing, and summary/noding/graph/rings/full selection levels.
- Added exact serialized-event byte accounting with checked arithmetic and explicit truncation metadata.
- Included schema version, library version, byte budget, canonical options, and recorded events in every enabled trace.
- Kept disabled tracing as `None`, so no recorder or metadata is constructed.
- Documented that pipeline event wiring remains incremental; no event-family roadmap checkbox was prematurely completed.

## Contract impact

- Adds a doc-hidden trace schema and recorder without changing semantic polygonization options or existing result schemas.
- The byte limit applies to serialized event payloads; fixed trace metadata remains present even for a zero-byte budget.
- Stage-specific levels retain summary events and ignore unrelated stage events.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `cargo test --workspace` — passed (core: 179 tests)
- `cargo test -p geo-polygonize-core --no-default-features` — passed (179 tests)
- `RUSTDOCFLAGS='-D warnings' cargo doc -p geo-polygonize-core --no-deps` — passed
- `npm test` — passed (19 tests)
- `npm run docs:build` — passed; npm reported 5 existing audit findings and the existing MUI/bundle-size warnings
- `git diff --check` — passed

## Agent handoff

Remaining:
- Wire normalized input and source-ID events.
- Wire noding, graph, ring, containment, canonicalization, and tiling event families incrementally.
- Persist an actual minimized novel failure when one is found.

Next dependency-ready slice:
- `agent/p1-trace-input-events`