### PR TITLE
feat(core): record debugger diagnostics in traces

### DIFF
--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -788,7 +788,10 @@ impl Polygonizer {
             trace.record_input_segments(&input_lines)?;
         }
 
-        let mut diag = if self.options.diagnostics.enabled || self.options.diagnostics.timings {
+        let return_diagnostics =
+            self.options.diagnostics.enabled || self.options.diagnostics.timings;
+        let collect_diagnostics = return_diagnostics || self.trace.is_some();
+        let mut diag = if collect_diagnostics {
             let d = PolygonizerDiagnostics {
                 input_segment_count: input_lines.len(),
                 ..Default::default()
@@ -801,7 +804,7 @@ impl Polygonizer {
         let t_ingest_start = get_time();
         self.build_graph(
             input_lines,
-            if self.options.diagnostics.enabled {
+            if self.options.diagnostics.enabled || self.trace.is_some() {
                 diag.as_mut()
             } else {
                 None
@@ -1010,12 +1013,15 @@ impl Polygonizer {
             d.invalid_ring_count = invalid_rings.len();
             // output_flatten time could be measured here if we had a separate pass, but we'll leave it 0 or record what we have
         }
+        if let (Some(trace), Some(diagnostics)) = (self.trace.as_mut(), diag.as_ref()) {
+            trace.record_diagnostics_summary(diagnostics);
+        }
         Ok(PolygonizerResult {
             polygons: result,
             dangles,
             cut_edges,
             invalid_rings,
-            diagnostics: diag,
+            diagnostics: if return_diagnostics { diag } else { None },
         })
     }
 }

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -10,7 +10,8 @@ use crate::noding::hot_pixel::{
 };
 use crate::noding::snap::{FloatingCandidateTrace, FloatingIntersectionTrace, FloatingSplitTrace};
 use crate::{
-    CoordinateFingerprintV1, Line3D, Polygon3D, PolygonizerOptions, PolygonizerResult, ZPolicy,
+    CoordinateFingerprintV1, Line3D, Polygon3D, PolygonizerDiagnostics, PolygonizerOptions,
+    PolygonizerResult, ZPolicy,
 };
 use serde::Serialize;
 
@@ -446,6 +447,34 @@ impl TraceRecorderV1 {
 
     pub fn finish(self) -> TopologyTraceV1 {
         self.trace
+    }
+
+    pub(crate) fn record_diagnostics_summary(&mut self, diagnostics: &PolygonizerDiagnostics) {
+        let stage = |stage: TraceStageV1| {
+            let index = stage.index();
+            serde_json::json!({
+                "limit": self.limits.stage(stage),
+                "bytes_used_before_summary": self.stage_bytes_used[index],
+                "truncated_before_summary": self.stage_truncated[index],
+            })
+        };
+        let payload = serde_json::json!({
+            "diagnostics": diagnostics,
+            "trace_budget": {
+                "total": {
+                    "limit": self.trace.byte_limit,
+                    "bytes_used_before_summary": self.trace.bytes_used,
+                    "truncated_before_summary": self.total_truncated,
+                },
+                "truncated_before_summary": self.trace.truncated,
+                "summary": stage(TraceStageV1::Summary),
+                "noding": stage(TraceStageV1::Noding),
+                "graph": stage(TraceStageV1::Graph),
+                "rings": stage(TraceStageV1::Rings),
+                "output": stage(TraceStageV1::Output),
+            },
+        });
+        self.record(TraceStageV1::Summary, "polygonizer_summary", payload);
     }
 
     pub(crate) fn records_stage(&self, stage: TraceStageV1) -> bool {
@@ -1330,6 +1359,71 @@ mod tests {
             .events
             .iter()
             .all(|event| event.kind != "z_reconciliation"));
+    }
+
+    #[test]
+    fn summary_trace_reuses_diagnostics_and_budget_metadata_without_enabling_result_diagnostics() {
+        let lines = vec![
+            Line3D::new(Coord3D::new(0.0, 0.0, 0.0), Coord3D::new(2.0, 2.0, 0.0), 1),
+            Line3D::new(Coord3D::new(0.0, 2.0, 0.0), Coord3D::new(2.0, 0.0, 0.0), 2),
+        ];
+        let options = PolygonizerOptions {
+            node_input: true,
+            ..Default::default()
+        };
+        let expected = polygonize(lines.clone(), &options).unwrap();
+        let traced = polygonize_with_trace(
+            lines.clone(),
+            &options,
+            &ExecutionPolicy::default(),
+            TraceLevelV1::Summary,
+            usize::MAX,
+        )
+        .unwrap();
+
+        assert!(expected.diagnostics.is_none());
+        assert!(traced.result.diagnostics.is_none());
+        assert_eq!(traced.trace.events.len(), 1);
+        let summary = &traced.trace.events[0];
+        assert_eq!(summary.kind, "polygonizer_summary");
+        assert_eq!(summary.stage, TraceStageV1::Summary);
+        assert_eq!(summary.payload["diagnostics"]["input_segment_count"], 2);
+        assert_eq!(
+            summary.payload["diagnostics"]["noding_work_stats"]["candidate_pairs"],
+            1
+        );
+        assert!(summary.payload["diagnostics"]["phase_times"].is_object());
+        assert_eq!(
+            summary.payload["trace_budget"]["total"]["limit"],
+            usize::MAX
+        );
+        assert_eq!(
+            summary.payload["trace_budget"]["total"]["bytes_used_before_summary"],
+            0
+        );
+        assert_eq!(
+            summary.payload["trace_budget"]["summary"]["bytes_used_before_summary"],
+            0
+        );
+        assert_eq!(
+            TopologyFingerprintV1::try_from_result(&traced.result, &options).unwrap(),
+            TopologyFingerprintV1::try_from_result(&expected, &options).unwrap()
+        );
+
+        let truncated = polygonize_with_trace_limits(
+            lines,
+            &options,
+            &ExecutionPolicy::default(),
+            TraceLevelV1::Summary,
+            TraceByteLimitsV1 {
+                summary_bytes: 0,
+                ..TraceByteLimitsV1::total(usize::MAX)
+            },
+        )
+        .unwrap()
+        .trace;
+        assert!(truncated.truncated);
+        assert!(truncated.events.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Stack

- Parent: `agent/p1-z-reconciliation-trace` (#1068)
- This PR: `agent/p1-trace-summary-evidence` (#1073)
- Children: None

## Delivered

- Emits one bounded `polygonizer_summary` event from the existing physical `PolygonizerDiagnostics` timings and work counters.
- Includes named total and per-stage trace limit, usage, and truncation snapshots taken before the summary event.
- Collects trace-only diagnostics internally while preserving the caller-controlled `result.diagnostics` option contract.
- Adds topology-equivalence, counter, metadata, disabled-result-diagnostics, and summary-stage truncation coverage.

## Contract impact

- Adds a bounded Summary event payload without changing public Trace V1 fields or semantic options.
- Trace-disabled execution retains the existing path; topology, provenance, and returned diagnostics semantics are unchanged.
- No generated bindings, package locks, playground, Wasm wrapper, or Roadmap files changed.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p geo-polygonize-core summary_trace_reuses_diagnostics_and_budget_metadata_without_enabling_result_diagnostics`
- `cargo test -p geo-polygonize-core --no-default-features summary_trace_reuses_diagnostics_and_budget_metadata_without_enabling_result_diagnostics`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `git diff --check`

## Agent handoff

- Remaining: partial failure outcome/V2 tracing and debugger UI consumption are intentionally deferred to the integration wave.
- Next dependency-ready slice: consume `z_reconciliation` and `polygonizer_summary` events in the debugger without reconstructing core evidence.