### PR TITLE
feat(wasm): show debugger execution evidence

### DIFF
--- a/playground/src/main.tsx
+++ b/playground/src/main.tsx
@@ -30,6 +30,7 @@ import { extractNormalizedError } from './error';
 import { buildPlaygroundOptions } from './options';
 import { decodePlaygroundRepro, encodePlaygroundRepro } from './repro';
 import {
+  extractExecutionEvidence,
   extractTraceLayers,
   extractZReconciliationDecisions,
   parsePlaygroundTraceReport,
@@ -428,6 +429,10 @@ function App() {
     () => trace ? extractZReconciliationDecisions(trace) : [],
     [trace],
   );
+  const executionEvidence = useMemo(
+    () => trace ? extractExecutionEvidence(trace) : null,
+    [trace],
+  );
 
   return (
     <Container maxWidth="lg" sx={{ mt: 4, mb: 4 }}>
@@ -653,6 +658,22 @@ function App() {
                        InputProps={{ readOnly: true }}
                        sx={{ mt: 2 }}
                      />
+                   )}
+                   {executionEvidence && (
+                     <>
+                       <TextField
+                         fullWidth
+                         multiline
+                         minRows={6}
+                         label="Execution evidence"
+                         value={JSON.stringify(executionEvidence, null, 2)}
+                         InputProps={{ readOnly: true }}
+                         sx={{ mt: 2 }}
+                       />
+                       <Typography variant="caption" color="text.secondary">
+                         Validation failures retain their structured witness in the error panel above.
+                       </Typography>
+                     </>
                    )}
                  </>
                )}

--- a/playground/src/trace.test.ts
+++ b/playground/src/trace.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { TopologyTraceV1 } from 'geo-polygonize';
 import {
   decodeTraceCoordinate,
+  extractExecutionEvidence,
   extractTraceLayers,
   extractZReconciliationDecisions,
   parsePlaygroundTraceReport,
@@ -126,5 +127,47 @@ describe('Z reconciliation decisions', () => {
         },
       },
     ]))).toEqual([]);
+  });
+});
+
+describe('execution evidence', () => {
+  it('extracts only existing summary timing, work, and budget fields', () => {
+    const phaseTimes = { ingest_and_node: { secs: 0, nanos: 42 } };
+    const workStats = { candidate_pairs: 7, exact_intersection_calls: 3 };
+    const traceBudget = {
+      total: { limit: 4096, bytes_used_before_summary: 1200, truncated_before_summary: false },
+      noding: { limit: 2000, bytes_used_before_summary: 900, truncated_before_summary: false },
+    };
+    expect(extractExecutionEvidence(trace([
+      {
+        sequence: 8,
+        stage: 'summary',
+        kind: 'polygonizer_summary',
+        payload: {
+          diagnostics: {
+            phase_times: phaseTimes,
+            noding_work_stats: workStats,
+            noding_iterations: 2,
+          },
+          trace_budget: traceBudget,
+        },
+      },
+    ]))).toEqual({
+      phase_times: phaseTimes,
+      noding_work_stats: workStats,
+      noding_iterations: 2,
+      trace_budget: traceBudget,
+    });
+  });
+
+  it('rejects incomplete summary evidence', () => {
+    expect(extractExecutionEvidence(trace([
+      {
+        sequence: 0,
+        stage: 'summary',
+        kind: 'polygonizer_summary',
+        payload: { diagnostics: {}, trace_budget: {} },
+      },
+    ]))).toBeNull();
   });
 });

--- a/playground/src/trace.ts
+++ b/playground/src/trace.ts
@@ -28,6 +28,13 @@ export type ZReconciliationDecision = {
   retainedZ: string;
 };
 
+export type ExecutionEvidence = {
+  phase_times: Record<string, unknown>;
+  noding_work_stats: Record<string, unknown>;
+  noding_iterations: number;
+  trace_budget: Record<string, unknown>;
+};
+
 export type PlaygroundTraceLayers = {
   snappedLines: TraceLine[];
   hotPixels: TracePoint[];
@@ -159,4 +166,19 @@ export function extractZReconciliationDecisions(
       retainedZ,
     }];
   });
+}
+
+export function extractExecutionEvidence(trace: TopologyTraceV1): ExecutionEvidence | null {
+  const summary = trace.events.find(({ kind }) => kind === 'polygonizer_summary');
+  if (!summary || !isObject(summary.payload)) return null;
+  const { diagnostics, trace_budget: traceBudget } = summary.payload;
+  if (!isObject(diagnostics) || !isObject(traceBudget)
+    || !isObject(diagnostics.phase_times) || !isObject(diagnostics.noding_work_stats)
+    || typeof diagnostics.noding_iterations !== 'number') return null;
+  return {
+    phase_times: diagnostics.phase_times,
+    noding_work_stats: diagnostics.noding_work_stats,
+    noding_iterations: diagnostics.noding_iterations,
+    trace_budget: traceBudget,
+  };
 }


### PR DESCRIPTION
## Stack

- Parent: #1077
- This PR: show debugger execution evidence
- Children: none

## Delivered

- Extract phase timings, noding work counters, noding iteration count, and per-stage trace budgets from the existing `polygonizer_summary` event.
- Show the extracted summary as read-only execution evidence.
- Keep validator failure witnesses in the already-merged normalized error panel instead of duplicating them.
- Reject incomplete summary payloads instead of presenting partial evidence as complete.

## Contract impact

Playground-only presentation of existing trace V1 and normalized-error payloads. No Rust core, WASM API, option, or schema changes.

## Validation

- `npx vitest run playground/src/trace.test.ts`
- strict source `tsc --noEmit`
- `npm run build --prefix playground`
- `npm test`
- `git diff --check`

## Agent handoff

- Remaining: successful validator witness details are not present in the trace summary schema; failure witnesses remain available through normalized errors.
- Next: review after #1077.