### PR TITLE
fix(core): bound containment trace capture growth

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -237,7 +237,9 @@ limit in the core regression suite.
 Trace-only floating, uniform-grid, and certified noding capture buffers now
 consume one shared remaining trace-byte budget before growing and mark the
 result truncated when that capture budget is exhausted. Stage-specific trace
-limits and non-noding capture buffers remain open.
+limits and non-noding capture buffers remain open. Containment candidate
+captures now apply the same pre-growth accounting; other non-noding captures
+remain open.
 
 ### P0.6 Cooperative cancellation
 

--- a/crates/geo-polygonize-core/src/containment.rs
+++ b/crates/geo-polygonize-core/src/containment.rs
@@ -5,6 +5,7 @@ use crate::polygonizer::{
     bounding_rect_3d, guaranteed_interior_probe_prepared, rings_share_edge_with_count,
     rings_touch_at_vertex_with_count,
 };
+use crate::trace::{TraceCapture, TraceCaptureBudget};
 use crate::types::{Polygon3D, RingGraphIdentity};
 use crate::utils::simd::SimdRing;
 use geo::algorithm::indexed::IntervalTreeMultiPolygon;
@@ -386,16 +387,18 @@ impl ContainmentForest {
         shells: &[Polygon3D],
         touch_policy: &TouchPolicy,
         collect_stats: bool,
+        capture_budget: &mut TraceCaptureBudget,
     ) -> (Option<usize>, ContainmentStats, Vec<usize>) {
         let mut stats = ContainmentStats::default();
         let mut candidates = Vec::new();
+        let mut trace = TraceCapture::new(&mut candidates, capture_budget);
         let best_shell_idx = self.assign_hole_impl(
             hole_3d,
             hole_graph_ids,
             shells,
             touch_policy,
             collect_stats.then_some(&mut stats),
-            Some(&mut candidates),
+            Some(&mut trace),
         );
         candidates.sort_unstable();
         (best_shell_idx, stats, candidates)
@@ -408,7 +411,7 @@ impl ContainmentForest {
         shells: &[Polygon3D],
         touch_policy: &TouchPolicy,
         mut stats: Option<&mut ContainmentStats>,
-        mut traced_candidates: Option<&mut Vec<usize>>,
+        mut traced_candidates: Option<&mut TraceCapture<'_, usize>>,
     ) -> Option<usize> {
         let track_queries = stats.is_some();
         let hole_locator = SimdRing::new_3d(&hole_3d.exterior);
@@ -584,5 +587,40 @@ mod tests {
             );
         }
         assert!(prepared.interval_locator.get().is_some());
+    }
+
+    #[test]
+    fn containment_trace_candidates_stop_before_budgeted_growth() {
+        let ring = |min: f64, max: f64| {
+            Polygon3D::new(
+                vec![
+                    Coord3D::new(min, min, 0.0),
+                    Coord3D::new(max, min, 0.0),
+                    Coord3D::new(max, max, 0.0),
+                    Coord3D::new(min, max, 0.0),
+                    Coord3D::new(min, min, 0.0),
+                ],
+                vec![],
+                vec![],
+                vec![],
+            )
+        };
+        let shells = vec![ring(0.0, 10.0)];
+        let hole = ring(2.0, 3.0);
+        let forest = ContainmentForest::new(&shells);
+        let mut budget = TraceCaptureBudget::new(0);
+
+        let (selected, _, candidates) = forest.assign_hole_with_graph_ids_and_trace(
+            &hole,
+            None,
+            &shells,
+            &TouchPolicy::AllowPointTouchDisallowEdgeShare,
+            false,
+            &mut budget,
+        );
+
+        assert_eq!(selected, Some(0));
+        assert!(candidates.is_empty());
+        assert!(budget.truncated());
     }
 }

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -11,7 +11,7 @@ use crate::noding::validate::ValidatingNoder;
 use crate::options::{
     ExecutionPolicy, NodingGuarantee, PolygonizerOptions, PrecisionModel, SnapStrategy, ZPolicy,
 };
-use crate::trace::{TraceLevelV1, TraceRecorderV1, TracedPolygonizerResultV1};
+use crate::trace::{TraceCaptureBudget, TraceLevelV1, TraceRecorderV1, TracedPolygonizerResultV1};
 use crate::types::{Coord3D, Line3D, Polygon3D, RingGraphIdentity};
 use crate::utils::simd::SimdRing;
 use crate::utils::z_order_index;
@@ -1330,63 +1330,79 @@ fn establish_topology(
             trace.record_classified_ring("containment_shell", index, shell)?;
         }
     }
-    let trace_containment = trace.is_some();
-    let process_hole_assignment = |(hole_3d, graph_ids): (Polygon3D, Option<RingGraphIdentity>)| -> (
-        Option<usize>,
-        Polygon3D,
-        ContainmentStats,
-        Option<Vec<usize>>,
-    ) {
-        let (best_shell_idx, stats, candidates) = if trace_containment {
+    let process_untraced_hole_assignment =
+        |(hole_3d, graph_ids): (Polygon3D, Option<RingGraphIdentity>)| -> (
+            Option<usize>,
+            Polygon3D,
+            ContainmentStats,
+            Option<Vec<usize>>,
+        ) {
+            let (best_shell_idx, stats) = if collect_stats {
+                let (best_shell_idx, stats) = forest.assign_hole_with_graph_ids_and_stats(
+                    &hole_3d,
+                    graph_ids.as_ref(),
+                    &shells,
+                    &options.containment.touch_policy,
+                );
+                (best_shell_idx, stats)
+            } else {
+                (
+                    forest.assign_hole_with_graph_ids(
+                        &hole_3d,
+                        graph_ids.as_ref(),
+                        &shells,
+                        &options.containment.touch_policy,
+                    ),
+                    ContainmentStats::default(),
+                )
+            };
+            (best_shell_idx, hole_3d, stats, None)
+        };
+
+    let mut capture_truncated = false;
+    let assignments: Vec<_> = if let Some(trace) = trace.as_ref() {
+        let mut capture_budget = TraceCaptureBudget::new(trace.capture_byte_limit());
+        let mut checked = Vec::with_capacity(holes.len());
+        for (index, hole) in holes.into_iter().enumerate() {
+            if let Some(execution_policy) = execution_policy {
+                execution_policy.check_cancelled_every("containment", index)?;
+            }
+            let (hole_3d, graph_ids) = hole;
             let (best_shell_idx, stats, candidates) = forest.assign_hole_with_graph_ids_and_trace(
                 &hole_3d,
                 graph_ids.as_ref(),
                 &shells,
                 &options.containment.touch_policy,
                 collect_stats,
+                &mut capture_budget,
             );
-            (best_shell_idx, stats, Some(candidates))
-        } else if collect_stats {
-            let (best_shell_idx, stats) = forest.assign_hole_with_graph_ids_and_stats(
-                &hole_3d,
-                graph_ids.as_ref(),
-                &shells,
-                &options.containment.touch_policy,
-            );
-            (best_shell_idx, stats, None)
-        } else {
-            (
-                forest.assign_hole_with_graph_ids(
-                    &hole_3d,
-                    graph_ids.as_ref(),
-                    &shells,
-                    &options.containment.touch_policy,
-                ),
-                ContainmentStats::default(),
-                None,
-            )
-        };
-        (best_shell_idx, hole_3d, stats, candidates)
-    };
-
-    let assignments: Vec<_>;
-    if let Some(execution_policy) = execution_policy {
+            checked.push((best_shell_idx, hole_3d, stats, Some(candidates)));
+        }
+        capture_truncated = capture_budget.truncated();
+        checked
+    } else if let Some(execution_policy) = execution_policy {
         let mut checked = Vec::with_capacity(holes.len());
         for (index, hole) in holes.into_iter().enumerate() {
             execution_policy.check_cancelled_every("containment", index)?;
-            checked.push(process_hole_assignment(hole));
+            checked.push(process_untraced_hole_assignment(hole));
         }
-        assignments = checked;
+        checked
     } else {
         #[cfg(feature = "parallel")]
         {
-            assignments = holes.into_par_iter().map(process_hole_assignment).collect();
+            holes
+                .into_par_iter()
+                .map(process_untraced_hole_assignment)
+                .collect()
         }
         #[cfg(not(feature = "parallel"))]
         {
-            assignments = holes.into_iter().map(process_hole_assignment).collect();
+            holes
+                .into_iter()
+                .map(process_untraced_hole_assignment)
+                .collect()
         }
-    }
+    };
 
     let mut shell_holes: Vec<Vec<Vec<Coord3D>>> = vec![vec![]; shells.len()];
     let mut shell_holes_ids: Vec<Vec<Vec<u32>>> = vec![vec![]; shells.len()];
@@ -1408,6 +1424,11 @@ fn establish_topology(
             unassigned_hole_count += 1;
             unassigned_hole_area += hole.exterior_unsigned_area_2d();
         }
+    }
+    if capture_truncated {
+        trace
+            .expect("trace capture exists")
+            .mark_capture_truncated();
     }
     if collect_stats {
         forest.record_locator_reuse(&mut containment_stats);


### PR DESCRIPTION
## Stack

Parent:
- #1035

This PR:
- Extends pre-growth trace accounting to containment candidate capture.

Children:
- #1037

## Delivered

- Shares one remaining-byte budget across every traced hole assignment.
- Stops candidate-ID capture before vector growth while continuing the physical containment decision.
- Keeps untraced containment on its existing parallel/statistics paths.
- Adds a zero-budget regression proving selection remains correct when capture truncates.

## Contract impact

- Trace V1 remains schema-compatible.
- Exhausting containment capture marks the trace truncated without changing shell selection, topology, provenance, or Z behavior.
- Only the opt-in traced containment path is serialized; the normal parallel path remains unchanged.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo test -p geo-polygonize-core containment_trace_candidates_stop_before_budgeted_growth` — 1 passed
- `cargo test -p geo-polygonize-core trace::tests::` — 9 passed
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings` — passed
- `cargo test -p geo-polygonize-core` — passed, 193 unit tests plus integration and doc tests
- `git diff --check` — passed after restoring test-generated TypeScript bindings

## Agent handoff

Remaining:
- Bound tiled ownership and maximal-ring trace capture.
- Add stage-specific trace budgets without silently changing Trace V1.

Next dependency-ready slice:
- #1037 (`agent/p0-trace-tiling-capture-bounds`)
