### PR TITLE
test(core): replay differential fuzz artifacts

### DIFF
--- a/crates/geo-polygonize-core/fuzz/examples/replay_adapter_differential.rs
+++ b/crates/geo-polygonize-core/fuzz/examples/replay_adapter_differential.rs
@@ -1,0 +1,29 @@
+use geo_polygonize_core_fuzz::{replay_adapter_differential, ReplayOutcome};
+use std::{env, fs, process::ExitCode};
+
+fn main() -> ExitCode {
+    let paths: Vec<_> = env::args_os().skip(1).collect();
+    if paths.is_empty() {
+        eprintln!("usage: replay_adapter_differential ARTIFACT...");
+        return ExitCode::FAILURE;
+    }
+
+    for path in paths {
+        let data = match fs::read(&path) {
+            Ok(data) => data,
+            Err(error) => {
+                eprintln!("{}: {error}", path.to_string_lossy());
+                return ExitCode::FAILURE;
+            }
+        };
+        match replay_adapter_differential(&data) {
+            Ok(ReplayOutcome::Matched) => println!("{}: matched", path.to_string_lossy()),
+            Ok(ReplayOutcome::Ignored) => println!("{}: ignored", path.to_string_lossy()),
+            Err(mismatch) => {
+                eprintln!("{}: {mismatch}", path.to_string_lossy());
+                return ExitCode::FAILURE;
+            }
+        }
+    }
+    ExitCode::SUCCESS
+}

--- a/crates/geo-polygonize-core/fuzz/fuzz_targets/adapter_differential.rs
+++ b/crates/geo-polygonize-core/fuzz/fuzz_targets/adapter_differential.rs
@@ -1,62 +1,12 @@
 #![no_main]
 
-use arbitrary::Arbitrary;
-use geo_polygonize_core::{
-    normalize_polygonize_error, polygonize, polygonize_with_workspace, Coord3D, Line3D,
-    PolygonizerOptions, PolygonizerWorkspace, PrecisionModel, SnapStrategy, TopologyFingerprintV1,
-};
-use libfuzzer_sys::fuzz_target;
+use geo_polygonize_core_fuzz::{replay_adapter_differential, ReplayOutcome};
+use libfuzzer_sys::{fuzz_target, Corpus};
 
-#[derive(Arbitrary, Debug)]
-struct FuzzInput {
-    lines: Vec<(f64, f64, f64, f64, f64, f64)>,
-    node_input: bool,
-    grid_size: f64,
-}
-
-fuzz_target!(|input: FuzzInput| {
-    if input.lines.len() > 64 {
-        return;
-    }
-    let lines: Vec<_> = input
-        .lines
-        .into_iter()
-        .enumerate()
-        .filter_map(|(index, (sx, sy, sz, ex, ey, ez))| {
-            [sx, sy, sz, ex, ey, ez]
-                .iter()
-                .all(|value| value.is_finite())
-                .then(|| {
-                    Line3D::new(
-                        Coord3D::new(sx, sy, sz),
-                        Coord3D::new(ex, ey, ez),
-                        u32::try_from(index).unwrap(),
-                    )
-                })
-        })
-        .collect();
-    let options = PolygonizerOptions {
-        node_input: input.node_input,
-        precision_model: PrecisionModel::FixedGrid {
-            grid_size: input.grid_size.abs().clamp(1e-10, 1.0),
-        },
-        snap_strategy: SnapStrategy::Grid,
-        ..Default::default()
-    };
-    let one_shot = polygonize(lines.iter().copied(), &options);
-    let workspace = polygonize_with_workspace(&lines, &options, &mut PolygonizerWorkspace::new());
-
-    match (one_shot, workspace) {
-        (Ok(one_shot), Ok(workspace)) => {
-            assert_eq!(
-                TopologyFingerprintV1::try_from_result(&one_shot, &options).unwrap(),
-                TopologyFingerprintV1::try_from_result(&workspace, &options).unwrap()
-            );
-        }
-        (Err(one_shot), Err(workspace)) => assert_eq!(
-            normalize_polygonize_error(&one_shot),
-            normalize_polygonize_error(&workspace)
-        ),
-        (one_shot, workspace) => panic!("adapter outcome mismatch: {one_shot:?} != {workspace:?}"),
+fuzz_target!(|data: &[u8]| -> Corpus {
+    match replay_adapter_differential(data) {
+        Ok(ReplayOutcome::Matched) => Corpus::Keep,
+        Ok(ReplayOutcome::Ignored) => Corpus::Reject,
+        Err(mismatch) => panic!("{mismatch}"),
     }
 });

--- a/crates/geo-polygonize-core/fuzz/src/lib.rs
+++ b/crates/geo-polygonize-core/fuzz/src/lib.rs
@@ -1,0 +1,105 @@
+use arbitrary::{Arbitrary, Unstructured};
+use geo_polygonize_core::{
+    normalize_polygonize_error, polygonize, polygonize_with_workspace, Coord3D, Line3D,
+    PolygonizerOptions, PolygonizerWorkspace, PrecisionModel, SnapStrategy, TopologyFingerprintV1,
+};
+
+#[derive(Arbitrary, Debug)]
+struct AdapterDifferentialInput {
+    lines: Vec<(f64, f64, f64, f64, f64, f64)>,
+    node_input: bool,
+    grid_size: f64,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum ReplayOutcome {
+    Ignored,
+    Matched,
+}
+
+/// Decode and compare one raw `adapter_differential` libFuzzer input.
+pub fn replay_adapter_differential(data: &[u8]) -> Result<ReplayOutcome, String> {
+    if data.len() < AdapterDifferentialInput::size_hint(0).0 {
+        return Ok(ReplayOutcome::Ignored);
+    }
+    let Ok(input) = AdapterDifferentialInput::arbitrary_take_rest(Unstructured::new(data)) else {
+        return Ok(ReplayOutcome::Ignored);
+    };
+    if input.lines.len() > 64 {
+        return Ok(ReplayOutcome::Ignored);
+    }
+
+    let lines: Vec<_> = input
+        .lines
+        .into_iter()
+        .enumerate()
+        .filter_map(|(index, (sx, sy, sz, ex, ey, ez))| {
+            if [sx, sy, sz, ex, ey, ez]
+                .iter()
+                .all(|value| value.is_finite())
+            {
+                Some(Line3D::new(
+                    Coord3D::new(sx, sy, sz),
+                    Coord3D::new(ex, ey, ez),
+                    u32::try_from(index).unwrap(),
+                ))
+            } else {
+                None
+            }
+        })
+        .collect();
+    let options = PolygonizerOptions {
+        node_input: input.node_input,
+        precision_model: PrecisionModel::FixedGrid {
+            grid_size: input.grid_size.abs().clamp(1e-10, 1.0),
+        },
+        snap_strategy: SnapStrategy::Grid,
+        ..Default::default()
+    };
+    let one_shot = polygonize(lines.iter().copied(), &options);
+    let workspace = polygonize_with_workspace(&lines, &options, &mut PolygonizerWorkspace::new());
+
+    match (one_shot, workspace) {
+        (Ok(one_shot), Ok(workspace)) => {
+            let one_shot = TopologyFingerprintV1::try_from_result(&one_shot, &options)
+                .map_err(|error| format!("one-shot fingerprint failed: {error}"))?;
+            let workspace = TopologyFingerprintV1::try_from_result(&workspace, &options)
+                .map_err(|error| format!("workspace fingerprint failed: {error}"))?;
+            if one_shot == workspace {
+                Ok(ReplayOutcome::Matched)
+            } else {
+                Err(format!(
+                    "adapter fingerprint mismatch: {one_shot:?} != {workspace:?}"
+                ))
+            }
+        }
+        (Err(one_shot), Err(workspace)) => {
+            let one_shot = normalize_polygonize_error(&one_shot);
+            let workspace = normalize_polygonize_error(&workspace);
+            if one_shot == workspace {
+                Ok(ReplayOutcome::Matched)
+            } else {
+                Err(format!(
+                    "adapter error mismatch: {one_shot:?} != {workspace:?}"
+                ))
+            }
+        }
+        (one_shot, workspace) => Err(format!(
+            "adapter outcome mismatch: {one_shot:?} != {workspace:?}"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn raw_replay_uses_the_fuzz_decoder_and_comparison() {
+        let artifact = [0_u8; 10];
+        assert_eq!(
+            replay_adapter_differential(&artifact),
+            Ok(ReplayOutcome::Matched)
+        );
+    }
+}


### PR DESCRIPTION
## Stack

- Parent: `main`
- This PR: `agent/p1-differential-artifact-replay`
- Children: none; persisted fixture v1 cannot represent arbitrary successful adapter fingerprint mismatches honestly

## Delivered

- Moves raw `adapter_differential` decoding, option construction, and outcome comparison into one shared fuzz-crate path.
- Adds deterministic replay with `cargo run --manifest-path crates/geo-polygonize-core/fuzz/Cargo.toml --example replay_adapter_differential -- ARTIFACT...`.
- Keeps malformed and oversized inputs rejected and reports replayed matches, ignored inputs, and mismatches deterministically.
- Adds one focused raw-byte replay self-test; no corpus fixture is classified or admitted.

## Contract impact

No production API, polygonization semantics, persisted-fixture schema, compatibility classification, or generated binding changes. The change is confined to the core fuzz package.

## Validation

- `rustfmt --edition 2021 --check` on changed Rust files
- `cargo +nightly-2026-07-15 fuzz build adapter_differential`
- `cargo test --manifest-path crates/geo-polygonize-core/fuzz/Cargo.toml --lib`
- replay example against `fuzz/Cargo.toml`: matched
- `cargo test -p geo-polygonize-core --test persisted_differential`
- `cargo test -p geo-polygonize-core --no-default-features` (199 unit tests plus integration and doc tests)
- `cargo clippy --workspace --all-targets -- -D warnings`
- fuzz lib and example Clippy with `-D warnings`
- `git diff --check`

## Agent handoff

- Remaining: extend persisted evidence before candidate export; fixture v1 stores one full fingerprint plus only reference summary metrics, while adapter mismatches may occur in coordinates, IDs, diagnostics, or normalized errors.
- Next: define and review a schema carrying the exact second fingerprint or normalized error outcome, then add minimization and explicit human classification against that schema.