### PR TITLE
feat(core): trace certified hot pixels

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -423,7 +423,9 @@ source ID, and both directed halfedges before pruning mutates graph state.
 Dangle and cut-edge events then capture the exact linework returned by their
 classification passes before canonical output sorting. Noding traces also
 record the physical post-pre-snap and post-noding segment coordinates, including
-fixed-grid output. Integer grid cells and certified hot pixels remain open.
+fixed-grid output. Certified noding now records the exact sorted hot-pixel set
+with integer grid coordinates from the physical snap-rounding pass. Candidate
+grid-cell events remain open.
 
 ### P1.6 Turn the playground into a topology debugger
 

--- a/crates/geo-polygonize-core/src/noding/hot_pixel.rs
+++ b/crates/geo-polygonize-core/src/noding/hot_pixel.rs
@@ -38,7 +38,7 @@ impl HotPixelNoder {
 
     pub fn node(&self, lines: Vec<Line3D>) -> Result<Vec<Line3D>> {
         self.node_with_stats_impl(lines, None)
-            .map(|(lines, _, _)| lines)
+            .map(|(lines, _, _, _)| lines)
     }
 
     pub(crate) fn node_with_stats(
@@ -46,6 +46,7 @@ impl HotPixelNoder {
         lines: Vec<Line3D>,
     ) -> Result<(Vec<Line3D>, usize, NodingWorkStats)> {
         self.node_with_stats_impl(lines, None)
+            .map(|(lines, intersections, work, _)| (lines, intersections, work))
     }
 
     pub(crate) fn node_with_execution_policy(
@@ -54,7 +55,7 @@ impl HotPixelNoder {
         execution_policy: &ExecutionPolicy,
     ) -> Result<Vec<Line3D>> {
         self.node_with_stats_impl(lines, Some(execution_policy))
-            .map(|(lines, _, _)| lines)
+            .map(|(lines, _, _, _)| lines)
     }
 
     pub(crate) fn node_with_stats_and_execution_policy(
@@ -63,13 +64,22 @@ impl HotPixelNoder {
         execution_policy: &ExecutionPolicy,
     ) -> Result<(Vec<Line3D>, usize, NodingWorkStats)> {
         self.node_with_stats_impl(lines, Some(execution_policy))
+            .map(|(lines, intersections, work, _)| (lines, intersections, work))
+    }
+
+    pub(crate) fn node_with_hot_pixels(
+        &self,
+        lines: Vec<Line3D>,
+        execution_policy: Option<&ExecutionPolicy>,
+    ) -> Result<(Vec<Line3D>, usize, NodingWorkStats, Vec<IPoint>)> {
+        self.node_with_stats_impl(lines, execution_policy)
     }
 
     fn node_with_stats_impl(
         &self,
         mut lines: Vec<Line3D>,
         execution_policy: Option<&ExecutionPolicy>,
-    ) -> Result<(Vec<Line3D>, usize, NodingWorkStats)> {
+    ) -> Result<(Vec<Line3D>, usize, NodingWorkStats, Vec<IPoint>)> {
         for line in &mut lines {
             line.start = self.snap(line.start)?;
             line.end = self.snap(line.end)?;
@@ -256,7 +266,7 @@ impl HotPixelNoder {
 
         snapper.normalize_and_dedup(&mut output);
         ValidatingNoder::new().validate(&output)?;
-        Ok((output, intersections, work))
+        Ok((output, intersections, work, hot_pixels))
     }
 
     fn grid_point(&self, coordinate: Coord3D) -> Result<IPoint> {

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -446,7 +446,33 @@ impl Polygonizer {
                         let input_segment_count = all_segments.len();
                         let noder =
                             HotPixelNoder::new(grid_size)?.with_z_policy(self.options.z.policy);
-                        if let Some(diagnostics) = diagnostics.as_deref_mut() {
+                        let trace_hot_pixels = self.trace.as_ref().is_some_and(|trace| {
+                            trace.records_stage(crate::trace::TraceStageV1::Noding)
+                        });
+                        if trace_hot_pixels {
+                            let (noded, intersections, mut work_stats, hot_pixels) = noder
+                                .node_with_hot_pixels(
+                                    all_segments,
+                                    has_execution_controls.then_some(&self.execution_policy),
+                                )?;
+                            work_stats.pre_snap_vertex_candidates = pre_snap_vertex_candidates;
+                            if let Some(trace) = self.trace.as_mut() {
+                                trace.record_hot_pixels(&hot_pixels, grid_size)?;
+                            }
+                            if let Some(diagnostics) = diagnostics.as_deref_mut() {
+                                diagnostics.intersection_stats.interpolated_intersections =
+                                    work_stats.split_events;
+                                diagnostics.intersection_stats.exact_intersections =
+                                    work_stats.exact_intersection_calls;
+                                diagnostics.noding_iterations = vec![NodingIterationStats {
+                                    iteration_index: 0,
+                                    intersections_found: intersections,
+                                    nodes_added: noded.len().saturating_sub(input_segment_count),
+                                }];
+                                diagnostics.noding_work_stats = work_stats;
+                            }
+                            segments = noded;
+                        } else if let Some(diagnostics) = diagnostics.as_deref_mut() {
                             let (noded, intersections, mut work_stats) = if has_execution_controls {
                                 noder.node_with_stats_and_execution_policy(
                                     all_segments,

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -44,6 +44,14 @@ pub struct InputSegmentTraceV1 {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct HotPixelTraceV1 {
+    pub index: usize,
+    pub grid_x: i64,
+    pub grid_y: i64,
+    pub coordinate: CoordinateFingerprintV1,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct GraphNodeTraceV1 {
     pub node_id: usize,
     pub coordinate: CoordinateFingerprintV1,
@@ -223,6 +231,33 @@ impl TraceRecorderV1 {
             })
             .expect("input trace event serializes");
             if !self.record(TraceStageV1::Noding, kind, payload) {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn record_hot_pixels(
+        &mut self,
+        hot_pixels: &[crate::types::IPoint],
+        grid_size: f64,
+    ) -> crate::Result<()> {
+        if !self.records_stage(TraceStageV1::Noding) {
+            return Ok(());
+        }
+        for (index, point) in hot_pixels.iter().enumerate() {
+            let payload = serde_json::to_value(HotPixelTraceV1 {
+                index,
+                grid_x: point.x,
+                grid_y: point.y,
+                coordinate: coordinate_fingerprint(crate::Coord3D::new(
+                    point.x as f64 * grid_size,
+                    point.y as f64 * grid_size,
+                    0.0,
+                ))?,
+            })
+            .expect("hot-pixel trace event serializes");
+            if !self.record(TraceStageV1::Noding, "certified_hot_pixel", payload) {
                 break;
             }
         }
@@ -513,7 +548,6 @@ impl TraceLevelV1 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::polygonizer::{apply_determinism, construct_final_polygons};
     use crate::{
         polygonize, polygonize_with_trace, Coord3D, ExecutionPolicy, TopologyFingerprintV1,
     };
@@ -720,5 +754,43 @@ mod tests {
             format!("0x{:016x}", (3.0f64 * 0.1).to_bits())
         );
         assert_eq!(snapped.payload["source_ids"], json!(["0x00000007"]));
+    }
+
+    #[test]
+    fn noding_trace_records_certified_hot_pixel_grid_cells() {
+        let lines = vec![
+            Line3D::new(Coord3D::new(0.0, 0.0, 0.0), Coord3D::new(2.0, 2.0, 0.0), 1),
+            Line3D::new(Coord3D::new(0.0, 2.0, 0.0), Coord3D::new(2.0, 0.0, 0.0), 2),
+        ];
+        let mut options = PolygonizerOptions {
+            node_input: true,
+            precision_model: crate::PrecisionModel::FixedGrid { grid_size: 1.0 },
+            ..Default::default()
+        };
+        options.noding.guarantee = crate::NodingGuarantee::CertifiedFixedPrecision;
+        let traced = polygonize_with_trace(
+            lines,
+            &options,
+            &ExecutionPolicy::default(),
+            TraceLevelV1::Noding,
+            usize::MAX,
+        )
+        .unwrap();
+        let hot_pixels: Vec<_> = traced
+            .trace
+            .events
+            .iter()
+            .filter(|event| event.kind == "certified_hot_pixel")
+            .collect();
+
+        assert_eq!(hot_pixels.len(), 5);
+        let intersection = hot_pixels
+            .iter()
+            .find(|event| event.payload["grid_x"] == 1 && event.payload["grid_y"] == 1)
+            .unwrap();
+        assert_eq!(
+            intersection.payload["coordinate"]["x"],
+            format!("0x{:016x}", 1.0f64.to_bits())
+        );
     }
 }


### PR DESCRIPTION
## Stack

Parent:
- #1026 (merged)

This PR:
- Records the exact sorted hot-pixel set produced by certified fixed-precision noding.

Children:
- #1028

## Delivered

- Returns the already-built integer hot-pixel vector from the physical certified noding pass.
- Records deterministic integer grid coordinates and exact world coordinates for every hot pixel.
- Preserves the existing diagnostics path without a duplicate candidate or intersection scan.
- Adds a crossing regression proving the endpoint and intersection hot pixels are retained.
- Removes stale test imports that made current `main` fail all-target Clippy after the stacked merges.

## Contract impact

- Extends only opt-in Noding/Full Trace V1 events.
- Certified noding output, work accounting, validation, provenance, and Z interpolation are unchanged.
- Disabled tracing keeps the existing wrappers and discards the already-existing hot-pixel vector normally.

## Validation

- `cargo check -p geo-polygonize-core` — passed
- `cargo test -p geo-polygonize-core --lib trace::tests::noding_trace_records_certified_hot_pixel_grid_cells -- --nocapture` — passed
- `cargo test -p geo-polygonize-core --no-default-features trace::tests -- --nocapture` — 6 passed
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed

## Agent handoff

Remaining:
- uniform-grid candidate cell events
- candidate-pair events
- exact intersection and split witnesses

Next dependency-ready slice:
- `agent/p1-trace-candidate-events`