### PR TITLE
feat(core): trace uniform grid cells

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -399,7 +399,7 @@ the entire pipeline.
 Candidate events and snapshots:
 
 - [x] normalized input segments and source IDs;
-- [ ] snapped coordinates, fixed-grid cells, and certified hot pixels;
+- [x] snapped coordinates, fixed-grid cells, and certified hot pixels;
 - [ ] candidate pairs and exact intersection/split witnesses;
 - [x] noded and dissolved edges with complete source sets;
 - [x] graph nodes and directed halfedges;
@@ -424,13 +424,15 @@ Dangle and cut-edge events then capture the exact linework returned by their
 classification passes before canonical output sorting. Noding traces also
 record the physical post-pre-snap and post-noding segment coordinates, including
 fixed-grid output. Certified noding now records the exact sorted hot-pixel set
-with integer grid coordinates from the physical snap-rounding pass. Candidate
-grid-cell events remain open. The same certified pass also records every
-candidate segment pair with source IDs and its exact point, collinear, or empty
-intersection witness. Floating SIMD candidate scans now emit the same evidence
-from their physical exact-predicate calls; uniform-grid cell and candidate events
-remain open. Certified replacement segments additionally retain their source
-segment, source ID, and exact emitted endpoints from the physical split loop.
+with integer grid coordinates from the physical snap-rounding pass. Uniform-grid
+candidate cells now retain their exact bounds, iteration, segment/source
+membership, and global-line fallback membership. The same certified pass also
+records every candidate segment pair with source IDs and its exact point,
+collinear, or empty intersection witness. Floating SIMD candidate scans now emit
+the same evidence from their physical exact-predicate calls; uniform-grid
+candidate events remain open. Certified replacement segments additionally
+retain their source segment, source ID, and exact emitted endpoints from the
+physical split loop.
 
 ### P1.6 Turn the playground into a topology debugger
 

--- a/crates/geo-polygonize-core/src/noding/grid.rs
+++ b/crates/geo-polygonize-core/src/noding/grid.rs
@@ -213,6 +213,22 @@ pub struct UniformGrid {
     bounds_min: Coord<f64>,
 }
 
+pub(crate) struct UniformGridCellTrace {
+    pub(crate) iteration_index: usize,
+    pub(crate) row: usize,
+    pub(crate) column: usize,
+    pub(crate) min: Coord3D,
+    pub(crate) max: Coord3D,
+    pub(crate) segment_indices: Vec<usize>,
+    pub(crate) source_ids: Vec<u32>,
+}
+
+pub(crate) struct UniformGridGlobalLineTrace {
+    pub(crate) iteration_index: usize,
+    pub(crate) segment_index: usize,
+    pub(crate) source_id: u32,
+}
+
 impl UniformGrid {
     pub fn new(lines: &[Line3D]) -> Self {
         Self::new_impl(lines, None).expect("unlimited grid construction cannot fail")
@@ -463,6 +479,57 @@ impl UniformGrid {
             rows: 0,
             bounds_min: Coord::zero(),
         }
+    }
+
+    pub(crate) fn trace_structure(
+        &self,
+        lines: &[Line3D],
+        iteration_index: usize,
+    ) -> (Vec<UniformGridCellTrace>, Vec<UniformGridGlobalLineTrace>) {
+        let mut cells = Vec::new();
+        for index in 0..self.rows * self.cols {
+            let start = self.cell_offsets[index];
+            let end = self.cell_offsets[index + 1];
+            if end - start < 2 {
+                continue;
+            }
+            let row = index / self.cols;
+            let column = index % self.cols;
+            let segment_indices: Vec<_> = self.cell_items[start..end]
+                .iter()
+                .map(|&segment| segment as usize)
+                .collect();
+            cells.push(UniformGridCellTrace {
+                iteration_index,
+                row,
+                column,
+                min: Coord3D::new(
+                    self.bounds_min.x + column as f64 * self.cell_size,
+                    self.bounds_min.y + row as f64 * self.cell_size,
+                    0.0,
+                ),
+                max: Coord3D::new(
+                    self.bounds_min.x + (column + 1) as f64 * self.cell_size,
+                    self.bounds_min.y + (row + 1) as f64 * self.cell_size,
+                    0.0,
+                ),
+                source_ids: segment_indices
+                    .iter()
+                    .map(|&segment| lines[segment].line_id)
+                    .collect(),
+                segment_indices,
+            });
+        }
+        let global_lines = self
+            .global_lines
+            .iter()
+            .map(|&segment_index| UniformGridGlobalLineTrace {
+                iteration_index,
+                segment_index,
+                source_id: lines[segment_index].line_id,
+            })
+            .collect();
+        (cells, global_lines)
     }
 
     /// Finds all intersections. Uses "Intersection Ownership" to deduplicate checks.

--- a/crates/geo-polygonize-core/src/noding/snap.rs
+++ b/crates/geo-polygonize-core/src/noding/snap.rs
@@ -1,7 +1,7 @@
 use crate::diagnostics::{ExecutionWorkTracker, NodingIterationStats, NodingWorkStats};
 use crate::error::PolygonizeError;
 use crate::index::{IndexedEnvelope, RStarBackend};
-use crate::noding::grid::UniformGrid;
+use crate::noding::grid::{UniformGrid, UniformGridCellTrace, UniformGridGlobalLineTrace};
 use crate::options::{ExecutionPolicy, SnapStrategy, ZPolicy};
 use crate::types::{Coord3D, Line3D};
 use crate::utils::soa::SoALines;
@@ -98,7 +98,16 @@ type FloatingNodingTraceResult = (
     Vec<NodingIterationStats>,
     NodingWorkStats,
     Vec<FloatingCandidateTrace>,
+    Vec<UniformGridCellTrace>,
+    Vec<UniformGridGlobalLineTrace>,
 );
+
+#[derive(Default)]
+struct FloatingTraceCapture {
+    candidates: Vec<FloatingCandidateTrace>,
+    grid_cells: Vec<UniformGridCellTrace>,
+    global_lines: Vec<UniformGridGlobalLineTrace>,
+}
 
 const AUTO_SIMD_LIMIT: usize = 1024;
 
@@ -185,15 +194,22 @@ impl SnapNoder {
     ) -> crate::Result<FloatingNodingTraceResult> {
         let mut stats = Vec::new();
         let mut work_stats = NodingWorkStats::default();
-        let mut candidates = Vec::new();
+        let mut trace = FloatingTraceCapture::default();
         let lines = self.node_impl(
             lines,
             Some(&mut stats),
             Some(&mut work_stats),
             execution_policy,
-            Some(&mut candidates),
+            Some(&mut trace),
         )?;
-        Ok((lines, stats, work_stats, candidates))
+        Ok((
+            lines,
+            stats,
+            work_stats,
+            trace.candidates,
+            trace.grid_cells,
+            trace.global_lines,
+        ))
     }
 
     fn node_impl(
@@ -202,7 +218,7 @@ impl SnapNoder {
         mut stats: Option<&mut Vec<NodingIterationStats>>,
         mut work_stats: Option<&mut NodingWorkStats>,
         execution_policy: Option<&ExecutionPolicy>,
-        mut trace_candidates: Option<&mut Vec<FloatingCandidateTrace>>,
+        mut trace: Option<&mut FloatingTraceCapture>,
     ) -> crate::Result<Vec<Line3D>> {
         // 1. Initial Snap of endpoints
         for line in &mut lines {
@@ -246,10 +262,10 @@ impl SnapNoder {
 
             let mut events = if !use_grid {
                 // STRATEGY A: Small Input -> SIMD Brute Force
-                if trace_candidates.is_some() {
+                if trace.is_some() {
                     let mut tracker =
                         ExecutionWorkTracker::new(execution_policy, work_stats.as_deref_mut());
-                    let candidates = trace_candidates.as_deref_mut().unwrap();
+                    let candidates = &mut trace.as_deref_mut().unwrap().candidates;
                     let first_candidate = candidates.len();
                     let events =
                         self.find_splits_simd_tracked(&lines, &mut tracker, Some(candidates))?;
@@ -271,6 +287,11 @@ impl SnapNoder {
                 } else {
                     UniformGrid::new(&lines)
                 };
+                if let Some(trace) = trace.as_deref_mut() {
+                    let (cells, global_lines) = grid.trace_structure(&lines, iteration_index);
+                    trace.grid_cells.extend(cells);
+                    trace.global_lines.extend(global_lines);
+                }
                 if execution_policy.is_some() || work_stats.is_some() {
                     let mut tracker =
                         ExecutionWorkTracker::new(execution_policy, work_stats.as_deref_mut());

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -531,14 +531,21 @@ impl Polygonizer {
                             trace.records_stage(crate::trace::TraceStageV1::Noding)
                         });
                         if trace_candidates {
-                            let (noded, stats, mut work_stats, candidates) = noder
-                                .node_with_trace(
-                                    all_segments,
-                                    has_execution_controls.then_some(&self.execution_policy),
-                                )?;
+                            let (
+                                noded,
+                                stats,
+                                mut work_stats,
+                                candidates,
+                                grid_cells,
+                                global_lines,
+                            ) = noder.node_with_trace(
+                                all_segments,
+                                has_execution_controls.then_some(&self.execution_policy),
+                            )?;
                             work_stats.pre_snap_vertex_candidates = pre_snap_vertex_candidates;
                             if let Some(trace) = self.trace.as_mut() {
                                 trace.record_floating_candidates(&candidates)?;
+                                trace.record_uniform_grid(&grid_cells, &global_lines)?;
                             }
                             if let Some(diagnostics) = diagnostics.as_deref_mut() {
                                 diagnostics.intersection_stats.interpolated_intersections = stats

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -2,6 +2,7 @@
 
 use crate::fingerprint::coordinate_fingerprint;
 use crate::graph::{ExtractedRing, PlanarGraph};
+use crate::noding::grid::{UniformGridCellTrace, UniformGridGlobalLineTrace};
 use crate::noding::hot_pixel::{
     HotPixelCandidateTrace, HotPixelIntersectionTrace, HotPixelSplitTrace,
 };
@@ -86,6 +87,26 @@ pub struct SplitEventTraceV1 {
     pub source_id: String,
     pub start: CoordinateFingerprintV1,
     pub end: CoordinateFingerprintV1,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct UniformGridCellTraceV1 {
+    pub index: usize,
+    pub iteration_index: usize,
+    pub row: usize,
+    pub column: usize,
+    pub min: CoordinateFingerprintV1,
+    pub max: CoordinateFingerprintV1,
+    pub segment_indices: Vec<usize>,
+    pub source_ids: Vec<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct UniformGridGlobalLineTraceV1 {
+    pub index: usize,
+    pub iteration_index: usize,
+    pub segment_index: usize,
+    pub source_id: String,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
@@ -373,6 +394,49 @@ impl TraceRecorderV1 {
             })
             .expect("candidate-pair trace event serializes");
             if !self.record(TraceStageV1::Noding, "floating_candidate_pair", payload) {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn record_uniform_grid(
+        &mut self,
+        cells: &[UniformGridCellTrace],
+        global_lines: &[UniformGridGlobalLineTrace],
+    ) -> crate::Result<()> {
+        if !self.records_stage(TraceStageV1::Noding) {
+            return Ok(());
+        }
+        for (index, cell) in cells.iter().enumerate() {
+            let payload = serde_json::to_value(UniformGridCellTraceV1 {
+                index,
+                iteration_index: cell.iteration_index,
+                row: cell.row,
+                column: cell.column,
+                min: coordinate_fingerprint(cell.min)?,
+                max: coordinate_fingerprint(cell.max)?,
+                segment_indices: cell.segment_indices.clone(),
+                source_ids: cell
+                    .source_ids
+                    .iter()
+                    .map(|source_id| format!("0x{source_id:08x}"))
+                    .collect(),
+            })
+            .expect("uniform-grid cell trace event serializes");
+            if !self.record(TraceStageV1::Noding, "uniform_grid_cell", payload) {
+                return Ok(());
+            }
+        }
+        for (index, line) in global_lines.iter().enumerate() {
+            let payload = serde_json::to_value(UniformGridGlobalLineTraceV1 {
+                index,
+                iteration_index: line.iteration_index,
+                segment_index: line.segment_index,
+                source_id: format!("0x{:08x}", line.source_id),
+            })
+            .expect("uniform-grid global-line trace event serializes");
+            if !self.record(TraceStageV1::Noding, "uniform_grid_global_line", payload) {
                 break;
             }
         }
@@ -997,6 +1061,55 @@ mod tests {
         assert_eq!(
             candidates[0].payload["witness"]["coordinate"]["x"],
             format!("0x{:016x}", 1.0f64.to_bits())
+        );
+    }
+
+    #[test]
+    fn noding_trace_records_uniform_grid_cells() {
+        let lines: Vec<_> = (0..256)
+            .map(|index| {
+                let y = index as f64;
+                Line3D::new(
+                    Coord3D::new(0.0, y, 0.0),
+                    Coord3D::new(10.0, y, 0.0),
+                    index as u32,
+                )
+            })
+            .collect();
+        let options = PolygonizerOptions {
+            node_input: true,
+            ..Default::default()
+        };
+        let traced = polygonize_with_trace(
+            lines,
+            &options,
+            &ExecutionPolicy::default(),
+            TraceLevelV1::Noding,
+            usize::MAX,
+        )
+        .unwrap();
+        let cells: Vec<_> = traced
+            .trace
+            .events
+            .iter()
+            .filter(|event| event.kind == "uniform_grid_cell")
+            .collect();
+
+        assert!(!cells.is_empty());
+        assert_eq!(cells[0].payload["iteration_index"], 0);
+        assert!(
+            cells[0].payload["segment_indices"]
+                .as_array()
+                .unwrap()
+                .len()
+                >= 2
+        );
+        assert_eq!(
+            cells[0].payload["segment_indices"]
+                .as_array()
+                .unwrap()
+                .len(),
+            cells[0].payload["source_ids"].as_array().unwrap().len()
         );
     }
 }


### PR DESCRIPTION
## Stack

Parent:
- #1030

This PR:
- Records the physical uniform-grid candidate-cell structure used by floating noding.

Children:
- #1032

## Delivered

- Records every grid cell capable of enumerating a pair, with iteration, exact bounds, segment indices, and source IDs.
- Records segments routed through the grid's global-line fallback.
- Reuses the built CSR grid rather than rebuilding spatial membership.
- Adds an end-to-end traced 256-segment regression that selects the grid path.
- Marks the snapped-coordinate/fixed-grid/hot-pixel roadmap slice complete while leaving candidate events open.

## Contract impact

- Extends only opt-in Noding/Full Trace V1 events with `uniform_grid_cell` and `uniform_grid_global_line`.
- Normal grid construction, candidate enumeration, output, provenance, Z behavior, work accounting, and cancellation are unchanged.

## Validation

- `cargo test -p geo-polygonize-core --lib trace::tests::noding_trace_records_uniform_grid_cells -- --nocapture` — passed
- `cargo test -p geo-polygonize-core --no-default-features trace::tests -- --nocapture` — 8 passed
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed

## Agent handoff

Remaining:
- uniform-grid cell-pair and global-line candidate witnesses
- floating and uniform-grid split evidence

Next dependency-ready slice:
- #1032 `agent/p1-trace-grid-candidates`
