### PR TITLE
ci(github): validate playground changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
             changed="$(git diff --name-only "$base" "${{ github.sha }}")"
           fi
 
-          if echo "$changed" | grep -Eq '^(crates/|fixtures/cfb/|pkg-wrapper/|scripts/build_wasm\.sh$|package(-lock)?\.json$|rollup\.config\.mjs$|tsconfig\.json$|\.github/workflows/ci\.yml$)'; then
+          if echo "$changed" | grep -Eq '^(crates/|fixtures/cfb/|pkg-wrapper/|playground/|scripts/build_wasm\.sh$|package(-lock)?\.json$|rollup\.config\.mjs$|tsconfig\.json$|\.github/workflows/ci\.yml$)'; then
             echo "wasm=true" >> "$GITHUB_OUTPUT"
           else
             echo "wasm=false" >> "$GITHUB_OUTPUT"
@@ -238,6 +238,9 @@ jobs:
 
       - name: Run JS Tests
         run: npm test
+
+      - name: Build playground
+        run: npm run build --prefix playground
 
   test:
     name: CI Required

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,7 +213,9 @@ jobs:
           cache: 'npm'
 
       - name: Install NPM dependencies
-        run: npm ci
+        run: |
+          npm ci
+          npm ci --prefix playground
 
       - name: Download scalar package
         uses: actions/download-artifact@v4

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -10,3 +10,10 @@ def test_required_ci_runs_for_stacked_child_bases():
 
     assert "branches:" not in pull_request_trigger
     assert "name: CI Required" in workflow
+
+
+def test_playground_changes_run_and_build_in_js_ci():
+    workflow = (ROOT / ".github/workflows/ci.yml").read_text()
+
+    assert "pkg-wrapper/|playground/|scripts/build_wasm" in workflow
+    assert "npm run build --prefix playground" in workflow

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -16,4 +16,7 @@ def test_playground_changes_run_and_build_in_js_ci():
     workflow = (ROOT / ".github/workflows/ci.yml").read_text()
 
     assert "pkg-wrapper/|playground/|scripts/build_wasm" in workflow
+    assert workflow.index("npm ci --prefix playground") < workflow.index(
+        "npm run build --prefix playground"
+    )
     assert "npm run build --prefix playground" in workflow


### PR DESCRIPTION
## Stack

- Parent: `main`
- This PR: `agent/p1-playground-ci`
- Children: `agent/p1-playground-profile-compare` (#1070)

## Delivered

- Treat `playground/` changes as WASM/JS changes so required CI cannot pass while those jobs skip.
- Build the playground in the JS job after the existing tests.
- Cover both workflow contracts with the static regression test.

## Contract impact

No runtime or public API changes. Playground changes now exercise the existing WASM build, JS test, and playground compile path in CI.

## Validation

- `pytest -q tests/test_ci_workflow.py` — 2 passed
- `actionlint .github/workflows/ci.yml` — passed
- `npm test` — 5 files, 32 tests passed
- `npm run build --prefix playground` — passed
- `git diff --check` — passed

Warnings: local dependency audit reported existing vulnerabilities; Vite emitted existing MUI directive, unresolved-at-build-time WASM URL, and large-chunk warnings.

## Agent handoff

- Remaining: compare two canonical playground option profiles.
- Next: review child PR #1070.