### PR TITLE
feat(wasm): draw playground linework

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -469,7 +469,7 @@ evidence from their shared physical split loop.
 ### P1.6 Turn the playground into a topology debugger
 
 - [x] Add the playground prominently to the docs navigation.
-- [ ] Support paste, upload, drag-and-drop, drawing, and fixture selection.
+- [x] Support paste, upload, drag-and-drop, drawing, and fixture selection.
 - [ ] Expose the canonical options schema, including `Validate` and
   `CertifiedFixedPrecision`.
 - [ ] Add layer toggles for raw lines, snapped lines, hot pixels, split points,

--- a/playground/src/input.test.ts
+++ b/playground/src/input.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { parseGeojsonInput } from './input';
+import { appendLineString, parseGeojsonInput } from './input';
 
 describe('parseGeojsonInput', () => {
   it('normalizes geometry and feature roots for the playground', () => {
@@ -14,5 +14,13 @@ describe('parseGeojsonInput', () => {
     expect(() => parseGeojsonInput('{"type":"FeatureCollection"}')).toThrow(
       'FeatureCollection.features must be an array',
     );
+  });
+
+  it('appends drawn linework without mutating the input', () => {
+    const input = parseGeojsonInput('{"type":"FeatureCollection","features":[]}');
+    const output = appendLineString(input, [[0, 0], [1, 1]]);
+
+    expect(input.features).toHaveLength(0);
+    expect(output.features).toHaveLength(1);
   });
 });

--- a/playground/src/input.ts
+++ b/playground/src/input.ts
@@ -28,3 +28,25 @@ export function parseGeojsonInput(text: string): GeoJsonObject {
 
   throw new Error('GeoJSON object is missing a type');
 }
+
+export function appendLineString(
+  collection: GeoJsonObject,
+  coordinates: number[][],
+): GeoJsonObject {
+  if (!Array.isArray(collection.features)) {
+    throw new Error('Drawing requires a FeatureCollection');
+  }
+  if (coordinates.length < 2) return collection;
+
+  return {
+    ...collection,
+    features: [
+      ...collection.features,
+      {
+        type: 'Feature',
+        properties: null,
+        geometry: { type: 'LineString', coordinates },
+      },
+    ],
+  };
+}

--- a/playground/src/main.tsx
+++ b/playground/src/main.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useRef } from 'react';
 import ReactDOM from 'react-dom/client';
 import init, {
   polygonizeReportWithOptions,
@@ -21,7 +21,7 @@ import {
   Grid,
   Alert
 } from '@mui/material';
-import { parseGeojsonInput } from './input';
+import { appendLineString, parseGeojsonInput } from './input';
 
 // --- Types ---
 interface ManifestEntry {
@@ -108,6 +108,10 @@ function App() {
   const [outputGeojson, setOutputGeojson] = useState<any>(null);
   const [report, setReport] = useState<TopologyFingerprintV1 | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [drawEnabled, setDrawEnabled] = useState(false);
+  const [drawnPoints, setDrawnPoints] = useState<number[][]>([]);
+  const drawnPointsRef = useRef<number[][]>([]);
+  const svgRef = useRef<SVGSVGElement>(null);
 
   // Options
   const [nodeInput, setNodeInput] = useState(false);
@@ -211,16 +215,19 @@ function App() {
     loadFixture();
   }, [selectedSlug, manifest]);
 
+  const setCustomInput = (data: Record<string, unknown>) => {
+    setInputGeojson(data);
+    setInputText(JSON.stringify(data, null, 2));
+    setSelectedSlug('');
+    const url = new URL(window.location.href);
+    url.searchParams.delete('scenario');
+    window.history.replaceState({}, '', url.toString());
+    setError(null);
+  };
+
   const applyInput = (text: string) => {
     try {
-      const data = parseGeojsonInput(text);
-      setInputGeojson(data);
-      setInputText(JSON.stringify(data, null, 2));
-      setSelectedSlug('');
-      const url = new URL(window.location.href);
-      url.searchParams.delete('scenario');
-      window.history.replaceState({}, '', url.toString());
-      setError(null);
+      setCustomInput(parseGeojsonInput(text));
     } catch (e) {
       setError(`Input Error: ${e instanceof Error ? e.message : String(e)}`);
     }
@@ -233,6 +240,37 @@ function App() {
     } catch (e) {
       setError(`Input Error: ${e instanceof Error ? e.message : String(e)}`);
     }
+  };
+
+  const pointerCoordinate = (event: React.PointerEvent<SVGSVGElement>) => {
+    const svg = svgRef.current;
+    const matrix = svg?.getScreenCTM();
+    if (!svg || !matrix) return null;
+    const point = svg.createSVGPoint();
+    point.x = event.clientX;
+    point.y = event.clientY;
+    const local = point.matrixTransform(matrix.inverse());
+    return [local.x, local.y];
+  };
+
+  const updateDrawnPoints = (points: number[][]) => {
+    drawnPointsRef.current = points;
+    setDrawnPoints(points);
+  };
+
+  const finishDrawing = (event: React.PointerEvent<SVGSVGElement>) => {
+    if (!drawEnabled) return;
+    const point = pointerCoordinate(event);
+    const previous = drawnPointsRef.current.at(-1);
+    const points = point && previous
+      && Math.hypot(point[0] - previous[0], point[1] - previous[1])
+        >= (bbox?.width ?? 1) * 0.002
+      ? [...drawnPointsRef.current, point]
+      : drawnPointsRef.current;
+    if (inputGeojson && points.length >= 2) {
+      setCustomInput(appendLineString(inputGeojson, points));
+    }
+    updateDrawnPoints([]);
   };
 
   // Run Polygonizer
@@ -333,9 +371,19 @@ function App() {
                     onChange={(event) => void loadFile(event.target.files?.[0])}
                   />
                 </Button>
+                <Button
+                  variant={drawEnabled ? 'contained' : 'outlined'}
+                  disabled={!bbox}
+                  onClick={() => {
+                    setDrawEnabled((enabled) => !enabled);
+                    updateDrawnPoints([]);
+                  }}
+                >
+                  {drawEnabled ? 'Stop drawing' : 'Draw line'}
+                </Button>
               </Box>
               <Typography variant="caption" color="text.secondary">
-                Paste, upload, or drop a GeoJSON file here.
+                Paste, upload, or drop GeoJSON, or drag across the geometry view to draw a line.
               </Typography>
             </Box>
 
@@ -377,11 +425,36 @@ function App() {
             {bbox && (
                <Box sx={{ flexGrow: 1, border: '1px solid #ccc', position: 'relative', overflow: 'hidden' }}>
                   <svg
+                    ref={svgRef}
                     width="100%"
                     height="100%"
                     viewBox={`${bbox.minX} ${bbox.minY} ${bbox.width} ${bbox.height}`}
                     preserveAspectRatio="xMidYMid meet"
-                    style={{ transform: 'scaleY(-1)' }} // Invert Y axis for standard Cartesian coords
+                    onPointerDown={(event) => {
+                      if (!drawEnabled) return;
+                      event.preventDefault();
+                      const point = pointerCoordinate(event);
+                      if (!point) return;
+                      event.currentTarget.setPointerCapture(event.pointerId);
+                      updateDrawnPoints([point]);
+                    }}
+                    onPointerMove={(event) => {
+                      if (!drawEnabled || drawnPointsRef.current.length === 0) return;
+                      const point = pointerCoordinate(event);
+                      if (!point) return;
+                      const previous = drawnPointsRef.current.at(-1)!;
+                      const minimumDistance = bbox.width * 0.002;
+                      if (Math.hypot(point[0] - previous[0], point[1] - previous[1]) >= minimumDistance) {
+                        updateDrawnPoints([...drawnPointsRef.current, point]);
+                      }
+                    }}
+                    onPointerUp={finishDrawing}
+                    onPointerCancel={() => updateDrawnPoints([])}
+                    style={{
+                      transform: 'scaleY(-1)',
+                      cursor: drawEnabled ? 'crosshair' : 'default',
+                      touchAction: drawEnabled ? 'none' : 'auto',
+                    }} // Invert Y axis for standard Cartesian coords
                   >
                      {/* Draw Output Polygons (filled) */}
                      {outputGeojson?.features.map((f: any, i: number) => {
@@ -406,6 +479,15 @@ function App() {
                         }
                         return null;
                      })}
+
+                     {drawnPoints.length > 1 && (
+                       <polyline
+                         points={drawnPoints.map((point) => point.join(',')).join(' ')}
+                         fill="none"
+                         stroke="#7b1fa2"
+                         strokeWidth={bbox.width * 0.004}
+                       />
+                     )}
                   </svg>
                </Box>
             )}


### PR DESCRIPTION
## Stack

Parent:
- #1049

This PR:
- Add native pointer drawing to the playground geometry view.

Children:
- #1051

## Delivered

- Added an explicit drawing mode with pointer capture and live stroke preview.
- Converted completed strokes into immutable GeoJSON LineString features through the existing custom-input path.
- Ignored zero-length click strokes and bounded sampling by view width.
- Marked the combined P1.6 paste/upload/drop/draw/fixture item complete.

## Contract impact

- Additive playground-only editing behavior; the core polygonization and fingerprint contracts are unchanged.
- Drawn linework uses the same normalized FeatureCollection representation as uploaded and pasted input.

## Validation

- `npm test` — passed, 22 tests.
- `cd playground && npm run build` — passed; existing MUI directive, bundle-size, and deferred Wasm URL warnings remain.
- `npx tsc --noEmit --jsx react-jsx --moduleResolution node --module esnext --target esnext --esModuleInterop --skipLibCheck playground/src/main.tsx playground/src/input.ts` — passed.
- `git diff --check` — passed.

## Agent handoff

Remaining:
- The playground still exposes only legacy noding controls, not the canonical options schema and certified validation profiles.

Next dependency-ready slice:
- #1051 adds canonical Validate and CertifiedFixedPrecision controls plus resolved option inspection.
