### PR TITLE
docs(wasm): add playground navigation

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -468,7 +468,7 @@ evidence from their shared physical split loop.
 
 ### P1.6 Turn the playground into a topology debugger
 
-- [ ] Add the playground prominently to the docs navigation.
+- [x] Add the playground prominently to the docs navigation.
 - [ ] Support paste, upload, drag-and-drop, drawing, and fixture selection.
 - [ ] Expose the canonical options schema, including `Validate` and
   `CertifiedFixedPrecision`.

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
   themeConfig: {
     nav: [
       { text: 'Home', link: '/' },
+      { text: 'Playground', link: '/playground/' },
       { text: 'Guide', link: '/guide/getting-started' },
       { text: 'Reference', link: '/reference/' },
       { text: 'Examples', link: '/examples/' }

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,4 +12,7 @@ hero:
     - theme: alt
       text: Reference
       link: /reference/
+    - theme: alt
+      text: Playground
+      link: /playground/
 ---


### PR DESCRIPTION
## Stack

Parent:
- #1047 (merged)

This PR:
- Link the deployed playground from the global documentation navigation and homepage hero.

Children:
- #1049

## Delivered

- Added a global Playground navigation entry.
- Added a homepage Playground action.
- Marked the precise P1.6 navigation item complete.

## Contract impact

- Documentation-only discoverability change; no runtime or schema behavior changes.

## Validation

- `npm test` — passed, 19 tests.
- `npm run docs:build` — passed; existing MUI directive, bundle-size, audit, and deferred Wasm URL warnings remain.
- `git diff --check` — passed.

## Agent handoff

Remaining:
- The remaining P1.6 topology-debugger capabilities, beginning with input ingestion.

Next dependency-ready slice:
- #1049 adds paste, upload, and drag-and-drop to the existing fixture selection flow.
