### PR TITLE
feat(wasm): add playground GeoJSON ingestion

### DIFF
--- a/playground/src/input.test.ts
+++ b/playground/src/input.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { parseGeojsonInput } from './input';
+
+describe('parseGeojsonInput', () => {
+  it('normalizes geometry and feature roots for the playground', () => {
+    const geometry = parseGeojsonInput('{"type":"LineString","coordinates":[[0,0],[1,1]]}');
+    const feature = parseGeojsonInput('{"type":"Feature","properties":null,"geometry":null}');
+
+    expect(geometry.features).toHaveLength(1);
+    expect(feature.features).toHaveLength(1);
+  });
+
+  it('rejects malformed feature collections', () => {
+    expect(() => parseGeojsonInput('{"type":"FeatureCollection"}')).toThrow(
+      'FeatureCollection.features must be an array',
+    );
+  });
+});

--- a/playground/src/input.ts
+++ b/playground/src/input.ts
@@ -1,0 +1,30 @@
+type GeoJsonObject = Record<string, unknown>;
+
+function isObject(value: unknown): value is GeoJsonObject {
+  return typeof value === 'object' && value !== null;
+}
+
+export function parseGeojsonInput(text: string): GeoJsonObject {
+  const value: unknown = JSON.parse(text);
+  if (!isObject(value)) throw new Error('GeoJSON must be an object');
+
+  if (value.type === 'FeatureCollection') {
+    if (!Array.isArray(value.features)) {
+      throw new Error('FeatureCollection.features must be an array');
+    }
+    return value;
+  }
+
+  if (value.type === 'Feature') {
+    return { type: 'FeatureCollection', features: [value] };
+  }
+
+  if (typeof value.type === 'string') {
+    return {
+      type: 'FeatureCollection',
+      features: [{ type: 'Feature', properties: null, geometry: value }],
+    };
+  }
+
+  throw new Error('GeoJSON object is missing a type');
+}

--- a/playground/src/main.tsx
+++ b/playground/src/main.tsx
@@ -15,11 +15,13 @@ import {
   Switch,
   FormControlLabel,
   TextField,
+  Button,
   Box,
   Paper,
   Grid,
   Alert
 } from '@mui/material';
+import { parseGeojsonInput } from './input';
 
 // --- Types ---
 interface ManifestEntry {
@@ -102,6 +104,7 @@ function App() {
   const [selectedSlug, setSelectedSlug] = useState<string>('');
   const [wasmReady, setWasmReady] = useState(false);
   const [inputGeojson, setInputGeojson] = useState<any>(null);
+  const [inputText, setInputText] = useState('');
   const [outputGeojson, setOutputGeojson] = useState<any>(null);
   const [report, setReport] = useState<TopologyFingerprintV1 | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -200,12 +203,37 @@ function App() {
         }
         if (!data) throw new Error("Could not load fixture");
         setInputGeojson(data);
+        setInputText(JSON.stringify(data, null, 2));
       } catch (e: any) {
         setError("Failed to load fixture: " + e.toString());
       }
     }
     loadFixture();
   }, [selectedSlug, manifest]);
+
+  const applyInput = (text: string) => {
+    try {
+      const data = parseGeojsonInput(text);
+      setInputGeojson(data);
+      setInputText(JSON.stringify(data, null, 2));
+      setSelectedSlug('');
+      const url = new URL(window.location.href);
+      url.searchParams.delete('scenario');
+      window.history.replaceState({}, '', url.toString());
+      setError(null);
+    } catch (e) {
+      setError(`Input Error: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  };
+
+  const loadFile = async (file?: File) => {
+    if (!file) return;
+    try {
+      applyInput(await file.text());
+    } catch (e) {
+      setError(`Input Error: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  };
 
   // Run Polygonizer
   useEffect(() => {
@@ -249,7 +277,7 @@ function App() {
 
       <Grid container spacing={3}>
         {/* Controls */}
-        <Grid item xs={12} md={4}>
+        <Grid size={{ xs: 12, md: 4 }}>
           <Paper sx={{ p: 2 }}>
             <FormControl fullWidth sx={{ mb: 3 }}>
               <InputLabel id="scenario-label">Scenario</InputLabel>
@@ -265,11 +293,51 @@ function App() {
                   window.history.replaceState({}, '', url.toString());
                 }}
               >
+                <MenuItem value="" disabled>Custom input</MenuItem>
                 {manifest.map(m => (
                   <MenuItem key={m.slug} value={m.slug}>{m.title}</MenuItem>
                 ))}
               </Select>
             </FormControl>
+
+            <Typography variant="h6" gutterBottom>Input GeoJSON</Typography>
+            <Box
+              onDragOver={(event) => {
+                event.preventDefault();
+                event.dataTransfer.dropEffect = 'copy';
+              }}
+              onDrop={(event) => {
+                event.preventDefault();
+                void loadFile(event.dataTransfer.files[0]);
+              }}
+              sx={{ mb: 3, p: 1.5, border: '1px dashed', borderColor: 'divider' }}
+            >
+              <TextField
+                fullWidth
+                multiline
+                minRows={6}
+                label="Paste GeoJSON"
+                value={inputText}
+                onChange={(event) => setInputText(event.target.value)}
+              />
+              <Box sx={{ display: 'flex', gap: 1, mt: 1 }}>
+                <Button variant="contained" onClick={() => applyInput(inputText)}>
+                  Apply
+                </Button>
+                <Button component="label" variant="outlined">
+                  Upload
+                  <input
+                    hidden
+                    type="file"
+                    accept=".geojson,.json,application/geo+json,application/json"
+                    onChange={(event) => void loadFile(event.target.files?.[0])}
+                  />
+                </Button>
+              </Box>
+              <Typography variant="caption" color="text.secondary">
+                Paste, upload, or drop a GeoJSON file here.
+              </Typography>
+            </Box>
 
             <Typography variant="h6" gutterBottom>Options</Typography>
             <FormControlLabel
@@ -303,7 +371,7 @@ function App() {
         </Grid>
 
         {/* Visualizer */}
-        <Grid item xs={12} md={8}>
+        <Grid size={{ xs: 12, md: 8 }}>
           <Paper sx={{ p: 2, height: '600px', display: 'flex', flexDirection: 'column' }}>
             <Typography variant="h6" gutterBottom>Geometry View</Typography>
             {bbox && (


### PR DESCRIPTION
## Stack

Parent:
- #1048

This PR:
- Add custom GeoJSON paste, upload, and drag-and-drop paths beside the existing fixture selector.

Children:
- #1050

## Delivered

- Normalized GeoJSON geometry, feature, and feature-collection roots for the playground.
- Added paste/apply, native file upload, and drag-and-drop controls.
- Kept fixture selection and custom-input URL state deterministic.
- Updated stale MUI Grid props so the modified app passes a direct TypeScript check.

## Contract impact

- Additive playground-only input paths; polygonization options, output, provenance, and fingerprint schemas are unchanged.
- Malformed feature collections fail before entering Wasm with a stable input error.

## Validation

- `npm test` — passed, 21 tests.
- `cd playground && npm run build` — passed; existing MUI directive, bundle-size, and deferred Wasm URL warnings remain.
- `npx tsc --noEmit --jsx react-jsx --moduleResolution node --module esnext --target esnext --esModuleInterop --skipLibCheck playground/src/main.tsx playground/src/input.ts` — passed.
- `git diff --check` — passed.

## Agent handoff

Remaining:
- Drawing support is supplied by child #1050 before the combined P1.6 input-mode roadmap item is complete.

Next dependency-ready slice:
- #1050 adds pointer-based line drawing through the same normalized GeoJSON input representation.
