### PR TITLE
feat(wasm): compare debugger profiles

### DIFF
--- a/playground/src/compare.test.ts
+++ b/playground/src/compare.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { PolygonizeTraceReportV1 } from 'geo-polygonize';
+import { comparePlaygroundProfiles } from './compare';
+
+function report(polygonCount: number): PolygonizeTraceReportV1 {
+  return {
+    schema_version: 1,
+    topology: {
+      schema_version: 1,
+      options: {},
+      polygons: Array.from({ length: polygonCount }, () => ({
+        exterior: [],
+        interiors: [],
+        exterior_edge_ids: [],
+        provenance: null,
+      })),
+      dangles: [],
+      cut_edges: [],
+      invalid_rings: [],
+      diagnostics: null,
+    },
+    trace: {
+      schema_version: 1,
+      library_version: 'test',
+      level: 'summary',
+      byte_limit: 4096,
+      bytes_used: 0,
+      truncated: false,
+      options: {},
+      events: [],
+    },
+  };
+}
+
+describe('profile comparison', () => {
+  it('runs the validated and certified profiles and detects topology divergence', async () => {
+    const run = vi.fn()
+      .mockResolvedValueOnce(JSON.stringify(report(1)))
+      .mockResolvedValueOnce(JSON.stringify(report(2)));
+    const signal = new AbortController().signal;
+
+    const comparison = await comparePlaygroundProfiles('{}', signal, run);
+
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(run.mock.calls.map((call) => call[1].noding.guarantee))
+      .toEqual(['Validate', 'CertifiedFixedPrecision']);
+    expect(run.mock.calls.every((call) => call[4].signal === signal)).toBe(true);
+    expect(comparison.results.map((result) => result.report.topology.polygons.length))
+      .toEqual([1, 2]);
+    expect(comparison.diverged).toBe(true);
+  });
+});

--- a/playground/src/compare.ts
+++ b/playground/src/compare.ts
@@ -1,0 +1,53 @@
+import type {
+  PolygonizeTraceReportV1,
+  PolygonizerOptions,
+  polygonizeTraceWithOptionsAsync,
+} from 'geo-polygonize';
+import { buildPlaygroundOptions } from './options';
+import { parsePlaygroundTraceReport, PLAYGROUND_TRACE_BYTE_LIMIT } from './trace';
+
+const profiles = [
+  {
+    label: 'Validated floating',
+    options: buildPlaygroundOptions(true, 0, 'Validate'),
+  },
+  {
+    label: 'Certified fixed precision',
+    options: buildPlaygroundOptions(true, 0.001, 'CertifiedFixedPrecision'),
+  },
+] satisfies { label: string; options: Partial<PolygonizerOptions> }[];
+
+export type ProfileResult = {
+  label: string;
+  report: PolygonizeTraceReportV1;
+};
+
+export type ProfileComparison = {
+  results: ProfileResult[];
+  diverged: boolean;
+};
+
+function fingerprint({ options: _, ...topology }: PolygonizeTraceReportV1['topology']) {
+  return JSON.stringify(topology);
+}
+
+export async function comparePlaygroundProfiles(
+  input: string,
+  signal: AbortSignal,
+  run: typeof polygonizeTraceWithOptionsAsync,
+): Promise<ProfileComparison> {
+  const results = await Promise.all(profiles.map(async ({ label, options }) => ({
+    label,
+    report: parsePlaygroundTraceReport(await run(
+      input,
+      options,
+      'summary',
+      PLAYGROUND_TRACE_BYTE_LIMIT,
+      { signal },
+    )),
+  })));
+  return {
+    results,
+    diverged: fingerprint(results[0].report.topology) !== fingerprint(results[1].report.topology),
+  };
+}

--- a/playground/src/main.tsx
+++ b/playground/src/main.tsx
@@ -24,6 +24,7 @@ import {
   Alert
 } from '@mui/material';
 import { appendLineString, parseGeojsonInput } from './input';
+import { comparePlaygroundProfiles, type ProfileComparison } from './compare';
 import { buildPlaygroundOptions } from './options';
 import { decodePlaygroundRepro, encodePlaygroundRepro } from './repro';
 import {
@@ -144,6 +145,9 @@ function App() {
   const [report, setReport] = useState<TopologyFingerprintV1 | null>(null);
   const [trace, setTrace] = useState<TopologyTraceV1 | null>(null);
   const [traceBusy, setTraceBusy] = useState(false);
+  const [comparison, setComparison] = useState<ProfileComparison | null>(null);
+  const [comparisonBusy, setComparisonBusy] = useState(false);
+  const [comparisonError, setComparisonError] = useState<string | null>(null);
   const [selectedFeature, setSelectedFeature] = useState<SelectedFeature | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [drawEnabled, setDrawEnabled] = useState(false);
@@ -382,6 +386,27 @@ function App() {
     return () => controller.abort();
   }, [wasmReady, inputGeojson, nodeInput, snapGridSize, nodingGuarantee]);
 
+  useEffect(() => {
+    if (!wasmReady || !inputGeojson) {
+      setComparisonBusy(false);
+      return;
+    }
+    const controller = new AbortController();
+    setComparisonBusy(true);
+    setComparison(null);
+    setComparisonError(null);
+    void comparePlaygroundProfiles(
+      JSON.stringify(inputGeojson),
+      controller.signal,
+      polygonizeTraceWithOptionsAsync,
+    ).then(setComparison).catch((e: Error) => {
+      if (e.name !== 'AbortError') setComparisonError(e.toString());
+    }).finally(() => {
+      if (!controller.signal.aborted) setComparisonBusy(false);
+    });
+    return () => controller.abort();
+  }, [wasmReady, inputGeojson]);
+
 
   // SVG Viewport calculation
   const bbox = useMemo(() => {
@@ -398,7 +423,9 @@ function App() {
 
       {!wasmReady && <Alert severity="info">Loading WebAssembly...</Alert>}
       {traceBusy && <Alert severity="info">Tracing topology in a worker...</Alert>}
+      {comparisonBusy && <Alert severity="info">Comparing canonical profiles...</Alert>}
       {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+      {comparisonError && <Alert severity="error" sx={{ mb: 2 }}>Profile comparison: {comparisonError}</Alert>}
 
       <Grid container spacing={3}>
         {/* Controls */}
@@ -607,6 +634,37 @@ function App() {
                    sx={{ mt: 2 }}
                  />
                )}
+            </Paper>
+          )}
+
+          {comparison && (
+            <Paper sx={{ p: 2, mt: 3 }}>
+              <Typography variant="h6">Profile comparison</Typography>
+              <Alert severity={comparison.diverged ? 'warning' : 'success'} sx={{ my: 1 }}>
+                Canonical topology fingerprints {comparison.diverged ? 'diverge' : 'match'}.
+              </Alert>
+              <Grid container spacing={2}>
+                {comparison.results.map(({ label, report: result }) => (
+                  <Grid key={label} size={{ xs: 12, sm: 6 }}>
+                    <Typography variant="subtitle1">{label}</Typography>
+                    <Typography>Polygons: {result.topology.polygons.length}</Typography>
+                    <Typography>Dangles: {result.topology.dangles.length}</Typography>
+                    <Typography>Cut edges: {result.topology.cut_edges.length}</Typography>
+                    <Typography>Invalid rings: {result.topology.invalid_rings.length}</Typography>
+                    <Typography>Trace events: {result.trace.events.length}</Typography>
+                    <Typography>Trace bytes: {result.trace.bytes_used.toLocaleString()}</Typography>
+                    <TextField
+                      fullWidth
+                      multiline
+                      minRows={4}
+                      label="Canonical options"
+                      value={JSON.stringify(result.topology.options, null, 2)}
+                      InputProps={{ readOnly: true }}
+                      sx={{ mt: 1 }}
+                    />
+                  </Grid>
+                ))}
+              </Grid>
             </Paper>
           )}
         </Grid>


### PR DESCRIPTION
## Stack

- Parent: `agent/p1-playground-ci` (#1069)
- This PR: `agent/p1-playground-profile-compare`
- Children: `agent/p1-playground-error-witness` (#1072)

## Delivered

- Run validated-floating and certified-fixed-precision canonical profiles through the existing abortable trace worker.
- Compare canonical topology fingerprints without treating their intentionally different resolved options as topology divergence.
- Show side-by-side topology/trace metrics and resolved canonical options.
- Cover the two calls, option guarantees, shared abort signal, metrics, and divergence result with a focused test.

## Contract impact

No wrapper or public API changes. The playground consumes existing `polygonizeTraceWithOptionsAsync` and V1 report contracts.

## Validation

- `npx vitest run playground/src/compare.test.ts` — 1 passed
- `npm test` — 6 files, 33 tests passed
- explicit strict playground source type-check — passed
- `npm run build --prefix playground` — passed
- `git diff --check` — passed

Warnings: Vite emitted existing MUI directive, unresolved-at-build-time WASM URL, and large-chunk warnings.

## Agent handoff

- Remaining: normalized worker error/witness rendering is isolated in child #1072.
- Next: review child #1072 after this PR.