### PR TITLE
feat(wasm): run playground traces in workers

### DIFF
--- a/playground/src/main.tsx
+++ b/playground/src/main.tsx
@@ -1,10 +1,11 @@
 import React, { useState, useEffect, useMemo, useRef } from 'react';
 import ReactDOM from 'react-dom/client';
 import init, {
-  polygonizeReportWithOptions,
+  polygonizeTraceWithOptionsAsync,
   type NodingGuarantee,
   type PolygonizerOptions,
   type TopologyFingerprintV1,
+  type TopologyTraceV1,
 } from 'geo-polygonize';
 import {
   Container,
@@ -24,6 +25,7 @@ import {
 } from '@mui/material';
 import { appendLineString, parseGeojsonInput } from './input';
 import { buildPlaygroundOptions } from './options';
+import { parsePlaygroundTraceReport, PLAYGROUND_TRACE_BYTE_LIMIT } from './trace';
 
 // --- Types ---
 interface ManifestEntry {
@@ -123,6 +125,8 @@ function App() {
   const [inputText, setInputText] = useState('');
   const [outputGeojson, setOutputGeojson] = useState<any>(null);
   const [report, setReport] = useState<TopologyFingerprintV1 | null>(null);
+  const [trace, setTrace] = useState<TopologyTraceV1 | null>(null);
+  const [traceBusy, setTraceBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [drawEnabled, setDrawEnabled] = useState(false);
   const [drawnPoints, setDrawnPoints] = useState<number[][]>([]);
@@ -210,6 +214,7 @@ function App() {
     setInputGeojson(null);
     setOutputGeojson(null);
     setReport(null);
+    setTrace(null);
     setError(null);
 
     async function loadFixture() {
@@ -302,24 +307,40 @@ function App() {
 
   // Run Polygonizer
   useEffect(() => {
-    if (!wasmReady || !inputGeojson) return;
-    try {
-      const options: Partial<PolygonizerOptions> = buildPlaygroundOptions(
-        nodeInput,
-        snapGridSize,
-        nodingGuarantee,
-      );
-      const nextReport = JSON.parse(
-        polygonizeReportWithOptions(JSON.stringify(inputGeojson), options),
-      ) as TopologyFingerprintV1;
-      setReport(nextReport);
-      setOutputGeojson(reportToGeojson(nextReport));
+    if (!wasmReady || !inputGeojson) {
+      setTraceBusy(false);
+      return;
+    }
+    const controller = new AbortController();
+    const options: Partial<PolygonizerOptions> = buildPlaygroundOptions(
+      nodeInput,
+      snapGridSize,
+      nodingGuarantee,
+    );
+    setTraceBusy(true);
+    setTrace(null);
+    void polygonizeTraceWithOptionsAsync(
+      JSON.stringify(inputGeojson),
+      options,
+      'full',
+      PLAYGROUND_TRACE_BYTE_LIMIT,
+      { signal: controller.signal },
+    ).then((text) => {
+      const next = parsePlaygroundTraceReport(text);
+      setReport(next.topology);
+      setTrace(next.trace);
+      setOutputGeojson(reportToGeojson(next.topology));
       setError(null);
-    } catch (e: any) {
+    }).catch((e: Error) => {
+      if (e.name === 'AbortError') return;
       setOutputGeojson(null);
       setReport(null);
+      setTrace(null);
       setError("Polygonize Error: " + e.toString());
-    }
+    }).finally(() => {
+      if (!controller.signal.aborted) setTraceBusy(false);
+    });
+    return () => controller.abort();
   }, [wasmReady, inputGeojson, nodeInput, snapGridSize, nodingGuarantee]);
 
 
@@ -336,6 +357,7 @@ function App() {
       </Typography>
 
       {!wasmReady && <Alert severity="info">Loading WebAssembly...</Alert>}
+      {traceBusy && <Alert severity="info">Tracing topology in a worker...</Alert>}
       {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
 
       <Grid container spacing={3}>
@@ -486,6 +508,15 @@ function App() {
                <Typography>Dangles: {report.dangles.length}</Typography>
                <Typography>Cut edges: {report.cut_edges.length}</Typography>
                <Typography>Invalid rings: {report.invalid_rings.length}</Typography>
+               {trace && (
+                 <>
+                   <Typography>Trace events: {trace.events.length}</Typography>
+                   <Typography>
+                     Trace bytes: {trace.bytes_used.toLocaleString()} / {trace.byte_limit.toLocaleString()}
+                   </Typography>
+                   {trace.truncated && <Alert severity="warning">Trace reached its byte budget.</Alert>}
+                 </>
+               )}
                <TextField
                  fullWidth
                  multiline

--- a/playground/src/trace.test.ts
+++ b/playground/src/trace.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import type { TopologyTraceV1 } from 'geo-polygonize';
-import { decodeTraceCoordinate, extractTraceLayers } from './trace';
+import {
+  decodeTraceCoordinate,
+  extractTraceLayers,
+  parsePlaygroundTraceReport,
+} from './trace';
 
 const view = new DataView(new ArrayBuffer(8));
 const bits = (value: number) => {
@@ -45,5 +49,10 @@ describe('trace layers', () => {
 
   it('ignores malformed coordinates', () => {
     expect(decodeTraceCoordinate({ x: 'bad', y: '0x0' })).toBeNull();
+  });
+
+  it('rejects unsupported trace envelopes', () => {
+    expect(() => parsePlaygroundTraceReport('{"schema_version":2}'))
+      .toThrow('Unsupported topology trace report');
   });
 });

--- a/playground/src/trace.ts
+++ b/playground/src/trace.ts
@@ -1,4 +1,6 @@
-import type { TopologyTraceV1 } from 'geo-polygonize';
+import type { PolygonizeTraceReportV1, TopologyTraceV1 } from 'geo-polygonize';
+
+export const PLAYGROUND_TRACE_BYTE_LIMIT = 4 * 1024 * 1024;
 
 export type TraceCoordinate = [number, number];
 
@@ -26,6 +28,17 @@ const coordinateView = new DataView(new ArrayBuffer(8));
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
+}
+
+export function parsePlaygroundTraceReport(text: string): PolygonizeTraceReportV1 {
+  const value: unknown = JSON.parse(text);
+  if (!isObject(value) || value.schema_version !== 1
+    || !isObject(value.topology) || value.topology.schema_version !== 1
+    || !isObject(value.trace) || value.trace.schema_version !== 1
+    || !Array.isArray(value.trace.events)) {
+    throw new Error('Unsupported topology trace report');
+  }
+  return value as unknown as PolygonizeTraceReportV1;
 }
 
 export function decodeTraceCoordinate(value: unknown): TraceCoordinate | null {


### PR DESCRIPTION
## Stack

Parent:
- #1059

This PR:
- Run playground polygonization through the bounded abortable trace worker.

Children:
- #1062

## Delivered

- Replaced the synchronous report call with `polygonizeTraceWithOptionsAsync`.
- Abort superseded worker calls when input or canonical options change.
- Validate the V1 report envelope before updating playground state.
- Display trace event count, byte use, and truncation state.

## Contract impact

- Playground execution only; semantic options and public trace schemas are unchanged.
- Every interactive run is bounded to 4 MiB of trace events and no longer blocks the browser main thread during polygonization.

## Validation

- `npx vitest run playground/src/trace.test.ts` — passed, 3 tests.
- `npm run build --prefix playground` — passed; existing MUI directive, deferred Wasm URL, and large-chunk warnings remain.
- `git diff --check` — passed.

## Agent handoff

Remaining:
- Child #1062 renders the retained physical trace layers.

Next dependency-ready slice:
- #1062 renders snapped lines, hot pixels, point witnesses, and dissolved graph edges.
