### PR TITLE
feat(core): trace ring extraction

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -404,7 +404,7 @@ Candidate events and snapshots:
 - [x] noded and dissolved edges with complete source sets;
 - [x] graph nodes and directed halfedges;
 - [x] dangle pruning and cut-edge classification;
-- [ ] maximal rings, minimal rings, and invalid-ring reasons;
+- [x] maximal rings, minimal rings, and invalid-ring reasons;
 - [ ] shell/hole classification and containment candidates;
 - [ ] canonical ordering decisions;
 - [ ] tile ownership, deduplication, retries, and fallback decisions.
@@ -421,7 +421,9 @@ input representation with exact coordinates and source IDs before noding. The
 post-build graph snapshot records exact nodes, noded/dissolved edges with every
 source ID, and both directed halfedges before pruning mutates graph state.
 Dangle and cut-edge events then capture the exact linework returned by their
-classification passes before canonical output sorting.
+classification passes before canonical output sorting. Ring-level traces retain
+both the pre-relink maximal cycles and post-relink minimal cycles, plus explicit
+reasons for invalid minimal rings.
 
 ### P1.6 Turn the playground into a topology debugger
 

--- a/crates/geo-polygonize-core/src/graph/planar_graph.rs
+++ b/crates/geo-polygonize-core/src/graph/planar_graph.rs
@@ -20,6 +20,7 @@ pub type EdgeId = usize;
 /// Index of a directed half-edge in the graph.
 pub type DirEdgeId = usize;
 
+#[derive(Clone)]
 pub(crate) struct ExtractedRing {
     pub coords: Vec<Coord3D>,
     pub line_ids: Vec<u32>,
@@ -835,7 +836,7 @@ impl PlanarGraph {
         include_graph_ids: bool,
         include_source_ids: bool,
     ) -> Vec<ExtractedRing> {
-        self.get_edge_rings_with_graph_ids_impl(include_graph_ids, include_source_ids, None)
+        self.get_edge_rings_with_graph_ids_impl(include_graph_ids, include_source_ids, None, None)
             .expect("unlimited ring extraction cannot fail")
     }
 
@@ -849,7 +850,24 @@ impl PlanarGraph {
             include_graph_ids,
             include_source_ids,
             Some(execution_policy),
+            None,
         )
+    }
+
+    pub(crate) fn get_edge_rings_with_maximal_and_execution_policy(
+        &mut self,
+        include_graph_ids: bool,
+        include_source_ids: bool,
+        execution_policy: &ExecutionPolicy,
+    ) -> crate::Result<(Vec<ExtractedRing>, Vec<ExtractedRing>)> {
+        let mut maximal = Vec::new();
+        let minimal = self.get_edge_rings_with_graph_ids_impl(
+            include_graph_ids,
+            include_source_ids,
+            Some(execution_policy),
+            Some(&mut maximal),
+        )?;
+        Ok((maximal, minimal))
     }
 
     fn get_edge_rings_with_graph_ids_impl(
@@ -857,6 +875,7 @@ impl PlanarGraph {
         include_graph_ids: bool,
         include_source_ids: bool,
         execution_policy: Option<&ExecutionPolicy>,
+        maximal_trace: Option<&mut Vec<ExtractedRing>>,
     ) -> crate::Result<Vec<ExtractedRing>> {
         if let Some(execution_policy) = execution_policy {
             execution_policy.check_cancelled("ring_extraction")?;
@@ -874,6 +893,15 @@ impl PlanarGraph {
             // Step 2: find and label maximal rings.
             let maximal_ring_starts =
                 self.find_and_label_maximal_rings(&next_pointers, &mut labels, execution_policy)?;
+            if let Some(maximal_trace) = maximal_trace {
+                *maximal_trace = self.extract_rings_from_starts(
+                    &maximal_ring_starts,
+                    &next_pointers,
+                    include_graph_ids,
+                    include_source_ids,
+                    execution_policy,
+                )?;
+            }
 
             // Step 3: convert maximal to minimal rings by relinking intersection nodes.
             self.convert_maximal_to_minimal_rings(
@@ -890,6 +918,125 @@ impl PlanarGraph {
                 include_source_ids,
                 execution_policy,
             )
+        })
+    }
+
+    fn extract_rings_from_starts(
+        &self,
+        starts: &[DirEdgeId],
+        next_pointers: &[usize],
+        include_graph_ids: bool,
+        include_source_ids: bool,
+        execution_policy: Option<&ExecutionPolicy>,
+    ) -> crate::Result<Vec<ExtractedRing>> {
+        let mut rings = Vec::with_capacity(starts.len());
+        let mut ring_edges = Vec::new();
+        let mut work_items = 0;
+        for &start in starts {
+            ring_edges.clear();
+            let mut current = start;
+            let mut valid = true;
+            loop {
+                if let Some(execution_policy) = execution_policy {
+                    execution_policy.check_cancelled_every("ring_extraction", work_items)?;
+                }
+                work_items += 1;
+                let directed = &self.directed_edges[current];
+                if directed.is_marked || self.edges[directed.edge_idx].deleted {
+                    valid = false;
+                    break;
+                }
+                ring_edges.push(current);
+                let next = next_pointers[directed.sym_idx];
+                if next == usize::MAX {
+                    valid = false;
+                    break;
+                }
+                if next == start {
+                    break;
+                }
+                if ring_edges.len() > self.directed_edges.len() {
+                    valid = false;
+                    break;
+                }
+                current = next;
+            }
+            if valid && !ring_edges.is_empty() {
+                rings.push(self.materialize_ring(
+                    &ring_edges,
+                    include_graph_ids,
+                    include_source_ids,
+                    execution_policy,
+                    &mut work_items,
+                )?);
+            }
+        }
+        Ok(rings)
+    }
+
+    fn materialize_ring(
+        &self,
+        ring_edges: &[DirEdgeId],
+        include_graph_ids: bool,
+        include_source_ids: bool,
+        execution_policy: Option<&ExecutionPolicy>,
+        work_items: &mut usize,
+    ) -> crate::Result<ExtractedRing> {
+        let mut coords = Vec::with_capacity(ring_edges.len() + 1);
+        let mut ids = Vec::with_capacity(ring_edges.len());
+        let mut source_ids = Vec::new();
+        let mut edge_keys = if include_graph_ids {
+            Vec::with_capacity(ring_edges.len())
+        } else {
+            Vec::new()
+        };
+        let mut node_ids = if include_graph_ids {
+            Vec::with_capacity(ring_edges.len())
+        } else {
+            Vec::new()
+        };
+        let start_node_idx = self.directed_edges[ring_edges[0]].src;
+        coords.push(Coord3D {
+            x: self.nodes_x[start_node_idx],
+            y: self.nodes_y[start_node_idx],
+            z: self.nodes_z[start_node_idx],
+        });
+
+        for &de_idx in ring_edges {
+            if let Some(execution_policy) = execution_policy {
+                execution_policy.check_cancelled_every("ring_extraction", *work_items)?;
+            }
+            *work_items += 1;
+            let de = &self.directed_edges[de_idx];
+            let edge_idx = de.edge_idx;
+            ids.push(self.edges[edge_idx].line.line_id);
+            if include_source_ids {
+                source_ids.extend_from_slice(&self.edges[edge_idx].sources.line_ids);
+            }
+            if include_graph_ids {
+                edge_keys.push(if de.src < de.dst {
+                    (de.src, de.dst)
+                } else {
+                    (de.dst, de.src)
+                });
+                node_ids.push(de.src);
+            }
+
+            coords.push(Coord3D {
+                x: self.nodes_x[de.dst],
+                y: self.nodes_y[de.dst],
+                z: self.nodes_z[de.dst],
+            });
+        }
+
+        source_ids.sort_unstable();
+        source_ids.dedup();
+        Ok(ExtractedRing {
+            coords,
+            line_ids: ids,
+            source_line_ids: source_ids,
+            edge_keys,
+            node_ids,
         })
     }
 
@@ -1138,63 +1285,13 @@ impl PlanarGraph {
             }
 
             if is_valid_ring && !ring_edges.is_empty() {
-                let mut coords = Vec::with_capacity(ring_edges.len() + 1);
-                let mut ids = Vec::with_capacity(ring_edges.len());
-                let mut source_ids = Vec::new();
-                let mut edge_keys = if include_graph_ids {
-                    Vec::with_capacity(ring_edges.len())
-                } else {
-                    Vec::new()
-                };
-                let mut node_ids = if include_graph_ids {
-                    Vec::with_capacity(ring_edges.len())
-                } else {
-                    Vec::new()
-                };
-                let start_node_idx = self.directed_edges[ring_edges[0]].src;
-                coords.push(Coord3D {
-                    x: self.nodes_x[start_node_idx],
-                    y: self.nodes_y[start_node_idx],
-                    z: self.nodes_z[start_node_idx],
-                });
-
-                for &de_idx in &ring_edges {
-                    if let Some(execution_policy) = execution_policy {
-                        execution_policy.check_cancelled_every("ring_extraction", work_items)?;
-                    }
-                    work_items += 1;
-                    let de = &self.directed_edges[de_idx];
-                    let edge_idx = de.edge_idx;
-                    ids.push(self.edges[edge_idx].line.line_id);
-                    if include_source_ids {
-                        source_ids.extend_from_slice(&self.edges[edge_idx].sources.line_ids);
-                    }
-                    if include_graph_ids {
-                        edge_keys.push(if de.src < de.dst {
-                            (de.src, de.dst)
-                        } else {
-                            (de.dst, de.src)
-                        });
-                        node_ids.push(de.src);
-                    }
-
-                    let dst_idx = de.dst;
-                    coords.push(Coord3D {
-                        x: self.nodes_x[dst_idx],
-                        y: self.nodes_y[dst_idx],
-                        z: self.nodes_z[dst_idx],
-                    });
-                }
-
-                source_ids.sort_unstable();
-                source_ids.dedup();
-                rings.push(ExtractedRing {
-                    coords,
-                    line_ids: ids,
-                    source_line_ids: source_ids,
-                    edge_keys,
-                    node_ids,
-                });
+                rings.push(self.materialize_ring(
+                    &ring_edges,
+                    include_graph_ids,
+                    include_source_ids,
+                    execution_policy,
+                    &mut work_items,
+                )?);
             }
         }
         Ok(rings)

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -701,14 +701,32 @@ impl Polygonizer {
         }
 
         // 4. Find rings (3D)
-        let rings_with_ids = self
-            .graph
-            .get_edge_rings_with_graph_ids_and_execution_policy(
-                self.options.node_input,
-                self.options.provenance.enabled
-                    && self.options.provenance.include_boundary_line_ids,
-                &self.execution_policy,
-            )?;
+        let include_source_ids =
+            self.options.provenance.enabled && self.options.provenance.include_boundary_line_ids;
+        let trace_rings = self
+            .trace
+            .as_ref()
+            .is_some_and(|trace| trace.records_stage(crate::trace::TraceStageV1::Rings));
+        let rings_with_ids = if trace_rings {
+            let (maximal, minimal) = self
+                .graph
+                .get_edge_rings_with_maximal_and_execution_policy(
+                    self.options.node_input,
+                    include_source_ids,
+                    &self.execution_policy,
+                )?;
+            let trace = self.trace.as_mut().unwrap();
+            trace.record_extracted_rings("maximal_ring", &maximal)?;
+            trace.record_extracted_rings("minimal_ring", &minimal)?;
+            minimal
+        } else {
+            self.graph
+                .get_edge_rings_with_graph_ids_and_execution_policy(
+                    self.options.node_input,
+                    include_source_ids,
+                    &self.execution_policy,
+                )?
+        };
         self.execution_policy.check(
             "rings",
             self.execution_policy.max_rings,
@@ -729,6 +747,11 @@ impl Polygonizer {
             self.options.node_input,
             &self.execution_policy,
         )?;
+        if let Some(trace) = self.trace.as_mut() {
+            for (index, ring) in invalid_rings_candidates.iter().enumerate() {
+                trace.record_invalid_ring(index, ring, invalid_ring_reason(ring))?;
+            }
+        }
 
         if let Some(ref mut d) = diag {
             d.phase_times.ring_extraction = get_elapsed(t_ring_extraction_start);
@@ -1426,6 +1449,16 @@ fn has_three_distinct_xy(coords: &[Coord3D]) -> bool {
         }
     }
     false
+}
+
+fn invalid_ring_reason(ring: &Polygon3D) -> &'static str {
+    if !has_three_distinct_xy(&ring.exterior) {
+        "fewer_than_three_distinct_xy"
+    } else if !ring.signed_area_2d().is_finite() {
+        "non_finite_area"
+    } else {
+        "zero_area"
+    }
 }
 
 #[cfg(test)]

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -1,8 +1,8 @@
 //! Internal bounded topology trace schema.
 
 use crate::fingerprint::coordinate_fingerprint;
-use crate::graph::PlanarGraph;
-use crate::{CoordinateFingerprintV1, Line3D, PolygonizerOptions, PolygonizerResult};
+use crate::graph::{ExtractedRing, PlanarGraph};
+use crate::{CoordinateFingerprintV1, Line3D, Polygon3D, PolygonizerOptions, PolygonizerResult};
 use serde::Serialize;
 
 pub const TOPOLOGY_TRACE_V1_SCHEMA_VERSION: u32 = 1;
@@ -71,6 +71,15 @@ pub struct DirectedHalfedgeTraceV1 {
 pub struct ClassifiedLineTraceV1 {
     pub index: usize,
     pub coordinates: Vec<CoordinateFingerprintV1>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct RingTraceV1 {
+    pub index: usize,
+    pub coordinates: Vec<CoordinateFingerprintV1>,
+    pub edge_ids: Vec<String>,
+    pub source_ids: Vec<String>,
+    pub invalid_reason: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
@@ -151,6 +160,10 @@ impl TraceRecorderV1 {
 
     pub fn finish(self) -> TopologyTraceV1 {
         self.trace
+    }
+
+    pub(crate) fn records_stage(&self, stage: TraceStageV1) -> bool {
+        self.trace.level.allows(stage) && !self.trace.truncated
     }
 
     pub(crate) fn record_input_segments(&mut self, lines: &[Line3D]) -> crate::Result<()> {
@@ -248,6 +261,82 @@ impl TraceRecorderV1 {
         }
         Ok(())
     }
+
+    pub(crate) fn record_extracted_rings(
+        &mut self,
+        kind: &'static str,
+        rings: &[ExtractedRing],
+    ) -> crate::Result<()> {
+        if !self.records_stage(TraceStageV1::Rings) {
+            return Ok(());
+        }
+        for (index, ring) in rings.iter().enumerate() {
+            if !self.record_ring(
+                kind,
+                RingTraceV1 {
+                    index,
+                    coordinates: exact_coordinates(&ring.coords)?,
+                    edge_ids: ring
+                        .line_ids
+                        .iter()
+                        .map(|id| format!("0x{id:08x}"))
+                        .collect(),
+                    source_ids: ring
+                        .source_line_ids
+                        .iter()
+                        .map(|id| format!("0x{id:08x}"))
+                        .collect(),
+                    invalid_reason: None,
+                },
+            ) {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn record_invalid_ring(
+        &mut self,
+        index: usize,
+        ring: &Polygon3D,
+        reason: &'static str,
+    ) -> crate::Result<()> {
+        let payload = RingTraceV1 {
+            index,
+            coordinates: exact_coordinates(&ring.exterior)?,
+            edge_ids: ring
+                .exterior_ids
+                .iter()
+                .map(|id| format!("0x{id:08x}"))
+                .collect(),
+            source_ids: ring
+                .boundary_source_line_ids
+                .iter()
+                .map(|id| format!("0x{id:08x}"))
+                .collect(),
+            invalid_reason: Some(reason.to_string()),
+        };
+        self.record_ring("invalid_ring", payload);
+        Ok(())
+    }
+
+    fn record_ring(&mut self, kind: &'static str, ring: RingTraceV1) -> bool {
+        self.record(
+            TraceStageV1::Rings,
+            kind,
+            serde_json::to_value(ring).expect("ring trace event serializes"),
+        )
+    }
+}
+
+fn exact_coordinates(
+    coordinates: &[crate::Coord3D],
+) -> crate::Result<Vec<CoordinateFingerprintV1>> {
+    coordinates
+        .iter()
+        .copied()
+        .map(coordinate_fingerprint)
+        .collect()
 }
 
 impl TraceLevelV1 {
@@ -435,5 +524,72 @@ mod tests {
         assert_eq!(dangles, traced.result.dangles.len());
         assert_eq!(cut_edges, traced.result.cut_edges.len());
         assert_eq!((dangles, cut_edges), (1, 1));
+    }
+
+    #[test]
+    fn ring_trace_records_maximal_minimal_and_invalid_reason() {
+        let square = [
+            ((0.0, 0.0), (1.0, 0.0)),
+            ((1.0, 0.0), (1.0, 1.0)),
+            ((1.0, 1.0), (0.0, 1.0)),
+            ((0.0, 1.0), (0.0, 0.0)),
+        ]
+        .into_iter()
+        .enumerate()
+        .map(|(index, (start, end))| {
+            Line3D::new(
+                Coord3D::new(start.0, start.1, 0.0),
+                Coord3D::new(end.0, end.1, 0.0),
+                index as u32,
+            )
+        });
+        let traced = polygonize_with_trace(
+            square,
+            &PolygonizerOptions::default(),
+            &ExecutionPolicy::default(),
+            TraceLevelV1::Rings,
+            usize::MAX,
+        )
+        .unwrap();
+        assert!(traced
+            .trace
+            .events
+            .iter()
+            .any(|event| event.kind == "maximal_ring"));
+        assert!(traced
+            .trace
+            .events
+            .iter()
+            .any(|event| event.kind == "minimal_ring"));
+
+        let collinear = [
+            ((0.0, 0.0), (1.0, 0.0)),
+            ((1.0, 0.0), (2.0, 0.0)),
+            ((2.0, 0.0), (0.0, 0.0)),
+        ]
+        .into_iter()
+        .enumerate()
+        .map(|(index, (start, end))| {
+            Line3D::new(
+                Coord3D::new(start.0, start.1, 0.0),
+                Coord3D::new(end.0, end.1, 0.0),
+                index as u32,
+            )
+        });
+        let invalid = polygonize_with_trace(
+            collinear,
+            &PolygonizerOptions::default(),
+            &ExecutionPolicy::default(),
+            TraceLevelV1::Rings,
+            usize::MAX,
+        )
+        .unwrap();
+        let invalid_ring = invalid
+            .trace
+            .events
+            .iter()
+            .find(|event| event.kind == "invalid_ring")
+            .unwrap();
+        assert_eq!(invalid_ring.payload["invalid_reason"], "zero_area");
     }
 }


### PR DESCRIPTION
## Stack

Parent:
- #1021 (merged)

This PR:
- Records maximal and minimal ring extraction events, including exact coordinates and edge/source attribution.

Children:
- #1023

## Delivered

- Captures maximal cycles before relinking and minimal cycles after relinking.
- Records invalid minimal-ring reasons without changing polygonization output.
- Preserves existing cancellation checks while sharing ring materialization.
- Marks the ring-extraction trace milestone complete in the roadmap.

## Contract impact

- Adds trace-only `Rings` stage events; semantic output, provenance, Z behavior, and canonical ordering are unchanged.
- Tracing remains opt-in and the disabled path retains the existing extraction method.

## Validation

- `cargo check -p geo-polygonize-core` — passed
- `cargo test -p geo-polygonize-core --lib -- --nocapture` — 183 passed
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings` — passed
- `cargo test -p geo-polygonize-core --no-default-features trace::tests -- --nocapture` — 5 passed
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed

## Agent handoff

Remaining:
- shell/hole classification and containment candidates
- canonical ordering decisions
- tiling events

Next dependency-ready slice:
- `agent/p1-trace-containment-events`