### PR TITLE
feat(wasm): expose canonical noding profiles

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -470,7 +470,7 @@ evidence from their shared physical split loop.
 
 - [x] Add the playground prominently to the docs navigation.
 - [x] Support paste, upload, drag-and-drop, drawing, and fixture selection.
-- [ ] Expose the canonical options schema, including `Validate` and
+- [x] Expose the canonical options schema, including `Validate` and
   `CertifiedFixedPrecision`.
 - [ ] Add layer toggles for raw lines, snapped lines, hot pixels, split points,
   graph edges, dangles, cut edges, invalid rings, shells, holes, and final faces.

--- a/playground/src/main.tsx
+++ b/playground/src/main.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useMemo, useRef } from 'react';
 import ReactDOM from 'react-dom/client';
 import init, {
   polygonizeReportWithOptions,
+  type NodingGuarantee,
   type PolygonizerOptions,
   type TopologyFingerprintV1,
 } from 'geo-polygonize';
@@ -22,6 +23,7 @@ import {
   Alert
 } from '@mui/material';
 import { appendLineString, parseGeojsonInput } from './input';
+import { buildPlaygroundOptions } from './options';
 
 // --- Types ---
 interface ManifestEntry {
@@ -116,6 +118,7 @@ function App() {
   // Options
   const [nodeInput, setNodeInput] = useState(false);
   const [snapGridSize, setSnapGridSize] = useState(0.0);
+  const [nodingGuarantee, setNodingGuarantee] = useState<NodingGuarantee>('Unchecked');
 
   // Initialize WASM and fetch manifest
   useEffect(() => {
@@ -175,6 +178,7 @@ function App() {
     if (!entry) return;
 
     setNodeInput(entry.defaultOptions.node_input);
+    setNodingGuarantee('Unchecked');
     setSnapGridSize(
       entry.defaultOptions.precision_model.type === 'fixed_grid'
         ? entry.defaultOptions.precision_model.grid_size
@@ -277,13 +281,11 @@ function App() {
   useEffect(() => {
     if (!wasmReady || !inputGeojson) return;
     try {
-      const options: Partial<PolygonizerOptions> = {
-        node_input: nodeInput,
-        precision_model:
-          nodeInput && snapGridSize !== 0
-            ? { type: 'fixed_grid', grid_size: snapGridSize }
-            : { type: 'floating' },
-      };
+      const options: Partial<PolygonizerOptions> = buildPlaygroundOptions(
+        nodeInput,
+        snapGridSize,
+        nodingGuarantee,
+      );
       const nextReport = JSON.parse(
         polygonizeReportWithOptions(JSON.stringify(inputGeojson), options),
       ) as TopologyFingerprintV1;
@@ -295,7 +297,7 @@ function App() {
       setReport(null);
       setError("Polygonize Error: " + e.toString());
     }
-  }, [wasmReady, inputGeojson, nodeInput, snapGridSize]);
+  }, [wasmReady, inputGeojson, nodeInput, snapGridSize, nodingGuarantee]);
 
 
   // SVG Viewport calculation
@@ -389,9 +391,35 @@ function App() {
 
             <Typography variant="h6" gutterBottom>Options</Typography>
             <FormControlLabel
-              control={<Switch checked={nodeInput} onChange={(e) => setNodeInput(e.target.checked)} />}
-              label="Node Input (Unchecked Iterative Noding)"
+              control={(
+                <Switch
+                  checked={nodeInput}
+                  disabled={nodingGuarantee === 'CertifiedFixedPrecision'}
+                  onChange={(e) => setNodeInput(e.target.checked)}
+                />
+              )}
+              label="Node input"
             />
+            <FormControl fullWidth sx={{ mt: 2 }}>
+              <InputLabel id="noding-guarantee-label">Noding guarantee</InputLabel>
+              <Select
+                labelId="noding-guarantee-label"
+                label="Noding guarantee"
+                value={nodingGuarantee}
+                onChange={(event) => {
+                  const guarantee = event.target.value as NodingGuarantee;
+                  setNodingGuarantee(guarantee);
+                  if (guarantee === 'CertifiedFixedPrecision') {
+                    setNodeInput(true);
+                    if (snapGridSize <= 0) setSnapGridSize(0.001);
+                  }
+                }}
+              >
+                <MenuItem value="Unchecked">Unchecked</MenuItem>
+                <MenuItem value="Validate">Validate</MenuItem>
+                <MenuItem value="CertifiedFixedPrecision">Certified fixed precision</MenuItem>
+              </Select>
+            </FormControl>
             <TextField
               fullWidth
               label="Snap Grid Size"
@@ -403,7 +431,8 @@ function App() {
               disabled={!nodeInput}
             />
             <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
-              Enable Node Input for dirty geometries. Snap Grid Size controls the snapping precision.
+              Enable noding for dirty geometries, then choose unchecked, independently validated,
+              or certified fixed-precision output.
             </Typography>
           </Paper>
 
@@ -414,6 +443,15 @@ function App() {
                <Typography>Dangles: {report.dangles.length}</Typography>
                <Typography>Cut edges: {report.cut_edges.length}</Typography>
                <Typography>Invalid rings: {report.invalid_rings.length}</Typography>
+               <TextField
+                 fullWidth
+                 multiline
+                 minRows={6}
+                 label="Resolved canonical options"
+                 value={JSON.stringify(report.options, null, 2)}
+                 InputProps={{ readOnly: true }}
+                 sx={{ mt: 2 }}
+               />
             </Paper>
           )}
         </Grid>

--- a/playground/src/options.test.ts
+++ b/playground/src/options.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { buildPlaygroundOptions } from './options';
+
+describe('buildPlaygroundOptions', () => {
+  it('selects independent validation for floating noding', () => {
+    expect(buildPlaygroundOptions(true, 0, 'Validate')).toMatchObject({
+      node_input: true,
+      precision_model: { type: 'floating' },
+      noding: { backend: 'Snap', guarantee: 'Validate' },
+    });
+  });
+
+  it('enforces the certified fixed-precision prerequisites', () => {
+    expect(buildPlaygroundOptions(false, 0.1, 'CertifiedFixedPrecision')).toMatchObject({
+      node_input: true,
+      precision_model: { type: 'fixed_grid', grid_size: 0.1 },
+      snap_strategy: 'Grid',
+    });
+  });
+});

--- a/playground/src/options.ts
+++ b/playground/src/options.ts
@@ -1,0 +1,17 @@
+import type { NodingGuarantee, PolygonizerOptions } from 'geo-polygonize';
+
+export function buildPlaygroundOptions(
+  nodeInput: boolean,
+  snapGridSize: number,
+  guarantee: NodingGuarantee,
+): Partial<PolygonizerOptions> {
+  const certified = guarantee === 'CertifiedFixedPrecision';
+  return {
+    node_input: certified || nodeInput,
+    precision_model: certified || (nodeInput && snapGridSize > 0)
+      ? { type: 'fixed_grid', grid_size: snapGridSize }
+      : { type: 'floating' },
+    snap_strategy: 'Grid',
+    noding: { backend: 'Snap', guarantee },
+  };
+}


### PR DESCRIPTION
## Stack

Parent:
- #1050

This PR:
- Expose canonical noding guarantees and resolved options in the playground.

Children:
- #1052

## Delivered

- Added Unchecked, Validate, and CertifiedFixedPrecision selectors using the exported canonical types.
- Enforced the certified profile's node-input, fixed-grid, Snap backend, and Grid strategy prerequisites.
- Displayed the full resolved canonical options returned by the topology report.
- Marked the precise P1.6 canonical-options item complete.

## Contract impact

- Additive playground controls only; options are passed through the existing canonical Wasm API.
- No semantic option, schema, fingerprint, provenance, or Z default changed.

## Validation

- `npm test` — passed, 24 tests.
- `cd playground && npm run build` — passed; existing MUI directive, bundle-size, and deferred Wasm URL warnings remain.
- `npx tsc --noEmit --jsx react-jsx --moduleResolution node --module esnext --target esnext --esModuleInterop --skipLibCheck playground/src/main.tsx playground/src/input.ts playground/src/options.ts` — passed.
- `git diff --check` — passed.

## Agent handoff

Remaining:
- The geometry view does not yet expose debugger layer toggles for intermediate topology stages.

Next dependency-ready slice:
- #1052 adds every input/report-backed layer toggle and records the remaining browser-trace dependency.
