### PR TITLE
fix(github): enable automerge for native stack roots

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -16,7 +16,6 @@ jobs:
       github.event.pull_request.user.login == 'graydonpleasants' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.base.ref == github.event.repository.default_branch &&
-      github.event.pull_request.stack == null &&
       !github.event.pull_request.draft
     runs-on: ubuntu-latest
 

--- a/tests/test_automerge_workflow.py
+++ b/tests/test_automerge_workflow.py
@@ -4,8 +4,8 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 
 
-def test_automerge_excludes_native_stacks():
+def test_automerge_allows_stack_roots_but_excludes_children():
     workflow = (ROOT / ".github/workflows/automerge.yml").read_text()
 
     assert "github.event.pull_request.base.ref == github.event.repository.default_branch" in workflow
-    assert "github.event.pull_request.stack == null" in workflow
+    assert "github.event.pull_request.stack" not in workflow


### PR DESCRIPTION
## Stack

Parent:
- none; starts from current `main`

This PR:
- Restore automerge for native stack roots while keeping child PRs excluded.

Children:
- not opened yet

## Delivered

- Removed the native-stack exclusion from the automerge workflow.
- Retained the default-branch guard, which already excludes child PRs.
- Added a regression proving stack metadata no longer suppresses root automerge.

## Contract impact

- Ready, same-repository PRs targeting the default branch may enable squash automerge whether or not they are native stack roots.
- Child PRs remain ineligible because they target their parent branch.

## Validation

- `python3 -m pytest tests/test_automerge_workflow.py` — passed, 1 test; existing pytest-asyncio configuration warning remains.
- `actionlint .github/workflows/automerge.yml` — passed.
- `git diff --check` — passed.

## Agent handoff

Remaining:
- Merge this workflow fix, then enable automerge once on #1059 because an existing PR will not receive a new qualifying event automatically.

Next dependency-ready slice:
- Resume native-stack progression from #1059.
