### PR TITLE
feat(core): trace ring containment

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -404,7 +404,7 @@ Candidate events and snapshots:
 - [x] noded and dissolved edges with complete source sets;
 - [x] graph nodes and directed halfedges;
 - [x] dangle pruning and cut-edge classification;
-- [ ] maximal rings, minimal rings, and invalid-ring reasons;
+- [x] maximal rings, minimal rings, and invalid-ring reasons;
 - [ ] shell/hole classification and containment candidates;
 - [ ] canonical ordering decisions;
 - [ ] tile ownership, deduplication, retries, and fallback decisions.
@@ -421,7 +421,9 @@ input representation with exact coordinates and source IDs before noding. The
 post-build graph snapshot records exact nodes, noded/dissolved edges with every
 source ID, and both directed halfedges before pruning mutates graph state.
 Dangle and cut-edge events then capture the exact linework returned by their
-classification passes before canonical output sorting.
+classification passes before canonical output sorting. Ring-level traces retain
+both the pre-relink maximal cycles and post-relink minimal cycles, plus explicit
+reasons for invalid minimal rings.
 
 ### P1.6 Turn the playground into a topology debugger
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -405,7 +405,7 @@ Candidate events and snapshots:
 - [x] graph nodes and directed halfedges;
 - [x] dangle pruning and cut-edge classification;
 - [x] maximal rings, minimal rings, and invalid-ring reasons;
-- [ ] shell/hole classification and containment candidates;
+- [x] shell/hole classification and containment candidates;
 - [ ] canonical ordering decisions;
 - [ ] tile ownership, deduplication, retries, and fallback decisions.
 
@@ -423,7 +423,9 @@ source ID, and both directed halfedges before pruning mutates graph state.
 Dangle and cut-edge events then capture the exact linework returned by their
 classification passes before canonical output sorting. Ring-level traces retain
 both the pre-relink maximal cycles and post-relink minimal cycles, plus explicit
-reasons for invalid minimal rings.
+reasons for invalid minimal rings. Classification events preserve exact shell
+and hole coordinates, while containment events record the actual indexed shell
+candidates and selected parent from the physical assignment pass.
 
 ### P1.6 Turn the playground into a topology debugger
 

--- a/crates/geo-polygonize-core/src/containment.rs
+++ b/crates/geo-polygonize-core/src/containment.rs
@@ -347,7 +347,7 @@ impl ContainmentForest {
         shells: &[Polygon3D],
         touch_policy: &TouchPolicy,
     ) -> Option<usize> {
-        self.assign_hole_impl(hole_3d, None, shells, touch_policy, None)
+        self.assign_hole_impl(hole_3d, None, shells, touch_policy, None, None)
     }
 
     pub(crate) fn assign_hole_with_graph_ids(
@@ -357,7 +357,7 @@ impl ContainmentForest {
         shells: &[Polygon3D],
         touch_policy: &TouchPolicy,
     ) -> Option<usize> {
-        self.assign_hole_impl(hole_3d, hole_graph_ids, shells, touch_policy, None)
+        self.assign_hole_impl(hole_3d, hole_graph_ids, shells, touch_policy, None, None)
     }
 
     pub(crate) fn assign_hole_with_graph_ids_and_stats(
@@ -374,8 +374,31 @@ impl ContainmentForest {
             shells,
             touch_policy,
             Some(&mut stats),
+            None,
         );
         (best_shell_idx, stats)
+    }
+
+    pub(crate) fn assign_hole_with_graph_ids_and_trace(
+        &self,
+        hole_3d: &Polygon3D,
+        hole_graph_ids: Option<&RingGraphIdentity>,
+        shells: &[Polygon3D],
+        touch_policy: &TouchPolicy,
+        collect_stats: bool,
+    ) -> (Option<usize>, ContainmentStats, Vec<usize>) {
+        let mut stats = ContainmentStats::default();
+        let mut candidates = Vec::new();
+        let best_shell_idx = self.assign_hole_impl(
+            hole_3d,
+            hole_graph_ids,
+            shells,
+            touch_policy,
+            collect_stats.then_some(&mut stats),
+            Some(&mut candidates),
+        );
+        candidates.sort_unstable();
+        (best_shell_idx, stats, candidates)
     }
 
     fn assign_hole_impl(
@@ -385,6 +408,7 @@ impl ContainmentForest {
         shells: &[Polygon3D],
         touch_policy: &TouchPolicy,
         mut stats: Option<&mut ContainmentStats>,
+        mut traced_candidates: Option<&mut Vec<usize>>,
     ) -> Option<usize> {
         let track_queries = stats.is_some();
         let hole_locator = SimdRing::new_3d(&hole_3d.exterior);
@@ -400,6 +424,9 @@ impl ContainmentForest {
         let hole_area = prepared_hole.signed_area.abs();
 
         for idx in candidates {
+            if let Some(traced_candidates) = traced_candidates.as_deref_mut() {
+                traced_candidates.push(idx);
+            }
             if let Some(stats) = stats.as_deref_mut() {
                 stats.envelope_candidates += 1;
             }

--- a/crates/geo-polygonize-core/src/graph/planar_graph.rs
+++ b/crates/geo-polygonize-core/src/graph/planar_graph.rs
@@ -20,6 +20,7 @@ pub type EdgeId = usize;
 /// Index of a directed half-edge in the graph.
 pub type DirEdgeId = usize;
 
+#[derive(Clone)]
 pub(crate) struct ExtractedRing {
     pub coords: Vec<Coord3D>,
     pub line_ids: Vec<u32>,
@@ -835,7 +836,7 @@ impl PlanarGraph {
         include_graph_ids: bool,
         include_source_ids: bool,
     ) -> Vec<ExtractedRing> {
-        self.get_edge_rings_with_graph_ids_impl(include_graph_ids, include_source_ids, None)
+        self.get_edge_rings_with_graph_ids_impl(include_graph_ids, include_source_ids, None, None)
             .expect("unlimited ring extraction cannot fail")
     }
 
@@ -849,7 +850,24 @@ impl PlanarGraph {
             include_graph_ids,
             include_source_ids,
             Some(execution_policy),
+            None,
         )
+    }
+
+    pub(crate) fn get_edge_rings_with_maximal_and_execution_policy(
+        &mut self,
+        include_graph_ids: bool,
+        include_source_ids: bool,
+        execution_policy: &ExecutionPolicy,
+    ) -> crate::Result<(Vec<ExtractedRing>, Vec<ExtractedRing>)> {
+        let mut maximal = Vec::new();
+        let minimal = self.get_edge_rings_with_graph_ids_impl(
+            include_graph_ids,
+            include_source_ids,
+            Some(execution_policy),
+            Some(&mut maximal),
+        )?;
+        Ok((maximal, minimal))
     }
 
     fn get_edge_rings_with_graph_ids_impl(
@@ -857,6 +875,7 @@ impl PlanarGraph {
         include_graph_ids: bool,
         include_source_ids: bool,
         execution_policy: Option<&ExecutionPolicy>,
+        maximal_trace: Option<&mut Vec<ExtractedRing>>,
     ) -> crate::Result<Vec<ExtractedRing>> {
         if let Some(execution_policy) = execution_policy {
             execution_policy.check_cancelled("ring_extraction")?;
@@ -874,6 +893,15 @@ impl PlanarGraph {
             // Step 2: find and label maximal rings.
             let maximal_ring_starts =
                 self.find_and_label_maximal_rings(&next_pointers, &mut labels, execution_policy)?;
+            if let Some(maximal_trace) = maximal_trace {
+                *maximal_trace = self.extract_rings_from_starts(
+                    &maximal_ring_starts,
+                    &next_pointers,
+                    include_graph_ids,
+                    include_source_ids,
+                    execution_policy,
+                )?;
+            }
 
             // Step 3: convert maximal to minimal rings by relinking intersection nodes.
             self.convert_maximal_to_minimal_rings(
@@ -890,6 +918,125 @@ impl PlanarGraph {
                 include_source_ids,
                 execution_policy,
             )
+        })
+    }
+
+    fn extract_rings_from_starts(
+        &self,
+        starts: &[DirEdgeId],
+        next_pointers: &[usize],
+        include_graph_ids: bool,
+        include_source_ids: bool,
+        execution_policy: Option<&ExecutionPolicy>,
+    ) -> crate::Result<Vec<ExtractedRing>> {
+        let mut rings = Vec::with_capacity(starts.len());
+        let mut ring_edges = Vec::new();
+        let mut work_items = 0;
+        for &start in starts {
+            ring_edges.clear();
+            let mut current = start;
+            let mut valid = true;
+            loop {
+                if let Some(execution_policy) = execution_policy {
+                    execution_policy.check_cancelled_every("ring_extraction", work_items)?;
+                }
+                work_items += 1;
+                let directed = &self.directed_edges[current];
+                if directed.is_marked || self.edges[directed.edge_idx].deleted {
+                    valid = false;
+                    break;
+                }
+                ring_edges.push(current);
+                let next = next_pointers[directed.sym_idx];
+                if next == usize::MAX {
+                    valid = false;
+                    break;
+                }
+                if next == start {
+                    break;
+                }
+                if ring_edges.len() > self.directed_edges.len() {
+                    valid = false;
+                    break;
+                }
+                current = next;
+            }
+            if valid && !ring_edges.is_empty() {
+                rings.push(self.materialize_ring(
+                    &ring_edges,
+                    include_graph_ids,
+                    include_source_ids,
+                    execution_policy,
+                    &mut work_items,
+                )?);
+            }
+        }
+        Ok(rings)
+    }
+
+    fn materialize_ring(
+        &self,
+        ring_edges: &[DirEdgeId],
+        include_graph_ids: bool,
+        include_source_ids: bool,
+        execution_policy: Option<&ExecutionPolicy>,
+        work_items: &mut usize,
+    ) -> crate::Result<ExtractedRing> {
+        let mut coords = Vec::with_capacity(ring_edges.len() + 1);
+        let mut ids = Vec::with_capacity(ring_edges.len());
+        let mut source_ids = Vec::new();
+        let mut edge_keys = if include_graph_ids {
+            Vec::with_capacity(ring_edges.len())
+        } else {
+            Vec::new()
+        };
+        let mut node_ids = if include_graph_ids {
+            Vec::with_capacity(ring_edges.len())
+        } else {
+            Vec::new()
+        };
+        let start_node_idx = self.directed_edges[ring_edges[0]].src;
+        coords.push(Coord3D {
+            x: self.nodes_x[start_node_idx],
+            y: self.nodes_y[start_node_idx],
+            z: self.nodes_z[start_node_idx],
+        });
+
+        for &de_idx in ring_edges {
+            if let Some(execution_policy) = execution_policy {
+                execution_policy.check_cancelled_every("ring_extraction", *work_items)?;
+            }
+            *work_items += 1;
+            let de = &self.directed_edges[de_idx];
+            let edge_idx = de.edge_idx;
+            ids.push(self.edges[edge_idx].line.line_id);
+            if include_source_ids {
+                source_ids.extend_from_slice(&self.edges[edge_idx].sources.line_ids);
+            }
+            if include_graph_ids {
+                edge_keys.push(if de.src < de.dst {
+                    (de.src, de.dst)
+                } else {
+                    (de.dst, de.src)
+                });
+                node_ids.push(de.src);
+            }
+
+            coords.push(Coord3D {
+                x: self.nodes_x[de.dst],
+                y: self.nodes_y[de.dst],
+                z: self.nodes_z[de.dst],
+            });
+        }
+
+        source_ids.sort_unstable();
+        source_ids.dedup();
+        Ok(ExtractedRing {
+            coords,
+            line_ids: ids,
+            source_line_ids: source_ids,
+            edge_keys,
+            node_ids,
         })
     }
 
@@ -1138,63 +1285,13 @@ impl PlanarGraph {
             }
 
             if is_valid_ring && !ring_edges.is_empty() {
-                let mut coords = Vec::with_capacity(ring_edges.len() + 1);
-                let mut ids = Vec::with_capacity(ring_edges.len());
-                let mut source_ids = Vec::new();
-                let mut edge_keys = if include_graph_ids {
-                    Vec::with_capacity(ring_edges.len())
-                } else {
-                    Vec::new()
-                };
-                let mut node_ids = if include_graph_ids {
-                    Vec::with_capacity(ring_edges.len())
-                } else {
-                    Vec::new()
-                };
-                let start_node_idx = self.directed_edges[ring_edges[0]].src;
-                coords.push(Coord3D {
-                    x: self.nodes_x[start_node_idx],
-                    y: self.nodes_y[start_node_idx],
-                    z: self.nodes_z[start_node_idx],
-                });
-
-                for &de_idx in &ring_edges {
-                    if let Some(execution_policy) = execution_policy {
-                        execution_policy.check_cancelled_every("ring_extraction", work_items)?;
-                    }
-                    work_items += 1;
-                    let de = &self.directed_edges[de_idx];
-                    let edge_idx = de.edge_idx;
-                    ids.push(self.edges[edge_idx].line.line_id);
-                    if include_source_ids {
-                        source_ids.extend_from_slice(&self.edges[edge_idx].sources.line_ids);
-                    }
-                    if include_graph_ids {
-                        edge_keys.push(if de.src < de.dst {
-                            (de.src, de.dst)
-                        } else {
-                            (de.dst, de.src)
-                        });
-                        node_ids.push(de.src);
-                    }
-
-                    let dst_idx = de.dst;
-                    coords.push(Coord3D {
-                        x: self.nodes_x[dst_idx],
-                        y: self.nodes_y[dst_idx],
-                        z: self.nodes_z[dst_idx],
-                    });
-                }
-
-                source_ids.sort_unstable();
-                source_ids.dedup();
-                rings.push(ExtractedRing {
-                    coords,
-                    line_ids: ids,
-                    source_line_ids: source_ids,
-                    edge_keys,
-                    node_ids,
-                });
+                rings.push(self.materialize_ring(
+                    &ring_edges,
+                    include_graph_ids,
+                    include_source_ids,
+                    execution_policy,
+                    &mut work_items,
+                )?);
             }
         }
         Ok(rings)

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -701,14 +701,32 @@ impl Polygonizer {
         }
 
         // 4. Find rings (3D)
-        let rings_with_ids = self
-            .graph
-            .get_edge_rings_with_graph_ids_and_execution_policy(
-                self.options.node_input,
-                self.options.provenance.enabled
-                    && self.options.provenance.include_boundary_line_ids,
-                &self.execution_policy,
-            )?;
+        let include_source_ids =
+            self.options.provenance.enabled && self.options.provenance.include_boundary_line_ids;
+        let trace_rings = self
+            .trace
+            .as_ref()
+            .is_some_and(|trace| trace.records_stage(crate::trace::TraceStageV1::Rings));
+        let rings_with_ids = if trace_rings {
+            let (maximal, minimal) = self
+                .graph
+                .get_edge_rings_with_maximal_and_execution_policy(
+                    self.options.node_input,
+                    include_source_ids,
+                    &self.execution_policy,
+                )?;
+            let trace = self.trace.as_mut().unwrap();
+            trace.record_extracted_rings("maximal_ring", &maximal)?;
+            trace.record_extracted_rings("minimal_ring", &minimal)?;
+            minimal
+        } else {
+            self.graph
+                .get_edge_rings_with_graph_ids_and_execution_policy(
+                    self.options.node_input,
+                    include_source_ids,
+                    &self.execution_policy,
+                )?
+        };
         self.execution_policy.check(
             "rings",
             self.execution_policy.max_rings,
@@ -729,6 +747,11 @@ impl Polygonizer {
             self.options.node_input,
             &self.execution_policy,
         )?;
+        if let Some(trace) = self.trace.as_mut() {
+            for (index, ring) in invalid_rings_candidates.iter().enumerate() {
+                trace.record_invalid_ring(index, ring, invalid_ring_reason(ring))?;
+            }
+        }
 
         if let Some(ref mut d) = diag {
             d.phase_times.ring_extraction = get_elapsed(t_ring_extraction_start);
@@ -1426,6 +1449,16 @@ fn has_three_distinct_xy(coords: &[Coord3D]) -> bool {
         }
     }
     false
+}
+
+fn invalid_ring_reason(ring: &Polygon3D) -> &'static str {
+    if !has_three_distinct_xy(&ring.exterior) {
+        "fewer_than_three_distinct_xy"
+    } else if !ring.signed_area_2d().is_finite() {
+        "non_finite_area"
+    } else {
+        "zero_area"
+    }
 }
 
 #[cfg(test)]

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -748,6 +748,12 @@ impl Polygonizer {
             &self.execution_policy,
         )?;
         if let Some(trace) = self.trace.as_mut() {
+            for (index, (ring, _)) in shells.iter().enumerate() {
+                trace.record_classified_ring("classified_shell", index, ring)?;
+            }
+            for (index, (ring, _)) in holes.iter().enumerate() {
+                trace.record_classified_ring("classified_hole", index, ring)?;
+            }
             for (index, ring) in invalid_rings_candidates.iter().enumerate() {
                 trace.record_invalid_ring(index, ring, invalid_ring_reason(ring))?;
             }
@@ -770,7 +776,13 @@ impl Polygonizer {
             containment_stats,
         ) = {
             self.execution_policy.check_cancelled("containment")?;
-            establish_topology(shells, holes, &self.options, Some(&self.execution_policy))?
+            establish_topology(
+                shells,
+                holes,
+                &self.options,
+                Some(&self.execution_policy),
+                self.trace.as_mut(),
+            )?
         };
 
         // 6. Construct Final Polygons
@@ -1157,6 +1169,7 @@ fn establish_topology(
     holes: Vec<ClassifiedRing>,
     options: &PolygonizerOptions,
     execution_policy: Option<&ExecutionPolicy>,
+    mut trace: Option<&mut TraceRecorderV1>,
 ) -> Result<(
     Vec<Polygon3D>,
     Vec<Vec<Vec<Coord3D>>>,
@@ -1207,31 +1220,49 @@ fn establish_topology(
         }
     }
 
-    let process_hole_assignment = |(hole_3d, graph_ids): (
+    if let Some(trace) = trace.as_deref_mut() {
+        for (index, shell) in shells.iter().enumerate() {
+            trace.record_classified_ring("containment_shell", index, shell)?;
+        }
+    }
+    let trace_containment = trace.is_some();
+    let process_hole_assignment = |(hole_3d, graph_ids): (Polygon3D, Option<RingGraphIdentity>)| -> (
+        Option<usize>,
         Polygon3D,
-        Option<RingGraphIdentity>,
-    )|
-     -> (Option<usize>, Polygon3D, ContainmentStats) {
-            let (best_shell_idx, stats) = if collect_stats {
-                forest.assign_hole_with_graph_ids_and_stats(
+        ContainmentStats,
+        Option<Vec<usize>>,
+    ) {
+        let (best_shell_idx, stats, candidates) = if trace_containment {
+            let (best_shell_idx, stats, candidates) = forest.assign_hole_with_graph_ids_and_trace(
+                &hole_3d,
+                graph_ids.as_ref(),
+                &shells,
+                &options.containment.touch_policy,
+                collect_stats,
+            );
+            (best_shell_idx, stats, Some(candidates))
+        } else if collect_stats {
+            let (best_shell_idx, stats) = forest.assign_hole_with_graph_ids_and_stats(
+                &hole_3d,
+                graph_ids.as_ref(),
+                &shells,
+                &options.containment.touch_policy,
+            );
+            (best_shell_idx, stats, None)
+        } else {
+            (
+                forest.assign_hole_with_graph_ids(
                     &hole_3d,
                     graph_ids.as_ref(),
                     &shells,
                     &options.containment.touch_policy,
-                )
-            } else {
-                (
-                    forest.assign_hole_with_graph_ids(
-                        &hole_3d,
-                        graph_ids.as_ref(),
-                        &shells,
-                        &options.containment.touch_policy,
-                    ),
-                    ContainmentStats::default(),
-                )
-            };
-            (best_shell_idx, hole_3d, stats)
+                ),
+                ContainmentStats::default(),
+                None,
+            )
         };
+        (best_shell_idx, hole_3d, stats, candidates)
+    };
 
     let assignments: Vec<_>;
     if let Some(execution_policy) = execution_policy {
@@ -1257,8 +1288,11 @@ fn establish_topology(
     let mut unassigned_hole_count = 0;
     let mut unassigned_hole_area = 0.0;
 
-    for (idx, hole, stats) in assignments {
+    for (hole_index, (idx, hole, stats, candidates)) in assignments.into_iter().enumerate() {
         containment_stats.merge(stats);
+        if let (Some(trace), Some(candidates)) = (trace.as_deref_mut(), candidates) {
+            trace.record_containment_candidates(hole_index, candidates, idx);
+        }
         if let Some(idx) = idx {
             shells[idx]
                 .boundary_source_line_ids
@@ -1486,6 +1520,7 @@ mod topology_tests {
             vec![(hole, None)],
             &PolygonizerOptions::default(),
             None,
+            None,
         )
         .unwrap();
 
@@ -1522,6 +1557,7 @@ mod topology_tests {
                 )],
                 &PolygonizerOptions::default(),
                 Some(&policy),
+                None,
             ),
             Err(PolygonizeError::Cancelled { stage }) if stage == "containment"
         ));

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -1,8 +1,8 @@
 //! Internal bounded topology trace schema.
 
 use crate::fingerprint::coordinate_fingerprint;
-use crate::graph::PlanarGraph;
-use crate::{CoordinateFingerprintV1, Line3D, PolygonizerOptions, PolygonizerResult};
+use crate::graph::{ExtractedRing, PlanarGraph};
+use crate::{CoordinateFingerprintV1, Line3D, Polygon3D, PolygonizerOptions, PolygonizerResult};
 use serde::Serialize;
 
 pub const TOPOLOGY_TRACE_V1_SCHEMA_VERSION: u32 = 1;
@@ -71,6 +71,15 @@ pub struct DirectedHalfedgeTraceV1 {
 pub struct ClassifiedLineTraceV1 {
     pub index: usize,
     pub coordinates: Vec<CoordinateFingerprintV1>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct RingTraceV1 {
+    pub index: usize,
+    pub coordinates: Vec<CoordinateFingerprintV1>,
+    pub edge_ids: Vec<String>,
+    pub source_ids: Vec<String>,
+    pub invalid_reason: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
@@ -151,6 +160,10 @@ impl TraceRecorderV1 {
 
     pub fn finish(self) -> TopologyTraceV1 {
         self.trace
+    }
+
+    pub(crate) fn records_stage(&self, stage: TraceStageV1) -> bool {
+        self.trace.level.allows(stage) && !self.trace.truncated
     }
 
     pub(crate) fn record_input_segments(&mut self, lines: &[Line3D]) -> crate::Result<()> {
@@ -248,6 +261,82 @@ impl TraceRecorderV1 {
         }
         Ok(())
     }
+
+    pub(crate) fn record_extracted_rings(
+        &mut self,
+        kind: &'static str,
+        rings: &[ExtractedRing],
+    ) -> crate::Result<()> {
+        if !self.records_stage(TraceStageV1::Rings) {
+            return Ok(());
+        }
+        for (index, ring) in rings.iter().enumerate() {
+            if !self.record_ring(
+                kind,
+                RingTraceV1 {
+                    index,
+                    coordinates: exact_coordinates(&ring.coords)?,
+                    edge_ids: ring
+                        .line_ids
+                        .iter()
+                        .map(|id| format!("0x{id:08x}"))
+                        .collect(),
+                    source_ids: ring
+                        .source_line_ids
+                        .iter()
+                        .map(|id| format!("0x{id:08x}"))
+                        .collect(),
+                    invalid_reason: None,
+                },
+            ) {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn record_invalid_ring(
+        &mut self,
+        index: usize,
+        ring: &Polygon3D,
+        reason: &'static str,
+    ) -> crate::Result<()> {
+        let payload = RingTraceV1 {
+            index,
+            coordinates: exact_coordinates(&ring.exterior)?,
+            edge_ids: ring
+                .exterior_ids
+                .iter()
+                .map(|id| format!("0x{id:08x}"))
+                .collect(),
+            source_ids: ring
+                .boundary_source_line_ids
+                .iter()
+                .map(|id| format!("0x{id:08x}"))
+                .collect(),
+            invalid_reason: Some(reason.to_string()),
+        };
+        self.record_ring("invalid_ring", payload);
+        Ok(())
+    }
+
+    fn record_ring(&mut self, kind: &'static str, ring: RingTraceV1) -> bool {
+        self.record(
+            TraceStageV1::Rings,
+            kind,
+            serde_json::to_value(ring).expect("ring trace event serializes"),
+        )
+    }
+}
+
+fn exact_coordinates(
+    coordinates: &[crate::Coord3D],
+) -> crate::Result<Vec<CoordinateFingerprintV1>> {
+    coordinates
+        .iter()
+        .copied()
+        .map(coordinate_fingerprint)
+        .collect()
 }
 
 impl TraceLevelV1 {
@@ -435,5 +524,72 @@ mod tests {
         assert_eq!(dangles, traced.result.dangles.len());
         assert_eq!(cut_edges, traced.result.cut_edges.len());
         assert_eq!((dangles, cut_edges), (1, 1));
+    }
+
+    #[test]
+    fn ring_trace_records_maximal_minimal_and_invalid_reason() {
+        let square = [
+            ((0.0, 0.0), (1.0, 0.0)),
+            ((1.0, 0.0), (1.0, 1.0)),
+            ((1.0, 1.0), (0.0, 1.0)),
+            ((0.0, 1.0), (0.0, 0.0)),
+        ]
+        .into_iter()
+        .enumerate()
+        .map(|(index, (start, end))| {
+            Line3D::new(
+                Coord3D::new(start.0, start.1, 0.0),
+                Coord3D::new(end.0, end.1, 0.0),
+                index as u32,
+            )
+        });
+        let traced = polygonize_with_trace(
+            square,
+            &PolygonizerOptions::default(),
+            &ExecutionPolicy::default(),
+            TraceLevelV1::Rings,
+            usize::MAX,
+        )
+        .unwrap();
+        assert!(traced
+            .trace
+            .events
+            .iter()
+            .any(|event| event.kind == "maximal_ring"));
+        assert!(traced
+            .trace
+            .events
+            .iter()
+            .any(|event| event.kind == "minimal_ring"));
+
+        let collinear = [
+            ((0.0, 0.0), (1.0, 0.0)),
+            ((1.0, 0.0), (2.0, 0.0)),
+            ((2.0, 0.0), (0.0, 0.0)),
+        ]
+        .into_iter()
+        .enumerate()
+        .map(|(index, (start, end))| {
+            Line3D::new(
+                Coord3D::new(start.0, start.1, 0.0),
+                Coord3D::new(end.0, end.1, 0.0),
+                index as u32,
+            )
+        });
+        let invalid = polygonize_with_trace(
+            collinear,
+            &PolygonizerOptions::default(),
+            &ExecutionPolicy::default(),
+            TraceLevelV1::Rings,
+            usize::MAX,
+        )
+        .unwrap();
+        let invalid_ring = invalid
+            .trace
+            .events
+            .iter()
+            .find(|event| event.kind == "invalid_ring")
+            .unwrap();
+        assert_eq!(invalid_ring.payload["invalid_reason"], "zero_area");
     }
 }

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -82,6 +82,13 @@ pub struct RingTraceV1 {
     pub invalid_reason: Option<String>,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ContainmentCandidateTraceV1 {
+    pub hole_index: usize,
+    pub candidate_shell_indices: Vec<usize>,
+    pub selected_shell_index: Option<usize>,
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct TopologyTraceV1 {
     pub schema_version: u32,
@@ -318,6 +325,49 @@ impl TraceRecorderV1 {
         };
         self.record_ring("invalid_ring", payload);
         Ok(())
+    }
+
+    pub(crate) fn record_classified_ring(
+        &mut self,
+        kind: &'static str,
+        index: usize,
+        ring: &Polygon3D,
+    ) -> crate::Result<()> {
+        let payload = RingTraceV1 {
+            index,
+            coordinates: exact_coordinates(&ring.exterior)?,
+            edge_ids: ring
+                .exterior_ids
+                .iter()
+                .map(|id| format!("0x{id:08x}"))
+                .collect(),
+            source_ids: ring
+                .boundary_source_line_ids
+                .iter()
+                .map(|id| format!("0x{id:08x}"))
+                .collect(),
+            invalid_reason: None,
+        };
+        self.record_ring(kind, payload);
+        Ok(())
+    }
+
+    pub(crate) fn record_containment_candidates(
+        &mut self,
+        hole_index: usize,
+        candidate_shell_indices: Vec<usize>,
+        selected_shell_index: Option<usize>,
+    ) {
+        self.record(
+            TraceStageV1::Rings,
+            "containment_candidates",
+            serde_json::to_value(ContainmentCandidateTraceV1 {
+                hole_index,
+                candidate_shell_indices,
+                selected_shell_index,
+            })
+            .expect("containment trace event serializes"),
+        );
     }
 
     fn record_ring(&mut self, kind: &'static str, ring: RingTraceV1) -> bool {
@@ -591,5 +641,61 @@ mod tests {
             .find(|event| event.kind == "invalid_ring")
             .unwrap();
         assert_eq!(invalid_ring.payload["invalid_reason"], "zero_area");
+    }
+
+    #[test]
+    fn ring_trace_records_classification_and_physical_containment_candidates() {
+        let mut lines = Vec::new();
+        for (first_id, points) in [
+            (0, [(0.0, 0.0), (10.0, 0.0), (10.0, 10.0), (0.0, 10.0)]),
+            (4, [(2.0, 2.0), (8.0, 2.0), (8.0, 8.0), (2.0, 8.0)]),
+        ] {
+            for index in 0..points.len() {
+                let start = points[index];
+                let end = points[(index + 1) % points.len()];
+                lines.push(Line3D::new(
+                    Coord3D::new(start.0, start.1, 0.0),
+                    Coord3D::new(end.0, end.1, 0.0),
+                    first_id + index as u32,
+                ));
+            }
+        }
+
+        let traced = polygonize_with_trace(
+            lines,
+            &PolygonizerOptions::default(),
+            &ExecutionPolicy::default(),
+            TraceLevelV1::Rings,
+            usize::MAX,
+        )
+        .unwrap();
+
+        assert_eq!(
+            traced
+                .trace
+                .events
+                .iter()
+                .filter(|event| event.kind == "classified_shell")
+                .count(),
+            2
+        );
+        assert_eq!(
+            traced
+                .trace
+                .events
+                .iter()
+                .filter(|event| event.kind == "classified_hole")
+                .count(),
+            2
+        );
+        let assigned = traced
+            .trace
+            .events
+            .iter()
+            .find(|event| {
+                event.kind == "containment_candidates" && event.payload["selected_shell_index"] == 0
+            })
+            .unwrap();
+        assert_eq!(assigned.payload["candidate_shell_indices"], json!([0, 1]));
     }
 }


### PR DESCRIPTION
## Stack

Parent:
- #1022

This PR:
- Records shell/hole classification and the actual indexed containment candidates used for hole assignment.

Children:
- #1024

## Delivered

- Records exact classified shell and hole rings.
- Records the post-filter shell index space used by containment.
- Collects candidate shell indices inside the physical R-tree assignment loop and records the selected parent.
- Sorts candidate IDs for deterministic trace serialization.
- Marks the classification/containment trace milestone complete in the roadmap.

## Contract impact

- Extends only opt-in Ring/Full Trace V1 events.
- Does not duplicate containment queries or change polygonization output, provenance, Z behavior, or canonical ordering.
- Candidate collection allocates only while ring tracing is enabled and remains covered by the trace byte budget.

## Validation

- `cargo check -p geo-polygonize-core` — passed
- `cargo test -p geo-polygonize-core --lib -- --nocapture` — 184 passed
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings` — passed
- `cargo test -p geo-polygonize-core --no-default-features trace::tests -- --nocapture` — 6 passed
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed after removing test-generated binding files

## Agent handoff

Remaining:
- canonical ordering decisions
- tile ownership, deduplication, retries, and fallback decisions

Next dependency-ready slice:
- `agent/p1-trace-canonical-events`