### PR TITLE
feat(core): trace normalized input segments

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -398,7 +398,7 @@ the entire pipeline.
 
 Candidate events and snapshots:
 
-- [ ] normalized input segments and source IDs;
+- [x] normalized input segments and source IDs;
 - [ ] snapped coordinates, fixed-grid cells, and certified hot pixels;
 - [ ] candidate pairs and exact intersection/split witnesses;
 - [ ] noded and dissolved edges with complete source sets;
@@ -416,7 +416,8 @@ Progress: Trace V1 now has explicit summary, noding, graph, ring, and full
 levels plus deterministic event sequencing. Its recorder bounds serialized
 event bytes, reports truncation, includes version/options metadata, and is not
 constructed when tracing is disabled. Pipeline event wiring remains incremental
-work and no event-family checkbox is complete yet.
+work. The owned traced entrypoint now records the validated canonical `Line3D`
+input representation with exact coordinates and source IDs before noding.
 
 ### P1.6 Turn the playground into a topology debugger
 

--- a/crates/geo-polygonize-core/src/differential.rs
+++ b/crates/geo-polygonize-core/src/differential.rs
@@ -1,8 +1,8 @@
 //! Internal differential-test minimization helpers.
 
+use crate::fingerprint::{coordinate_fingerprint, float_bits};
 use crate::{
-    CoordinateFingerprintV1, FingerprintDiffV1, Line3D, PolygonizeError, PolygonizerOptions,
-    TopologyFingerprintV1,
+    CoordinateFingerprintV1, FingerprintDiffV1, Line3D, PolygonizerOptions, TopologyFingerprintV1,
 };
 use serde::Serialize;
 use std::collections::BTreeMap;
@@ -41,7 +41,7 @@ impl ReferenceMetricsV1 {
             dangle_count,
             cut_edge_count,
             invalid_ring_count,
-            total_area: exact_float(total_area)?,
+            total_area: float_bits(total_area)?,
         })
     }
 }
@@ -76,8 +76,8 @@ impl ReproBundleV1 {
                 .iter()
                 .map(|line| {
                     Ok(ReproLineV1 {
-                        start: exact_coordinate(line.start)?,
-                        end: exact_coordinate(line.end)?,
+                        start: coordinate_fingerprint(line.start)?,
+                        end: coordinate_fingerprint(line.end)?,
                         line_id: format!("0x{:08x}", line.line_id),
                     })
                 })
@@ -93,26 +93,6 @@ impl ReproBundleV1 {
     pub fn to_pretty_json(&self) -> serde_json::Result<String> {
         serde_json::to_string_pretty(self)
     }
-}
-
-fn exact_coordinate(coord: crate::Coord3D) -> crate::Result<CoordinateFingerprintV1> {
-    Ok(CoordinateFingerprintV1 {
-        x: exact_float(coord.x)?,
-        y: exact_float(coord.y)?,
-        z: exact_float(coord.z)?,
-    })
-}
-
-fn exact_float(value: f64) -> crate::Result<String> {
-    if !value.is_finite() {
-        return Err(PolygonizeError::InvalidGeometry {
-            reason: "repro bundle values must be finite".to_string(),
-        });
-    }
-    Ok(format!(
-        "0x{:016x}",
-        if value == 0.0 { 0 } else { value.to_bits() }
-    ))
 }
 
 /// Delta-debug a line set while the caller's exact mismatch predicate holds.

--- a/crates/geo-polygonize-core/src/fingerprint.rs
+++ b/crates/geo-polygonize-core/src/fingerprint.rs
@@ -424,19 +424,18 @@ fn minimum_rotation_index<T: Ord>(ring: &[T]) -> usize {
 }
 
 fn coordinates(points: &[Coord3D]) -> crate::Result<Vec<CoordinateFingerprintV1>> {
-    points
-        .iter()
-        .map(|point| {
-            Ok(CoordinateFingerprintV1 {
-                x: float_bits(point.x)?,
-                y: float_bits(point.y)?,
-                z: float_bits(point.z)?,
-            })
-        })
-        .collect()
+    points.iter().copied().map(coordinate_fingerprint).collect()
 }
 
-fn float_bits(value: f64) -> crate::Result<String> {
+pub(crate) fn coordinate_fingerprint(point: Coord3D) -> crate::Result<CoordinateFingerprintV1> {
+    Ok(CoordinateFingerprintV1 {
+        x: float_bits(point.x)?,
+        y: float_bits(point.y)?,
+        z: float_bits(point.z)?,
+    })
+}
+
+pub(crate) fn float_bits(value: f64) -> crate::Result<String> {
     if !value.is_finite() {
         return Err(PolygonizeError::InvalidGeometry {
             reason: "fingerprint coordinates must be finite".to_string(),

--- a/crates/geo-polygonize-core/src/lib.rs
+++ b/crates/geo-polygonize-core/src/lib.rs
@@ -59,8 +59,9 @@ pub use options::{DedupPolicy, TileOwnershipPolicy};
 pub use polygonizer::Polygonizer;
 pub use polygonizer::{
     polygonize, polygonize_line_strings, polygonize_line_strings_with_execution_policy,
-    polygonize_to_multi_polygon, polygonize_with_execution_policy, polygonize_with_workspace,
-    polygonize_with_workspace_and_execution_policy, PolygonizerResult, PolygonizerWorkspace,
+    polygonize_to_multi_polygon, polygonize_with_execution_policy, polygonize_with_trace,
+    polygonize_with_workspace, polygonize_with_workspace_and_execution_policy, PolygonizerResult,
+    PolygonizerWorkspace,
 };
 #[doc(hidden)]
 pub use tiling::{StitchingReport, TileReport, TiledPolygonizeResult, TiledPolygonizer};

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -11,6 +11,7 @@ use crate::noding::validate::ValidatingNoder;
 use crate::options::{
     ExecutionPolicy, NodingGuarantee, PolygonizerOptions, PrecisionModel, SnapStrategy, ZPolicy,
 };
+use crate::trace::{TraceLevelV1, TraceRecorderV1, TracedPolygonizerResultV1};
 use crate::types::{Coord3D, Line3D, Polygon3D, RingGraphIdentity};
 use crate::utils::simd::SimdRing;
 use crate::utils::z_order_index;
@@ -42,6 +43,7 @@ pub struct Polygonizer {
     options: PolygonizerOptions,
     execution_policy: ExecutionPolicy,
     input_lines: Vec<Line3D>,
+    trace: Option<TraceRecorderV1>,
 }
 
 /// Reusable allocation storage for stateless polygonization calls.
@@ -99,6 +101,36 @@ pub fn polygonize_with_execution_policy(
     options: &PolygonizerOptions,
     execution_policy: &ExecutionPolicy,
 ) -> Result<PolygonizerResult> {
+    let collected = collect_owned_lines(lines, execution_policy)?;
+    Polygonizer::with_options(options.clone())
+        .with_execution_policy(execution_policy.clone())
+        .polygonize_owned(collected)
+}
+
+/// Polygonize an owned stream while recording a bounded topology trace.
+#[doc(hidden)]
+pub fn polygonize_with_trace(
+    lines: impl IntoIterator<Item = Line3D>,
+    options: &PolygonizerOptions,
+    execution_policy: &ExecutionPolicy,
+    level: TraceLevelV1,
+    byte_limit: usize,
+) -> Result<TracedPolygonizerResultV1> {
+    let collected = collect_owned_lines(lines, execution_policy)?;
+    let mut runner = Polygonizer::with_options(options.clone())
+        .with_execution_policy(execution_policy.clone())
+        .with_trace(TraceRecorderV1::new(Some(level), byte_limit, options).unwrap());
+    let result = runner.polygonize_owned(collected)?;
+    Ok(TracedPolygonizerResultV1 {
+        result,
+        trace: runner.trace.take().unwrap().finish(),
+    })
+}
+
+fn collect_owned_lines(
+    lines: impl IntoIterator<Item = Line3D>,
+    execution_policy: &ExecutionPolicy,
+) -> Result<Vec<Line3D>> {
     execution_policy.check_cancelled("ingest")?;
     let mut collected = Vec::new();
     for line in lines {
@@ -126,9 +158,7 @@ pub fn polygonize_with_execution_policy(
         execution_policy.check_cancelled_every("ingest", observed)?;
         collected.push(line);
     }
-    Polygonizer::with_options(options.clone())
-        .with_execution_policy(execution_policy.clone())
-        .polygonize_owned(collected)
+    Ok(collected)
 }
 
 /// Polygonize borrowed or owned GeoRust line strings without first building [`Line3D`] values.
@@ -269,6 +299,7 @@ pub fn polygonize_with_workspace_and_execution_policy(
         options: options.clone(),
         execution_policy: execution_policy.clone(),
         input_lines: Vec::new(),
+        trace: None,
     };
     let result = runner.polygonize_owned(lines.to_vec());
     runner.graph.clear();
@@ -284,6 +315,7 @@ impl Polygonizer {
             options: PolygonizerOptions::default(),
             execution_policy: ExecutionPolicy::default(),
             input_lines: Vec::new(),
+            trace: None,
         }
     }
     /// Creates a new `Polygonizer` with specific options.
@@ -293,6 +325,7 @@ impl Polygonizer {
             options,
             execution_policy: ExecutionPolicy::default(),
             input_lines: Vec::new(),
+            trace: None,
         }
     }
 
@@ -323,6 +356,11 @@ impl Polygonizer {
     /// Sets non-semantic limits for this polygonizer instance.
     pub fn with_execution_policy(mut self, execution_policy: ExecutionPolicy) -> Self {
         self.execution_policy = execution_policy;
+        self
+    }
+
+    fn with_trace(mut self, trace: TraceRecorderV1) -> Self {
+        self.trace = Some(trace);
         self
     }
 
@@ -605,6 +643,9 @@ impl Polygonizer {
             input_lines.len(),
         )?;
         validate_lines(&input_lines, &self.execution_policy)?;
+        if let Some(trace) = self.trace.as_mut() {
+            trace.record_input_segments(&input_lines)?;
+        }
 
         let mut diag = if self.options.diagnostics.enabled || self.options.diagnostics.timings {
             let d = PolygonizerDiagnostics {

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -1,6 +1,7 @@
 //! Internal bounded topology trace schema.
 
-use crate::PolygonizerOptions;
+use crate::fingerprint::coordinate_fingerprint;
+use crate::{CoordinateFingerprintV1, Line3D, PolygonizerOptions, PolygonizerResult};
 use serde::Serialize;
 
 pub const TOPOLOGY_TRACE_V1_SCHEMA_VERSION: u32 = 1;
@@ -33,6 +34,14 @@ pub struct TraceEventV1 {
     pub payload: serde_json::Value,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct InputSegmentTraceV1 {
+    pub index: usize,
+    pub start: CoordinateFingerprintV1,
+    pub end: CoordinateFingerprintV1,
+    pub source_ids: Vec<String>,
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct TopologyTraceV1 {
     pub schema_version: u32,
@@ -50,6 +59,11 @@ pub struct TopologyTraceV1 {
 /// Callers hold this as an `Option`; `None` is the disabled fast path.
 pub struct TraceRecorderV1 {
     trace: TopologyTraceV1,
+}
+
+pub struct TracedPolygonizerResultV1 {
+    pub result: PolygonizerResult,
+    pub trace: TopologyTraceV1,
 }
 
 impl TraceRecorderV1 {
@@ -107,6 +121,25 @@ impl TraceRecorderV1 {
     pub fn finish(self) -> TopologyTraceV1 {
         self.trace
     }
+
+    pub(crate) fn record_input_segments(&mut self, lines: &[Line3D]) -> crate::Result<()> {
+        if !self.trace.level.allows(TraceStageV1::Noding) {
+            return Ok(());
+        }
+        for (index, line) in lines.iter().enumerate() {
+            let payload = serde_json::to_value(InputSegmentTraceV1 {
+                index,
+                start: coordinate_fingerprint(line.start)?,
+                end: coordinate_fingerprint(line.end)?,
+                source_ids: vec![format!("0x{:08x}", line.line_id)],
+            })
+            .expect("input trace event serializes");
+            if !self.record(TraceStageV1::Noding, "normalized_input_segment", payload) {
+                break;
+            }
+        }
+        Ok(())
+    }
 }
 
 impl TraceLevelV1 {
@@ -125,6 +158,9 @@ impl TraceLevelV1 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{
+        polygonize, polygonize_with_trace, Coord3D, ExecutionPolicy, TopologyFingerprintV1,
+    };
     use serde_json::json;
 
     #[test]
@@ -152,5 +188,45 @@ mod tests {
         assert!(trace.bytes_used <= trace.byte_limit);
         assert!(trace.truncated);
         assert!(trace.options.is_object());
+    }
+
+    #[test]
+    fn traced_entrypoint_records_exact_input_without_changing_results() {
+        let lines = vec![
+            Line3D::new(
+                Coord3D::new(-0.0, 0.0, 10.0),
+                Coord3D::new(1.0, 0.0, 20.0),
+                7,
+            ),
+            Line3D::new(
+                Coord3D::new(1.0, 0.0, 30.0),
+                Coord3D::new(0.0, 1.0, 40.0),
+                9,
+            ),
+        ];
+        let options = PolygonizerOptions::default();
+        let expected = polygonize(lines.iter().copied(), &options).unwrap();
+        let traced = polygonize_with_trace(
+            lines,
+            &options,
+            &ExecutionPolicy::default(),
+            TraceLevelV1::Noding,
+            usize::MAX,
+        )
+        .unwrap();
+
+        assert_eq!(traced.trace.events.len(), 2);
+        assert_eq!(
+            traced.trace.events[0].payload["start"]["x"],
+            "0x0000000000000000"
+        );
+        assert_eq!(
+            traced.trace.events[0].payload["source_ids"],
+            json!(["0x00000007"])
+        );
+        assert_eq!(
+            TopologyFingerprintV1::try_from_result(&traced.result, &options).unwrap(),
+            TopologyFingerprintV1::try_from_result(&expected, &options).unwrap()
+        );
     }
 }


### PR DESCRIPTION
## Stack

Parent:
- #1018 (merged)

This PR:
- Wires exact normalized input and source-ID events into the bounded trace.

Children:
- #1020

## Delivered

- Added a traced owned-input entrypoint that shares the existing bounded-ingest collector and execution-policy checks.
- Recorded each validated canonical `Line3D` input with exact IEEE-754 coordinates, stable sequence, and source ID.
- Reused the fingerprint encoder for exact coordinate and negative-zero normalization instead of maintaining duplicate encoding logic.
- Kept the ordinary polygonization, workspace, and builder paths on a `None` trace fast path.
- Proved traced and ordinary runs produce identical topology fingerprints.

## Contract impact

- Adds a doc-hidden traced result wrapper and entrypoint; semantic polygonization options and existing result schemas are unchanged.
- Input events are emitted for noding/full trace levels and stop at the existing serialized-event byte limit.
- A trace is returned only for successful runs in this slice; failure-outcome traces remain future work.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo check -p geo-polygonize-core` — passed
- `cargo test -p geo-polygonize-core --lib -- --nocapture` — passed (180 tests before child additions)
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings` — passed
- `cargo test -p geo-polygonize-core --no-default-features trace::tests -- --nocapture` — passed (2 tests)
- `git diff --check` — passed after removing test-generated TS bindings

## Agent handoff

Remaining:
- Return partial traces for failed runs.
- Wire noding, graph, ring, containment, canonicalization, and tiling event families.

Next dependency-ready slice:
- `agent/p1-trace-graph-events`