### PR TITLE
feat(wasm): render playground trace layers

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -474,12 +474,13 @@ entrypoint so browser tooling does not reconstruct pipeline evidence.
 - [x] Support paste, upload, drag-and-drop, drawing, and fixture selection.
 - [x] Expose the canonical options schema, including `Validate` and
   `CertifiedFixedPrecision`.
-- [ ] Add layer toggles for raw lines, snapped lines, hot pixels, split points,
+- [x] Add layer toggles for raw lines, snapped lines, hot pixels, split points,
   graph edges, dangles, cut edges, invalid rings, shells, holes, and final faces.
 
-Progress: the playground now toggles raw lines and every retained report layer:
-dangles, cut edges, invalid rings, shells, holes, and final faces. Snapped lines,
-hot pixels, split points, and graph edges still require a browser trace contract.
+Progress: the playground now runs the bounded V1 trace in an abortable worker
+and toggles raw lines, physical snapped lines, certified hot pixels, exact point
+witnesses, dissolved graph edges, and every retained report layer. Trace event
+count, byte use, and truncation state remain visible alongside canonical options.
 
 - [ ] Make edges/rings clickable to inspect source provenance and Z decisions.
 - [ ] Show phase timings, work counters, resource budgets, and validator witnesses.

--- a/playground/src/main.tsx
+++ b/playground/src/main.tsx
@@ -25,7 +25,11 @@ import {
 } from '@mui/material';
 import { appendLineString, parseGeojsonInput } from './input';
 import { buildPlaygroundOptions } from './options';
-import { parsePlaygroundTraceReport, PLAYGROUND_TRACE_BYTE_LIMIT } from './trace';
+import {
+  extractTraceLayers,
+  parsePlaygroundTraceReport,
+  PLAYGROUND_TRACE_BYTE_LIMIT,
+} from './trace';
 
 // --- Types ---
 interface ManifestEntry {
@@ -43,6 +47,10 @@ interface ManifestEntry {
 
 const layerOptions = [
   ['rawLines', 'Raw lines'],
+  ['snappedLines', 'Snapped lines'],
+  ['hotPixels', 'Hot pixels'],
+  ['splitPoints', 'Split points'],
+  ['graphEdges', 'Graph edges'],
   ['dangles', 'Dangles'],
   ['cutEdges', 'Cut edges'],
   ['invalidRings', 'Invalid rings'],
@@ -139,6 +147,10 @@ function App() {
   const [nodingGuarantee, setNodingGuarantee] = useState<NodingGuarantee>('Unchecked');
   const [layers, setLayers] = useState<Record<LayerKey, boolean>>({
     rawLines: true,
+    snappedLines: true,
+    hotPixels: true,
+    splitPoints: true,
+    graphEdges: true,
     dangles: true,
     cutEdges: true,
     invalidRings: true,
@@ -349,6 +361,7 @@ function App() {
     if (!inputGeojson) return null;
     return computeBoundingBox(inputGeojson);
   }, [inputGeojson]);
+  const traceLayers = useMemo(() => trace ? extractTraceLayers(trace) : null, [trace]);
 
   return (
     <Container maxWidth="lg" sx={{ mt: 4, mb: 4 }}>
@@ -584,13 +597,58 @@ function App() {
                      })}
 
                      {/* Draw Input Lines (dashed) */}
-                     {layers.rawLines && inputGeojson?.features.map((f: any, i: number) => {
+                   {layers.rawLines && inputGeojson?.features.map((f: any, i: number) => {
                         if (f.geometry?.type === 'LineString') {
                            const pts = f.geometry.coordinates.map((c: any) => `${c[0]},${c[1]}`).join(" ");
                            return <polyline key={`line-${i}`} points={pts} fill="none" stroke="#ff0000" strokeWidth={bbox.width * 0.003} strokeDasharray={`${bbox.width * 0.01},${bbox.width * 0.01}`} />;
                         }
                         return null;
                      })}
+
+                     {layers.snappedLines && traceLayers?.snappedLines.map((line) => (
+                       <line
+                         key={`snapped-${line.sequence}`}
+                         x1={line.start[0]}
+                         y1={line.start[1]}
+                         x2={line.end[0]}
+                         y2={line.end[1]}
+                         stroke="#3949ab"
+                         strokeWidth={bbox.width * 0.004}
+                       />
+                     ))}
+
+                     {layers.graphEdges && traceLayers?.graphEdges.map((line) => (
+                       <line
+                         key={`graph-${line.sequence}`}
+                         x1={line.start[0]}
+                         y1={line.start[1]}
+                         x2={line.end[0]}
+                         y2={line.end[1]}
+                         stroke="#263238"
+                         strokeWidth={bbox.width * 0.002}
+                       />
+                     ))}
+
+                     {layers.hotPixels && traceLayers?.hotPixels.map((point) => (
+                       <rect
+                         key={`hot-${point.sequence}`}
+                         x={point.coordinate[0] - bbox.width * 0.004}
+                         y={point.coordinate[1] - bbox.width * 0.004}
+                         width={bbox.width * 0.008}
+                         height={bbox.width * 0.008}
+                         fill="#d81b60"
+                       />
+                     ))}
+
+                     {layers.splitPoints && traceLayers?.splitPoints.map((point) => (
+                       <circle
+                         key={`split-${point.sequence}`}
+                         cx={point.coordinate[0]}
+                         cy={point.coordinate[1]}
+                         r={bbox.width * 0.005}
+                         fill="#8e24aa"
+                       />
+                     ))}
 
                      {layers.shells && report?.polygons.map((polygon, index) => (
                        <polyline


### PR DESCRIPTION
## Stack

Parent:
- #1060

This PR:
- Render physical noding and graph layers retained by the playground trace.

Children:
- #1063

## Delivered

- Added independent toggles for snapped lines, certified hot pixels, split witnesses, and dissolved graph edges.
- Rendered only physical trace events captured by the worker, without reconstructing hidden work.
- Updated P1.6 roadmap progress for the first retained trace layers.

## Contract impact

- Playground-only visualization; topology, provenance, Z behavior, and public trace schemas are unchanged.
- Layer geometry comes directly from bounded V1 trace events.

## Validation

- `npm test` — passed, 29 tests across 4 files; existing deprecated Wasm initialization warning remains.
- `npm run build --prefix playground` — passed; existing MUI directive, deferred Wasm URL, and large-chunk warnings remain.
- `git diff --check` — passed.

## Agent handoff

Remaining:
- Child #1063 makes the rendered features inspectable.

Next dependency-ready slice:
- #1063 exposes source IDs, representative edge IDs, and retained exact Z bits.
