### PR TITLE
feat(wasm): inspect Z reconciliation decisions

### DIFF
--- a/playground/src/main.tsx
+++ b/playground/src/main.tsx
@@ -31,6 +31,7 @@ import { buildPlaygroundOptions } from './options';
 import { decodePlaygroundRepro, encodePlaygroundRepro } from './repro';
 import {
   extractTraceLayers,
+  extractZReconciliationDecisions,
   parsePlaygroundTraceReport,
   PLAYGROUND_TRACE_BYTE_LIMIT,
 } from './trace';
@@ -423,6 +424,10 @@ function App() {
     return computeBoundingBox(inputGeojson);
   }, [inputGeojson]);
   const traceLayers = useMemo(() => trace ? extractTraceLayers(trace) : null, [trace]);
+  const zDecisions = useMemo(
+    () => trace ? extractZReconciliationDecisions(trace) : [],
+    [trace],
+  );
 
   return (
     <Container maxWidth="lg" sx={{ mt: 4, mb: 4 }}>
@@ -631,7 +636,24 @@ function App() {
                    <Typography>
                      Trace bytes: {trace.bytes_used.toLocaleString()} / {trace.byte_limit.toLocaleString()}
                    </Typography>
+                   <Typography>
+                     Z reconciliation decisions: {zDecisions.length}
+                     {zDecisions.some(({ conflict }) => conflict)
+                       ? ` (${zDecisions.filter(({ conflict }) => conflict).length} conflicts)`
+                       : ''}
+                   </Typography>
                    {trace.truncated && <Alert severity="warning">Trace reached its byte budget.</Alert>}
+                   {zDecisions.length > 0 && (
+                     <TextField
+                       fullWidth
+                       multiline
+                       minRows={5}
+                       label="Physical Z reconciliation decisions"
+                       value={JSON.stringify(zDecisions, null, 2)}
+                       InputProps={{ readOnly: true }}
+                       sx={{ mt: 2 }}
+                     />
+                   )}
                  </>
                )}
                <TextField

--- a/playground/src/trace.test.ts
+++ b/playground/src/trace.test.ts
@@ -3,6 +3,7 @@ import type { TopologyTraceV1 } from 'geo-polygonize';
 import {
   decodeTraceCoordinate,
   extractTraceLayers,
+  extractZReconciliationDecisions,
   parsePlaygroundTraceReport,
 } from './trace';
 
@@ -54,5 +55,76 @@ describe('trace layers', () => {
   it('rejects unsupported trace envelopes', () => {
     expect(() => parsePlaygroundTraceReport('{"schema_version":2}'))
       .toThrow('Unsupported topology trace report');
+  });
+});
+
+describe('Z reconciliation decisions', () => {
+  it('preserves physical order and exact evidence bits', () => {
+    const result = extractZReconciliationDecisions(trace([
+      {
+        sequence: 4,
+        stage: 'noding',
+        kind: 'z_reconciliation',
+        payload: {
+          x: bits(1),
+          y: bits(2),
+          policy: 'InterpolateAlongEdge',
+          conflict_tolerance: bits(5),
+          candidates: [
+            { source_id: '0x00000009', z: bits(20) },
+            { source_id: '0x00000007', z: bits(30) },
+          ],
+          conflict: true,
+          retained_z: bits(30),
+        },
+      },
+      {
+        sequence: 5,
+        stage: 'noding',
+        kind: 'z_reconciliation',
+        payload: {
+          x: bits(3),
+          y: bits(4),
+          policy: 'First',
+          conflict_tolerance: bits(0),
+          candidates: [{ source_id: '0x00000001', z: bits(10) }],
+          conflict: false,
+          retained_z: bits(10),
+        },
+      },
+    ]));
+
+    expect(result.map(({ sequence }) => sequence)).toEqual([4, 5]);
+    expect(result[0]).toMatchObject({
+      coordinate: [1, 2],
+      coordinateBits: { x: bits(1), y: bits(2) },
+      policy: 'InterpolateAlongEdge',
+      conflictTolerance: bits(5),
+      candidates: [
+        { sourceId: '0x00000009', z: bits(20) },
+        { sourceId: '0x00000007', z: bits(30) },
+      ],
+      conflict: true,
+      retainedZ: bits(30),
+    });
+  });
+
+  it('ignores malformed decisions instead of inventing evidence', () => {
+    expect(extractZReconciliationDecisions(trace([
+      {
+        sequence: 0,
+        stage: 'noding',
+        kind: 'z_reconciliation',
+        payload: {
+          x: bits(1),
+          y: bits(2),
+          policy: 'First',
+          conflict_tolerance: bits(0),
+          candidates: [{ source_id: 'a' }],
+          conflict: false,
+          retained_z: bits(3),
+        },
+      },
+    ]))).toEqual([]);
   });
 });

--- a/playground/src/trace.ts
+++ b/playground/src/trace.ts
@@ -17,6 +17,17 @@ export type TracePoint = {
   sourceIds: string[];
 };
 
+export type ZReconciliationDecision = {
+  sequence: number;
+  coordinate: TraceCoordinate;
+  coordinateBits: { x: string; y: string };
+  policy: string;
+  conflictTolerance: string;
+  candidates: Array<{ sourceId: string; z: string }>;
+  conflict: boolean;
+  retainedZ: string;
+};
+
 export type PlaygroundTraceLayers = {
   snappedLines: TraceLine[];
   hotPixels: TracePoint[];
@@ -109,4 +120,43 @@ export function extractTraceLayers(trace: TopologyTraceV1): PlaygroundTraceLayer
   }
 
   return { snappedLines, hotPixels, splitPoints: [...splitPoints.values()], graphEdges };
+}
+
+export function extractZReconciliationDecisions(
+  trace: TopologyTraceV1,
+): ZReconciliationDecision[] {
+  return trace.events.flatMap((event) => {
+    if (event.kind !== 'z_reconciliation' || !isObject(event.payload)) return [];
+    const {
+      x,
+      y,
+      policy,
+      conflict_tolerance: conflictTolerance,
+      candidates,
+      conflict,
+      retained_z: retainedZ,
+    } = event.payload;
+    const coordinate = decodeTraceCoordinate({ x, y });
+    if (!coordinate || typeof x !== 'string' || typeof y !== 'string'
+      || typeof policy !== 'string' || typeof conflictTolerance !== 'string'
+      || !Array.isArray(candidates) || typeof conflict !== 'boolean'
+      || typeof retainedZ !== 'string') return [];
+    const parsedCandidates = candidates.flatMap((candidate) => (
+      isObject(candidate) && typeof candidate.source_id === 'string'
+        && typeof candidate.z === 'string'
+        ? [{ sourceId: candidate.source_id, z: candidate.z }]
+        : []
+    ));
+    if (parsedCandidates.length !== candidates.length) return [];
+    return [{
+      sequence: event.sequence,
+      coordinate,
+      coordinateBits: { x, y },
+      policy,
+      conflictTolerance,
+      candidates: parsedCandidates,
+      conflict,
+      retainedZ,
+    }];
+  });
 }


### PR DESCRIPTION
## Stack

- Parent: `main`
- This PR: inspect physical Z reconciliation decisions
- Child: #1078

## Delivered

- Parse bounded `z_reconciliation` trace events in physical sequence order.
- Show decoded XY coordinates alongside exact coordinate, tolerance, candidate, and retained-Z bits.
- Report decision and conflict counts without adding API options.
- Reject malformed event payloads instead of manufacturing evidence.

## Contract impact

Playground-only inspection of the existing trace V1 payload. No Rust core, WASM API, option, or schema changes.

## Validation

- `npx vitest run playground/src/trace.test.ts`
- strict source `tsc --noEmit`
- `npm run build --prefix playground`
- `npm test`
- `git diff --check`

## Agent handoff

- Remaining: none in this slice.
- Next: review and merge this root before #1078.