### PR TITLE
fix(github): run required CI for stacked children

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ "main", "develop" ]
   pull_request:
-    branches: [ "main", "develop" ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_required_ci_runs_for_stacked_child_bases():
+    workflow = (ROOT / ".github/workflows/ci.yml").read_text()
+    pull_request_trigger = workflow.split("  pull_request:", 1)[1].split("\nenv:", 1)[0]
+
+    assert "branches:" not in pull_request_trigger
+    assert "name: CI Required" in workflow


### PR DESCRIPTION
## Stack

Parent:
- none; starts from current `main`

This PR:
- Run the required CI workflow for pull requests targeting stacked parent branches.

Children:
- not opened yet

## Delivered

- Removed the `main`/`develop` base filter from the required CI pull-request trigger.
- Retained the existing push filter for `main` and `develop`.
- Added a regression proving `CI Required` remains present and child-base PRs are not filtered out.

## Contract impact

- Every pull request now receives the same `CI Required` aggregator, including native stacked children such as #1060.
- Push CI remains limited to `main` and `develop`.

## Validation

- `python3 -m pytest tests/test_ci_workflow.py tests/test_automerge_workflow.py` — passed, 2 tests; existing pytest-asyncio configuration warning remains.
- `actionlint .github/workflows/ci.yml` — passed.
- `git diff --check` — passed.

## Agent handoff

Remaining:
- After merge, sync stack #1061 onto current `main`; the resulting synchronize events will run required CI on #1060 and the other child bases.

Next dependency-ready slice:
- `gh stack checkout 1061 && gh stack sync --prune`, then continue merging from #1059 upward.
