### PR TITLE
feat(wasm): expose bounded topology traces

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -464,7 +464,9 @@ result. Global-line fallback scans emit the same exact candidate evidence with
 an explicit scan origin. Certified replacement segments additionally retain
 their source segment, source ID, and exact emitted endpoints from the physical
 split loop. Floating SIMD and uniform-grid noding now record the same replacement
-evidence from their shared physical split loop.
+evidence from their shared physical split loop. Wasm now exposes the same
+bounded trace and canonical topology report through a dedicated non-semantic
+entrypoint so browser tooling does not reconstruct pipeline evidence.
 
 ### P1.6 Turn the playground into a topology debugger
 

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -757,6 +757,23 @@ impl Polygonizer {
         self.polygonize_owned(self.input_lines.clone())
     }
 
+    /// Computes polygons while recording a bounded topology trace.
+    #[doc(hidden)]
+    pub fn polygonize_with_trace(
+        &mut self,
+        level: TraceLevelV1,
+        byte_limit: usize,
+    ) -> Result<TracedPolygonizerResultV1> {
+        self.trace = TraceRecorderV1::new(Some(level), byte_limit, &self.options);
+        let result = self.polygonize_owned(self.input_lines.clone());
+        let trace = self
+            .trace
+            .take()
+            .expect("enabled trace recorder exists")
+            .finish();
+        result.map(|result| TracedPolygonizerResultV1 { result, trace })
+    }
+
     fn polygonize_owned(&mut self, input_lines: Vec<Line3D>) -> Result<PolygonizerResult> {
         self.options.validate()?;
         self.execution_policy.check_cancelled("ingest")?;

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -1055,6 +1055,26 @@ mod tests {
     }
 
     #[test]
+    fn polygonizer_builder_records_its_collected_input_with_a_bound() {
+        let options = PolygonizerOptions::default();
+        let mut polygonizer = crate::Polygonizer::with_options(options);
+        polygonizer.add_lines(vec![Line3D::new(
+            Coord3D::new(0.0, 0.0, 0.0),
+            Coord3D::new(1.0, 0.0, 0.0),
+            7,
+        )]);
+
+        let traced = polygonizer
+            .polygonize_with_trace(TraceLevelV1::Full, 0)
+            .unwrap();
+
+        assert!(traced.result.polygons.is_empty());
+        assert!(traced.trace.events.is_empty());
+        assert!(traced.trace.truncated);
+        assert_eq!(traced.trace.byte_limit, 0);
+    }
+
+    #[test]
     fn exhausted_stage_limit_does_not_suppress_later_stages() {
         let options = PolygonizerOptions::default();
         let limits = TraceByteLimitsV1 {

--- a/crates/geo-polygonize-wasm/src/lib.rs
+++ b/crates/geo-polygonize-wasm/src/lib.rs
@@ -5,8 +5,10 @@ use arrow::compute::concat;
 use arrow_ipc::reader::StreamReader;
 pub use buffer::parse_buffer_lines;
 use geo_polygonize_arrow::{polygonize_arrow, PolygonizerOptions};
+use geo_polygonize_core::trace::TraceLevelV1;
 use geo_polygonize_core::{
-    polygonize as polygonize_lines, Line3D, Polygonizer, PolygonizerResult, TopologyFingerprintV1,
+    polygonize as polygonize_lines, Line3D, PolygonizeError, Polygonizer, PolygonizerResult,
+    TopologyFingerprintV1,
 };
 use geoarrow::array::GeoArrowArray;
 use geojson::{GeoJson, Geometry, Value};
@@ -109,10 +111,85 @@ pub fn polygonize_report_with_options_js(
     polygonize_fingerprint_with_options_js(geojson_str, options_val)
 }
 
+#[wasm_bindgen(js_name = polygonizeTraceWithOptions)]
+/// Returns a versioned topology report and bounded physical-pipeline trace.
+pub fn polygonize_trace_with_options_js(
+    geojson_str: &str,
+    options_val: JsValue,
+    trace_level: &str,
+    byte_limit: f64,
+) -> Result<String, JsValue> {
+    let options: geo_polygonize_core::PolygonizerOptions =
+        serde_wasm_bindgen::from_value(options_val).map_err(|e| {
+            to_js_error(
+                "InvalidArgumentType",
+                format!("Failed to parse options: {e}"),
+            )
+        })?;
+    let level = match trace_level {
+        "summary" => TraceLevelV1::Summary,
+        "noding" => TraceLevelV1::Noding,
+        "graph" => TraceLevelV1::Graph,
+        "rings" => TraceLevelV1::Rings,
+        "full" => TraceLevelV1::Full,
+        actual => {
+            return Err(from_polygonizer_error(
+                PolygonizeError::InvalidArgumentType {
+                    field: "trace_level".to_string(),
+                    expected: "summary, noding, graph, rings, or full".to_string(),
+                    actual: actual.to_string(),
+                },
+            ));
+        }
+    };
+    if !byte_limit.is_finite()
+        || byte_limit < 0.0
+        || byte_limit > f64::from(u32::MAX)
+        || byte_limit.fract() != 0.0
+    {
+        return Err(from_polygonizer_error(
+            PolygonizeError::InvalidArgumentType {
+                field: "byte_limit".to_string(),
+                expected: "an integer from 0 through u32::MAX".to_string(),
+                actual: byte_limit.to_string(),
+            },
+        ));
+    }
+    let byte_limit = usize::try_from(byte_limit as u32).map_err(|_| {
+        from_polygonizer_error(PolygonizeError::InvalidArgumentType {
+            field: "byte_limit".to_string(),
+            expected: "a platform-sized unsigned integer".to_string(),
+            actual: byte_limit.to_string(),
+        })
+    })?;
+    let mut polygonizer = polygonizer_from_geojson(geojson_str, &options)?;
+    let traced = polygonizer
+        .polygonize_with_trace(level, byte_limit)
+        .map_err(from_polygonizer_error)?;
+    let topology = TopologyFingerprintV1::try_from_result(&traced.result, &options)
+        .map_err(from_polygonizer_error)?;
+
+    serde_json::to_string(&serde_json::json!({
+        "schema_version": 1,
+        "topology": topology,
+        "trace": traced.trace,
+    }))
+    .map_err(|e| to_js_error("InternalInvariantViolation", e))
+}
+
 fn polygonize_geojson(
     geojson_str: &str,
     options: &geo_polygonize_core::PolygonizerOptions,
 ) -> Result<PolygonizerResult, JsValue> {
+    polygonizer_from_geojson(geojson_str, options)?
+        .polygonize()
+        .map_err(from_polygonizer_error)
+}
+
+fn polygonizer_from_geojson(
+    geojson_str: &str,
+    options: &geo_polygonize_core::PolygonizerOptions,
+) -> Result<Polygonizer, JsValue> {
     let geojson = GeoJson::from_str(geojson_str)
         .map_err(|e| to_js_error("InvalidArgumentType", format!("Invalid GeoJSON: {e}")))?;
     let mut polygonizer = Polygonizer::with_options(options.clone());
@@ -139,7 +216,7 @@ fn polygonize_geojson(
         }
         GeoJson::Geometry(geometry) => add(geometry)?,
     }
-    polygonizer.polygonize().map_err(from_polygonizer_error)
+    Ok(polygonizer)
 }
 
 #[wasm_bindgen]

--- a/crates/geo-polygonize-wasm/tests/wasm.test.js
+++ b/crates/geo-polygonize-wasm/tests/wasm.test.js
@@ -127,6 +127,53 @@ describe('WASM Polygonizer', () => {
         })).features).toHaveLength(0);
     });
 
+    it('should expose a versioned topology report with a bounded trace', async () => {
+        const {
+            default: initModule,
+            polygonizeReportWithOptions,
+            polygonizeTraceWithOptions,
+        } = await import('../../../dist/standard/es/index.js');
+        await initModule();
+        const input = {
+            type: 'FeatureCollection',
+            features: [{
+                type: 'Feature',
+                geometry: {
+                    type: 'LineString',
+                    coordinates: [[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]],
+                },
+            }],
+        };
+
+        const report = JSON.parse(
+            polygonizeTraceWithOptions(JSON.stringify(input), {}, 'full', 0),
+        );
+        expect(report.schema_version).toBe(1);
+        expect(report.topology).toEqual(JSON.parse(
+            polygonizeReportWithOptions(JSON.stringify(input), {}),
+        ));
+        expect(report.trace).toMatchObject({
+            schema_version: 1,
+            level: 'full',
+            byte_limit: 0,
+            bytes_used: 0,
+            truncated: true,
+            events: [],
+        });
+        expect(() => polygonizeTraceWithOptions(
+            JSON.stringify(input),
+            {},
+            'everything',
+            1024,
+        )).toThrow(/trace_level/);
+        expect(() => polygonizeTraceWithOptions(
+            JSON.stringify(input),
+            {},
+            'full',
+            -1,
+        )).toThrow(/byte_limit/);
+    });
+
     it('should match the shared canonical fixture through GeoJSON and buffers', async () => {
         const {
             default: initModule,

--- a/docs/WASM_API.md
+++ b/docs/WASM_API.md
@@ -58,6 +58,27 @@ const resultStr = wasm.polygonizeWithOptions(
 );
 ```
 
+### `polygonizeTraceWithOptions(geojson, options, level, byteLimit)`
+
+Returns a JSON string containing the canonical topology report and the physical
+pipeline's versioned trace. Trace capture is opt-in and bounded by `byteLimit`;
+the response reports exact bytes used and whether capture was truncated.
+
+* `level`: `summary`, `noding`, `graph`, `rings`, or `full`.
+* `byteLimit`: an integer from `0` through `u32::MAX`. This is an operational
+  trace budget and is not part of `PolygonizerOptions`.
+
+```ts
+const traced = JSON.parse(wasm.polygonizeTraceWithOptions(
+  JSON.stringify(geojson),
+  cfbRobustOptions,
+  "noding",
+  1_000_000,
+));
+
+console.log(traced.topology, traced.trace.events, traced.trace.truncated);
+```
+
 ### `polygonize_buffers(coords, offsets, stride, node_input, snap_grid_size)`
 
 Polygonizes raw coordinate arrays. This is an advanced API for high-performance integrations bypassing JSON serialization.

--- a/pkg-wrapper/shims.d.ts
+++ b/pkg-wrapper/shims.d.ts
@@ -18,6 +18,14 @@ export declare function polygonizeReportWithOptions(
     options_val: Partial<PolygonizerOptions>
 ): string;
 
+/** Versioned topology report plus a bounded physical-pipeline trace. */
+export declare function polygonizeTraceWithOptions(
+    geojson_str: string,
+    options_val: Partial<PolygonizerOptions>,
+    trace_level: 'summary' | 'noding' | 'graph' | 'rings' | 'full',
+    byte_limit: number
+): string;
+
 export declare function polygonizeGeoArrowWithOptions(
     ipc_bytes: Uint8Array,
     options_val: Partial<PolygonizerOptions>


### PR DESCRIPTION
## Stack

Parent:
- #1047 (merged; this stack starts from current `main`)

This PR:
- Expose the existing bounded physical topology trace through the canonical Wasm GeoJSON path.

Children:
- #1055

## Delivered

- Added a bounded trace method to the geometry-collecting `Polygonizer` path used by Wasm.
- Added `polygonizeTraceWithOptions`, returning a V1 envelope with the unchanged canonical topology report and `TopologyTraceV1`.
- Kept trace level and byte limits outside semantic polygonizer options.
- Validated trace levels and exact `0..=u32::MAX` integer byte limits before conversion.
- Documented the public Wasm API and updated P1.5 progress precisely.

## Contract impact

- Additive Wasm API only; existing topology fingerprint, trace, options, provenance, and Z schemas are unchanged.
- A zero-byte trace deterministically returns the normal topology result with an empty, truncated trace.
- Trace capture remains disabled on all existing result paths.

## Validation

- `cargo fmt --all -- --check` — passed.
- `cargo clippy --workspace --all-targets -- -D warnings` — passed.
- `cargo test --workspace` — passed.
- `cargo test -p geo-polygonize-core --no-default-features` — passed.
- `RUSTDOCFLAGS='-D warnings' cargo doc -p geo-polygonize-core --no-deps` — passed.
- `cargo check -p geo-polygonize-wasm` — passed.
- `./scripts/build_wasm.sh --variant scalar --no-bundle` — passed.
- `./scripts/build_wasm.sh --variant simd --no-bundle` — passed.
- `./scripts/build_wasm.sh --bundle-only` — passed.
- `npm test` — passed, 20 tests.
- `npm run docs:build` — passed; existing MUI directive, bundle-size, audit, and deferred Wasm URL warnings remain.
- `npx vitepress build docs` — passed after the API documentation edit.
- `git diff --check` — passed.

## Agent handoff

Remaining:
- Direct trace calls are synchronous; child #1055 adds abortable worker transport.

Next dependency-ready slice:
- #1055 preserves runtime selection and terminate-on-abort behavior for bounded trace calls.
