### PR TITLE
feat(core): export minimized compatibility fixtures

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -405,7 +405,10 @@ options and recompute both sides for every candidate. Retained segments are
 copied unchanged. Shared X/Y values can then be simplified atomically while
 source IDs and Z conflicts remain untouched; persisted fixtures and standalone
 repro bundles use an exact, versioned JSON representation. Persisting novel
-minimized failures as strict golden/compatibility cases remains separate work.
+minimized failures no longer requires rewriting geometry: a versioned persisted
+fixture now pairs the exact repro bundle with a strict compatibility
+classification and validated stable case ID. Wiring every fuzz and production
+mismatch producer to store that artifact remains open.
 
 ### P1.5 Trace schema
 

--- a/crates/geo-polygonize-core/src/differential.rs
+++ b/crates/geo-polygonize-core/src/differential.rs
@@ -9,6 +9,16 @@ use std::collections::BTreeMap;
 
 /// The standalone differential reproduction bundle schema version.
 pub const REPRO_BUNDLE_V1_SCHEMA_VERSION: u32 = 1;
+/// The persisted differential fixture schema version.
+pub const PERSISTED_DIFFERENTIAL_FIXTURE_V1_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CompatibilityClassificationV1 {
+    ExpectedParity,
+    ExpectedDivergence,
+    InvalidAmbiguous,
+}
 
 /// Exact, portable input segment for a differential reproduction bundle.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
@@ -56,6 +66,46 @@ pub struct ReproBundleV1 {
     pub fingerprint: TopologyFingerprintV1,
     pub reference_metrics: ReferenceMetricsV1,
     pub witness: FingerprintDiffV1,
+}
+
+/// A strict golden repro paired with its compatibility classification.
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct PersistedDifferentialFixtureV1 {
+    pub schema_version: u32,
+    pub case_id: String,
+    pub classification: CompatibilityClassificationV1,
+    pub golden: ReproBundleV1,
+}
+
+impl PersistedDifferentialFixtureV1 {
+    pub fn new(
+        case_id: impl Into<String>,
+        classification: CompatibilityClassificationV1,
+        golden: ReproBundleV1,
+    ) -> crate::Result<Self> {
+        let case_id = case_id.into();
+        if case_id.is_empty()
+            || !case_id.bytes().all(|byte| {
+                byte.is_ascii_lowercase() || byte.is_ascii_digit() || b"-._".contains(&byte)
+            })
+        {
+            return Err(crate::PolygonizeError::InvalidArgumentType {
+                field: "case_id".to_string(),
+                expected: "a nonempty lowercase fixture identifier".to_string(),
+                actual: case_id,
+            });
+        }
+        Ok(Self {
+            schema_version: PERSISTED_DIFFERENTIAL_FIXTURE_V1_SCHEMA_VERSION,
+            case_id,
+            classification,
+            golden,
+        })
+    }
+
+    pub fn to_pretty_json(&self) -> serde_json::Result<String> {
+        serde_json::to_string_pretty(self)
+    }
 }
 
 impl ReproBundleV1 {
@@ -353,5 +403,28 @@ mod tests {
         assert_eq!(json["witness"]["path"], "$.polygons");
         assert!(json["options"].is_object());
         assert!(json["fingerprint"].is_object());
+
+        let persisted = PersistedDifferentialFixtureV1::new(
+            "geos-microface-v1",
+            CompatibilityClassificationV1::ExpectedDivergence,
+            bundle,
+        )
+        .unwrap();
+        let persisted_json: serde_json::Value =
+            serde_json::from_str(&persisted.to_pretty_json().unwrap()).unwrap();
+        assert_eq!(persisted_json["schema_version"], 1);
+        assert_eq!(persisted_json["case_id"], "geos-microface-v1");
+        assert_eq!(persisted_json["classification"], "expected_divergence");
+        assert_eq!(
+            persisted_json["golden"]["input"][0]["line_id"],
+            "0x00000007"
+        );
+        assert_eq!(persisted_json["golden"]["witness"]["path"], "$.polygons");
+        assert!(PersistedDifferentialFixtureV1::new(
+            "Unsafe Name",
+            CompatibilityClassificationV1::InvalidAmbiguous,
+            persisted.golden,
+        )
+        .is_err());
     }
 }


### PR DESCRIPTION
## Stack

Parent:
- #1043

This PR:
- Export minimized repro bundles as strict compatibility-classified fixtures.

Children:
- not opened yet

## Delivered

- Add a versioned persisted differential fixture schema in Rust.
- Pair the complete exact repro bundle with expected-parity, expected-divergence, or invalid-ambiguous classification.
- Validate stable lowercase case IDs before serialization.
- Prove exact coordinate bits, source IDs, witness, fingerprint, options, versions, and reference metrics survive export without manual geometry rewriting.

## Contract impact

- Additive doc-hidden evidence API only; polygonization semantics and existing repro bundle V1 are unchanged.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo test -p geo-polygonize-core exports_an_exact_standalone_repro_bundle` — 1 passed
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings` — passed
- `git diff --check` — passed

## Agent handoff

Remaining:
- Fuzz and production mismatch producers still need to store each exported artifact in the checked-in strict corpus.
- The roadmap checkbox remains open until those producers enforce persistence.

Next dependency-ready slice:
- Add a strict persisted-differential corpus loader and require scheduled fuzz output to enter it before a novel mismatch can be closed.