### PR TITLE
test(core): seed persisted differential corpus

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -409,6 +409,10 @@ minimized failures no longer requires rewriting geometry: a versioned persisted
 fixture now pairs the exact repro bundle with a strict compatibility
 classification and validated stable case ID. Wiring every fuzz and production
 mismatch producer to store that artifact remains open.
+The strict persisted-differential corpus is now exercised in CI by decoding
+the exact IEEE-754 input, rerunning the recorded options, requiring byte-exact
+fingerprint equality, and checking compatibility-classification evidence. It is
+seeded with the existing documented floating-microfaces GEOS divergence.
 
 ### P1.5 Trace schema
 

--- a/crates/geo-polygonize-core/tests/persisted_differential.rs
+++ b/crates/geo-polygonize-core/tests/persisted_differential.rs
@@ -1,0 +1,114 @@
+use geo_polygonize_core::{polygonize, Coord3D, Line3D, PolygonizerOptions, TopologyFingerprintV1};
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+
+fn assert_keys(value: &Value, expected: &[&str]) {
+    let mut actual: Vec<_> = value
+        .as_object()
+        .unwrap()
+        .keys()
+        .map(String::as_str)
+        .collect();
+    actual.sort_unstable();
+    let mut expected = expected.to_vec();
+    expected.sort_unstable();
+    assert_eq!(actual, expected);
+}
+
+fn decode_bits(value: &Value) -> f64 {
+    let bits = value.as_str().unwrap().strip_prefix("0x").unwrap();
+    f64::from_bits(u64::from_str_radix(bits, 16).unwrap())
+}
+
+fn coordinate(value: &Value) -> Coord3D {
+    Coord3D::new(
+        decode_bits(&value["x"]),
+        decode_bits(&value["y"]),
+        decode_bits(&value["z"]),
+    )
+}
+
+#[test]
+fn persisted_differential_corpus_reproduces_strict_fingerprints() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../fixtures/differential");
+    let mut paths: Vec<_> = fs::read_dir(root)
+        .unwrap()
+        .map(|entry| entry.unwrap().path())
+        .filter(|path| {
+            path.extension()
+                .is_some_and(|extension| extension == "json")
+        })
+        .collect();
+    paths.sort();
+    assert!(
+        !paths.is_empty(),
+        "expected persisted differential fixtures"
+    );
+
+    for path in paths {
+        let fixture: Value = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        assert_keys(
+            &fixture,
+            &["case_id", "classification", "golden", "schema_version"],
+        );
+        assert_eq!(fixture["schema_version"], 1);
+        assert_eq!(
+            fixture["case_id"].as_str().unwrap(),
+            path.file_stem().unwrap().to_str().unwrap()
+        );
+        assert!(matches!(
+            fixture["classification"].as_str().unwrap(),
+            "expected_parity" | "expected_divergence" | "invalid_ambiguous"
+        ));
+
+        let golden = &fixture["golden"];
+        assert_keys(
+            golden,
+            &[
+                "fingerprint",
+                "input",
+                "options",
+                "reference_metrics",
+                "schema_version",
+                "versions",
+                "witness",
+            ],
+        );
+        assert_eq!(golden["schema_version"], 1);
+        let options: PolygonizerOptions =
+            serde_json::from_value(golden["options"].clone()).unwrap();
+        let lines: Vec<_> = golden["input"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|line| {
+                let line_id = line["line_id"]
+                    .as_str()
+                    .unwrap()
+                    .strip_prefix("0x")
+                    .unwrap();
+                Line3D::new(
+                    coordinate(&line["start"]),
+                    coordinate(&line["end"]),
+                    u32::from_str_radix(line_id, 16).unwrap(),
+                )
+            })
+            .collect();
+        let result = polygonize(lines, &options).unwrap();
+        let actual = TopologyFingerprintV1::try_from_result(&result, &options).unwrap();
+        assert_eq!(serde_json::to_value(actual).unwrap(), golden["fingerprint"]);
+        assert!(golden["versions"]
+            .as_object()
+            .is_some_and(|versions| !versions.is_empty()));
+        assert!(!golden["witness"]["path"].as_str().unwrap().is_empty());
+
+        if fixture["classification"] == "expected_divergence" {
+            let expected = &golden["reference_metrics"]["polygon_count"];
+            let actual = golden["fingerprint"]["polygons"].as_array().unwrap().len();
+            assert_ne!(expected, actual);
+            assert_eq!(&golden["witness"]["expected"], expected);
+            assert_eq!(golden["witness"]["actual"], actual);
+        }
+    }
+}

--- a/fixtures/differential/floating_microfaces_expected_divergence.json
+++ b/fixtures/differential/floating_microfaces_expected_divergence.json
@@ -1,0 +1,261 @@
+{
+  "schema_version": 1,
+  "case_id": "floating_microfaces_expected_divergence",
+  "classification": "expected_divergence",
+  "golden": {
+    "schema_version": 1,
+    "input": [
+      {
+        "start": {
+          "x": "0x4053800000000000",
+          "y": "0x4032000000000000",
+          "z": "0x0000000000000000"
+        },
+        "end": {
+          "x": "0x4045000000000000",
+          "y": "0x4042000000000000",
+          "z": "0x0000000000000000"
+        },
+        "line_id": "0x00000001"
+      },
+      {
+        "start": {
+          "x": "0x4044000000000000",
+          "y": "0x4042800000000000",
+          "z": "0x0000000000000000"
+        },
+        "end": {
+          "x": "0x4054000000000000",
+          "y": "0x4031000000000000",
+          "z": "0x0000000000000000"
+        },
+        "line_id": "0x00000002"
+      },
+      {
+        "start": {
+          "x": "0x404b800000000000",
+          "y": "0x4031000000000000",
+          "z": "0x0000000000000000"
+        },
+        "end": {
+          "x": "0x4056400000000000",
+          "y": "0x403b000000000000",
+          "z": "0x0000000000000000"
+        },
+        "line_id": "0x00000003"
+      }
+    ],
+    "options": {
+      "containment": {
+        "touch_policy": "AllowPointTouchDisallowEdgeShare"
+      },
+      "determinism": {
+        "canonical_ring_rotation": true,
+        "canonical_sort": true,
+        "stable_tie_breaks": true
+      },
+      "diagnostics": {
+        "enabled": false,
+        "report_mode": false,
+        "timings": false
+      },
+      "extract_only_polygonal": false,
+      "input_profile_id": null,
+      "node_input": true,
+      "noding": {
+        "backend": "Snap",
+        "guarantee": "Unchecked"
+      },
+      "output_filter": {
+        "minimum_face_area": null
+      },
+      "pre_snap_tolerance": 0.0,
+      "precision_model": {
+        "type": "floating"
+      },
+      "provenance": {
+        "enabled": false,
+        "include_boundary_line_ids": false
+      },
+      "snap_strategy": "Grid",
+      "z": {
+        "conflict_tolerance": 0.0,
+        "policy": "InterpolateAlongEdge"
+      }
+    },
+    "versions": {
+      "geo-polygonize-core": "0.76.2",
+      "reference": "Shapely 2.1.2 / GEOS 3.13.1"
+    },
+    "fingerprint": {
+      "schema_version": 1,
+      "options": {
+        "containment": {
+          "touch_policy": "AllowPointTouchDisallowEdgeShare"
+        },
+        "determinism": {
+          "canonical_ring_rotation": true,
+          "canonical_sort": true,
+          "stable_tie_breaks": true
+        },
+        "diagnostics": {
+          "enabled": false,
+          "report_mode": false,
+          "timings": false
+        },
+        "extract_only_polygonal": false,
+        "input_profile_id": null,
+        "node_input": true,
+        "noding": {
+          "backend": "Snap",
+          "guarantee": "Unchecked"
+        },
+        "output_filter": {
+          "minimum_face_area": null
+        },
+        "pre_snap_tolerance": 0.0,
+        "precision_model": {
+          "type": "floating"
+        },
+        "provenance": {
+          "enabled": false,
+          "include_boundary_line_ids": false
+        },
+        "snap_strategy": "Grid",
+        "z": {
+          "conflict_tolerance": 0.0,
+          "policy": "InterpolateAlongEdge"
+        }
+      },
+      "polygons": [
+        {
+          "exterior": [
+            {
+              "x": "0x4045000000000000",
+              "y": "0x4042000000000000",
+              "z": "0x0000000000000000"
+            },
+            {
+              "x": "0x4051af684bda12f6",
+              "y": "0x4035a12f684bda13",
+              "z": "0x0000000000000000"
+            },
+            {
+              "x": "0x4051af684bda12f7",
+              "y": "0x4035a12f684bda13",
+              "z": "0x0000000000000000"
+            },
+            {
+              "x": "0x4045000000000000",
+              "y": "0x4042000000000000",
+              "z": "0x0000000000000000"
+            }
+          ],
+          "interiors": [],
+          "exterior_edge_ids": [
+            "0x00000001",
+            "0x00000003",
+            "0x00000002"
+          ],
+          "provenance": null
+        },
+        {
+          "exterior": [
+            {
+              "x": "0x4051af684bda12f6",
+              "y": "0x4035a12f684bda13",
+              "z": "0x0000000000000000"
+            },
+            {
+              "x": "0x4053800000000000",
+              "y": "0x4032000000000000",
+              "z": "0x0000000000000000"
+            },
+            {
+              "x": "0x4051af684bda12f7",
+              "y": "0x4035a12f684bda13",
+              "z": "0x0000000000000000"
+            },
+            {
+              "x": "0x4051af684bda12f6",
+              "y": "0x4035a12f684bda13",
+              "z": "0x0000000000000000"
+            }
+          ],
+          "interiors": [],
+          "exterior_edge_ids": [
+            "0x00000001",
+            "0x00000002",
+            "0x00000003"
+          ],
+          "provenance": null
+        }
+      ],
+      "dangles": [
+        [
+          {
+            "x": "0x4044000000000000",
+            "y": "0x4042800000000000",
+            "z": "0x0000000000000000"
+          },
+          {
+            "x": "0x4045000000000000",
+            "y": "0x4042000000000000",
+            "z": "0x0000000000000000"
+          }
+        ],
+        [
+          {
+            "x": "0x404b800000000000",
+            "y": "0x4031000000000000",
+            "z": "0x0000000000000000"
+          },
+          {
+            "x": "0x4051af684bda12f6",
+            "y": "0x4035a12f684bda13",
+            "z": "0x0000000000000000"
+          }
+        ],
+        [
+          {
+            "x": "0x4051af684bda12f7",
+            "y": "0x4035a12f684bda13",
+            "z": "0x0000000000000000"
+          },
+          {
+            "x": "0x4056400000000000",
+            "y": "0x403b000000000000",
+            "z": "0x0000000000000000"
+          }
+        ],
+        [
+          {
+            "x": "0x4053800000000000",
+            "y": "0x4032000000000000",
+            "z": "0x0000000000000000"
+          },
+          {
+            "x": "0x4054000000000000",
+            "y": "0x4031000000000000",
+            "z": "0x0000000000000000"
+          }
+        ]
+      ],
+      "cut_edges": [],
+      "invalid_rings": [],
+      "diagnostics": null
+    },
+    "reference_metrics": {
+      "polygon_count": 0,
+      "dangle_count": 0,
+      "cut_edge_count": 0,
+      "invalid_ring_count": 0,
+      "total_area": "0x0000000000000000"
+    },
+    "witness": {
+      "path": "$.polygons.length",
+      "expected": 0,
+      "actual": 2
+    }
+  }
+}


### PR DESCRIPTION
## Stack

Parent:
- #1044 (merged)

This PR:
- Seed and enforce the strict persisted differential corpus.

Children:\n- #1046

## Delivered

- Persist the existing documented floating-microfaces Shapely/GEOS divergence as an exact V1 differential fixture.
- Decode IEEE-754 input bits, rerun recorded options, and require exact topology fingerprint equality.
- Reject unknown/missing envelope fields and require stable case ID/file identity.
- Verify compatibility classification, reference metrics, versions, and witness counts remain internally consistent.

## Contract impact

- Test/evidence only; polygonization semantics and existing compatibility fixtures are unchanged.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo test -p geo-polygonize-core --test persisted_differential` — 1 passed
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings` — passed
- `git diff --check` — passed

## Agent handoff

Remaining:
- Fuzz and production mismatch producers must automatically place novel minimized exports into this corpus.
- The roadmap persistence checkbox remains open until that ingestion path is enforced.

Next dependency-ready slice:
- Add scheduled differential-fuzz artifact ingestion validation and a fail-closed corpus admission command.