### PR TITLE
ci(github): publish dedicated benchmark evidence

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - benchmark-dedicated

--- a/.github/workflows/benchmark-publication.yml
+++ b/.github/workflows/benchmark-publication.yml
@@ -1,0 +1,97 @@
+name: Publish benchmark evidence
+
+on:
+  workflow_dispatch:
+    inputs:
+      workload:
+        description: Public workload manifest ID
+        required: true
+        default: already-noded-coverage-v1
+      lane:
+        description: GEOS-comparable benchmark lane
+        required: true
+        type: choice
+        options:
+          - already-noded
+          - floating
+          - certified-fixed
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: [self-hosted, benchmark-dedicated, linux, x64]
+    timeout-minutes: 60
+    env:
+      MAVEN_IMAGE: maven:3.9.11-eclipse-temurin-21@sha256:6fdc855a6ed81d288ca7ca37ac6ff5e9308b612485c0801d70b25a858c83d237
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.96.1"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12.11"
+
+      - run: python -m pip install -r benchmarks/reference-requirements.txt
+      - run: cargo build --locked --release -p geo-polygonize-core --example benchmark_record
+
+      - name: Generate external correctness reference
+        run: |
+          mkdir -p target/benchmark-publication
+          if [ "${{ inputs.lane }}" = certified-fixed ]; then
+            docker run --rm -v "$PWD:/workspace" -w /workspace "$MAVEN_IMAGE" \
+              mvn -q -f benchmarks/jts-reference/pom.xml package
+            docker run --rm -v "$PWD:/workspace" -w /workspace "$MAVEN_IMAGE" \
+              java -jar benchmarks/jts-reference/target/geo-polygonize-jts-reference-1.0.0.jar \
+              --root /workspace --workload "${{ inputs.workload }}" \
+              --output /workspace/target/benchmark-publication/reference.json
+          else
+            python benchmarks/reference_geos.py \
+              --lane "${{ inputs.lane }}" \
+              --workload "${{ inputs.workload }}" \
+              --output target/benchmark-publication/reference.json
+          fi
+
+      - name: Measure peak RSS and collect independent records
+        run: |
+          binary=target/release/examples/benchmark_record
+          reference=target/benchmark-publication/reference.json
+          /usr/bin/time -f '%M' -o target/benchmark-publication/peak-rss-kib.txt \
+            "$binary" --lane "${{ inputs.lane }}" --workload "${{ inputs.workload }}" \
+            --reference-result "$reference" --check-only
+          peak_kib=$(tr -d '[:space:]' < target/benchmark-publication/peak-rss-kib.txt)
+          case "$peak_kib" in *[!0-9]*|'') exit 1 ;; esac
+          peak_bytes=$((peak_kib * 1024))
+          for repetition in 1 2 3 4 5; do
+            "$binary" --lane "${{ inputs.lane }}" --workload "${{ inputs.workload }}" \
+              --samples 30 --warmup-iterations 5 --repetition "$repetition" \
+              --peak-rss-bytes "$peak_bytes" --reference-result "$reference" \
+              --output "target/benchmark-publication/record-${repetition}.json"
+          done
+
+      - name: Validate publication and render trends
+        run: |
+          python benchmarks/publish_benchmark.py \
+            --runner-class dedicated --warmup-iterations 5 \
+            --record target/benchmark-publication/record-1.json \
+            --record target/benchmark-publication/record-2.json \
+            --record target/benchmark-publication/record-3.json \
+            --record target/benchmark-publication/record-4.json \
+            --record target/benchmark-publication/record-5.json \
+            --output target/benchmark-publication/publication.json
+          python benchmarks/render_benchmark_trends.py \
+            --publication target/benchmark-publication/publication.json \
+            --output target/benchmark-publication/trends.md
+          sha256sum target/benchmark-publication/*.json > target/benchmark-publication/SHA256SUMS
+          cat target/benchmark-publication/trends.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Retain decision-quality publication
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-publication-${{ inputs.workload }}-${{ inputs.lane }}-${{ github.sha }}
+          path: target/benchmark-publication/
+          retention-days: 90

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -353,7 +353,7 @@ Record:
 
 ### P1.3 Durable benchmark reporting
 
-- [ ] Publish machine-readable artifacts and a human-readable trend dashboard.
+- [x] Publish machine-readable artifacts and a human-readable trend dashboard.
 - [x] Separate noisy runner samples from decision-quality measurements.
 - [x] Pin GEOS, JTS, Shapely, Rust, and Node versions in comparison jobs.
 - [x] Define the minimum effect size and regression budget before each backend or
@@ -380,6 +380,10 @@ publication and decision artifacts into a human-readable trend view. The
 correctness workflow now retains its validated GEOS and JTS reference results
 for 30 days. Decision-quality timing publication still requires records from a
 dedicated runner; no timing rows are fabricated in their absence.
+The manual publication workflow runs only on a labeled dedicated self-hosted
+runner, collects five independent correctness-gated records, validates their
+dispersion, renders the trend report into the job summary, and retains the
+records, publication, checksums, reference, and Markdown report for 90 days.
 
 ### P1.4 Differential minimization
 

--- a/tests/test_benchmark_artifacts.py
+++ b/tests/test_benchmark_artifacts.py
@@ -20,3 +20,18 @@ def test_correctness_references_are_persistable_and_retained():
     assert "path: target/geos-reference/*.json" in workflow
     assert "path: target/jts-reference/*.json" in workflow
     assert workflow.count("retention-days: 30") == 2
+
+
+def test_publication_requires_a_dedicated_runner_and_retains_gated_outputs():
+    workflow = (ROOT / ".github/workflows/benchmark-publication.yml").read_text()
+    assert "runs-on: [self-hosted, benchmark-dedicated, linux, x64]" in workflow
+    assert workflow.count("--repetition") == 1
+    assert "for repetition in 1 2 3 4 5" in workflow
+    assert "--runner-class dedicated" in workflow
+    assert "certified-fixed" in workflow
+    assert "geo-polygonize-jts-reference-1.0.0.jar" in workflow
+    assert "maven:3.9.11-eclipse-temurin-21@sha256:" in workflow
+    assert "--publication target/benchmark-publication/publication.json" in workflow
+    assert 'cat target/benchmark-publication/trends.md >> "$GITHUB_STEP_SUMMARY"' in workflow
+    assert "retention-days: 90" in workflow
+    assert "ubuntu-latest" not in workflow


### PR DESCRIPTION
## Stack

Parent:
- #1042 (merged)

This PR:
- Publish correctness-gated benchmark evidence from a dedicated runner.

Children:\n- #1044

## Delivered

- Add a manual workflow restricted to a labeled dedicated Linux x64 self-hosted runner.
- Support already-noded, floating, and certified-fixed lanes using pinned GEOS/Shapely or JTS references.
- Collect five independent 30-sample records after warmup with externally measured peak RSS.
- Enforce the existing publication policy, render the Markdown trend report, publish checksums, append the report to the job summary, and retain all evidence for 90 days.
- Declare the custom runner label to actionlint and mark durable benchmark publication complete.

## Contract impact

- No polygonization or benchmark schema changes.
- Shared hosted runners cannot execute or publish decision-quality records.

## Validation

- `actionlint .github/workflows/benchmark-publication.yml` — passed
- `pytest -q tests/test_reference_geos.py tests/test_publish_benchmark.py tests/test_benchmark_workflow_pins.py tests/test_benchmark_artifacts.py` — 9 passed
- parse workflow and actionlint configuration with PyYAML — passed
- `git diff --check` — passed

## Agent handoff

Remaining:
- A live dedicated-runner dispatch is required for the first retained timing artifact; no timing result was fabricated locally.
- Local pytest emitted the existing pytest-asyncio future-default warning.

Next dependency-ready slice:
- Export minimized repro bundles directly into strict golden fixtures plus compatibility classifications without manual geometry rewriting.