### PR TITLE
test(core): admit persisted differential fixtures

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -415,8 +415,9 @@ fingerprint equality, and checking compatibility-classification evidence. It is
 seeded with the existing documented floating-microfaces GEOS divergence.
 Scheduled fuzzing now compares one-shot and reusable-workspace fingerprints or
 normalized errors, runs the persisted corpus before fuzzing, and retains
-libFuzzer failure artifacts for admission. Converting those raw minimized bytes
-into checked-in persisted fixtures remains a reviewed step.
+libFuzzer failure artifacts for admission. The reviewed admission command now
+validates a candidate with the strict Rust corpus runner before exclusively
+creating its case-ID-named JSON file; existing fixtures cannot be overwritten.
 
 ### P1.5 Trace schema
 

--- a/crates/geo-polygonize-core/tests/persisted_differential.rs
+++ b/crates/geo-polygonize-core/tests/persisted_differential.rs
@@ -40,6 +40,9 @@ fn persisted_differential_corpus_reproduces_strict_fingerprints() {
                 .is_some_and(|extension| extension == "json")
         })
         .collect();
+    if let Some(candidate) = std::env::var_os("PERSISTED_DIFFERENTIAL_CANDIDATE") {
+        paths.push(candidate.into());
+    }
     paths.sort();
     assert!(
         !paths.is_empty(),

--- a/scripts/admit_differential_fixture.py
+++ b/scripts/admit_differential_fixture.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Validate a persisted differential fixture before admitting it to the corpus."""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CASE_ID = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("candidate", type=Path)
+    parser.add_argument("--output-dir", type=Path, default=ROOT / "fixtures/differential")
+    parser.add_argument("--check-only", action="store_true")
+    args = parser.parse_args()
+
+    candidate = args.candidate.resolve(strict=True)
+    payload = json.loads(candidate.read_text())
+    case_id = payload.get("case_id", "")
+    if not CASE_ID.fullmatch(case_id):
+        raise SystemExit("candidate has an invalid case_id")
+
+    env = os.environ.copy()
+    env["PERSISTED_DIFFERENTIAL_CANDIDATE"] = str(candidate)
+    subprocess.run(
+        ["cargo", "test", "-p", "geo-polygonize-core", "--test", "persisted_differential"],
+        cwd=ROOT,
+        env=env,
+        check=True,
+    )
+    if args.check_only:
+        return
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    destination = args.output_dir / f"{case_id}.json"
+    with destination.open("x") as output:
+        json.dump(payload, output, indent=2, allow_nan=False)
+        output.write("\n")
+    print(destination)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Stack

Parent:
- #1046 (merged)

This PR:
- Add fail-closed admission for reviewed persisted differential fixtures.

Children:
- not opened yet

## Delivered

- Let the strict Rust corpus test validate an explicit candidate before admission.
- Add a case-ID-validated admission command with check-only mode.
- Write accepted fixtures only after validation and use exclusive creation to prevent overwriting evidence.
- Document the reviewed raw-fuzz-artifact admission boundary.

## Contract impact

- Test/tooling only; polygonization semantics remain unchanged.

## Validation

- `cargo fmt --all -- --check` — passed
- `python3 -m py_compile scripts/admit_differential_fixture.py` — passed
- `python3 scripts/admit_differential_fixture.py fixtures/differential/floating_microfaces_expected_divergence.json --check-only` — passed
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings` — passed
- `git diff --check` — passed

## Agent handoff

Remaining:
- Raw libFuzzer bytes still require reviewed decoding/minimization into a persisted V1 candidate.
- Automatic repository writes remain intentionally disabled.

Next dependency-ready slice:
- Add a deterministic raw-fuzz decoder that emits a reviewable persisted-fixture candidate without admitting it automatically.