### PR TITLE
feat(core): trace floating split emission

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -400,7 +400,7 @@ Candidate events and snapshots:
 
 - [x] normalized input segments and source IDs;
 - [x] snapped coordinates, fixed-grid cells, and certified hot pixels;
-- [ ] candidate pairs and exact intersection/split witnesses;
+- [x] candidate pairs and exact intersection/split witnesses;
 - [x] noded and dissolved edges with complete source sets;
 - [x] graph nodes and directed halfedges;
 - [x] dangle pruning and cut-edge classification;
@@ -434,7 +434,8 @@ cell-pair scans now record exact witnesses and whether the cell owned the
 result. Global-line fallback scans emit the same exact candidate evidence with
 an explicit scan origin. Certified replacement segments additionally retain
 their source segment, source ID, and exact emitted endpoints from the physical
-split loop. Floating split-emission evidence remains open.
+split loop. Floating SIMD and uniform-grid noding now record the same replacement
+evidence from their shared physical split loop.
 
 ### P1.6 Turn the playground into a topology debugger
 

--- a/crates/geo-polygonize-core/src/noding/snap.rs
+++ b/crates/geo-polygonize-core/src/noding/snap.rs
@@ -95,6 +95,15 @@ pub(crate) struct FloatingCandidateTrace {
     pub(crate) witness: Option<FloatingIntersectionTrace>,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct FloatingSplitTrace {
+    pub(crate) iteration_index: usize,
+    pub(crate) source_segment: usize,
+    pub(crate) source_id: u32,
+    pub(crate) start: Coord3D,
+    pub(crate) end: Coord3D,
+}
+
 type FloatingNodingTraceResult = (
     Vec<Line3D>,
     Vec<NodingIterationStats>,
@@ -103,6 +112,7 @@ type FloatingNodingTraceResult = (
     Vec<UniformGridCellTrace>,
     Vec<UniformGridGlobalLineTrace>,
     Vec<UniformGridCandidateTrace>,
+    Vec<FloatingSplitTrace>,
 );
 
 #[derive(Default)]
@@ -111,6 +121,7 @@ struct FloatingTraceCapture {
     grid_cells: Vec<UniformGridCellTrace>,
     global_lines: Vec<UniformGridGlobalLineTrace>,
     grid_candidates: Vec<UniformGridCandidateTrace>,
+    splits: Vec<FloatingSplitTrace>,
 }
 
 const AUTO_SIMD_LIMIT: usize = 1024;
@@ -214,6 +225,7 @@ impl SnapNoder {
             trace.grid_cells,
             trace.global_lines,
             trace.grid_candidates,
+            trace.splits,
         ))
     }
 
@@ -455,6 +467,15 @@ impl SnapNoder {
                             )?;
                         }
                         new_lines.push(Line3D::new(p0, p1, line.line_id));
+                        if let Some(trace) = trace.as_deref_mut() {
+                            trace.splits.push(FloatingSplitTrace {
+                                iteration_index,
+                                source_segment: line_idx,
+                                source_id: line.line_id,
+                                start: p0,
+                                end: p1,
+                            });
+                        }
                     }
                 }
 
@@ -1210,6 +1231,18 @@ mod tests {
             assert_eq!(e_g.0, e_s.0, "Index mismatch");
             assert!((e_g.1.x - e_s.1.x).abs() < 1e-10 && (e_g.1.y - e_s.1.y).abs() < 1e-10);
         }
+    }
+
+    #[test]
+    fn grid_trace_records_shared_replacement_loop() {
+        let lines = vec![make_line(0.0, 0.0, 2.0, 2.0), make_line(0.0, 2.0, 2.0, 0.0)];
+        let (_, _, _, _, _, _, _, splits) = SnapNoder::new(0.0)
+            .with_strategy(NodingStrategy::Grid)
+            .node_with_trace(lines, None)
+            .unwrap();
+
+        assert_eq!(splits.len(), 4);
+        assert!(splits.iter().all(|split| split.iteration_index == 0));
     }
 
     #[test]

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -539,6 +539,7 @@ impl Polygonizer {
                                 grid_cells,
                                 global_lines,
                                 grid_candidates,
+                                split_events,
                             ) = noder.node_with_trace(
                                 all_segments,
                                 has_execution_controls.then_some(&self.execution_policy),
@@ -548,6 +549,7 @@ impl Polygonizer {
                                 trace.record_floating_candidates(&candidates)?;
                                 trace.record_uniform_grid(&grid_cells, &global_lines)?;
                                 trace.record_uniform_grid_candidates(&grid_candidates)?;
+                                trace.record_floating_splits(&split_events)?;
                             }
                             if let Some(diagnostics) = diagnostics.as_deref_mut() {
                                 diagnostics.intersection_stats.interpolated_intersections = stats

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -8,7 +8,7 @@ use crate::noding::grid::{
 use crate::noding::hot_pixel::{
     HotPixelCandidateTrace, HotPixelIntersectionTrace, HotPixelSplitTrace,
 };
-use crate::noding::snap::{FloatingCandidateTrace, FloatingIntersectionTrace};
+use crate::noding::snap::{FloatingCandidateTrace, FloatingIntersectionTrace, FloatingSplitTrace};
 use crate::{CoordinateFingerprintV1, Line3D, Polygon3D, PolygonizerOptions, PolygonizerResult};
 use serde::Serialize;
 
@@ -85,6 +85,8 @@ pub struct CandidatePairTraceV1 {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct SplitEventTraceV1 {
     pub index: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub iteration_index: Option<usize>,
     pub source_segment: usize,
     pub source_id: String,
     pub start: CoordinateFingerprintV1,
@@ -516,6 +518,7 @@ impl TraceRecorderV1 {
         for (index, split) in splits.iter().enumerate() {
             let payload = serde_json::to_value(SplitEventTraceV1 {
                 index,
+                iteration_index: None,
                 source_segment: split.source_segment,
                 source_id: format!("0x{:08x}", split.source_id),
                 start: coordinate_fingerprint(split.start)?,
@@ -523,6 +526,30 @@ impl TraceRecorderV1 {
             })
             .expect("split-event trace serializes");
             if !self.record(TraceStageV1::Noding, "certified_split_segment", payload) {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn record_floating_splits(
+        &mut self,
+        splits: &[FloatingSplitTrace],
+    ) -> crate::Result<()> {
+        if !self.records_stage(TraceStageV1::Noding) {
+            return Ok(());
+        }
+        for (index, split) in splits.iter().enumerate() {
+            let payload = serde_json::to_value(SplitEventTraceV1 {
+                index,
+                iteration_index: Some(split.iteration_index),
+                source_segment: split.source_segment,
+                source_id: format!("0x{:08x}", split.source_id),
+                start: coordinate_fingerprint(split.start)?,
+                end: coordinate_fingerprint(split.end)?,
+            })
+            .expect("split-event trace serializes");
+            if !self.record(TraceStageV1::Noding, "floating_split_segment", payload) {
                 break;
             }
         }
@@ -1124,6 +1151,23 @@ mod tests {
         assert_eq!(
             candidates[0].payload["witness"]["coordinate"]["x"],
             format!("0x{:016x}", 1.0f64.to_bits())
+        );
+        let splits: Vec<_> = traced
+            .trace
+            .events
+            .iter()
+            .filter(|event| event.kind == "floating_split_segment")
+            .collect();
+        assert_eq!(splits.len(), 4);
+        assert!(splits
+            .iter()
+            .all(|event| event.payload["iteration_index"] == 0));
+        assert_eq!(
+            splits
+                .iter()
+                .filter(|event| event.payload["source_id"] == "0x00000001")
+                .count(),
+            2
         );
     }
 


### PR DESCRIPTION
## Stack

Parent:
- #1033

This PR:
- Records replacement segments from the shared floating SIMD/uniform-grid split loop.

Children:
- not opened yet

## Delivered

- Captures iteration, source segment/source ID, and exact emitted endpoints at the physical `new_lines.push`.
- Uses one implementation for both floating SIMD and uniform-grid enumeration.
- Adds public traced SIMD coverage and a forced-grid regression for the shared loop.
- Keeps certified one-pass split payloads compatible by omitting the new optional iteration field.
- Closes the P1.5 candidate/intersection/split witness slice.

## Contract impact

- Extends only opt-in Noding/Full Trace V1 events with `floating_split_segment`.
- Split ordering, output, provenance, Z behavior, work accounting, cancellation, and the disabled-trace paths are unchanged.

## Validation

- `cargo test -p geo-polygonize-core --lib trace::tests::noding_trace_records_floating_simd_candidates -- --nocapture` — passed
- `cargo test -p geo-polygonize-core --lib noding::snap::tests::grid_trace_records_shared_replacement_loop -- --nocapture` — passed
- `cargo fmt --all -- --check` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `cargo test --workspace` — passed
- `cargo test -p geo-polygonize-core --no-default-features` — passed
- `RUSTDOCFLAGS='-D warnings' cargo doc -p geo-polygonize-core --no-deps` — passed
- `npm test` — 19 passed
- `npm run docs:build` — passed with existing dependency, MUI, WASM URL, and chunk-size warnings
- post-rebase core Clippy and no-default trace tests — passed
- `git diff --check` — passed

## Agent handoff

Remaining:
- P1.5 tile retry/fallback decisions when those paths exist
- P0.5 trace-memory accounting

Next dependency-ready slice:
- start a fresh stack from current `main` after this five-PR stack begins merging
