### PR TITLE
feat(wasm): transport topology traces in workers

### DIFF
--- a/crates/geo-polygonize-wasm/tests/wasm.test.js
+++ b/crates/geo-polygonize-wasm/tests/wasm.test.js
@@ -13,10 +13,46 @@ describe('WASM Polygonizer', () => {
 
     it('should publish the browser worker cancellation entry point', async () => {
         expect(existsSync(resolve('dist/standard/es/polygonize_worker.js'))).toBe(true);
-        const { polygonizeReportWithOptionsAsync, polygonizeWithOptionsAsync } =
+        const {
+            polygonizeReportWithOptionsAsync,
+            polygonizeTraceWithOptionsAsync,
+            polygonizeWithOptionsAsync,
+        } =
             await import('../../../dist/standard/es/index.js');
         expect(polygonizeWithOptionsAsync).toBeTypeOf('function');
         expect(polygonizeReportWithOptionsAsync).toBeTypeOf('function');
+        expect(polygonizeTraceWithOptionsAsync).toBeTypeOf('function');
+    });
+
+    it('should send trace level and byte budget through the worker request', async () => {
+        const { polygonizeTraceWithOptionsAsync } =
+            await import('../../../dist/standard/es/index.js');
+        const originalWorker = globalThis.Worker;
+        let request;
+        class TestWorker {
+            postMessage(message) {
+                request = message;
+                queueMicrotask(() => this.onmessage({ data: { id: 0, result: 'traced' } }));
+            }
+            terminate() {}
+        }
+        globalThis.Worker = TestWorker;
+        try {
+            await expect(polygonizeTraceWithOptionsAsync(
+                '{"type":"FeatureCollection","features":[]}',
+                {},
+                'graph',
+                4096,
+            )).resolves.toBe('traced');
+            expect(request).toMatchObject({
+                operation: 'trace',
+                traceLevel: 'graph',
+                byteLimit: 4096,
+            });
+        } finally {
+            if (originalWorker === undefined) delete globalThis.Worker;
+            else globalThis.Worker = originalWorker;
+        }
     });
 
     it('should select the same scalar and SIMD variants for direct and worker runtimes', () => {
@@ -30,6 +66,7 @@ describe('WASM Polygonizer', () => {
         });
 
         const worker = readFileSync(resolve('dist/standard/es/polygonize_worker.js'), 'utf8');
+        expect(worker).toContain('polygonizeTraceWithOptions');
         for (const wasm of ['dist/geo_polygonize.wasm', 'dist/geo_polygonize_simd.wasm']) {
             expect(worker).toContain(readFileSync(resolve(wasm)).toString('base64'));
         }

--- a/docs/WASM_API.md
+++ b/docs/WASM_API.md
@@ -79,6 +79,10 @@ const traced = JSON.parse(wasm.polygonizeTraceWithOptions(
 console.log(traced.topology, traced.trace.events, traced.trace.truncated);
 ```
 
+Use `polygonizeTraceWithOptionsAsync` when the call must be abortable. It uses
+the same scalar/SIMD runtime selection as direct calls and terminates its worker
+when the supplied `AbortSignal` fires.
+
 ### `polygonize_buffers(coords, offsets, stride, node_input, snap_grid_size)`
 
 Polygonizes raw coordinate arrays. This is an advanced API for high-performance integrations bypassing JSON serialization.

--- a/pkg-wrapper/index.ts
+++ b/pkg-wrapper/index.ts
@@ -37,7 +37,9 @@ export type WasmWorkerOptions = {
     signal?: AbortSignal;
 };
 
-type WorkerOperation = "polygons" | "report";
+export type TopologyTraceLevel = "summary" | "noding" | "graph" | "rings" | "full";
+
+type WorkerOperation = "polygons" | "report" | "trace";
 
 type WorkerReply = {
     id: number;
@@ -56,6 +58,7 @@ function polygonizeInWorker(
     geojson: string,
     options: Partial<PolygonizerOptions>,
     { signal }: WasmWorkerOptions = {},
+    trace?: { level: TopologyTraceLevel; byteLimit: number },
 ): Promise<string> {
     if (signal?.aborted) return Promise.reject(abortError());
     if (typeof Worker === "undefined") {
@@ -88,7 +91,14 @@ function polygonizeInWorker(
             reject(new Error(message));
         };
         signal?.addEventListener("abort", abort, { once: true });
-        worker.postMessage({ id: 0, operation, geojson, options });
+        worker.postMessage({
+            id: 0,
+            operation,
+            geojson,
+            options,
+            traceLevel: trace?.level,
+            byteLimit: trace?.byteLimit,
+        });
     });
 }
 
@@ -113,6 +123,23 @@ export function polygonizeReportWithOptionsAsync(
     workerOptions?: WasmWorkerOptions,
 ): Promise<string> {
     return polygonizeInWorker("report", geojson, options, workerOptions);
+}
+
+/** Returns a bounded topology trace in an abortable browser worker. */
+export function polygonizeTraceWithOptionsAsync(
+    geojson: string,
+    options: Partial<PolygonizerOptions>,
+    traceLevel: TopologyTraceLevel,
+    byteLimit: number,
+    workerOptions?: WasmWorkerOptions,
+): Promise<string> {
+    return polygonizeInWorker(
+        "trace",
+        geojson,
+        options,
+        workerOptions,
+        { level: traceLevel, byteLimit },
+    );
 }
 
 // Override the init function

--- a/pkg-wrapper/polygonize_worker.ts
+++ b/pkg-wrapper/polygonize_worker.ts
@@ -1,18 +1,21 @@
 import init, {
     polygonizeReportWithOptions,
+    polygonizeTraceWithOptions,
     polygonizeWithOptions,
 } from "../pkg-scalar/geo_polygonize.js";
 import wasmScalarUrl from "../pkg-scalar/geo_polygonize_bg.wasm";
 import wasmSimdUrl from "../pkg-simd/geo_polygonize_bg.wasm";
 import { selectRuntime } from "./runtime";
 
-type Operation = "initialize" | "polygons" | "report";
+type Operation = "initialize" | "polygons" | "report" | "trace";
 
 type Request = {
     id: number;
     operation: Operation;
     geojson: string;
     options: object;
+    traceLevel?: string;
+    byteLimit?: number;
 };
 
 let initialized: Promise<void> | undefined;
@@ -26,11 +29,26 @@ function initialize() {
 self.addEventListener("message", async ({ data }: MessageEvent<Request>) => {
     try {
         await initialize();
-        const result = data.operation === "initialize"
-            ? runtime.variant
-            : data.operation === "polygons"
-                ? polygonizeWithOptions(data.geojson, data.options)
-                : polygonizeReportWithOptions(data.geojson, data.options);
+        let result: string;
+        switch (data.operation) {
+            case "initialize":
+                result = runtime.variant;
+                break;
+            case "polygons":
+                result = polygonizeWithOptions(data.geojson, data.options);
+                break;
+            case "report":
+                result = polygonizeReportWithOptions(data.geojson, data.options);
+                break;
+            case "trace":
+                result = polygonizeTraceWithOptions(
+                    data.geojson,
+                    data.options,
+                    data.traceLevel!,
+                    data.byteLimit!,
+                );
+                break;
+        }
         self.postMessage({ id: data.id, result });
     } catch (error) {
         const exception = error instanceof Error ? error : new Error(String(error));


### PR DESCRIPTION
## Stack

Parent:
- #1054

This PR:
- Transport bounded topology-trace requests through the existing abortable worker path.

Children:
- #1057

## Delivered

- Added a `trace` worker operation using the same scalar/SIMD runtime selection as direct calls.
- Added `polygonizeTraceWithOptionsAsync` with typed trace levels and an explicit byte budget.
- Preserved terminate-on-abort and one-worker-per-call behavior.
- Added a request-transport regression proving the level and byte budget reach the worker.

## Contract impact

- Additive wrapper API only; direct Wasm, topology, trace, options, provenance, and Z contracts are unchanged.
- No worker pool or semantic option was added.

## Validation

- `npx tsc --noEmit` — passed.
- `./scripts/build_wasm.sh --bundle-only` — passed.
- `npm test` — passed, 21 tests.
- `npx vitepress build docs` — passed.
- `git diff --check` — passed.

## Agent handoff

Remaining:
- Child #1057 publishes the exact trace report and event types consumed by downstream UI code.

Next dependency-ready slice:
- #1057 exposes the V1 trace contract across the standard, slim, and threads packages.
