### PR TITLE
feat(core): trace uniform grid candidates

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -399,7 +399,7 @@ the entire pipeline.
 Candidate events and snapshots:
 
 - [x] normalized input segments and source IDs;
-- [ ] snapped coordinates, fixed-grid cells, and certified hot pixels;
+- [x] snapped coordinates, fixed-grid cells, and certified hot pixels;
 - [ ] candidate pairs and exact intersection/split witnesses;
 - [x] noded and dissolved edges with complete source sets;
 - [x] graph nodes and directed halfedges;
@@ -424,13 +424,15 @@ Dangle and cut-edge events then capture the exact linework returned by their
 classification passes before canonical output sorting. Noding traces also
 record the physical post-pre-snap and post-noding segment coordinates, including
 fixed-grid output. Certified noding now records the exact sorted hot-pixel set
-with integer grid coordinates from the physical snap-rounding pass. Candidate
-grid-cell events remain open. The same certified pass also records every
-candidate segment pair with source IDs and its exact point, collinear, or empty
-intersection witness. Floating SIMD candidate scans now emit the same evidence
-from their physical exact-predicate calls; uniform-grid cell and candidate events
-remain open. Certified replacement segments additionally retain their source
-segment, source ID, and exact emitted endpoints from the physical split loop.
+with integer grid coordinates from the physical snap-rounding pass. Uniform-grid
+candidate cells now retain their exact bounds, iteration, segment/source
+membership, and global-line fallback membership. The same certified pass also
+records every candidate segment pair with source IDs and its exact point,
+collinear, or empty intersection witness. Floating SIMD candidate scans now emit
+the same evidence from their physical exact-predicate calls; uniform-grid
+candidate events remain open. Certified replacement segments additionally
+retain their source segment, source ID, and exact emitted endpoints from the
+physical split loop.
 
 ### P1.6 Turn the playground into a topology debugger
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -430,9 +430,10 @@ membership, and global-line fallback membership. The same certified pass also
 records every candidate segment pair with source IDs and its exact point,
 collinear, or empty intersection witness. Floating SIMD candidate scans now emit
 the same evidence from their physical exact-predicate calls; uniform-grid
-candidate events remain open. Certified replacement segments additionally
-retain their source segment, source ID, and exact emitted endpoints from the
-physical split loop.
+cell-pair scans now record exact witnesses and whether the cell owned the
+result. Global-line candidate events remain open. Certified replacement
+segments additionally retain their source segment, source ID, and exact emitted
+endpoints from the physical split loop.
 
 ### P1.6 Turn the playground into a topology debugger
 

--- a/crates/geo-polygonize-core/src/noding/grid.rs
+++ b/crates/geo-polygonize-core/src/noding/grid.rs
@@ -1,5 +1,5 @@
 use crate::diagnostics::ExecutionWorkTracker;
-use crate::noding::snap::SnapNoder;
+use crate::noding::snap::{FloatingIntersectionTrace, SnapNoder};
 use crate::options::ExecutionPolicy;
 use crate::types::{Coord3D, Line3D};
 use crate::utils::soa::SoALines;
@@ -227,6 +227,18 @@ pub(crate) struct UniformGridGlobalLineTrace {
     pub(crate) iteration_index: usize,
     pub(crate) segment_index: usize,
     pub(crate) source_id: u32,
+}
+
+pub(crate) struct UniformGridCandidateTrace {
+    pub(crate) iteration_index: usize,
+    pub(crate) row: usize,
+    pub(crate) column: usize,
+    pub(crate) first_segment: usize,
+    pub(crate) second_segment: usize,
+    pub(crate) first_source_id: u32,
+    pub(crate) second_source_id: u32,
+    pub(crate) witness: Option<FloatingIntersectionTrace>,
+    pub(crate) owned_by_cell: bool,
 }
 
 impl UniformGrid {
@@ -560,6 +572,8 @@ impl UniformGrid {
                             &soa,
                             &mut acc,
                             None,
+                            0,
+                            None,
                         )
                         .expect("unlimited noding cannot fail");
                     }
@@ -593,6 +607,8 @@ impl UniformGrid {
                         &soa,
                         &mut splits,
                         None,
+                        0,
+                        None,
                     )
                     .expect("unlimited noding cannot fail");
                 }
@@ -614,6 +630,8 @@ impl UniformGrid {
         lines: &[Line3D],
         snap_noder: &SnapNoder,
         tracker: &mut ExecutionWorkTracker<'_>,
+        iteration_index: usize,
+        mut trace_candidates: Option<&mut Vec<UniformGridCandidateTrace>>,
     ) -> crate::Result<Vec<(usize, Coord3D)>> {
         let soa = SoALines::new(lines);
         let mut splits = Vec::new();
@@ -635,6 +653,8 @@ impl UniformGrid {
                 &soa,
                 &mut splits,
                 Some(tracker),
+                iteration_index,
+                trace_candidates.as_deref_mut(),
             )?;
         }
         if !self.global_lines.is_empty() {
@@ -776,7 +796,7 @@ impl UniformGrid {
         l1: Line3D,
         l2: Line3D,
         splits: &mut Vec<(usize, Coord3D)>,
-    ) {
+    ) -> bool {
         // Collinear is rare. Just process start/end and let HashMap dedup later.
         // SnapNoder::snap expects Coord3D. Overlap has 2D coords.
         // We construct dummy 3D coords (Z=0).
@@ -790,6 +810,9 @@ impl UniformGrid {
             snap_noder.handle_intersection(res, idx1, idx2, l1, l2, |idx, pt| {
                 splits.push((idx, pt));
             });
+            true
+        } else {
+            false
         }
     }
 
@@ -805,6 +828,8 @@ impl UniformGrid {
         soa: &SoALines,
         splits: &mut Vec<(usize, Coord3D)>,
         mut tracker: Option<&mut ExecutionWorkTracker<'_>>,
+        iteration_index: usize,
+        mut trace_candidates: Option<&mut Vec<UniformGridCandidateTrace>>,
     ) -> crate::Result<()> {
         if cell_indices.len() < 2 {
             return Ok(());
@@ -850,7 +875,24 @@ impl UniformGrid {
                     let l1_2d = l1.to_line_2d();
                     let l2_2d = l2.to_line_2d();
 
-                    if let Some(res) = line_intersection(l1_2d, l2_2d) {
+                    let intersection = line_intersection(l1_2d, l2_2d);
+                    let witness = intersection.map(|intersection| match intersection {
+                        LineIntersection::SinglePoint { intersection, .. } => {
+                            FloatingIntersectionTrace::Point(Coord3D::new(
+                                intersection.x,
+                                intersection.y,
+                                0.0,
+                            ))
+                        }
+                        LineIntersection::Collinear { intersection } => {
+                            FloatingIntersectionTrace::Collinear(
+                                Coord3D::new(intersection.start.x, intersection.start.y, 0.0),
+                                Coord3D::new(intersection.end.x, intersection.end.y, 0.0),
+                            )
+                        }
+                    });
+                    let mut owned_by_cell = false;
+                    if let Some(res) = intersection {
                         match res {
                             LineIntersection::SinglePoint {
                                 intersection: pt, ..
@@ -867,6 +909,7 @@ impl UniformGrid {
                                         || (r == self.rows - 1 && pt.y <= cell_max_y));
 
                                 if is_in_x && is_in_y {
+                                    owned_by_cell = true;
                                     snap_noder.handle_intersection(
                                         res,
                                         idx1,
@@ -881,11 +924,26 @@ impl UniformGrid {
                             }
                             LineIntersection::Collinear {
                                 intersection: overlap,
-                            } => self.handle_collinear(
-                                c, r, cell_min_x, cell_max_x, cell_min_y, cell_max_y, overlap,
-                                snap_noder, res, idx1, idx2, l1, l2, splits,
-                            ),
+                            } => {
+                                owned_by_cell = self.handle_collinear(
+                                    c, r, cell_min_x, cell_max_x, cell_min_y, cell_max_y, overlap,
+                                    snap_noder, res, idx1, idx2, l1, l2, splits,
+                                );
+                            }
                         }
+                    }
+                    if let Some(trace_candidates) = trace_candidates.as_deref_mut() {
+                        trace_candidates.push(UniformGridCandidateTrace {
+                            iteration_index,
+                            row: r,
+                            column: c,
+                            first_segment: idx1,
+                            second_segment: idx2,
+                            first_source_id: l1.line_id,
+                            second_source_id: l2.line_id,
+                            witness,
+                            owned_by_cell,
+                        });
                     }
                 }
             }
@@ -937,6 +995,8 @@ mod tests {
                 &[],
                 &SnapNoder::new(1.0),
                 &mut ExecutionWorkTracker::new(Some(&policy), None),
+                0,
+                None,
             ),
             Err(PolygonizeError::Cancelled { stage }) if stage == "candidate_enumeration"
         ));
@@ -975,6 +1035,8 @@ mod tests {
             &lines,
             &SnapNoder::new(0.0),
             &mut ExecutionWorkTracker::new(Some(&policy), Some(&mut stats)),
+            0,
+            None,
         );
 
         assert!(matches!(
@@ -1004,6 +1066,8 @@ mod tests {
             &SnapNoder::new(0.0),
             &mut ExecutionWorkTracker::new(Some(&policy), Some(&mut stats))
                 .cancel_at_candidate(token, 17),
+            0,
+            None,
         );
 
         assert!(matches!(

--- a/crates/geo-polygonize-core/src/noding/grid.rs
+++ b/crates/geo-polygonize-core/src/noding/grid.rs
@@ -213,6 +213,22 @@ pub struct UniformGrid {
     bounds_min: Coord<f64>,
 }
 
+pub(crate) struct UniformGridCellTrace {
+    pub(crate) iteration_index: usize,
+    pub(crate) row: usize,
+    pub(crate) column: usize,
+    pub(crate) min: Coord3D,
+    pub(crate) max: Coord3D,
+    pub(crate) segment_indices: Vec<usize>,
+    pub(crate) source_ids: Vec<u32>,
+}
+
+pub(crate) struct UniformGridGlobalLineTrace {
+    pub(crate) iteration_index: usize,
+    pub(crate) segment_index: usize,
+    pub(crate) source_id: u32,
+}
+
 impl UniformGrid {
     pub fn new(lines: &[Line3D]) -> Self {
         Self::new_impl(lines, None).expect("unlimited grid construction cannot fail")
@@ -463,6 +479,57 @@ impl UniformGrid {
             rows: 0,
             bounds_min: Coord::zero(),
         }
+    }
+
+    pub(crate) fn trace_structure(
+        &self,
+        lines: &[Line3D],
+        iteration_index: usize,
+    ) -> (Vec<UniformGridCellTrace>, Vec<UniformGridGlobalLineTrace>) {
+        let mut cells = Vec::new();
+        for index in 0..self.rows * self.cols {
+            let start = self.cell_offsets[index];
+            let end = self.cell_offsets[index + 1];
+            if end - start < 2 {
+                continue;
+            }
+            let row = index / self.cols;
+            let column = index % self.cols;
+            let segment_indices: Vec<_> = self.cell_items[start..end]
+                .iter()
+                .map(|&segment| segment as usize)
+                .collect();
+            cells.push(UniformGridCellTrace {
+                iteration_index,
+                row,
+                column,
+                min: Coord3D::new(
+                    self.bounds_min.x + column as f64 * self.cell_size,
+                    self.bounds_min.y + row as f64 * self.cell_size,
+                    0.0,
+                ),
+                max: Coord3D::new(
+                    self.bounds_min.x + (column + 1) as f64 * self.cell_size,
+                    self.bounds_min.y + (row + 1) as f64 * self.cell_size,
+                    0.0,
+                ),
+                source_ids: segment_indices
+                    .iter()
+                    .map(|&segment| lines[segment].line_id)
+                    .collect(),
+                segment_indices,
+            });
+        }
+        let global_lines = self
+            .global_lines
+            .iter()
+            .map(|&segment_index| UniformGridGlobalLineTrace {
+                iteration_index,
+                segment_index,
+                source_id: lines[segment_index].line_id,
+            })
+            .collect();
+        (cells, global_lines)
     }
 
     /// Finds all intersections. Uses "Intersection Ownership" to deduplicate checks.

--- a/crates/geo-polygonize-core/src/noding/snap.rs
+++ b/crates/geo-polygonize-core/src/noding/snap.rs
@@ -1,7 +1,9 @@
 use crate::diagnostics::{ExecutionWorkTracker, NodingIterationStats, NodingWorkStats};
 use crate::error::PolygonizeError;
 use crate::index::{IndexedEnvelope, RStarBackend};
-use crate::noding::grid::{UniformGrid, UniformGridCellTrace, UniformGridGlobalLineTrace};
+use crate::noding::grid::{
+    UniformGrid, UniformGridCandidateTrace, UniformGridCellTrace, UniformGridGlobalLineTrace,
+};
 use crate::options::{ExecutionPolicy, SnapStrategy, ZPolicy};
 use crate::types::{Coord3D, Line3D};
 use crate::utils::soa::SoALines;
@@ -100,6 +102,7 @@ type FloatingNodingTraceResult = (
     Vec<FloatingCandidateTrace>,
     Vec<UniformGridCellTrace>,
     Vec<UniformGridGlobalLineTrace>,
+    Vec<UniformGridCandidateTrace>,
 );
 
 #[derive(Default)]
@@ -107,6 +110,7 @@ struct FloatingTraceCapture {
     candidates: Vec<FloatingCandidateTrace>,
     grid_cells: Vec<UniformGridCellTrace>,
     global_lines: Vec<UniformGridGlobalLineTrace>,
+    grid_candidates: Vec<UniformGridCandidateTrace>,
 }
 
 const AUTO_SIMD_LIMIT: usize = 1024;
@@ -209,6 +213,7 @@ impl SnapNoder {
             trace.candidates,
             trace.grid_cells,
             trace.global_lines,
+            trace.grid_candidates,
         ))
     }
 
@@ -295,7 +300,13 @@ impl SnapNoder {
                 if execution_policy.is_some() || work_stats.is_some() {
                     let mut tracker =
                         ExecutionWorkTracker::new(execution_policy, work_stats.as_deref_mut());
-                    grid.find_splits_tracked(&lines, self, &mut tracker)?
+                    grid.find_splits_tracked(
+                        &lines,
+                        self,
+                        &mut tracker,
+                        iteration_index,
+                        trace.as_deref_mut().map(|trace| &mut trace.grid_candidates),
+                    )?
                 } else {
                     grid.find_splits(&lines, self)
                 }

--- a/crates/geo-polygonize-core/src/noding/snap.rs
+++ b/crates/geo-polygonize-core/src/noding/snap.rs
@@ -1,7 +1,7 @@
 use crate::diagnostics::{ExecutionWorkTracker, NodingIterationStats, NodingWorkStats};
 use crate::error::PolygonizeError;
 use crate::index::{IndexedEnvelope, RStarBackend};
-use crate::noding::grid::UniformGrid;
+use crate::noding::grid::{UniformGrid, UniformGridCellTrace, UniformGridGlobalLineTrace};
 use crate::options::{ExecutionPolicy, SnapStrategy, ZPolicy};
 use crate::types::{Coord3D, Line3D};
 use crate::utils::soa::SoALines;
@@ -98,7 +98,16 @@ type FloatingNodingTraceResult = (
     Vec<NodingIterationStats>,
     NodingWorkStats,
     Vec<FloatingCandidateTrace>,
+    Vec<UniformGridCellTrace>,
+    Vec<UniformGridGlobalLineTrace>,
 );
+
+#[derive(Default)]
+struct FloatingTraceCapture {
+    candidates: Vec<FloatingCandidateTrace>,
+    grid_cells: Vec<UniformGridCellTrace>,
+    global_lines: Vec<UniformGridGlobalLineTrace>,
+}
 
 const AUTO_SIMD_LIMIT: usize = 1024;
 
@@ -185,15 +194,22 @@ impl SnapNoder {
     ) -> crate::Result<FloatingNodingTraceResult> {
         let mut stats = Vec::new();
         let mut work_stats = NodingWorkStats::default();
-        let mut candidates = Vec::new();
+        let mut trace = FloatingTraceCapture::default();
         let lines = self.node_impl(
             lines,
             Some(&mut stats),
             Some(&mut work_stats),
             execution_policy,
-            Some(&mut candidates),
+            Some(&mut trace),
         )?;
-        Ok((lines, stats, work_stats, candidates))
+        Ok((
+            lines,
+            stats,
+            work_stats,
+            trace.candidates,
+            trace.grid_cells,
+            trace.global_lines,
+        ))
     }
 
     fn node_impl(
@@ -202,7 +218,7 @@ impl SnapNoder {
         mut stats: Option<&mut Vec<NodingIterationStats>>,
         mut work_stats: Option<&mut NodingWorkStats>,
         execution_policy: Option<&ExecutionPolicy>,
-        mut trace_candidates: Option<&mut Vec<FloatingCandidateTrace>>,
+        mut trace: Option<&mut FloatingTraceCapture>,
     ) -> crate::Result<Vec<Line3D>> {
         // 1. Initial Snap of endpoints
         for line in &mut lines {
@@ -246,10 +262,10 @@ impl SnapNoder {
 
             let mut events = if !use_grid {
                 // STRATEGY A: Small Input -> SIMD Brute Force
-                if trace_candidates.is_some() {
+                if trace.is_some() {
                     let mut tracker =
                         ExecutionWorkTracker::new(execution_policy, work_stats.as_deref_mut());
-                    let candidates = trace_candidates.as_deref_mut().unwrap();
+                    let candidates = &mut trace.as_deref_mut().unwrap().candidates;
                     let first_candidate = candidates.len();
                     let events =
                         self.find_splits_simd_tracked(&lines, &mut tracker, Some(candidates))?;
@@ -271,6 +287,11 @@ impl SnapNoder {
                 } else {
                     UniformGrid::new(&lines)
                 };
+                if let Some(trace) = trace.as_deref_mut() {
+                    let (cells, global_lines) = grid.trace_structure(&lines, iteration_index);
+                    trace.grid_cells.extend(cells);
+                    trace.global_lines.extend(global_lines);
+                }
                 if execution_policy.is_some() || work_stats.is_some() {
                     let mut tracker =
                         ExecutionWorkTracker::new(execution_policy, work_stats.as_deref_mut());

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -538,6 +538,7 @@ impl Polygonizer {
                                 candidates,
                                 grid_cells,
                                 global_lines,
+                                grid_candidates,
                             ) = noder.node_with_trace(
                                 all_segments,
                                 has_execution_controls.then_some(&self.execution_policy),
@@ -546,6 +547,7 @@ impl Polygonizer {
                             if let Some(trace) = self.trace.as_mut() {
                                 trace.record_floating_candidates(&candidates)?;
                                 trace.record_uniform_grid(&grid_cells, &global_lines)?;
+                                trace.record_uniform_grid_candidates(&grid_candidates)?;
                             }
                             if let Some(diagnostics) = diagnostics.as_deref_mut() {
                                 diagnostics.intersection_stats.interpolated_intersections = stats

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -531,14 +531,21 @@ impl Polygonizer {
                             trace.records_stage(crate::trace::TraceStageV1::Noding)
                         });
                         if trace_candidates {
-                            let (noded, stats, mut work_stats, candidates) = noder
-                                .node_with_trace(
-                                    all_segments,
-                                    has_execution_controls.then_some(&self.execution_policy),
-                                )?;
+                            let (
+                                noded,
+                                stats,
+                                mut work_stats,
+                                candidates,
+                                grid_cells,
+                                global_lines,
+                            ) = noder.node_with_trace(
+                                all_segments,
+                                has_execution_controls.then_some(&self.execution_policy),
+                            )?;
                             work_stats.pre_snap_vertex_candidates = pre_snap_vertex_candidates;
                             if let Some(trace) = self.trace.as_mut() {
                                 trace.record_floating_candidates(&candidates)?;
+                                trace.record_uniform_grid(&grid_cells, &global_lines)?;
                             }
                             if let Some(diagnostics) = diagnostics.as_deref_mut() {
                                 diagnostics.intersection_stats.interpolated_intersections = stats

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -2,6 +2,7 @@
 
 use crate::fingerprint::coordinate_fingerprint;
 use crate::graph::{ExtractedRing, PlanarGraph};
+use crate::noding::grid::{UniformGridCellTrace, UniformGridGlobalLineTrace};
 use crate::noding::hot_pixel::{
     HotPixelCandidateTrace, HotPixelIntersectionTrace, HotPixelSplitTrace,
 };
@@ -86,6 +87,26 @@ pub struct SplitEventTraceV1 {
     pub source_id: String,
     pub start: CoordinateFingerprintV1,
     pub end: CoordinateFingerprintV1,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct UniformGridCellTraceV1 {
+    pub index: usize,
+    pub iteration_index: usize,
+    pub row: usize,
+    pub column: usize,
+    pub min: CoordinateFingerprintV1,
+    pub max: CoordinateFingerprintV1,
+    pub segment_indices: Vec<usize>,
+    pub source_ids: Vec<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct UniformGridGlobalLineTraceV1 {
+    pub index: usize,
+    pub iteration_index: usize,
+    pub segment_index: usize,
+    pub source_id: String,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
@@ -373,6 +394,49 @@ impl TraceRecorderV1 {
             })
             .expect("candidate-pair trace event serializes");
             if !self.record(TraceStageV1::Noding, "floating_candidate_pair", payload) {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn record_uniform_grid(
+        &mut self,
+        cells: &[UniformGridCellTrace],
+        global_lines: &[UniformGridGlobalLineTrace],
+    ) -> crate::Result<()> {
+        if !self.records_stage(TraceStageV1::Noding) {
+            return Ok(());
+        }
+        for (index, cell) in cells.iter().enumerate() {
+            let payload = serde_json::to_value(UniformGridCellTraceV1 {
+                index,
+                iteration_index: cell.iteration_index,
+                row: cell.row,
+                column: cell.column,
+                min: coordinate_fingerprint(cell.min)?,
+                max: coordinate_fingerprint(cell.max)?,
+                segment_indices: cell.segment_indices.clone(),
+                source_ids: cell
+                    .source_ids
+                    .iter()
+                    .map(|source_id| format!("0x{source_id:08x}"))
+                    .collect(),
+            })
+            .expect("uniform-grid cell trace event serializes");
+            if !self.record(TraceStageV1::Noding, "uniform_grid_cell", payload) {
+                return Ok(());
+            }
+        }
+        for (index, line) in global_lines.iter().enumerate() {
+            let payload = serde_json::to_value(UniformGridGlobalLineTraceV1 {
+                index,
+                iteration_index: line.iteration_index,
+                segment_index: line.segment_index,
+                source_id: format!("0x{:08x}", line.source_id),
+            })
+            .expect("uniform-grid global-line trace event serializes");
+            if !self.record(TraceStageV1::Noding, "uniform_grid_global_line", payload) {
                 break;
             }
         }
@@ -997,6 +1061,55 @@ mod tests {
         assert_eq!(
             candidates[0].payload["witness"]["coordinate"]["x"],
             format!("0x{:016x}", 1.0f64.to_bits())
+        );
+    }
+
+    #[test]
+    fn noding_trace_records_uniform_grid_cells() {
+        let lines: Vec<_> = (0..256)
+            .map(|index| {
+                let y = index as f64;
+                Line3D::new(
+                    Coord3D::new(0.0, y, 0.0),
+                    Coord3D::new(10.0, y, 0.0),
+                    index as u32,
+                )
+            })
+            .collect();
+        let options = PolygonizerOptions {
+            node_input: true,
+            ..Default::default()
+        };
+        let traced = polygonize_with_trace(
+            lines,
+            &options,
+            &ExecutionPolicy::default(),
+            TraceLevelV1::Noding,
+            usize::MAX,
+        )
+        .unwrap();
+        let cells: Vec<_> = traced
+            .trace
+            .events
+            .iter()
+            .filter(|event| event.kind == "uniform_grid_cell")
+            .collect();
+
+        assert!(!cells.is_empty());
+        assert_eq!(cells[0].payload["iteration_index"], 0);
+        assert!(
+            cells[0].payload["segment_indices"]
+                .as_array()
+                .unwrap()
+                .len()
+                >= 2
+        );
+        assert_eq!(
+            cells[0].payload["segment_indices"]
+                .as_array()
+                .unwrap()
+                .len(),
+            cells[0].payload["source_ids"].as_array().unwrap().len()
         );
     }
 }

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -2,7 +2,9 @@
 
 use crate::fingerprint::coordinate_fingerprint;
 use crate::graph::{ExtractedRing, PlanarGraph};
-use crate::noding::grid::{UniformGridCellTrace, UniformGridGlobalLineTrace};
+use crate::noding::grid::{
+    UniformGridCandidateTrace, UniformGridCellTrace, UniformGridGlobalLineTrace,
+};
 use crate::noding::hot_pixel::{
     HotPixelCandidateTrace, HotPixelIntersectionTrace, HotPixelSplitTrace,
 };
@@ -107,6 +109,20 @@ pub struct UniformGridGlobalLineTraceV1 {
     pub iteration_index: usize,
     pub segment_index: usize,
     pub source_id: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct UniformGridCandidateTraceV1 {
+    pub index: usize,
+    pub iteration_index: usize,
+    pub row: usize,
+    pub column: usize,
+    pub first_segment: usize,
+    pub second_segment: usize,
+    pub first_source_id: String,
+    pub second_source_id: String,
+    pub witness: Option<IntersectionWitnessTraceV1>,
+    pub owned_by_cell: bool,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
@@ -437,6 +453,48 @@ impl TraceRecorderV1 {
             })
             .expect("uniform-grid global-line trace event serializes");
             if !self.record(TraceStageV1::Noding, "uniform_grid_global_line", payload) {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn record_uniform_grid_candidates(
+        &mut self,
+        candidates: &[UniformGridCandidateTrace],
+    ) -> crate::Result<()> {
+        if !self.records_stage(TraceStageV1::Noding) {
+            return Ok(());
+        }
+        for (index, candidate) in candidates.iter().enumerate() {
+            let witness = match candidate.witness {
+                Some(FloatingIntersectionTrace::Point(coordinate)) => {
+                    Some(IntersectionWitnessTraceV1::Point {
+                        coordinate: coordinate_fingerprint(coordinate)?,
+                    })
+                }
+                Some(FloatingIntersectionTrace::Collinear(start, end)) => {
+                    Some(IntersectionWitnessTraceV1::Collinear {
+                        start: coordinate_fingerprint(start)?,
+                        end: coordinate_fingerprint(end)?,
+                    })
+                }
+                None => None,
+            };
+            let payload = serde_json::to_value(UniformGridCandidateTraceV1 {
+                index,
+                iteration_index: candidate.iteration_index,
+                row: candidate.row,
+                column: candidate.column,
+                first_segment: candidate.first_segment,
+                second_segment: candidate.second_segment,
+                first_source_id: format!("0x{:08x}", candidate.first_source_id),
+                second_source_id: format!("0x{:08x}", candidate.second_source_id),
+                witness,
+                owned_by_cell: candidate.owned_by_cell,
+            })
+            .expect("uniform-grid candidate trace event serializes");
+            if !self.record(TraceStageV1::Noding, "uniform_grid_candidate_pair", payload) {
                 break;
             }
         }
@@ -1071,7 +1129,7 @@ mod tests {
                 let y = index as f64;
                 Line3D::new(
                     Coord3D::new(0.0, y, 0.0),
-                    Coord3D::new(10.0, y, 0.0),
+                    Coord3D::new(10.0, y + 10.0, 0.0),
                     index as u32,
                 )
             })
@@ -1111,5 +1169,15 @@ mod tests {
                 .len(),
             cells[0].payload["source_ids"].as_array().unwrap().len()
         );
+        let candidates: Vec<_> = traced
+            .trace
+            .events
+            .iter()
+            .filter(|event| event.kind == "uniform_grid_candidate_pair")
+            .collect();
+        assert!(!candidates.is_empty());
+        assert_eq!(candidates[0].payload["iteration_index"], 0);
+        assert!(candidates[0].payload["witness"].is_null());
+        assert_eq!(candidates[0].payload["owned_by_cell"], false);
     }
 }


### PR DESCRIPTION
## Stack

Parent:
- #1031

This PR:
- Records uniform-grid cell-pair candidates and exact witnesses from the physical scan.

Children:
- #1033

## Delivered

- Captures iteration, owning cell, segment/source identity, exact point/collinear/empty witness, and ownership decision.
- Reuses the same `line_intersection` result used for split emission.
- Leaves the normal parallel grid path unchanged when tracing is disabled.
- Extends the grid regression with overlapping-bbox parallel lines that produce empty exact witnesses.
- Keeps global-line candidate evidence in the focused child.

## Contract impact

- Extends only opt-in Noding/Full Trace V1 events with `uniform_grid_candidate_pair`.
- Grid ownership, split emission, output, provenance, Z behavior, work accounting, and cancellation are unchanged.

## Validation

- `cargo test -p geo-polygonize-core --lib trace::tests::noding_trace_records_uniform_grid_cells -- --nocapture` — passed
- `cargo test -p geo-polygonize-core --no-default-features trace::tests -- --nocapture` — 8 passed
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed

## Agent handoff

Remaining:
- global-line candidate witnesses
- floating and uniform-grid split evidence

Next dependency-ready slice:
- #1033 `agent/p1-trace-grid-global-candidates`
