### PR TITLE
feat(wasm): type topology trace reports

### DIFF
--- a/crates/geo-polygonize-wasm/tests/wasm.test.js
+++ b/crates/geo-polygonize-wasm/tests/wasm.test.js
@@ -9,6 +9,9 @@ describe('WASM Polygonizer', () => {
         expect(existsSync(resolve('dist/standard/pkg-scalar/geo_polygonize.d.ts'))).toBe(true);
         expect(existsSync(resolve('dist/slim/pkg-scalar/geo_polygonize.d.ts'))).toBe(true);
         expect(existsSync(resolve('dist/threads/pkg-threads/geo_polygonize.d.ts'))).toBe(true);
+        for (const variant of ['standard', 'slim', 'threads']) {
+            expect(existsSync(resolve(`dist/${variant}/es/topology_trace.d.ts`))).toBe(true);
+        }
     });
 
     it('should publish the browser worker cancellation entry point', async () => {

--- a/pkg-wrapper/index.ts
+++ b/pkg-wrapper/index.ts
@@ -2,6 +2,7 @@ import wasmInit, * as exports from "../pkg-scalar/geo_polygonize.js";
 import wasmScalarUrl from "../pkg-scalar/geo_polygonize_bg.wasm";
 import wasmSimdUrl from "../pkg-simd/geo_polygonize_bg.wasm";
 import type { PolygonizerOptions } from "./bindings/PolygonizerOptions";
+import type { TopologyTraceLevelV1 } from "./topology_trace";
 import { selectRuntime } from "./runtime";
 
 // Cache the initialization promise
@@ -32,12 +33,11 @@ export * from "./bindings/ZPolicy";
 export * from "./bindings/TopologyFingerprintV1";
 export * from "./bindings/NormalizedPolygonizeErrorV1";
 export * from "./cfb";
+export * from "./topology_trace";
 
 export type WasmWorkerOptions = {
     signal?: AbortSignal;
 };
-
-export type TopologyTraceLevel = "summary" | "noding" | "graph" | "rings" | "full";
 
 type WorkerOperation = "polygons" | "report" | "trace";
 
@@ -58,7 +58,7 @@ function polygonizeInWorker(
     geojson: string,
     options: Partial<PolygonizerOptions>,
     { signal }: WasmWorkerOptions = {},
-    trace?: { level: TopologyTraceLevel; byteLimit: number },
+    trace?: { level: TopologyTraceLevelV1; byteLimit: number },
 ): Promise<string> {
     if (signal?.aborted) return Promise.reject(abortError());
     if (typeof Worker === "undefined") {
@@ -129,7 +129,7 @@ export function polygonizeReportWithOptionsAsync(
 export function polygonizeTraceWithOptionsAsync(
     geojson: string,
     options: Partial<PolygonizerOptions>,
-    traceLevel: TopologyTraceLevel,
+    traceLevel: TopologyTraceLevelV1,
     byteLimit: number,
     workerOptions?: WasmWorkerOptions,
 ): Promise<string> {

--- a/pkg-wrapper/index_slim.ts
+++ b/pkg-wrapper/index_slim.ts
@@ -21,6 +21,7 @@ export * from "./bindings/TouchPolicy";
 export * from "./bindings/ZOptions";
 export * from "./bindings/ZPolicy";
 export * from "./cfb";
+export * from "./topology_trace";
 
 // We provide a helper to choose based on feature detection if the user wants to use it
 function normalizeInitInput(input: any) {

--- a/pkg-wrapper/index_threads.ts
+++ b/pkg-wrapper/index_threads.ts
@@ -18,5 +18,6 @@ export * from "./bindings/TouchPolicy";
 export * from "./bindings/ZOptions";
 export * from "./bindings/ZPolicy";
 export * from "./cfb";
+export * from "./topology_trace";
 
 export default init;

--- a/pkg-wrapper/shims.d.ts
+++ b/pkg-wrapper/shims.d.ts
@@ -5,6 +5,7 @@ declare module '*.wasm' {
 
 // Override auto-generated WASM typings to use our auto-generated types
 import { PolygonizerOptions } from './bindings/PolygonizerOptions';
+import { TopologyTraceLevelV1 } from './topology_trace';
 import { WasmPolygonResult } from '../pkg-scalar/geo_polygonize.js';
 
 export declare function polygonizeWithOptions(
@@ -22,7 +23,7 @@ export declare function polygonizeReportWithOptions(
 export declare function polygonizeTraceWithOptions(
     geojson_str: string,
     options_val: Partial<PolygonizerOptions>,
-    trace_level: 'summary' | 'noding' | 'graph' | 'rings' | 'full',
+    trace_level: TopologyTraceLevelV1,
     byte_limit: number
 ): string;
 

--- a/pkg-wrapper/topology_trace.ts
+++ b/pkg-wrapper/topology_trace.ts
@@ -1,0 +1,28 @@
+import type { TopologyFingerprintV1 } from "./bindings/TopologyFingerprintV1";
+
+export type TopologyTraceLevelV1 = "summary" | "noding" | "graph" | "rings" | "full";
+export type TopologyTraceStageV1 = "summary" | "noding" | "graph" | "rings" | "output";
+
+export type TopologyTraceEventV1 = {
+    sequence: number;
+    stage: TopologyTraceStageV1;
+    kind: string;
+    payload: unknown;
+};
+
+export type TopologyTraceV1 = {
+    schema_version: 1;
+    library_version: string;
+    level: TopologyTraceLevelV1;
+    byte_limit: number;
+    bytes_used: number;
+    truncated: boolean;
+    options: unknown;
+    events: TopologyTraceEventV1[];
+};
+
+export type PolygonizeTraceReportV1 = {
+    schema_version: 1;
+    topology: TopologyFingerprintV1;
+    trace: TopologyTraceV1;
+};


### PR DESCRIPTION
## Stack

Parent:
- #1055

This PR:
- Publish exact TypeScript V1 types for topology-trace reports and events.

Children:
- not opened yet

## Delivered

- Added shared `TopologyTraceLevelV1`, stage, event, trace, and report-envelope types.
- Re-exported the types from the standard, slim, and threads wrapper entry points.
- Reused the shared trace-level type in direct and worker APIs.
- Added a declaration-artifact regression for every published wrapper variant.

## Contract impact

- Type declarations only; serialized Rust/Wasm topology and trace schemas are unchanged.
- Existing runtime exports and default polygonization behavior are unchanged.

## Validation

- `npx tsc --noEmit` — passed.
- `./scripts/build_wasm.sh --bundle-only` — passed.
- `npm test` — passed, 21 tests.
- `git diff --check` — passed.

## Agent handoff

Remaining:
- The playground does not yet consume `PolygonizeTraceReportV1` to render trace layers.

Next dependency-ready slice:
- After the playground stack lands, consume the typed worker report and render snapped-line, hot-pixel, split-point, and graph-edge layers.
