### PR TITLE
feat(wasm): decode playground trace layers

### DIFF
--- a/playground/src/trace.test.ts
+++ b/playground/src/trace.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import type { TopologyTraceV1 } from 'geo-polygonize';
+import { decodeTraceCoordinate, extractTraceLayers } from './trace';
+
+const view = new DataView(new ArrayBuffer(8));
+const bits = (value: number) => {
+  view.setFloat64(0, value);
+  return `0x${view.getBigUint64(0).toString(16).padStart(16, '0')}`;
+};
+const point = (x: number, y: number) => ({
+  x: bits(x),
+  y: bits(y),
+  z: null,
+});
+
+function trace(events: TopologyTraceV1['events']): TopologyTraceV1 {
+  return {
+    schema_version: 1,
+    library_version: 'test',
+    level: 'full',
+    byte_limit: 4096,
+    bytes_used: 0,
+    truncated: false,
+    options: {},
+    events,
+  };
+}
+
+describe('trace layers', () => {
+  it('decodes physical noding and graph events', () => {
+    const start = point(0, 0);
+    const end = point(2, 1);
+    const result = extractTraceLayers(trace([
+      { sequence: 0, stage: 'noding', kind: 'fixed_grid_segment', payload: { start, end, source_ids: ['a'] } },
+      { sequence: 1, stage: 'noding', kind: 'certified_hot_pixel', payload: { coordinate: end } },
+      { sequence: 2, stage: 'noding', kind: 'certified_candidate_pair', payload: { first_source_id: 'b', second_source_id: 'a', witness: { kind: 'point', coordinate: end } } },
+      { sequence: 3, stage: 'graph', kind: 'dissolved_edge', payload: { start, end, source_ids: ['a', 'b'] } },
+    ]));
+
+    expect(result.snappedLines).toEqual([{ sequence: 0, start: [0, 0], end: [2, 1], sourceIds: ['a'] }]);
+    expect(result.hotPixels[0].coordinate).toEqual([2, 1]);
+    expect(result.splitPoints).toEqual([{ sequence: 2, coordinate: [2, 1], sourceIds: ['a', 'b'] }]);
+    expect(result.graphEdges[0].sourceIds).toEqual(['a', 'b']);
+  });
+
+  it('ignores malformed coordinates', () => {
+    expect(decodeTraceCoordinate({ x: 'bad', y: '0x0' })).toBeNull();
+  });
+});

--- a/playground/src/trace.ts
+++ b/playground/src/trace.ts
@@ -1,0 +1,99 @@
+import type { TopologyTraceV1 } from 'geo-polygonize';
+
+export type TraceCoordinate = [number, number];
+
+export type TraceLine = {
+  sequence: number;
+  start: TraceCoordinate;
+  end: TraceCoordinate;
+  sourceIds: string[];
+};
+
+export type TracePoint = {
+  sequence: number;
+  coordinate: TraceCoordinate;
+  sourceIds: string[];
+};
+
+export type PlaygroundTraceLayers = {
+  snappedLines: TraceLine[];
+  hotPixels: TracePoint[];
+  splitPoints: TracePoint[];
+  graphEdges: TraceLine[];
+};
+
+const coordinateView = new DataView(new ArrayBuffer(8));
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+export function decodeTraceCoordinate(value: unknown): TraceCoordinate | null {
+  if (!isObject(value) || typeof value.x !== 'string' || typeof value.y !== 'string') {
+    return null;
+  }
+  try {
+    const number = (bits: string) => {
+      coordinateView.setBigUint64(0, BigInt(bits));
+      return coordinateView.getFloat64(0);
+    };
+    const coordinate: TraceCoordinate = [number(value.x), number(value.y)];
+    return coordinate.every(Number.isFinite) ? coordinate : null;
+  } catch {
+    return null;
+  }
+}
+
+function sourceIds(payload: Record<string, unknown>) {
+  return Array.isArray(payload.source_ids)
+    ? payload.source_ids.filter((value): value is string => typeof value === 'string')
+    : [];
+}
+
+function line(sequence: number, payload: unknown): TraceLine | null {
+  if (!isObject(payload)) return null;
+  const start = decodeTraceCoordinate(payload.start);
+  const end = decodeTraceCoordinate(payload.end);
+  return start && end ? { sequence, start, end, sourceIds: sourceIds(payload) } : null;
+}
+
+export function extractTraceLayers(trace: TopologyTraceV1): PlaygroundTraceLayers {
+  const snappedLines: TraceLine[] = [];
+  const hotPixels: TracePoint[] = [];
+  const graphEdges: TraceLine[] = [];
+  const splitPoints = new Map<string, TracePoint>();
+
+  for (const event of trace.events) {
+    if (event.kind === 'fixed_grid_segment' || event.kind === 'noded_segment') {
+      const value = line(event.sequence, event.payload);
+      if (value) snappedLines.push(value);
+      continue;
+    }
+    if (event.kind === 'dissolved_edge') {
+      const value = line(event.sequence, event.payload);
+      if (value) graphEdges.push(value);
+      continue;
+    }
+    if (event.kind === 'certified_hot_pixel' && isObject(event.payload)) {
+      const coordinate = decodeTraceCoordinate(event.payload.coordinate);
+      if (coordinate) hotPixels.push({ sequence: event.sequence, coordinate, sourceIds: [] });
+      continue;
+    }
+    if (!event.kind.endsWith('_candidate_pair') || !isObject(event.payload)) continue;
+    const witness = event.payload.witness;
+    if (!isObject(witness) || witness.kind !== 'point') continue;
+    const coordinate = decodeTraceCoordinate(witness.coordinate);
+    if (!coordinate) continue;
+    const key = JSON.stringify(coordinate);
+    const ids = [event.payload.first_source_id, event.payload.second_source_id]
+      .filter((value): value is string => typeof value === 'string');
+    const existing = splitPoints.get(key);
+    if (existing) {
+      existing.sourceIds = [...new Set([...existing.sourceIds, ...ids])].sort();
+    } else {
+      splitPoints.set(key, { sequence: event.sequence, coordinate, sourceIds: ids.sort() });
+    }
+  }
+
+  return { snappedLines, hotPixels, splitPoints: [...splitPoints.values()], graphEdges };
+}


### PR DESCRIPTION
## Stack

Parent:
- #1058 (merged; this branch was rebased onto current `main`)

This PR:
- Decode bounded V1 trace events into typed playground view models.

Children:
- #1060

## Delivered

- Added strict coordinate decoding for fingerprinted trace payloads.
- Extracted final snapped segments, certified hot pixels, deduplicated point witnesses, and dissolved graph edges.
- Preserved source IDs for line and split-point inspection.
- Added focused malformed-payload and physical-event regressions.

## Contract impact

- Playground-only view models; public topology and trace schemas are unchanged.
- Unknown or malformed trace events are ignored instead of crashing the debugger.

## Validation

- `npx vitest run playground/src/trace.test.ts` — passed, 2 tests.
- `git diff --check` — passed.
- `npx tsc --noEmit -p playground/tsconfig.json` — not run successfully; the playground has no local tsconfig and inherits a root config that only includes `pkg-wrapper`.

## Agent handoff

Remaining:
- Child #1060 moves polygonization onto the bounded abortable trace worker.

Next dependency-ready slice:
- #1060 retains the typed trace report in playground state and exposes budget/truncation metadata.
