### PR TITLE
feat(core): add per-stage trace byte limits

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -221,7 +221,7 @@ Add opt-in limits for:
 - [x] split events and iterative-noding passes;
 - [x] graph nodes, edges, and rings;
 - [x] polygons and output coordinates;
-- [ ] per-stage and total trace bytes;
+- [x] per-stage and total trace bytes;
 - [ ] estimated working memory where a reliable bound is available.
 
 Return a typed result such as
@@ -239,7 +239,10 @@ consume one shared remaining trace-byte budget before growing and mark the
 result truncated when that capture budget is exhausted. Containment candidate,
 tiled ownership, and maximal-ring snapshot captures apply the same pre-growth
 accounting. All currently known trace-only capture vectors are covered;
-stage-specific trace limits remain open.
+callers can now independently bound summary, noding, graph, ring, and output
+trace bytes while retaining the existing total-only API as a compatibility
+wrapper. Exhausting one stage marks the trace truncated without suppressing
+later stages.
 
 ### P0.6 Cooperative cancellation
 

--- a/crates/geo-polygonize-core/src/lib.rs
+++ b/crates/geo-polygonize-core/src/lib.rs
@@ -60,8 +60,8 @@ pub use polygonizer::Polygonizer;
 pub use polygonizer::{
     polygonize, polygonize_line_strings, polygonize_line_strings_with_execution_policy,
     polygonize_to_multi_polygon, polygonize_with_execution_policy, polygonize_with_trace,
-    polygonize_with_workspace, polygonize_with_workspace_and_execution_policy, PolygonizerResult,
-    PolygonizerWorkspace,
+    polygonize_with_trace_limits, polygonize_with_workspace,
+    polygonize_with_workspace_and_execution_policy, PolygonizerResult, PolygonizerWorkspace,
 };
 #[doc(hidden)]
 pub use tiling::{

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -11,7 +11,10 @@ use crate::noding::validate::ValidatingNoder;
 use crate::options::{
     ExecutionPolicy, NodingGuarantee, PolygonizerOptions, PrecisionModel, SnapStrategy, ZPolicy,
 };
-use crate::trace::{TraceCaptureBudget, TraceLevelV1, TraceRecorderV1, TracedPolygonizerResultV1};
+use crate::trace::{
+    TraceByteLimitsV1, TraceCaptureBudget, TraceLevelV1, TraceRecorderV1, TraceStageV1,
+    TracedPolygonizerResultV1,
+};
 use crate::types::{Coord3D, Line3D, Polygon3D, RingGraphIdentity};
 use crate::utils::simd::SimdRing;
 use crate::utils::z_order_index;
@@ -116,10 +119,28 @@ pub fn polygonize_with_trace(
     level: TraceLevelV1,
     byte_limit: usize,
 ) -> Result<TracedPolygonizerResultV1> {
+    polygonize_with_trace_limits(
+        lines,
+        options,
+        execution_policy,
+        level,
+        TraceByteLimitsV1::total(byte_limit),
+    )
+}
+
+/// Polygonize an owned stream with independent total and per-stage trace limits.
+#[doc(hidden)]
+pub fn polygonize_with_trace_limits(
+    lines: impl IntoIterator<Item = Line3D>,
+    options: &PolygonizerOptions,
+    execution_policy: &ExecutionPolicy,
+    level: TraceLevelV1,
+    limits: TraceByteLimitsV1,
+) -> Result<TracedPolygonizerResultV1> {
     let collected = collect_owned_lines(lines, execution_policy)?;
     let mut runner = Polygonizer::with_options(options.clone())
         .with_execution_policy(execution_policy.clone())
-        .with_trace(TraceRecorderV1::new(Some(level), byte_limit, options).unwrap());
+        .with_trace(TraceRecorderV1::new_with_limits(Some(level), limits, options).unwrap());
     let result = runner.polygonize_owned(collected)?;
     Ok(TracedPolygonizerResultV1 {
         result,
@@ -453,7 +474,7 @@ impl Polygonizer {
                             let capture_byte_limit = self
                                 .trace
                                 .as_ref()
-                                .map(TraceRecorderV1::capture_byte_limit)
+                                .map(|trace| trace.capture_byte_limit(TraceStageV1::Noding))
                                 .unwrap_or(0);
                             let (
                                 noded,
@@ -474,7 +495,7 @@ impl Polygonizer {
                                 trace.record_certified_candidates(&candidates)?;
                                 trace.record_certified_splits(&split_events)?;
                                 if capture_truncated {
-                                    trace.mark_capture_truncated();
+                                    trace.mark_capture_truncated(TraceStageV1::Noding);
                                 }
                             }
                             if let Some(diagnostics) = diagnostics.as_deref_mut() {
@@ -544,7 +565,7 @@ impl Polygonizer {
                             let capture_byte_limit = self
                                 .trace
                                 .as_ref()
-                                .map(TraceRecorderV1::capture_byte_limit)
+                                .map(|trace| trace.capture_byte_limit(TraceStageV1::Noding))
                                 .unwrap_or(0);
                             let (
                                 noded,
@@ -568,7 +589,7 @@ impl Polygonizer {
                                 trace.record_uniform_grid_candidates(&grid_candidates)?;
                                 trace.record_floating_splits(&split_events)?;
                                 if capture_truncated {
-                                    trace.mark_capture_truncated();
+                                    trace.mark_capture_truncated(TraceStageV1::Noding);
                                 }
                             }
                             if let Some(diagnostics) = diagnostics.as_deref_mut() {
@@ -813,7 +834,7 @@ impl Polygonizer {
             let capture_byte_limit = self
                 .trace
                 .as_ref()
-                .map(TraceRecorderV1::capture_byte_limit)
+                .map(|trace| trace.capture_byte_limit(TraceStageV1::Rings))
                 .unwrap_or(0);
             let (maximal, minimal, capture_truncated) = self
                 .graph
@@ -827,7 +848,7 @@ impl Polygonizer {
             trace.record_extracted_rings("maximal_ring", &maximal)?;
             trace.record_extracted_rings("minimal_ring", &minimal)?;
             if capture_truncated {
-                trace.mark_capture_truncated();
+                trace.mark_capture_truncated(TraceStageV1::Rings);
             }
             minimal
         } else {
@@ -1370,7 +1391,8 @@ fn establish_topology(
 
     let mut capture_truncated = false;
     let assignments: Vec<_> = if let Some(trace) = trace.as_ref() {
-        let mut capture_budget = TraceCaptureBudget::new(trace.capture_byte_limit());
+        let mut capture_budget =
+            TraceCaptureBudget::new(trace.capture_byte_limit(TraceStageV1::Rings));
         let mut checked = Vec::with_capacity(holes.len());
         for (index, hole) in holes.into_iter().enumerate() {
             if let Some(execution_policy) = execution_policy {
@@ -1437,7 +1459,7 @@ fn establish_topology(
     if capture_truncated {
         trace
             .expect("trace capture exists")
-            .mark_capture_truncated();
+            .mark_capture_truncated(TraceStageV1::Rings);
     }
     if collect_stats {
         forest.record_locator_reuse(&mut containment_stats);

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -1,7 +1,8 @@
 use crate::options::{DedupPolicy, ExecutionPolicy, TileOwnershipPolicy};
 use crate::polygonizer::{apply_determinism, canonicalize_ring};
 use crate::trace::{
-    TopologyTraceV1, TraceCaptureBudget, TraceLevelV1, TraceRecorderV1, TraceStageV1,
+    TopologyTraceV1, TraceByteLimitsV1, TraceCaptureBudget, TraceLevelV1, TraceRecorderV1,
+    TraceStageV1,
 };
 use crate::types::{Coord3D, Polygon3D};
 use crate::{PolygonizeError, Polygonizer, PolygonizerOptions, Result};
@@ -270,8 +271,16 @@ impl<'a> TiledPolygonizer<'a> {
         level: TraceLevelV1,
         byte_limit: usize,
     ) -> Result<TracedTiledPolygonizeResultV1> {
-        let mut trace =
-            TraceRecorderV1::new(Some(level), byte_limit, &self.options).expect("trace enabled");
+        self.polygonize_with_trace_limits(level, TraceByteLimitsV1::total(byte_limit))
+    }
+
+    pub fn polygonize_with_trace_limits(
+        &self,
+        level: TraceLevelV1,
+        limits: TraceByteLimitsV1,
+    ) -> Result<TracedTiledPolygonizeResultV1> {
+        let mut trace = TraceRecorderV1::new_with_limits(Some(level), limits, &self.options)
+            .expect("trace enabled");
         let result = self.polygonize_impl(Some(&mut trace))?;
         Ok(TracedTiledPolygonizeResultV1 {
             result,
@@ -296,7 +305,7 @@ impl<'a> TiledPolygonizer<'a> {
                 let capture_byte_limit = trace.as_ref().and_then(|trace| {
                     trace
                         .records_stage(TraceStageV1::Output)
-                        .then(|| trace.capture_byte_limit())
+                        .then(|| trace.capture_byte_limit(TraceStageV1::Output))
                 });
                 let (polygons, report, ownership_decisions, capture_truncated) =
                     self.process_tile(tile, capture_byte_limit)?;
@@ -310,7 +319,7 @@ impl<'a> TiledPolygonizer<'a> {
                     )?;
                 }
                 if capture_truncated {
-                    trace.mark_capture_truncated();
+                    trace.mark_capture_truncated(TraceStageV1::Output);
                 }
                 tile_polygons.push(polygons);
                 tile_reports.push(report);

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -34,6 +34,43 @@ pub enum TraceStageV1 {
     Output,
 }
 
+/// Independent serialized-byte limits for a topology trace.
+///
+/// `total_bytes` bounds the complete trace. Each stage limit independently
+/// bounds events and temporary capture buffers for that stage.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct TraceByteLimitsV1 {
+    pub total_bytes: usize,
+    pub summary_bytes: usize,
+    pub noding_bytes: usize,
+    pub graph_bytes: usize,
+    pub ring_bytes: usize,
+    pub output_bytes: usize,
+}
+
+impl TraceByteLimitsV1 {
+    pub const fn total(total_bytes: usize) -> Self {
+        Self {
+            total_bytes,
+            summary_bytes: usize::MAX,
+            noding_bytes: usize::MAX,
+            graph_bytes: usize::MAX,
+            ring_bytes: usize::MAX,
+            output_bytes: usize::MAX,
+        }
+    }
+
+    const fn stage(self, stage: TraceStageV1) -> usize {
+        match stage {
+            TraceStageV1::Summary => self.summary_bytes,
+            TraceStageV1::Noding => self.noding_bytes,
+            TraceStageV1::Graph => self.graph_bytes,
+            TraceStageV1::Rings => self.ring_bytes,
+            TraceStageV1::Output => self.output_bytes,
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct TraceEventV1 {
     pub sequence: usize,
@@ -223,6 +260,10 @@ pub struct TopologyTraceV1 {
 /// Callers hold this as an `Option`; `None` is the disabled fast path.
 pub struct TraceRecorderV1 {
     trace: TopologyTraceV1,
+    limits: TraceByteLimitsV1,
+    stage_bytes_used: [usize; 5],
+    stage_truncated: [bool; 5],
+    total_truncated: bool,
 }
 
 pub(crate) struct TraceCaptureBudget {
@@ -286,17 +327,29 @@ impl TraceRecorderV1 {
         byte_limit: usize,
         options: &PolygonizerOptions,
     ) -> Option<Self> {
+        Self::new_with_limits(level, TraceByteLimitsV1::total(byte_limit), options)
+    }
+
+    pub fn new_with_limits(
+        level: Option<TraceLevelV1>,
+        limits: TraceByteLimitsV1,
+        options: &PolygonizerOptions,
+    ) -> Option<Self> {
         level.map(|level| Self {
             trace: TopologyTraceV1 {
                 schema_version: TOPOLOGY_TRACE_V1_SCHEMA_VERSION,
                 library_version: env!("CARGO_PKG_VERSION").to_string(),
                 level,
-                byte_limit,
+                byte_limit: limits.total_bytes,
                 bytes_used: 0,
                 truncated: false,
                 options: serde_json::to_value(options).expect("validated options serialize"),
                 events: Vec::new(),
             },
+            limits,
+            stage_bytes_used: [0; 5],
+            stage_truncated: [false; 5],
+            total_truncated: false,
         })
     }
 
@@ -307,8 +360,12 @@ impl TraceRecorderV1 {
         kind: impl Into<String>,
         payload: serde_json::Value,
     ) -> bool {
-        if self.trace.truncated || !self.trace.level.allows(stage) {
-            return !self.trace.truncated;
+        if !self.trace.level.allows(stage) {
+            return true;
+        }
+        let stage_index = stage.index();
+        if self.total_truncated || self.stage_truncated[stage_index] {
+            return false;
         }
         let event = TraceEventV1 {
             sequence: self.trace.events.len(),
@@ -321,13 +378,27 @@ impl TraceRecorderV1 {
             .len();
         let Some(bytes_used) = self.trace.bytes_used.checked_add(event_bytes) else {
             self.trace.truncated = true;
+            self.total_truncated = true;
             return false;
         };
         if bytes_used > self.trace.byte_limit {
             self.trace.truncated = true;
+            self.total_truncated = true;
+            return false;
+        }
+        let Some(stage_bytes_used) = self.stage_bytes_used[stage_index].checked_add(event_bytes)
+        else {
+            self.trace.truncated = true;
+            self.stage_truncated[stage_index] = true;
+            return false;
+        };
+        if stage_bytes_used > self.limits.stage(stage) {
+            self.trace.truncated = true;
+            self.stage_truncated[stage_index] = true;
             return false;
         }
         self.trace.bytes_used = bytes_used;
+        self.stage_bytes_used[stage_index] = stage_bytes_used;
         self.trace.events.push(event);
         true
     }
@@ -337,15 +408,35 @@ impl TraceRecorderV1 {
     }
 
     pub(crate) fn records_stage(&self, stage: TraceStageV1) -> bool {
-        self.trace.level.allows(stage) && !self.trace.truncated
+        self.trace.level.allows(stage)
+            && !self.total_truncated
+            && !self.stage_truncated[stage.index()]
     }
 
-    pub(crate) fn capture_byte_limit(&self) -> usize {
-        self.trace.byte_limit.saturating_sub(self.trace.bytes_used)
+    pub(crate) fn capture_byte_limit(&self, stage: TraceStageV1) -> usize {
+        self.trace
+            .byte_limit
+            .saturating_sub(self.trace.bytes_used)
+            .min(
+                self.limits
+                    .stage(stage)
+                    .saturating_sub(self.stage_bytes_used[stage.index()]),
+            )
     }
 
-    pub(crate) fn mark_capture_truncated(&mut self) {
+    pub(crate) fn mark_capture_truncated(&mut self, stage: TraceStageV1) {
         self.trace.truncated = true;
+        let total_remaining = self.trace.byte_limit.saturating_sub(self.trace.bytes_used);
+        let stage_remaining = self
+            .limits
+            .stage(stage)
+            .saturating_sub(self.stage_bytes_used[stage.index()]);
+        if total_remaining <= stage_remaining {
+            self.total_truncated = true;
+        }
+        if stage_remaining <= total_remaining {
+            self.stage_truncated[stage.index()] = true;
+        }
     }
 
     pub(crate) fn record_input_segments(&mut self, lines: &[Line3D]) -> crate::Result<()> {
@@ -895,11 +986,24 @@ impl TraceLevelV1 {
     }
 }
 
+impl TraceStageV1 {
+    const fn index(self) -> usize {
+        match self {
+            Self::Summary => 0,
+            Self::Noding => 1,
+            Self::Graph => 2,
+            Self::Rings => 3,
+            Self::Output => 4,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::{
-        polygonize, polygonize_with_trace, Coord3D, ExecutionPolicy, TopologyFingerprintV1,
+        polygonize, polygonize_with_trace, polygonize_with_trace_limits, Coord3D, ExecutionPolicy,
+        TopologyFingerprintV1,
     };
     use serde_json::json;
 
@@ -948,6 +1052,82 @@ mod tests {
         assert!(!budget.capture(&mut values, split));
         assert_eq!(values.len(), 2);
         assert!(budget.truncated());
+    }
+
+    #[test]
+    fn exhausted_stage_limit_does_not_suppress_later_stages() {
+        let options = PolygonizerOptions::default();
+        let limits = TraceByteLimitsV1 {
+            noding_bytes: 0,
+            ..TraceByteLimitsV1::total(usize::MAX)
+        };
+        let mut recorder =
+            TraceRecorderV1::new_with_limits(Some(TraceLevelV1::Full), limits, &options).unwrap();
+
+        assert!(!recorder.record(TraceStageV1::Noding, "candidate", json!({"pair": [1, 2]})));
+        assert!(recorder.record(TraceStageV1::Graph, "node", json!({"id": 1})));
+
+        let trace = recorder.finish();
+        assert!(trace.truncated);
+        assert_eq!(trace.events.len(), 1);
+        assert_eq!(trace.events[0].stage, TraceStageV1::Graph);
+    }
+
+    #[test]
+    fn capture_truncation_distinguishes_stage_and_total_limits() {
+        let options = PolygonizerOptions::default();
+        let stage_limits = TraceByteLimitsV1 {
+            ring_bytes: 0,
+            ..TraceByteLimitsV1::total(usize::MAX)
+        };
+        let mut stage_limited =
+            TraceRecorderV1::new_with_limits(Some(TraceLevelV1::Full), stage_limits, &options)
+                .unwrap();
+        stage_limited.mark_capture_truncated(TraceStageV1::Rings);
+        assert!(stage_limited.record(TraceStageV1::Graph, "node", json!({"id": 1})));
+
+        let mut total_limited =
+            TraceRecorderV1::new(Some(TraceLevelV1::Full), 0, &options).unwrap();
+        total_limited.mark_capture_truncated(TraceStageV1::Rings);
+        assert!(!total_limited.record(TraceStageV1::Graph, "node", json!({"id": 1})));
+    }
+
+    #[test]
+    fn traced_entrypoint_applies_stage_limits_without_changing_results() {
+        let lines = vec![
+            Line3D::new(Coord3D::new(0.0, 0.0, 0.0), Coord3D::new(1.0, 0.0, 0.0), 7),
+            Line3D::new(Coord3D::new(0.0, 0.0, 0.0), Coord3D::new(1.0, 0.0, 0.0), 9),
+        ];
+        let options = PolygonizerOptions::default();
+        let expected = polygonize(lines.iter().copied(), &options).unwrap();
+        let limits = TraceByteLimitsV1 {
+            noding_bytes: 0,
+            ..TraceByteLimitsV1::total(usize::MAX)
+        };
+        let traced = polygonize_with_trace_limits(
+            lines,
+            &options,
+            &ExecutionPolicy::default(),
+            TraceLevelV1::Full,
+            limits,
+        )
+        .unwrap();
+
+        assert!(traced.trace.truncated);
+        assert!(traced
+            .trace
+            .events
+            .iter()
+            .all(|event| event.stage != TraceStageV1::Noding));
+        assert!(traced
+            .trace
+            .events
+            .iter()
+            .any(|event| event.stage == TraceStageV1::Graph));
+        assert_eq!(
+            TopologyFingerprintV1::try_from_result(&traced.result, &options).unwrap(),
+            TopologyFingerprintV1::try_from_result(&expected, &options).unwrap()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Stack

Parent:
- #1038 (merged)

This PR:
- Add independent summary, noding, graph, ring, output, and total trace-byte limits.

Children:\n- #1040

## Delivered

- Add `TraceByteLimitsV1` and additive traced entrypoints while retaining total-only compatibility wrappers.
- Apply stage budgets to serialized events and trace-only capture buffers.
- Let later stages continue after a stage-local truncation while preserving global-stop behavior for total exhaustion.
- Mark the per-stage and total trace-byte roadmap item complete.

## Contract impact

- TopologyTraceV1 serialization is unchanged.
- Existing total-only APIs preserve their behavior.
- Trace limits remain operational and do not affect polygonization topology.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo test -p geo-polygonize-core stage` — 3 passed
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings` — passed
- `cargo test -p geo-polygonize-core` — passed (197 unit tests plus integration and doc tests)
- `cargo test -p geo-polygonize-core --no-default-features` — passed (197 unit tests plus integration and doc tests)
- `RUSTDOCFLAGS="-D warnings" cargo doc -p geo-polygonize-core --no-deps` — passed
- `git diff --check` — passed after restoring unrelated generated binding rewrites

## Agent handoff

Remaining:
- Estimated working-memory limits remain open where reliable pre-allocation bounds exist.
- Full workspace, npm, and docs-site checks were not run for this core-only slice.

Next dependency-ready slice:
- Add conservative pre-allocation working-memory accounting for known core buffers without claiming a process-wide memory cap.