### PR TITLE
feat(wasm): show debugger error witnesses

### DIFF
--- a/playground/src/error.test.ts
+++ b/playground/src/error.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { extractNormalizedError } from './error';
+
+describe('normalized worker errors', () => {
+  it('extracts the preserved V1 error and witness without accepting unknown shapes', () => {
+    const normalized = {
+      schema_version: 1,
+      family: 'noding',
+      code: 'intersection',
+      stage: 'noding',
+      field: null,
+      expected: null,
+      actual: null,
+      limit: null,
+      observed: null,
+      witness: { ids: ['0x01'], coordinate: null },
+    };
+
+    expect(extractNormalizedError(Object.assign(new Error('failed'), { normalized })))
+      .toEqual(normalized);
+    expect(extractNormalizedError({ normalized: { schema_version: 2 } })).toBeNull();
+  });
+});

--- a/playground/src/error.ts
+++ b/playground/src/error.ts
@@ -1,0 +1,16 @@
+import type { NormalizedPolygonizeErrorV1 } from 'geo-polygonize';
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+export function extractNormalizedError(error: unknown): NormalizedPolygonizeErrorV1 | null {
+  if (!isObject(error) || !isObject(error.normalized)) return null;
+  const normalized = error.normalized;
+  return normalized.schema_version === 1
+    && typeof normalized.family === 'string'
+    && typeof normalized.code === 'string'
+    && typeof normalized.stage === 'string'
+    ? normalized as unknown as NormalizedPolygonizeErrorV1
+    : null;
+}

--- a/playground/src/main.tsx
+++ b/playground/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import init, {
   polygonizeTraceWithOptionsAsync,
   type NodingGuarantee,
+  type NormalizedPolygonizeErrorV1,
   type PolygonizerOptions,
   type TopologyFingerprintV1,
   type TopologyTraceV1,
@@ -25,6 +26,7 @@ import {
 } from '@mui/material';
 import { appendLineString, parseGeojsonInput } from './input';
 import { comparePlaygroundProfiles, type ProfileComparison } from './compare';
+import { extractNormalizedError } from './error';
 import { buildPlaygroundOptions } from './options';
 import { decodePlaygroundRepro, encodePlaygroundRepro } from './repro';
 import {
@@ -148,6 +150,7 @@ function App() {
   const [comparison, setComparison] = useState<ProfileComparison | null>(null);
   const [comparisonBusy, setComparisonBusy] = useState(false);
   const [comparisonError, setComparisonError] = useState<string | null>(null);
+  const [normalizedError, setNormalizedError] = useState<NormalizedPolygonizeErrorV1 | null>(null);
   const [selectedFeature, setSelectedFeature] = useState<SelectedFeature | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [drawEnabled, setDrawEnabled] = useState(false);
@@ -257,6 +260,7 @@ function App() {
     setTrace(null);
     setSelectedFeature(null);
     setError(null);
+    setNormalizedError(null);
 
     async function loadFixture() {
       try {
@@ -362,6 +366,7 @@ function App() {
     setTraceBusy(true);
     setTrace(null);
     setSelectedFeature(null);
+    setNormalizedError(null);
     void polygonizeTraceWithOptionsAsync(
       JSON.stringify(inputGeojson),
       options,
@@ -379,6 +384,7 @@ function App() {
       setOutputGeojson(null);
       setReport(null);
       setTrace(null);
+      setNormalizedError(extractNormalizedError(e));
       setError("Polygonize Error: " + e.toString());
     }).finally(() => {
       if (!controller.signal.aborted) setTraceBusy(false);
@@ -400,7 +406,10 @@ function App() {
       controller.signal,
       polygonizeTraceWithOptionsAsync,
     ).then(setComparison).catch((e: Error) => {
-      if (e.name !== 'AbortError') setComparisonError(e.toString());
+      if (e.name !== 'AbortError') {
+        setNormalizedError(extractNormalizedError(e));
+        setComparisonError(e.toString());
+      }
     }).finally(() => {
       if (!controller.signal.aborted) setComparisonBusy(false);
     });
@@ -426,6 +435,21 @@ function App() {
       {comparisonBusy && <Alert severity="info">Comparing canonical profiles...</Alert>}
       {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
       {comparisonError && <Alert severity="error" sx={{ mb: 2 }}>Profile comparison: {comparisonError}</Alert>}
+      {normalizedError && (
+        <Paper sx={{ p: 2, mb: 2 }}>
+          <Typography variant="h6">Normalized worker error</Typography>
+          <Typography>{normalizedError.family} / {normalizedError.code} at {normalizedError.stage}</Typography>
+          <TextField
+            fullWidth
+            multiline
+            minRows={4}
+            label="Structured error and witness"
+            value={JSON.stringify(normalizedError, null, 2)}
+            InputProps={{ readOnly: true }}
+            sx={{ mt: 1 }}
+          />
+        </Paper>
+      )}
 
       <Grid container spacing={3}>
         {/* Controls */}


### PR DESCRIPTION
## Stack

- Parent: `agent/p1-playground-profile-compare` (#1070)
- This PR: `agent/p1-playground-error-witness`
- Children: none

## Delivered

- Recognize the V1 normalized error object already preserved on rejected worker errors.
- Show its stable family, code, stage, structured fields, and exact witness in the debugger.
- Cover accepted V1 and rejected unknown shapes with a focused test.

## Contract impact

No wrapper or public API changes. This consumes the existing exported `NormalizedPolygonizeErrorV1` and `error.normalized` worker behavior.

## Validation

- `npx vitest run playground/src/error.test.ts` — 1 passed
- `npm test` — 7 files, 34 tests passed
- explicit strict playground source type-check — passed
- `npm run build --prefix playground` — passed
- `git diff --check` — passed

Warnings: Vite emitted existing MUI directive, unresolved-at-build-time WASM URL, and large-chunk warnings.

## Agent handoff

- Remaining: fixture export and differential minimization remain separate roadmap work.
- Next: review this final stack child after #1070.