### PR TITLE
feat(core): trace snapped segments

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -421,7 +421,9 @@ input representation with exact coordinates and source IDs before noding. The
 post-build graph snapshot records exact nodes, noded/dissolved edges with every
 source ID, and both directed halfedges before pruning mutates graph state.
 Dangle and cut-edge events then capture the exact linework returned by their
-classification passes before canonical output sorting.
+classification passes before canonical output sorting. Noding traces also
+record the physical post-pre-snap and post-noding segment coordinates, including
+fixed-grid output. Integer grid cells and certified hot pixels remain open.
 
 ### P1.6 Turn the playground into a topology debugger
 

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -403,6 +403,9 @@ impl Polygonizer {
                 )?;
                 all_segments = snapped;
                 pre_snap_vertex_candidates = candidates;
+                if let Some(trace) = self.trace.as_mut() {
+                    trace.record_noding_segments("pre_snapped_segment", &all_segments)?;
+                }
             }
 
             // Sort by 2D coordinates
@@ -576,6 +579,16 @@ impl Polygonizer {
             segments = all_segments;
         }
 
+        if self.options.node_input || grid_size > 0.0 {
+            if let Some(trace) = self.trace.as_mut() {
+                let kind = if grid_size > 0.0 {
+                    "fixed_grid_segment"
+                } else {
+                    "noded_segment"
+                };
+                trace.record_noding_segments(kind, &segments)?;
+            }
+        }
         self.execution_policy.check(
             "noded_segments",
             self.execution_policy.max_noded_segments,

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -154,6 +154,14 @@ impl TraceRecorderV1 {
     }
 
     pub(crate) fn record_input_segments(&mut self, lines: &[Line3D]) -> crate::Result<()> {
+        self.record_noding_segments("normalized_input_segment", lines)
+    }
+
+    pub(crate) fn record_noding_segments(
+        &mut self,
+        kind: &'static str,
+        lines: &[Line3D],
+    ) -> crate::Result<()> {
         if !self.trace.level.allows(TraceStageV1::Noding) {
             return Ok(());
         }
@@ -165,7 +173,7 @@ impl TraceRecorderV1 {
                 source_ids: vec![format!("0x{:08x}", line.line_id)],
             })
             .expect("input trace event serializes");
-            if !self.record(TraceStageV1::Noding, "normalized_input_segment", payload) {
+            if !self.record(TraceStageV1::Noding, kind, payload) {
                 break;
             }
         }
@@ -435,5 +443,42 @@ mod tests {
         assert_eq!(dangles, traced.result.dangles.len());
         assert_eq!(cut_edges, traced.result.cut_edges.len());
         assert_eq!((dangles, cut_edges), (1, 1));
+    }
+
+    #[test]
+    fn noding_trace_records_the_physical_fixed_grid_output() {
+        let lines = vec![Line3D::new(
+            Coord3D::new(0.14, 0.26, 3.0),
+            Coord3D::new(1.04, 0.26, 4.0),
+            7,
+        )];
+        let options = PolygonizerOptions {
+            precision_model: crate::PrecisionModel::FixedGrid { grid_size: 0.1 },
+            ..Default::default()
+        };
+        let traced = polygonize_with_trace(
+            lines,
+            &options,
+            &ExecutionPolicy::default(),
+            TraceLevelV1::Noding,
+            usize::MAX,
+        )
+        .unwrap();
+        let snapped = traced
+            .trace
+            .events
+            .iter()
+            .find(|event| event.kind == "fixed_grid_segment")
+            .unwrap();
+
+        assert_eq!(
+            snapped.payload["start"]["x"],
+            format!("0x{:016x}", 0.1f64.to_bits())
+        );
+        assert_eq!(
+            snapped.payload["start"]["y"],
+            format!("0x{:016x}", (3.0f64 * 0.1).to_bits())
+        );
+        assert_eq!(snapped.payload["source_ids"], json!(["0x00000007"]));
     }
 }


### PR DESCRIPTION
## Stack

Parent:
- `main` (independent noding-trace stack)

This PR:
- Records the exact segment coordinates produced by pre-snap, floating noding, and fixed-grid noding paths.

Children:
- not opened yet

## Delivered

- Reuses the existing exact input-segment payload for named noding snapshots.
- Records pre-snap output directly after reference-vertex snapping.
- Records post-noding segment output once, after the physical noder path completes.
- Distinguishes fixed-grid output from floating noded output.
- Documents that integer grid-cell and certified hot-pixel events remain open.

## Contract impact

- Extends only opt-in Noding/Full Trace V1 events.
- Does not duplicate snapping or noding work and does not change output, provenance, Z behavior, or canonical ordering.
- The no-noding floating path emits no redundant second input snapshot.

## Validation

- `cargo test -p geo-polygonize-core --lib trace::tests::noding_trace_records_the_physical_fixed_grid_output -- --nocapture` — passed
- `cargo test -p geo-polygonize-core --no-default-features trace::tests -- --nocapture` — 5 passed
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed

## Agent handoff

Remaining:
- integer fixed-grid cell events
- certified hot-pixel events
- candidate pairs and exact intersection/split witnesses

Next dependency-ready slice:
- `agent/p1-trace-hot-pixel-events`