### PR TITLE
fix(github): skip automerge for native stacks

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -16,6 +16,7 @@ jobs:
       github.event.pull_request.user.login == 'graydonpleasants' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.base.ref == github.event.repository.default_branch &&
+      github.event.pull_request.stack == null &&
       !github.event.pull_request.draft
     runs-on: ubuntu-latest
 

--- a/tests/test_automerge_workflow.py
+++ b/tests/test_automerge_workflow.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_automerge_excludes_native_stacks():
+    workflow = (ROOT / ".github/workflows/automerge.yml").read_text()
+
+    assert "github.event.pull_request.base.ref == github.event.repository.default_branch" in workflow
+    assert "github.event.pull_request.stack == null" in workflow


### PR DESCRIPTION
## Stack

Parent:
- current `main`

This PR:
- Prevent the default-branch automerge workflow from targeting native stacked PRs.

Children:
- not opened yet

## Delivered

- Added the native stack-membership exclusion to the existing automerge guard.
- Added a focused regression that retains both the default-branch and stack guards.

## Contract impact

- Native stack members no longer receive a failing `Enable automerge` check.
- Ordinary ready PRs authored in this repository still enable squash automerge.

## Validation

- `python3 -m pytest tests/test_automerge_workflow.py` — passed, 1 test; existing pytest-asyncio configuration warning remains.
- `actionlint .github/workflows/automerge.yml` — passed.
- `git diff --check` — passed.

## Agent handoff

Remaining:
- P1 playground trace integration is delivered in stacked children.

Next dependency-ready slice:
- Consume the bounded typed worker trace in the playground without changing semantic options.
