### PR TITLE
feat(wasm): share playground repro URLs

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -485,11 +485,14 @@ Snapped lines, split witnesses, graph edges, shells, and holes are clickable for
 source and representative-edge provenance; rings also show their exact retained
 Z bit patterns. Z reconciliation decisions are not yet traced, so the broader
 inspection item remains open.
+Small V1 repro envelopes now encode input plus canonical noding controls as
+deterministic UTF-8 base64url query data, reject payloads beyond 8 KiB, and load
+directly into the worker-backed debugger.
 
 - [ ] Make edges/rings clickable to inspect source provenance and Z decisions.
 - [ ] Show phase timings, work counters, resource budgets, and validator witnesses.
 - [ ] Compare two option profiles side by side.
-- [ ] Encode small deterministic repros in shareable URLs.
+- [x] Encode small deterministic repros in shareable URLs.
 - [ ] Export an exact golden/compatibility fixture bundle.
 - [ ] Run differential minimization in a worker and visualize each reduction.
 

--- a/playground/src/main.tsx
+++ b/playground/src/main.tsx
@@ -25,6 +25,7 @@ import {
 } from '@mui/material';
 import { appendLineString, parseGeojsonInput } from './input';
 import { buildPlaygroundOptions } from './options';
+import { decodePlaygroundRepro, encodePlaygroundRepro } from './repro';
 import {
   extractTraceLayers,
   parsePlaygroundTraceReport,
@@ -210,6 +211,20 @@ function App() {
   useEffect(() => {
     if (manifest.length > 0 && !selectedSlug) {
       const params = new URLSearchParams(window.location.search);
+      const encodedRepro = params.get('repro');
+      if (encodedRepro) {
+        try {
+          const repro = decodePlaygroundRepro(encodedRepro);
+          setInputGeojson(repro.input);
+          setInputText(JSON.stringify(repro.input, null, 2));
+          setNodeInput(repro.node_input);
+          setSnapGridSize(repro.snap_grid_size);
+          setNodingGuarantee(repro.noding_guarantee);
+          return;
+        } catch (e) {
+          setError(`Shared repro error: ${e instanceof Error ? e.message : String(e)}`);
+        }
+      }
       const scenario = params.get('scenario');
       if (scenario && manifest.find(m => m.slug === scenario)) {
         setSelectedSlug(scenario);
@@ -275,6 +290,7 @@ function App() {
     setSelectedSlug('');
     const url = new URL(window.location.href);
     url.searchParams.delete('scenario');
+    url.searchParams.delete('repro');
     window.history.replaceState({}, '', url.toString());
     setError(null);
   };
@@ -399,6 +415,7 @@ function App() {
                   // Update URL
                   const url = new URL(window.location.href);
                   url.searchParams.set('scenario', e.target.value as string);
+                  url.searchParams.delete('repro');
                   window.history.replaceState({}, '', url.toString());
                 }}
               >
@@ -451,6 +468,31 @@ function App() {
                   }}
                 >
                   {drawEnabled ? 'Stop drawing' : 'Draw line'}
+                </Button>
+                <Button
+                  variant="outlined"
+                  disabled={!inputGeojson}
+                  onClick={async () => {
+                    try {
+                      const encoded = encodePlaygroundRepro({
+                        schema_version: 1,
+                        input: inputGeojson,
+                        node_input: nodeInput,
+                        snap_grid_size: snapGridSize,
+                        noding_guarantee: nodingGuarantee,
+                      });
+                      const url = new URL(window.location.href);
+                      url.searchParams.delete('scenario');
+                      url.searchParams.set('repro', encoded);
+                      window.history.replaceState({}, '', url.toString());
+                      await navigator.clipboard.writeText(url.toString());
+                      setError(null);
+                    } catch (e) {
+                      setError(`Share Error: ${e instanceof Error ? e.message : String(e)}`);
+                    }
+                  }}
+                >
+                  Copy repro URL
                 </Button>
               </Box>
               <Typography variant="caption" color="text.secondary">

--- a/playground/src/repro.test.ts
+++ b/playground/src/repro.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import {
+  decodePlaygroundRepro,
+  encodePlaygroundRepro,
+  MAX_REPRO_QUERY_LENGTH,
+  type PlaygroundReproV1,
+} from './repro';
+
+const repro = (input: Record<string, unknown>): PlaygroundReproV1 => ({
+  schema_version: 1,
+  input,
+  node_input: true,
+  snap_grid_size: 0.25,
+  noding_guarantee: 'Validate',
+});
+
+describe('shareable playground repros', () => {
+  it('round trips UTF-8 input and canonical options', () => {
+    const value = repro({ type: 'FeatureCollection', label: 'café', features: [] });
+    expect(decodePlaygroundRepro(encodePlaygroundRepro(value))).toEqual(value);
+  });
+
+  it('is deterministic across object key order', () => {
+    expect(encodePlaygroundRepro(repro({ b: 2, a: 1 })))
+      .toBe(encodePlaygroundRepro(repro({ a: 1, b: 2 })));
+  });
+
+  it('rejects oversized query payloads', () => {
+    expect(() => decodePlaygroundRepro('a'.repeat(MAX_REPRO_QUERY_LENGTH + 1)))
+      .toThrow('Shared repro exceeds the URL limit');
+  });
+});

--- a/playground/src/repro.ts
+++ b/playground/src/repro.ts
@@ -1,0 +1,56 @@
+import type { NodingGuarantee } from 'geo-polygonize';
+
+export const MAX_REPRO_QUERY_LENGTH = 8192;
+
+export type PlaygroundReproV1 = {
+  schema_version: 1;
+  input: Record<string, unknown>;
+  node_input: boolean;
+  snap_grid_size: number;
+  noding_guarantee: NodingGuarantee;
+};
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (typeof value !== 'object' || value === null) return value;
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0)
+      .map(([key, child]) => [key, canonicalize(child)]),
+  );
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function encodePlaygroundRepro(repro: PlaygroundReproV1): string {
+  const bytes = new TextEncoder().encode(JSON.stringify(canonicalize(repro)));
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  const encoded = btoa(binary).replaceAll('+', '-').replaceAll('/', '_').replace(/=+$/, '');
+  if (encoded.length > MAX_REPRO_QUERY_LENGTH) {
+    throw new Error('Repro is too large for a shareable URL');
+  }
+  return encoded;
+}
+
+export function decodePlaygroundRepro(encoded: string): PlaygroundReproV1 {
+  if (encoded.length > MAX_REPRO_QUERY_LENGTH) {
+    throw new Error('Shared repro exceeds the URL limit');
+  }
+  const base64 = encoded.replaceAll('-', '+').replaceAll('_', '/');
+  const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, '=');
+  const binary = atob(padded);
+  const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0));
+  const value: unknown = JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(bytes));
+  if (!isObject(value) || value.schema_version !== 1 || !isObject(value.input)
+    || typeof value.node_input !== 'boolean'
+    || typeof value.snap_grid_size !== 'number' || !Number.isFinite(value.snap_grid_size)
+    || !['Unchecked', 'Validate', 'CertifiedFixedPrecision'].includes(
+      value.noding_guarantee as string,
+    )) {
+    throw new Error('Unsupported shared repro');
+  }
+  return value as PlaygroundReproV1;
+}


### PR DESCRIPTION
## Stack

Parent:
- #1063

This PR:
- Encode and load small deterministic playground repro URLs.

Children:
- not opened yet

## Delivered

- Added a versioned V1 repro envelope for GeoJSON input and canonical noding controls.
- Canonicalized object keys before UTF-8 base64url encoding.
- Rejected encoded query payloads larger than 8 KiB.
- Added Copy repro URL and startup decoding in the worker-backed playground.
- Added UTF-8 round-trip, deterministic-order, and size-limit regressions.

## Contract impact

- Additive playground URL format only; semantic options, topology, fingerprints, provenance, Z behavior, and public trace schemas are unchanged.
- Oversized or unsupported repro payloads fail before polygonization.

## Validation

- `npx vitest run playground/src/repro.test.ts playground/src/trace.test.ts` — passed, 6 tests.
- `npm test` — passed, 32 tests across 5 files; existing deprecated Wasm initialization warning remains.
- `npm run build --prefix playground` — passed; existing MUI directive, deferred Wasm URL, and large-chunk warnings remain.
- `cargo fmt --all -- --check` — passed.
- `cargo clippy --workspace --all-targets -- -D warnings` — passed.
- `cargo test --workspace` — passed.
- `cargo test -p geo-polygonize-core --no-default-features` — passed.
- `RUSTDOCFLAGS='-D warnings' cargo doc -p geo-polygonize-core --no-deps` — passed.
- `npm run docs:build` — passed; existing bundler warnings remain and npm reported 5 dependency audit findings.
- `git diff --check` — passed before the commit; docs generation churn was removed after the successful build.

## Agent handoff

Remaining:
- P1.6 still needs exact Z reconciliation events, diagnostics and budgets, side-by-side profile comparison, fixture export, and worker minimization.

Next dependency-ready slice:
- `agent/p1-trace-z-reconciliation` adds physical Z reconciliation decisions for the inspector after stack capacity opens.
