### PR TITLE
feat(core): trace floating noding candidates

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -427,9 +427,10 @@ fixed-grid output. Certified noding now records the exact sorted hot-pixel set
 with integer grid coordinates from the physical snap-rounding pass. Candidate
 grid-cell events remain open. The same certified pass also records every
 candidate segment pair with source IDs and its exact point, collinear, or empty
-intersection witness; floating SIMD and uniform-grid candidate events remain
-open. Certified replacement segments additionally retain their source segment,
-source ID, and exact emitted endpoints from the physical split loop.
+intersection witness. Floating SIMD candidate scans now emit the same evidence
+from their physical exact-predicate calls; uniform-grid cell and candidate events
+remain open. Certified replacement segments additionally retain their source
+segment, source ID, and exact emitted endpoints from the physical split loop.
 
 ### P1.6 Turn the playground into a topology debugger
 

--- a/crates/geo-polygonize-core/src/noding/snap.rs
+++ b/crates/geo-polygonize-core/src/noding/snap.rs
@@ -77,6 +77,29 @@ pub enum NodingStrategy {
     Grid,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) enum FloatingIntersectionTrace {
+    Point(Coord3D),
+    Collinear(Coord3D, Coord3D),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct FloatingCandidateTrace {
+    pub(crate) iteration_index: usize,
+    pub(crate) first_segment: usize,
+    pub(crate) second_segment: usize,
+    pub(crate) first_source_id: u32,
+    pub(crate) second_source_id: u32,
+    pub(crate) witness: Option<FloatingIntersectionTrace>,
+}
+
+type FloatingNodingTraceResult = (
+    Vec<Line3D>,
+    Vec<NodingIterationStats>,
+    NodingWorkStats,
+    Vec<FloatingCandidateTrace>,
+);
+
 const AUTO_SIMD_LIMIT: usize = 1024;
 
 pub struct SnapNoder {
@@ -114,7 +137,7 @@ impl SnapNoder {
     }
 
     pub fn node(&self, lines: Vec<Line3D>) -> Vec<Line3D> {
-        self.node_impl(lines, None, None, None)
+        self.node_impl(lines, None, None, None, None)
             .expect("unlimited noding cannot fail")
     }
 
@@ -125,7 +148,7 @@ impl SnapNoder {
         let mut stats = Vec::new();
         let mut work_stats = NodingWorkStats::default();
         let lines = self
-            .node_impl(lines, Some(&mut stats), Some(&mut work_stats), None)
+            .node_impl(lines, Some(&mut stats), Some(&mut work_stats), None, None)
             .expect("unlimited noding cannot fail");
         (lines, stats, work_stats)
     }
@@ -135,7 +158,7 @@ impl SnapNoder {
         lines: Vec<Line3D>,
         execution_policy: &ExecutionPolicy,
     ) -> crate::Result<Vec<Line3D>> {
-        self.node_impl(lines, None, None, Some(execution_policy))
+        self.node_impl(lines, None, None, Some(execution_policy), None)
     }
 
     pub(crate) fn node_with_stats_and_execution_policy(
@@ -150,8 +173,27 @@ impl SnapNoder {
             Some(&mut stats),
             Some(&mut work_stats),
             Some(execution_policy),
+            None,
         )?;
         Ok((lines, stats, work_stats))
+    }
+
+    pub(crate) fn node_with_trace(
+        &self,
+        lines: Vec<Line3D>,
+        execution_policy: Option<&ExecutionPolicy>,
+    ) -> crate::Result<FloatingNodingTraceResult> {
+        let mut stats = Vec::new();
+        let mut work_stats = NodingWorkStats::default();
+        let mut candidates = Vec::new();
+        let lines = self.node_impl(
+            lines,
+            Some(&mut stats),
+            Some(&mut work_stats),
+            execution_policy,
+            Some(&mut candidates),
+        )?;
+        Ok((lines, stats, work_stats, candidates))
     }
 
     fn node_impl(
@@ -160,6 +202,7 @@ impl SnapNoder {
         mut stats: Option<&mut Vec<NodingIterationStats>>,
         mut work_stats: Option<&mut NodingWorkStats>,
         execution_policy: Option<&ExecutionPolicy>,
+        mut trace_candidates: Option<&mut Vec<FloatingCandidateTrace>>,
     ) -> crate::Result<Vec<Line3D>> {
         // 1. Initial Snap of endpoints
         for line in &mut lines {
@@ -203,10 +246,21 @@ impl SnapNoder {
 
             let mut events = if !use_grid {
                 // STRATEGY A: Small Input -> SIMD Brute Force
-                if execution_policy.is_some() || work_stats.is_some() {
+                if trace_candidates.is_some() {
                     let mut tracker =
                         ExecutionWorkTracker::new(execution_policy, work_stats.as_deref_mut());
-                    self.find_splits_simd_tracked(&lines, &mut tracker)?
+                    let candidates = trace_candidates.as_deref_mut().unwrap();
+                    let first_candidate = candidates.len();
+                    let events =
+                        self.find_splits_simd_tracked(&lines, &mut tracker, Some(candidates))?;
+                    for candidate in &mut candidates[first_candidate..] {
+                        candidate.iteration_index = iteration_index;
+                    }
+                    events
+                } else if execution_policy.is_some() || work_stats.is_some() {
+                    let mut tracker =
+                        ExecutionWorkTracker::new(execution_policy, work_stats.as_deref_mut());
+                    self.find_splits_simd_tracked(&lines, &mut tracker, None)?
                 } else {
                     self.find_splits_simd(&lines)
                 }
@@ -832,7 +886,7 @@ impl SnapNoder {
                     .par_iter()
                     .enumerate()
                     .flat_map(|(i, &query_line)| {
-                        self.check_intersection_simd(query_line, i, lines, &soa, None)
+                        self.check_intersection_simd(query_line, i, lines, &soa, None, None)
                             .expect("unlimited noding cannot fail")
                     })
                     .collect()
@@ -842,7 +896,7 @@ impl SnapNoder {
                     .iter()
                     .enumerate()
                     .flat_map(|(i, &query_line)| {
-                        self.check_intersection_simd(query_line, i, lines, &soa, None)
+                        self.check_intersection_simd(query_line, i, lines, &soa, None, None)
                             .expect("unlimited noding cannot fail")
                     })
                     .collect()
@@ -854,7 +908,7 @@ impl SnapNoder {
             let mut splits = Vec::new();
             for (i, &query_line) in lines.iter().enumerate() {
                 let events = self
-                    .check_intersection_simd(query_line, i, lines, &soa, None)
+                    .check_intersection_simd(query_line, i, lines, &soa, None, None)
                     .expect("unlimited noding cannot fail");
                 splits.extend(events);
             }
@@ -866,6 +920,7 @@ impl SnapNoder {
         &self,
         lines: &[Line3D],
         tracker: &mut ExecutionWorkTracker<'_>,
+        mut trace_candidates: Option<&mut Vec<FloatingCandidateTrace>>,
     ) -> crate::Result<Vec<(usize, Coord3D)>> {
         let soa = SoALines::new(lines);
         let mut splits = Vec::new();
@@ -877,6 +932,7 @@ impl SnapNoder {
                 lines,
                 &soa,
                 Some(tracker),
+                trace_candidates.as_deref_mut(),
             )?);
         }
         tracker.check_cancelled()?;
@@ -912,6 +968,7 @@ impl SnapNoder {
         lines: &[Line3D],
         soa: &SoALines,
         mut tracker: Option<&mut ExecutionWorkTracker<'_>>,
+        mut trace_candidates: Option<&mut Vec<FloatingCandidateTrace>>,
     ) -> crate::Result<Vec<(usize, Coord3D)>> {
         let mut events = Vec::new();
         // Start block to avoid duplicate checks (j > i)
@@ -945,9 +1002,14 @@ impl SnapNoder {
                 tracker.candidate(overlaps)?;
             }
             if overlaps {
-                self.process_intersection(query_line, target_line, i, j, |idx, pt| {
-                    events.push((idx, pt))
-                });
+                self.process_candidate(
+                    query_line,
+                    target_line,
+                    i,
+                    j,
+                    &mut events,
+                    trace_candidates.as_deref_mut(),
+                );
             }
         }
 
@@ -971,13 +1033,65 @@ impl SnapNoder {
                 }
                 if overlaps {
                     let target_line = lines[target_idx];
-                    self.process_intersection(query_line, target_line, i, target_idx, |idx, pt| {
-                        events.push((idx, pt))
-                    });
+                    self.process_candidate(
+                        query_line,
+                        target_line,
+                        i,
+                        target_idx,
+                        &mut events,
+                        trace_candidates.as_deref_mut(),
+                    );
                 }
             }
         }
         Ok(events)
+    }
+
+    fn process_candidate(
+        &self,
+        first: Line3D,
+        second: Line3D,
+        first_segment: usize,
+        second_segment: usize,
+        events: &mut Vec<(usize, Coord3D)>,
+        trace_candidates: Option<&mut Vec<FloatingCandidateTrace>>,
+    ) {
+        let intersection = line_intersection(first.to_line_2d(), second.to_line_2d());
+        if let Some(trace_candidates) = trace_candidates {
+            let witness = intersection.map(|intersection| match intersection {
+                LineIntersection::SinglePoint { intersection, .. } => {
+                    FloatingIntersectionTrace::Point(Coord3D::new(
+                        intersection.x,
+                        intersection.y,
+                        0.0,
+                    ))
+                }
+                LineIntersection::Collinear { intersection } => {
+                    FloatingIntersectionTrace::Collinear(
+                        Coord3D::new(intersection.start.x, intersection.start.y, 0.0),
+                        Coord3D::new(intersection.end.x, intersection.end.y, 0.0),
+                    )
+                }
+            });
+            trace_candidates.push(FloatingCandidateTrace {
+                iteration_index: 0,
+                first_segment,
+                second_segment,
+                first_source_id: first.line_id,
+                second_source_id: second.line_id,
+                witness,
+            });
+        }
+        if let Some(intersection) = intersection {
+            self.handle_intersection(
+                intersection,
+                first_segment,
+                second_segment,
+                first,
+                second,
+                |index, point| events.push((index, point)),
+            );
+        }
     }
 
     #[inline]
@@ -1082,6 +1196,7 @@ mod tests {
             SnapNoder::new(1.0).find_splits_simd_tracked(
                 &lines,
                 &mut ExecutionWorkTracker::new(Some(&policy), None),
+                None,
             ),
             Err(PolygonizeError::Cancelled { stage }) if stage == "candidate_enumeration"
         ));
@@ -1102,6 +1217,7 @@ mod tests {
             &lines,
             &mut ExecutionWorkTracker::new(Some(&policy), Some(&mut stats))
                 .cancel_at_candidate(token, 17),
+            None,
         );
 
         assert!(matches!(
@@ -1130,6 +1246,7 @@ mod tests {
         let result = SnapNoder::new(0.0).find_splits_simd_tracked(
             &lines,
             &mut ExecutionWorkTracker::new(Some(&policy), Some(&mut stats)),
+            None,
         );
 
         assert!(matches!(

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -527,7 +527,31 @@ impl Polygonizer {
                             } else {
                                 None
                             };
-                        if let Some(diagnostics) = diagnostics.as_deref_mut() {
+                        let trace_candidates = self.trace.as_ref().is_some_and(|trace| {
+                            trace.records_stage(crate::trace::TraceStageV1::Noding)
+                        });
+                        if trace_candidates {
+                            let (noded, stats, mut work_stats, candidates) = noder
+                                .node_with_trace(
+                                    all_segments,
+                                    has_execution_controls.then_some(&self.execution_policy),
+                                )?;
+                            work_stats.pre_snap_vertex_candidates = pre_snap_vertex_candidates;
+                            if let Some(trace) = self.trace.as_mut() {
+                                trace.record_floating_candidates(&candidates)?;
+                            }
+                            if let Some(diagnostics) = diagnostics.as_deref_mut() {
+                                diagnostics.intersection_stats.interpolated_intersections = stats
+                                    .iter()
+                                    .map(|iteration| iteration.intersections_found)
+                                    .sum();
+                                diagnostics.noding_iterations = stats;
+                                diagnostics.intersection_stats.exact_intersections =
+                                    work_stats.exact_intersection_calls;
+                                diagnostics.noding_work_stats = work_stats;
+                            }
+                            segments = noded;
+                        } else if let Some(diagnostics) = diagnostics.as_deref_mut() {
                             let (noded, stats, mut work_stats) = if has_execution_controls {
                                 noder.node_with_stats_and_execution_policy(
                                     all_segments,

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -5,6 +5,7 @@ use crate::graph::{ExtractedRing, PlanarGraph};
 use crate::noding::hot_pixel::{
     HotPixelCandidateTrace, HotPixelIntersectionTrace, HotPixelSplitTrace,
 };
+use crate::noding::snap::{FloatingCandidateTrace, FloatingIntersectionTrace};
 use crate::{CoordinateFingerprintV1, Line3D, Polygon3D, PolygonizerOptions, PolygonizerResult};
 use serde::Serialize;
 
@@ -69,6 +70,8 @@ pub enum IntersectionWitnessTraceV1 {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct CandidatePairTraceV1 {
     pub index: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub iteration_index: Option<usize>,
     pub first_segment: usize,
     pub second_segment: usize,
     pub first_source_id: String,
@@ -322,6 +325,7 @@ impl TraceRecorderV1 {
             };
             let payload = serde_json::to_value(CandidatePairTraceV1 {
                 index,
+                iteration_index: None,
                 first_segment: candidate.first_segment,
                 second_segment: candidate.second_segment,
                 first_source_id: format!("0x{:08x}", candidate.first_source_id),
@@ -330,6 +334,45 @@ impl TraceRecorderV1 {
             })
             .expect("candidate-pair trace event serializes");
             if !self.record(TraceStageV1::Noding, "certified_candidate_pair", payload) {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn record_floating_candidates(
+        &mut self,
+        candidates: &[FloatingCandidateTrace],
+    ) -> crate::Result<()> {
+        if !self.records_stage(TraceStageV1::Noding) {
+            return Ok(());
+        }
+        for (index, candidate) in candidates.iter().enumerate() {
+            let witness = match candidate.witness {
+                Some(FloatingIntersectionTrace::Point(coordinate)) => {
+                    Some(IntersectionWitnessTraceV1::Point {
+                        coordinate: coordinate_fingerprint(coordinate)?,
+                    })
+                }
+                Some(FloatingIntersectionTrace::Collinear(start, end)) => {
+                    Some(IntersectionWitnessTraceV1::Collinear {
+                        start: coordinate_fingerprint(start)?,
+                        end: coordinate_fingerprint(end)?,
+                    })
+                }
+                None => None,
+            };
+            let payload = serde_json::to_value(CandidatePairTraceV1 {
+                index,
+                iteration_index: Some(candidate.iteration_index),
+                first_segment: candidate.first_segment,
+                second_segment: candidate.second_segment,
+                first_source_id: format!("0x{:08x}", candidate.first_source_id),
+                second_source_id: format!("0x{:08x}", candidate.second_source_id),
+                witness,
+            })
+            .expect("candidate-pair trace event serializes");
+            if !self.record(TraceStageV1::Noding, "floating_candidate_pair", payload) {
                 break;
             }
         }
@@ -919,5 +962,41 @@ mod tests {
             event.payload["end"]["x"] == format!("0x{:016x}", 1.0f64.to_bits())
                 && event.payload["end"]["y"] == format!("0x{:016x}", 1.0f64.to_bits())
         }));
+    }
+
+    #[test]
+    fn noding_trace_records_floating_simd_candidates() {
+        let lines = vec![
+            Line3D::new(Coord3D::new(0.0, 0.0, 0.0), Coord3D::new(2.0, 2.0, 0.0), 1),
+            Line3D::new(Coord3D::new(0.0, 2.0, 0.0), Coord3D::new(2.0, 0.0, 0.0), 2),
+        ];
+        let options = PolygonizerOptions {
+            node_input: true,
+            ..Default::default()
+        };
+        let traced = polygonize_with_trace(
+            lines,
+            &options,
+            &ExecutionPolicy::default(),
+            TraceLevelV1::Noding,
+            usize::MAX,
+        )
+        .unwrap();
+        let candidates: Vec<_> = traced
+            .trace
+            .events
+            .iter()
+            .filter(|event| event.kind == "floating_candidate_pair")
+            .collect();
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].payload["iteration_index"], 0);
+        assert_eq!(candidates[0].payload["first_source_id"], "0x00000001");
+        assert_eq!(candidates[0].payload["second_source_id"], "0x00000002");
+        assert_eq!(candidates[0].payload["witness"]["kind"], "point");
+        assert_eq!(
+            candidates[0].payload["witness"]["coordinate"]["x"],
+            format!("0x{:016x}", 1.0f64.to_bits())
+        );
     }
 }


### PR DESCRIPTION
## Stack

Parent:
- #1029 (merged)

This PR:
- Records floating SIMD candidate pairs and exact intersection witnesses from the physical noding scan.

Children:
- #1031

## Delivered

- Captures iteration, source segment indices, and source IDs only while Noding/Full tracing is enabled.
- Reuses the exact `line_intersection` result that drives split emission.
- Preserves the token-free parallel path when tracing is disabled.
- Adds an end-to-end traced crossing regression.
- Updates P1.5 without closing the uniform-grid work.

## Contract impact

- Extends only opt-in Noding/Full Trace V1 events with `floating_candidate_pair`.
- Certified candidate payloads remain compatible; the floating event adds its required iteration index.
- Polygon output, candidate ordering, work accounting, cancellation, provenance, and Z behavior are unchanged.

## Validation

- `cargo test -p geo-polygonize-core --lib trace::tests -- --nocapture` — 7 passed
- `cargo test -p geo-polygonize-core --no-default-features trace::tests -- --nocapture` — 7 passed
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed

## Agent handoff

Remaining:
- uniform-grid cell and candidate events
- floating and uniform-grid split evidence

Next dependency-ready slice:
- #1031 `agent/p1-trace-grid-cells`
