### PR TITLE
fix(core): bound noding trace capture growth

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -234,6 +234,11 @@ multiplicity, deeply nested rings, and output amplification.
 Progress: Each named adversarial family now exercises a typed execution-policy
 limit in the core regression suite.
 
+Trace-only floating, uniform-grid, and certified noding capture buffers now
+consume one shared remaining trace-byte budget before growing and mark the
+result truncated when that capture budget is exhausted. Stage-specific trace
+limits and non-noding capture buffers remain open.
+
 ### P0.6 Cooperative cancellation
 
 Progress: Native `CancellationToken` values live in `ExecutionPolicy`, not

--- a/crates/geo-polygonize-core/src/noding/grid.rs
+++ b/crates/geo-polygonize-core/src/noding/grid.rs
@@ -1,6 +1,7 @@
 use crate::diagnostics::ExecutionWorkTracker;
 use crate::noding::snap::{FloatingIntersectionTrace, SnapNoder};
 use crate::options::ExecutionPolicy;
+use crate::trace::{TraceCapture, TraceCaptureBudget};
 use crate::types::{Coord3D, Line3D};
 use crate::utils::soa::SoALines;
 use geo::algorithm::line_intersection::{line_intersection, LineIntersection};
@@ -498,6 +499,7 @@ impl UniformGrid {
         &self,
         lines: &[Line3D],
         iteration_index: usize,
+        budget: &mut TraceCaptureBudget,
     ) -> (Vec<UniformGridCellTrace>, Vec<UniformGridGlobalLineTrace>) {
         let mut cells = Vec::new();
         for index in 0..self.rows * self.cols {
@@ -505,6 +507,13 @@ impl UniformGrid {
             let end = self.cell_offsets[index + 1];
             if end - start < 2 {
                 continue;
+            }
+            let member_bytes = (end - start)
+                .saturating_mul(std::mem::size_of::<usize>() + std::mem::size_of::<u32>());
+            let capture_bytes =
+                std::mem::size_of::<UniformGridCellTrace>().saturating_add(member_bytes);
+            if !budget.take(capture_bytes) {
+                break;
             }
             let row = index / self.cols;
             let column = index % self.cols;
@@ -533,15 +542,17 @@ impl UniformGrid {
                 segment_indices,
             });
         }
-        let global_lines = self
-            .global_lines
-            .iter()
-            .map(|&segment_index| UniformGridGlobalLineTrace {
+        let mut global_lines = Vec::new();
+        for &segment_index in &self.global_lines {
+            let line = UniformGridGlobalLineTrace {
                 iteration_index,
                 segment_index,
                 source_id: lines[segment_index].line_id,
-            })
-            .collect();
+            };
+            if !budget.capture(&mut global_lines, line) {
+                break;
+            }
+        }
         (cells, global_lines)
     }
 
@@ -632,7 +643,7 @@ impl UniformGrid {
         snap_noder: &SnapNoder,
         tracker: &mut ExecutionWorkTracker<'_>,
         iteration_index: usize,
-        mut trace_candidates: Option<&mut Vec<UniformGridCandidateTrace>>,
+        mut trace_candidates: Option<&mut TraceCapture<'_, UniformGridCandidateTrace>>,
     ) -> crate::Result<Vec<(usize, Coord3D)>> {
         let soa = SoALines::new(lines);
         let mut splits = Vec::new();
@@ -757,7 +768,7 @@ impl UniformGrid {
         snap_noder: &SnapNoder,
         tracker: &mut ExecutionWorkTracker<'_>,
         iteration_index: usize,
-        mut trace_candidates: Option<&mut Vec<UniformGridCandidateTrace>>,
+        mut trace_candidates: Option<&mut TraceCapture<'_, UniformGridCandidateTrace>>,
     ) -> crate::Result<Vec<(usize, Coord3D)>> {
         let mut events = Vec::new();
         for &left_idx in &self.global_lines {
@@ -871,7 +882,7 @@ impl UniformGrid {
         splits: &mut Vec<(usize, Coord3D)>,
         mut tracker: Option<&mut ExecutionWorkTracker<'_>>,
         iteration_index: usize,
-        mut trace_candidates: Option<&mut Vec<UniformGridCandidateTrace>>,
+        mut trace_candidates: Option<&mut TraceCapture<'_, UniformGridCandidateTrace>>,
     ) -> crate::Result<()> {
         if cell_indices.len() < 2 {
             return Ok(());
@@ -1054,13 +1065,15 @@ mod tests {
         let mut grid = UniformGrid::empty();
         grid.global_lines.push(0);
         let mut candidates = Vec::new();
+        let mut budget = TraceCaptureBudget::new(usize::MAX);
+        let mut trace = TraceCapture::new(&mut candidates, &mut budget);
         let splits = grid
             .find_splits_tracked(
                 &lines,
                 &SnapNoder::new(0.0),
                 &mut ExecutionWorkTracker::new(None, None),
                 0,
-                Some(&mut candidates),
+                Some(&mut trace),
             )
             .unwrap();
 

--- a/crates/geo-polygonize-core/src/noding/hot_pixel.rs
+++ b/crates/geo-polygonize-core/src/noding/hot_pixel.rs
@@ -4,6 +4,7 @@ use crate::index::{IndexedEnvelope, RStarBackend};
 use crate::noding::snap::SnapNoder;
 use crate::noding::validate::ValidatingNoder;
 use crate::options::{ExecutionPolicy, ZPolicy};
+use crate::trace::TraceCaptureBudget;
 use crate::types::{Coord3D, IPoint, Line3D};
 use geo::algorithm::line_intersection::{line_intersection, LineIntersection};
 use rstar::AABB;
@@ -38,6 +39,7 @@ type HotPixelNodingResult = (
     Vec<IPoint>,
     Vec<HotPixelCandidateTrace>,
     Vec<HotPixelSplitTrace>,
+    bool,
 );
 
 /// Fixed-precision hot-pixel snap-rounding noder.
@@ -67,16 +69,16 @@ impl HotPixelNoder {
     }
 
     pub fn node(&self, lines: Vec<Line3D>) -> Result<Vec<Line3D>> {
-        self.node_with_stats_impl(lines, None, false)
-            .map(|(lines, _, _, _, _, _)| lines)
+        self.node_with_stats_impl(lines, None, None)
+            .map(|(lines, _, _, _, _, _, _)| lines)
     }
 
     pub(crate) fn node_with_stats(
         &self,
         lines: Vec<Line3D>,
     ) -> Result<(Vec<Line3D>, usize, NodingWorkStats)> {
-        self.node_with_stats_impl(lines, None, false)
-            .map(|(lines, intersections, work, _, _, _)| (lines, intersections, work))
+        self.node_with_stats_impl(lines, None, None)
+            .map(|(lines, intersections, work, _, _, _, _)| (lines, intersections, work))
     }
 
     pub(crate) fn node_with_execution_policy(
@@ -84,8 +86,8 @@ impl HotPixelNoder {
         lines: Vec<Line3D>,
         execution_policy: &ExecutionPolicy,
     ) -> Result<Vec<Line3D>> {
-        self.node_with_stats_impl(lines, Some(execution_policy), false)
-            .map(|(lines, _, _, _, _, _)| lines)
+        self.node_with_stats_impl(lines, Some(execution_policy), None)
+            .map(|(lines, _, _, _, _, _, _)| lines)
     }
 
     pub(crate) fn node_with_stats_and_execution_policy(
@@ -93,24 +95,26 @@ impl HotPixelNoder {
         lines: Vec<Line3D>,
         execution_policy: &ExecutionPolicy,
     ) -> Result<(Vec<Line3D>, usize, NodingWorkStats)> {
-        self.node_with_stats_impl(lines, Some(execution_policy), false)
-            .map(|(lines, intersections, work, _, _, _)| (lines, intersections, work))
+        self.node_with_stats_impl(lines, Some(execution_policy), None)
+            .map(|(lines, intersections, work, _, _, _, _)| (lines, intersections, work))
     }
 
     pub(crate) fn node_with_hot_pixels(
         &self,
         lines: Vec<Line3D>,
         execution_policy: Option<&ExecutionPolicy>,
+        capture_byte_limit: usize,
     ) -> Result<HotPixelNodingResult> {
-        self.node_with_stats_impl(lines, execution_policy, true)
+        self.node_with_stats_impl(lines, execution_policy, Some(capture_byte_limit))
     }
 
     fn node_with_stats_impl(
         &self,
         mut lines: Vec<Line3D>,
         execution_policy: Option<&ExecutionPolicy>,
-        capture_trace: bool,
+        capture_byte_limit: Option<usize>,
     ) -> Result<HotPixelNodingResult> {
+        let mut capture_budget = capture_byte_limit.map(TraceCaptureBudget::new);
         for line in &mut lines {
             line.start = self.snap(line.start)?;
             line.end = self.snap(line.end)?;
@@ -178,25 +182,28 @@ impl HotPixelNoder {
                 }
                 let intersection =
                     line_intersection(first.to_line_2d(), lines[second_index].to_line_2d());
-                if capture_trace {
-                    candidate_trace.push(HotPixelCandidateTrace {
-                        first_segment: first_index,
-                        second_segment: second_index,
-                        first_source_id: first.line_id,
-                        second_source_id: lines[second_index].line_id,
-                        witness: match intersection {
-                            Some(LineIntersection::SinglePoint { intersection, .. }) => Some(
-                                HotPixelIntersectionTrace::Point(Coord3D::from(intersection)),
-                            ),
-                            Some(LineIntersection::Collinear { intersection }) => {
-                                Some(HotPixelIntersectionTrace::Collinear(
-                                    Coord3D::from(intersection.start),
-                                    Coord3D::from(intersection.end),
-                                ))
-                            }
-                            None => None,
+                if let Some(budget) = capture_budget.as_mut() {
+                    budget.capture(
+                        &mut candidate_trace,
+                        HotPixelCandidateTrace {
+                            first_segment: first_index,
+                            second_segment: second_index,
+                            first_source_id: first.line_id,
+                            second_source_id: lines[second_index].line_id,
+                            witness: match intersection {
+                                Some(LineIntersection::SinglePoint { intersection, .. }) => Some(
+                                    HotPixelIntersectionTrace::Point(Coord3D::from(intersection)),
+                                ),
+                                Some(LineIntersection::Collinear { intersection }) => {
+                                    Some(HotPixelIntersectionTrace::Collinear(
+                                        Coord3D::from(intersection.start),
+                                        Coord3D::from(intersection.end),
+                                    ))
+                                }
+                                None => None,
+                            },
                         },
-                    });
+                    );
                 }
                 match intersection {
                     Some(LineIntersection::SinglePoint { intersection, .. }) => {
@@ -315,13 +322,16 @@ impl HotPixelNoder {
                         )?;
                     }
                     output.push(Line3D::new(pair[0], pair[1], line.line_id));
-                    if capture_trace {
-                        split_trace.push(HotPixelSplitTrace {
-                            source_segment,
-                            source_id: line.line_id,
-                            start: pair[0],
-                            end: pair[1],
-                        });
+                    if let Some(budget) = capture_budget.as_mut() {
+                        budget.capture(
+                            &mut split_trace,
+                            HotPixelSplitTrace {
+                                source_segment,
+                                source_id: line.line_id,
+                                start: pair[0],
+                                end: pair[1],
+                            },
+                        );
                     }
                 }
             }
@@ -336,6 +346,7 @@ impl HotPixelNoder {
             hot_pixels,
             candidate_trace,
             split_trace,
+            capture_budget.is_some_and(|budget| budget.truncated()),
         ))
     }
 
@@ -455,5 +466,23 @@ mod tests {
         assert!(output.iter().all(|line| [line.start, line.end]
             .iter()
             .all(|point| point.x == point.x.round() && point.y == point.y.round())));
+    }
+
+    #[test]
+    fn trace_capture_budget_stops_certified_capture_growth() {
+        let lines = vec![
+            line((-2.0, 0.0), (2.0, 0.0), 1),
+            line((0.0, -2.0), (0.0, 2.0), 2),
+        ];
+        let noder = HotPixelNoder::new(1.0).unwrap();
+        let expected = noder.node(lines.clone()).unwrap();
+        let (output, _, work, _, candidates, splits, truncated) =
+            noder.node_with_hot_pixels(lines, None, 0).unwrap();
+
+        assert_eq!(output, expected);
+        assert!(work.exact_intersection_calls > 0);
+        assert!(candidates.is_empty());
+        assert!(splits.is_empty());
+        assert!(truncated);
     }
 }

--- a/crates/geo-polygonize-core/src/noding/snap.rs
+++ b/crates/geo-polygonize-core/src/noding/snap.rs
@@ -5,6 +5,7 @@ use crate::noding::grid::{
     UniformGrid, UniformGridCandidateTrace, UniformGridCellTrace, UniformGridGlobalLineTrace,
 };
 use crate::options::{ExecutionPolicy, SnapStrategy, ZPolicy};
+use crate::trace::{TraceCapture, TraceCaptureBudget};
 use crate::types::{Coord3D, Line3D};
 use crate::utils::soa::SoALines;
 use geo::algorithm::line_intersection::{line_intersection, LineIntersection};
@@ -113,15 +114,29 @@ type FloatingNodingTraceResult = (
     Vec<UniformGridGlobalLineTrace>,
     Vec<UniformGridCandidateTrace>,
     Vec<FloatingSplitTrace>,
+    bool,
 );
 
-#[derive(Default)]
 struct FloatingTraceCapture {
     candidates: Vec<FloatingCandidateTrace>,
     grid_cells: Vec<UniformGridCellTrace>,
     global_lines: Vec<UniformGridGlobalLineTrace>,
     grid_candidates: Vec<UniformGridCandidateTrace>,
     splits: Vec<FloatingSplitTrace>,
+    budget: TraceCaptureBudget,
+}
+
+impl FloatingTraceCapture {
+    fn new(byte_limit: usize) -> Self {
+        Self {
+            candidates: Vec::new(),
+            grid_cells: Vec::new(),
+            global_lines: Vec::new(),
+            grid_candidates: Vec::new(),
+            splits: Vec::new(),
+            budget: TraceCaptureBudget::new(byte_limit),
+        }
+    }
 }
 
 const AUTO_SIMD_LIMIT: usize = 1024;
@@ -206,10 +221,11 @@ impl SnapNoder {
         &self,
         lines: Vec<Line3D>,
         execution_policy: Option<&ExecutionPolicy>,
+        capture_byte_limit: usize,
     ) -> crate::Result<FloatingNodingTraceResult> {
         let mut stats = Vec::new();
         let mut work_stats = NodingWorkStats::default();
-        let mut trace = FloatingTraceCapture::default();
+        let mut trace = FloatingTraceCapture::new(capture_byte_limit);
         let lines = self.node_impl(
             lines,
             Some(&mut stats),
@@ -226,6 +242,7 @@ impl SnapNoder {
             trace.global_lines,
             trace.grid_candidates,
             trace.splits,
+            trace.budget.truncated(),
         ))
     }
 
@@ -282,11 +299,13 @@ impl SnapNoder {
                 if trace.is_some() {
                     let mut tracker =
                         ExecutionWorkTracker::new(execution_policy, work_stats.as_deref_mut());
-                    let candidates = &mut trace.as_deref_mut().unwrap().candidates;
-                    let first_candidate = candidates.len();
+                    let trace = trace.as_deref_mut().unwrap();
+                    let first_candidate = trace.candidates.len();
+                    let mut candidates =
+                        TraceCapture::new(&mut trace.candidates, &mut trace.budget);
                     let events =
-                        self.find_splits_simd_tracked(&lines, &mut tracker, Some(candidates))?;
-                    for candidate in &mut candidates[first_candidate..] {
+                        self.find_splits_simd_tracked(&lines, &mut tracker, Some(&mut candidates))?;
+                    for candidate in &mut trace.candidates[first_candidate..] {
                         candidate.iteration_index = iteration_index;
                     }
                     events
@@ -305,19 +324,23 @@ impl SnapNoder {
                     UniformGrid::new(&lines)
                 };
                 if let Some(trace) = trace.as_deref_mut() {
-                    let (cells, global_lines) = grid.trace_structure(&lines, iteration_index);
+                    let (cells, global_lines) =
+                        grid.trace_structure(&lines, iteration_index, &mut trace.budget);
                     trace.grid_cells.extend(cells);
                     trace.global_lines.extend(global_lines);
                 }
                 if execution_policy.is_some() || work_stats.is_some() {
                     let mut tracker =
                         ExecutionWorkTracker::new(execution_policy, work_stats.as_deref_mut());
+                    let mut grid_candidates = trace.as_deref_mut().map(|trace| {
+                        TraceCapture::new(&mut trace.grid_candidates, &mut trace.budget)
+                    });
                     grid.find_splits_tracked(
                         &lines,
                         self,
                         &mut tracker,
                         iteration_index,
-                        trace.as_deref_mut().map(|trace| &mut trace.grid_candidates),
+                        grid_candidates.as_mut(),
                     )?
                 } else {
                     grid.find_splits(&lines, self)
@@ -468,13 +491,16 @@ impl SnapNoder {
                         }
                         new_lines.push(Line3D::new(p0, p1, line.line_id));
                         if let Some(trace) = trace.as_deref_mut() {
-                            trace.splits.push(FloatingSplitTrace {
-                                iteration_index,
-                                source_segment: line_idx,
-                                source_id: line.line_id,
-                                start: p0,
-                                end: p1,
-                            });
+                            trace.budget.capture(
+                                &mut trace.splits,
+                                FloatingSplitTrace {
+                                    iteration_index,
+                                    source_segment: line_idx,
+                                    source_id: line.line_id,
+                                    start: p0,
+                                    end: p1,
+                                },
+                            );
                         }
                     }
                 }
@@ -973,7 +999,7 @@ impl SnapNoder {
         &self,
         lines: &[Line3D],
         tracker: &mut ExecutionWorkTracker<'_>,
-        mut trace_candidates: Option<&mut Vec<FloatingCandidateTrace>>,
+        mut trace_candidates: Option<&mut TraceCapture<'_, FloatingCandidateTrace>>,
     ) -> crate::Result<Vec<(usize, Coord3D)>> {
         let soa = SoALines::new(lines);
         let mut splits = Vec::new();
@@ -1021,7 +1047,7 @@ impl SnapNoder {
         lines: &[Line3D],
         soa: &SoALines,
         mut tracker: Option<&mut ExecutionWorkTracker<'_>>,
-        mut trace_candidates: Option<&mut Vec<FloatingCandidateTrace>>,
+        mut trace_candidates: Option<&mut TraceCapture<'_, FloatingCandidateTrace>>,
     ) -> crate::Result<Vec<(usize, Coord3D)>> {
         let mut events = Vec::new();
         // Start block to avoid duplicate checks (j > i)
@@ -1107,7 +1133,7 @@ impl SnapNoder {
         first_segment: usize,
         second_segment: usize,
         events: &mut Vec<(usize, Coord3D)>,
-        trace_candidates: Option<&mut Vec<FloatingCandidateTrace>>,
+        trace_candidates: Option<&mut TraceCapture<'_, FloatingCandidateTrace>>,
     ) {
         let intersection = line_intersection(first.to_line_2d(), second.to_line_2d());
         if let Some(trace_candidates) = trace_candidates {
@@ -1236,13 +1262,32 @@ mod tests {
     #[test]
     fn grid_trace_records_shared_replacement_loop() {
         let lines = vec![make_line(0.0, 0.0, 2.0, 2.0), make_line(0.0, 2.0, 2.0, 0.0)];
-        let (_, _, _, _, _, _, _, splits) = SnapNoder::new(0.0)
+        let (_, _, _, _, _, _, _, splits, truncated) = SnapNoder::new(0.0)
             .with_strategy(NodingStrategy::Grid)
-            .node_with_trace(lines, None)
+            .node_with_trace(lines, None, usize::MAX)
             .unwrap();
 
         assert_eq!(splits.len(), 4);
         assert!(splits.iter().all(|split| split.iteration_index == 0));
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn trace_capture_budget_stops_all_floating_capture_growth() {
+        let lines = vec![make_line(0.0, 0.0, 2.0, 2.0), make_line(0.0, 2.0, 2.0, 0.0)];
+        let noder = SnapNoder::new(0.0).with_strategy(NodingStrategy::Simd);
+        let expected = noder.node(lines.clone());
+        let (noded, _, work, candidates, cells, globals, grid_candidates, splits, truncated) =
+            noder.node_with_trace(lines, None, 0).unwrap();
+
+        assert_eq!(noded, expected);
+        assert!(work.exact_intersection_calls > 0);
+        assert!(candidates.is_empty());
+        assert!(cells.is_empty());
+        assert!(globals.is_empty());
+        assert!(grid_candidates.is_empty());
+        assert!(splits.is_empty());
+        assert!(truncated);
     }
 
     #[test]

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -450,6 +450,11 @@ impl Polygonizer {
                             trace.records_stage(crate::trace::TraceStageV1::Noding)
                         });
                         if trace_hot_pixels {
+                            let capture_byte_limit = self
+                                .trace
+                                .as_ref()
+                                .map(TraceRecorderV1::capture_byte_limit)
+                                .unwrap_or(0);
                             let (
                                 noded,
                                 intersections,
@@ -457,15 +462,20 @@ impl Polygonizer {
                                 hot_pixels,
                                 candidates,
                                 split_events,
+                                capture_truncated,
                             ) = noder.node_with_hot_pixels(
                                 all_segments,
                                 has_execution_controls.then_some(&self.execution_policy),
+                                capture_byte_limit,
                             )?;
                             work_stats.pre_snap_vertex_candidates = pre_snap_vertex_candidates;
                             if let Some(trace) = self.trace.as_mut() {
                                 trace.record_hot_pixels(&hot_pixels, grid_size)?;
                                 trace.record_certified_candidates(&candidates)?;
                                 trace.record_certified_splits(&split_events)?;
+                                if capture_truncated {
+                                    trace.mark_capture_truncated();
+                                }
                             }
                             if let Some(diagnostics) = diagnostics.as_deref_mut() {
                                 diagnostics.intersection_stats.interpolated_intersections =
@@ -531,6 +541,11 @@ impl Polygonizer {
                             trace.records_stage(crate::trace::TraceStageV1::Noding)
                         });
                         if trace_candidates {
+                            let capture_byte_limit = self
+                                .trace
+                                .as_ref()
+                                .map(TraceRecorderV1::capture_byte_limit)
+                                .unwrap_or(0);
                             let (
                                 noded,
                                 stats,
@@ -540,9 +555,11 @@ impl Polygonizer {
                                 global_lines,
                                 grid_candidates,
                                 split_events,
+                                capture_truncated,
                             ) = noder.node_with_trace(
                                 all_segments,
                                 has_execution_controls.then_some(&self.execution_policy),
+                                capture_byte_limit,
                             )?;
                             work_stats.pre_snap_vertex_candidates = pre_snap_vertex_candidates;
                             if let Some(trace) = self.trace.as_mut() {
@@ -550,6 +567,9 @@ impl Polygonizer {
                                 trace.record_uniform_grid(&grid_cells, &global_lines)?;
                                 trace.record_uniform_grid_candidates(&grid_candidates)?;
                                 trace.record_floating_splits(&split_events)?;
+                                if capture_truncated {
+                                    trace.mark_capture_truncated();
+                                }
                             }
                             if let Some(diagnostics) = diagnostics.as_deref_mut() {
                                 diagnostics.intersection_stats.interpolated_intersections = stats

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -225,9 +225,59 @@ pub struct TraceRecorderV1 {
     trace: TopologyTraceV1,
 }
 
+pub(crate) struct TraceCaptureBudget {
+    remaining_bytes: usize,
+    truncated: bool,
+}
+
+pub(crate) struct TraceCapture<'a, T> {
+    values: &'a mut Vec<T>,
+    budget: &'a mut TraceCaptureBudget,
+}
+
 pub struct TracedPolygonizerResultV1 {
     pub result: PolygonizerResult,
     pub trace: TopologyTraceV1,
+}
+
+impl TraceCaptureBudget {
+    pub(crate) fn new(byte_limit: usize) -> Self {
+        Self {
+            remaining_bytes: byte_limit,
+            truncated: false,
+        }
+    }
+
+    pub(crate) fn capture<T>(&mut self, values: &mut Vec<T>, value: T) -> bool {
+        if !self.take(std::mem::size_of::<T>().max(1)) {
+            return false;
+        }
+        values.push(value);
+        true
+    }
+
+    pub(crate) fn take(&mut self, bytes: usize) -> bool {
+        let Some(remaining_bytes) = self.remaining_bytes.checked_sub(bytes) else {
+            self.truncated = true;
+            return false;
+        };
+        self.remaining_bytes = remaining_bytes;
+        true
+    }
+
+    pub(crate) fn truncated(&self) -> bool {
+        self.truncated
+    }
+}
+
+impl<'a, T> TraceCapture<'a, T> {
+    pub(crate) fn new(values: &'a mut Vec<T>, budget: &'a mut TraceCaptureBudget) -> Self {
+        Self { values, budget }
+    }
+
+    pub(crate) fn push(&mut self, value: T) -> bool {
+        self.budget.capture(self.values, value)
+    }
 }
 
 impl TraceRecorderV1 {
@@ -288,6 +338,14 @@ impl TraceRecorderV1 {
 
     pub(crate) fn records_stage(&self, stage: TraceStageV1) -> bool {
         self.trace.level.allows(stage) && !self.trace.truncated
+    }
+
+    pub(crate) fn capture_byte_limit(&self) -> usize {
+        self.trace.byte_limit.saturating_sub(self.trace.bytes_used)
+    }
+
+    pub(crate) fn mark_capture_truncated(&mut self) {
+        self.trace.truncated = true;
     }
 
     pub(crate) fn record_input_segments(&mut self, lines: &[Line3D]) -> crate::Result<()> {
@@ -870,6 +928,26 @@ mod tests {
         assert!(trace.bytes_used <= trace.byte_limit);
         assert!(trace.truncated);
         assert!(trace.options.is_object());
+    }
+
+    #[test]
+    fn capture_budget_stops_before_trace_only_vector_growth() {
+        let item_bytes = std::mem::size_of::<FloatingSplitTrace>();
+        let mut budget = TraceCaptureBudget::new(item_bytes * 2);
+        let mut values = Vec::new();
+        let split = FloatingSplitTrace {
+            iteration_index: 0,
+            source_segment: 0,
+            source_id: 1,
+            start: Coord3D::new(0.0, 0.0, 0.0),
+            end: Coord3D::new(1.0, 0.0, 0.0),
+        };
+
+        assert!(budget.capture(&mut values, split));
+        assert!(budget.capture(&mut values, split));
+        assert!(!budget.capture(&mut values, split));
+        assert_eq!(values.len(), 2);
+        assert!(budget.truncated());
     }
 
     #[test]


### PR DESCRIPTION
## Stack

Parent:
- main

This PR:
- Bounds temporary floating, uniform-grid, and certified noding trace captures with one shared remaining-byte budget.

Children:
- #1036

## Delivered

- Charges fixed-size candidate and split captures before vector growth.
- Charges uniform-grid cell membership and global-line captures before materialization.
- Marks the final trace truncated when capture stops without changing physical noding work or output.
- Adds zero-budget regressions for floating and certified noding.

## Contract impact

- Trace V1 remains schema-compatible and retains its exact serialized byte limit.
- Enabled noding traces now stop accepting temporary capture items when the remaining trace budget is exhausted.
- Normal topology, provenance, Z behavior, diagnostics, and disabled tracing are unchanged.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo test -p geo-polygonize-core trace_capture_budget -- --nocapture` — 2 passed
- `cargo test -p geo-polygonize-core noding_trace_records -- --nocapture` — 4 passed
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings` — passed
- `cargo test -p geo-polygonize-core` — passed, 192 unit tests plus integration and doc tests
- `cargo test -p geo-polygonize-core --no-default-features` — passed, 192 unit tests plus integration and doc tests
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `cargo test --workspace` — passed
- `RUSTDOCFLAGS='-D warnings' cargo doc -p geo-polygonize-core --no-deps` — passed
- `git diff --check` — passed after restoring test-generated TypeScript bindings

## Agent handoff

Remaining:
- Bound non-noding temporary trace captures.
- Add stage-specific trace budgets without silently changing Trace V1.

Next dependency-ready slice:
- #1036 (`agent/p0-trace-containment-capture-bounds`)
