### PR TITLE
ci(github): pin benchmark comparison toolchains

### DIFF
--- a/.github/workflows/benchmark-evidence.yml
+++ b/.github/workflows/benchmark-evidence.yml
@@ -10,6 +10,7 @@ on:
       - "crates/geo-polygonize-core/tests/workloads/**"
       - "tests/test_reference_geos.py"
       - "tests/test_publish_benchmark.py"
+      - "tests/test_benchmark_workflow_pins.py"
   push:
     branches: [main]
     paths:
@@ -18,6 +19,7 @@ on:
       - "crates/geo-polygonize-core/tests/workloads/**"
       - "tests/test_reference_geos.py"
       - "tests/test_publish_benchmark.py"
+      - "tests/test_benchmark_workflow_pins.py"
 
 permissions:
   contents: read
@@ -46,7 +48,7 @@ jobs:
 
       - run: cargo build --locked --release -p geo-polygonize-core --example benchmark_record
 
-      - run: pytest -q tests/test_reference_geos.py tests/test_publish_benchmark.py
+      - run: pytest -q tests/test_reference_geos.py tests/test_publish_benchmark.py tests/test_benchmark_workflow_pins.py
 
       - run: python benchmarks/check_geos_references.py
 

--- a/.github/workflows/cross-architecture-benchmarks.yml
+++ b/.github/workflows/cross-architecture-benchmarks.yml
@@ -41,6 +41,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.96.1"
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -79,12 +81,14 @@ jobs:
       - name: Set up nightly Rust
         uses: dtolnay/rust-toolchain@nightly
         with:
+          toolchain: "nightly-2026-07-15"
           components: rust-src
           targets: wasm32-unknown-unknown
 
       - name: Set up stable Rust
         uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: "1.96.1"
           targets: wasm32-unknown-unknown
 
       - uses: Swatinem/rust-cache@v2
@@ -93,7 +97,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "22.17.1"
           cache: npm
 
       - run: npm ci

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: '1.96.1'
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
@@ -40,21 +42,21 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.12.11'
           cache: 'pip'
 
       - name: Install Python dependencies
         run: |
-          pip install shapely numpy
+          pip install Shapely==2.1.2 numpy==2.3.2
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '22.17.1'
           cache: 'npm'
 
       - name: Install Wasm tools
-        run: npm install -g wasm-pack
+        run: npm install -g wasm-pack@0.13.1
 
       - name: Run Benchmarks
         run: |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -355,7 +355,7 @@ Record:
 
 - [ ] Publish machine-readable artifacts and a human-readable trend dashboard.
 - [x] Separate noisy runner samples from decision-quality measurements.
-- [ ] Pin GEOS, JTS, Shapely, Rust, and Node versions in comparison jobs.
+- [x] Pin GEOS, JTS, Shapely, Rust, and Node versions in comparison jobs.
 - [x] Define the minimum effect size and regression budget before each backend or
   dispatch experiment.
 - [x] Keep rejected experiments and crossover measurements linked from the
@@ -363,8 +363,10 @@ Record:
 
 Progress: The correctness jobs pin Rust, Python, Shapely and its bundled GEOS,
 plus the Maven/Java image, JTS, and JSON adapter used by the certified lane.
-Node remains to be pinned when a Node comparison job exists; neither correctness
-job publishes timing artifacts. Benchmark decision policy V1 now classifies
+The cross-architecture and maintenance comparisons now pin stable and nightly
+Rust, Python, Shapely and its bundled GEOS, JTS, Node, NumPy, and Wasm tooling;
+a regression test rejects floating selectors. Neither correctness job publishes
+timing artifacts. Benchmark decision policy V1 now classifies
 diagnostic results as nonpublishable and requires dedicated-runner repetitions,
 warmup, dispersion, correctness, environment, and commit gates for
 decision-quality evidence. It also predeclares a 5% minimum effect size and 2%

--- a/tests/test_benchmark_workflow_pins.py
+++ b/tests/test_benchmark_workflow_pins.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def workflow(name):
+    return (ROOT / ".github" / "workflows" / name).read_text()
+
+
+def test_comparison_workflows_pin_toolchains_and_references():
+    evidence = workflow("benchmark-evidence.yml")
+    cross_arch = workflow("cross-architecture-benchmarks.yml")
+    maintenance = workflow("maintenance.yml")
+    requirements = (ROOT / "benchmarks" / "reference-requirements.txt").read_text()
+    pom = (ROOT / "benchmarks" / "jts-reference" / "pom.xml").read_text()
+
+    assert evidence.count('toolchain: "1.96.1"') == 2
+    assert 'python-version: "3.12.11"' in evidence
+    assert "Shapely==2.1.2" in requirements
+    assert "<jts.version>1.20.0</jts.version>" in pom
+
+    assert cross_arch.count('toolchain: "1.96.1"') == 2
+    assert 'toolchain: "nightly-2026-07-15"' in cross_arch
+    assert 'node-version: "22.17.1"' in cross_arch
+
+    assert "toolchain: '1.96.1'" in maintenance
+    assert "python-version: '3.12.11'" in maintenance
+    assert "Shapely==2.1.2 numpy==2.3.2" in maintenance
+    assert "node-version: '22.17.1'" in maintenance
+    assert "wasm-pack@0.13.1" in maintenance


### PR DESCRIPTION
## Stack

Parent:
- #1040 (merged)

This PR:
- Pin every toolchain and reference dependency used by benchmark comparison jobs.

Children:\n- #1042

## Delivered

- Pin stable and nightly Rust plus Node in cross-architecture comparisons.
- Pin Rust, Python, Shapely/GEOS, NumPy, Node, and wasm-pack in maintenance comparisons.
- Add a regression that rejects floating comparison selectors and verifies existing JTS/Shapely correctness pins.
- Mark the P1 comparison-version pinning item complete.

## Contract impact

- No polygonization API or semantic behavior changes.
- Benchmark comparisons become reproducible against declared tool versions.

## Validation

- `pytest -q tests/test_reference_geos.py tests/test_publish_benchmark.py tests/test_benchmark_workflow_pins.py` — 7 passed
- parse every workflow with PyYAML — passed
- `npm view wasm-pack@0.13.1 version` — confirmed 0.13.1
- `git diff --check` — passed

## Agent handoff

Remaining:
- Durable benchmark artifact publication and retention remain open.
- The local pytest run emitted the existing pytest-asyncio future-default warning.
- The pinned dated nightly was not installed locally; remote workflow execution remains the authoritative availability check.

Next dependency-ready slice:
- Upload correctness-gated benchmark publications and rendered trend reports as retained workflow artifacts.