### PR TITLE
test(core): prepare fuzz mismatches for admission

### DIFF
--- a/crates/geo-polygonize-core/fuzz/examples/prepare_adapter_differential_candidate.rs
+++ b/crates/geo-polygonize-core/fuzz/examples/prepare_adapter_differential_candidate.rs
@@ -1,0 +1,55 @@
+use geo_polygonize_core_fuzz::{prepare_adapter_differential_candidate, CandidatePreparation};
+use std::{env, fs, fs::OpenOptions, io::Write, process::ExitCode};
+
+fn main() -> ExitCode {
+    let args: Vec<_> = env::args_os().skip(1).collect();
+    if args.len() != 2 {
+        eprintln!("usage: prepare_adapter_differential_candidate ARTIFACT OUTPUT");
+        return ExitCode::FAILURE;
+    }
+    let data = match fs::read(&args[0]) {
+        Ok(data) => data,
+        Err(error) => {
+            eprintln!("{}: {error}", args[0].to_string_lossy());
+            return ExitCode::FAILURE;
+        }
+    };
+    let prepared = match prepare_adapter_differential_candidate(&data) {
+        Ok(CandidatePreparation::Candidate(prepared)) => prepared,
+        Ok(CandidatePreparation::Ignored) => {
+            eprintln!("artifact is not a decodable adapter_differential input");
+            return ExitCode::FAILURE;
+        }
+        Ok(CandidatePreparation::Matched) => {
+            eprintln!("artifact does not reproduce an adapter mismatch");
+            return ExitCode::FAILURE;
+        }
+        Err(error) => {
+            eprintln!("{error}");
+            return ExitCode::FAILURE;
+        }
+    };
+    let json = prepared.candidate.to_pretty_json().unwrap();
+    let mut output = match OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&args[1])
+    {
+        Ok(output) => output,
+        Err(error) => {
+            eprintln!("{}: {error}", args[1].to_string_lossy());
+            return ExitCode::FAILURE;
+        }
+    };
+    if let Err(error) = writeln!(output, "{json}") {
+        eprintln!("{}: {error}", args[1].to_string_lossy());
+        return ExitCode::FAILURE;
+    }
+    println!(
+        "{}: prepared {} -> {} lines for review; not admitted",
+        args[1].to_string_lossy(),
+        prepared.original_line_count,
+        prepared.minimized_line_count
+    );
+    ExitCode::SUCCESS
+}

--- a/crates/geo-polygonize-core/fuzz/src/lib.rs
+++ b/crates/geo-polygonize-core/fuzz/src/lib.rs
@@ -1,8 +1,14 @@
 use arbitrary::{Arbitrary, Unstructured};
 use geo_polygonize_core::{
-    normalize_polygonize_error, polygonize, polygonize_with_workspace, Coord3D, Line3D,
-    PolygonizerOptions, PolygonizerWorkspace, PrecisionModel, SnapStrategy, TopologyFingerprintV1,
+    differential::{
+        minimize_line_set, minimize_xy_coordinates, DifferentialMismatchCandidateV1,
+        DifferentialOutcomeV1, DifferentialRunV1,
+    },
+    polygonize, polygonize_with_workspace, Coord3D, FingerprintDiffV1, Line3D,
+    NormalizedPolygonizeErrorV1, PolygonizerOptions, PolygonizerWorkspace, PrecisionModel,
+    SnapStrategy,
 };
+use std::collections::BTreeMap;
 
 #[derive(Arbitrary, Debug)]
 struct AdapterDifferentialInput {
@@ -17,16 +23,34 @@ pub enum ReplayOutcome {
     Matched,
 }
 
-/// Decode and compare one raw `adapter_differential` libFuzzer input.
-pub fn replay_adapter_differential(data: &[u8]) -> Result<ReplayOutcome, String> {
+pub struct AdapterDifferentialCase {
+    pub lines: Vec<Line3D>,
+    pub options: PolygonizerOptions,
+}
+
+#[derive(Debug)]
+pub struct PreparedDifferentialCandidate {
+    pub candidate: DifferentialMismatchCandidateV1,
+    pub original_line_count: usize,
+    pub minimized_line_count: usize,
+}
+
+#[derive(Debug)]
+pub enum CandidatePreparation {
+    Ignored,
+    Matched,
+    Candidate(Box<PreparedDifferentialCandidate>),
+}
+
+fn decode_adapter_differential(data: &[u8]) -> Option<AdapterDifferentialCase> {
     if data.len() < AdapterDifferentialInput::size_hint(0).0 {
-        return Ok(ReplayOutcome::Ignored);
+        return None;
     }
     let Ok(input) = AdapterDifferentialInput::arbitrary_take_rest(Unstructured::new(data)) else {
-        return Ok(ReplayOutcome::Ignored);
+        return None;
     };
     if input.lines.len() > 64 {
-        return Ok(ReplayOutcome::Ignored);
+        return None;
     }
 
     let lines: Vec<_> = input
@@ -48,46 +72,145 @@ pub fn replay_adapter_differential(data: &[u8]) -> Result<ReplayOutcome, String>
             }
         })
         .collect();
-    let options = PolygonizerOptions {
-        node_input: input.node_input,
-        precision_model: PrecisionModel::FixedGrid {
-            grid_size: input.grid_size.abs().clamp(1e-10, 1.0),
+    Some(AdapterDifferentialCase {
+        lines,
+        options: PolygonizerOptions {
+            node_input: input.node_input,
+            precision_model: PrecisionModel::FixedGrid {
+                grid_size: input.grid_size.abs().clamp(1e-10, 1.0),
+            },
+            snap_strategy: SnapStrategy::Grid,
+            ..Default::default()
         },
-        snap_strategy: SnapStrategy::Grid,
-        ..Default::default()
-    };
-    let one_shot = polygonize(lines.iter().copied(), &options);
-    let workspace = polygonize_with_workspace(&lines, &options, &mut PolygonizerWorkspace::new());
+    })
+}
 
-    match (one_shot, workspace) {
-        (Ok(one_shot), Ok(workspace)) => {
-            let one_shot = TopologyFingerprintV1::try_from_result(&one_shot, &options)
-                .map_err(|error| format!("one-shot fingerprint failed: {error}"))?;
-            let workspace = TopologyFingerprintV1::try_from_result(&workspace, &options)
-                .map_err(|error| format!("workspace fingerprint failed: {error}"))?;
-            if one_shot == workspace {
-                Ok(ReplayOutcome::Matched)
-            } else {
-                Err(format!(
-                    "adapter fingerprint mismatch: {one_shot:?} != {workspace:?}"
-                ))
-            }
+fn adapter_outcomes(
+    lines: &[Line3D],
+    options: &PolygonizerOptions,
+) -> Result<(DifferentialOutcomeV1, DifferentialOutcomeV1), String> {
+    let baseline =
+        DifferentialOutcomeV1::from_result(polygonize(lines.iter().copied(), options), options)
+            .map_err(|error| format!("one-shot fingerprint failed: {error}"))?;
+    let comparison = DifferentialOutcomeV1::from_result(
+        polygonize_with_workspace(lines, options, &mut PolygonizerWorkspace::new()),
+        options,
+    )
+    .map_err(|error| format!("workspace fingerprint failed: {error}"))?;
+    Ok((baseline, comparison))
+}
+
+/// Decode and compare one raw `adapter_differential` libFuzzer input.
+pub fn replay_adapter_differential(data: &[u8]) -> Result<ReplayOutcome, String> {
+    let Some(case) = decode_adapter_differential(data) else {
+        return Ok(ReplayOutcome::Ignored);
+    };
+    let (baseline, comparison) = adapter_outcomes(&case.lines, &case.options)?;
+    if baseline == comparison {
+        Ok(ReplayOutcome::Matched)
+    } else {
+        Err(format!(
+            "adapter outcome mismatch: {baseline:?} != {comparison:?}"
+        ))
+    }
+}
+
+/// Minimize one raw mismatch artifact and prepare it for human review.
+pub fn prepare_adapter_differential_candidate(data: &[u8]) -> Result<CandidatePreparation, String> {
+    let Some(case) = decode_adapter_differential(data) else {
+        return Ok(CandidatePreparation::Ignored);
+    };
+    Ok(match prepare_case_with(case, adapter_outcomes)? {
+        Some(candidate) => CandidatePreparation::Candidate(Box::new(candidate)),
+        None => CandidatePreparation::Matched,
+    })
+}
+
+#[derive(Clone, Debug, PartialEq)]
+enum MismatchSignature {
+    Fingerprint(FingerprintDiffV1),
+    Errors(
+        Box<NormalizedPolygonizeErrorV1>,
+        Box<NormalizedPolygonizeErrorV1>,
+    ),
+    OutcomeKinds(bool, bool),
+}
+
+fn mismatch_signature(
+    baseline: &DifferentialOutcomeV1,
+    comparison: &DifferentialOutcomeV1,
+) -> Option<MismatchSignature> {
+    match (baseline, comparison) {
+        (DifferentialOutcomeV1::Success(baseline), DifferentialOutcomeV1::Success(comparison)) => {
+            baseline
+                .diff(comparison)
+                .map(MismatchSignature::Fingerprint)
         }
-        (Err(one_shot), Err(workspace)) => {
-            let one_shot = normalize_polygonize_error(&one_shot);
-            let workspace = normalize_polygonize_error(&workspace);
-            if one_shot == workspace {
-                Ok(ReplayOutcome::Matched)
-            } else {
-                Err(format!(
-                    "adapter error mismatch: {one_shot:?} != {workspace:?}"
-                ))
-            }
+        (DifferentialOutcomeV1::Error(baseline), DifferentialOutcomeV1::Error(comparison)) => {
+            (baseline != comparison).then(|| {
+                MismatchSignature::Errors(Box::new(baseline.clone()), Box::new(comparison.clone()))
+            })
         }
-        (one_shot, workspace) => Err(format!(
-            "adapter outcome mismatch: {one_shot:?} != {workspace:?}"
+        (baseline, comparison) => Some(MismatchSignature::OutcomeKinds(
+            matches!(baseline, DifferentialOutcomeV1::Success(_)),
+            matches!(comparison, DifferentialOutcomeV1::Success(_)),
         )),
     }
+}
+
+fn prepare_case_with<F>(
+    case: AdapterDifferentialCase,
+    mut compare: F,
+) -> Result<Option<PreparedDifferentialCandidate>, String>
+where
+    F: FnMut(
+        &[Line3D],
+        &PolygonizerOptions,
+    ) -> Result<(DifferentialOutcomeV1, DifferentialOutcomeV1), String>,
+{
+    let original_line_count = case.lines.len();
+    let (baseline, comparison) = compare(&case.lines, &case.options)?;
+    let Some(signature) = mismatch_signature(&baseline, &comparison) else {
+        return Ok(None);
+    };
+    let minimized = {
+        let mut reproduces = |lines: &[Line3D]| {
+            compare(lines, &case.options)
+                .ok()
+                .and_then(|(baseline, comparison)| mismatch_signature(&baseline, &comparison))
+                .is_some_and(|candidate| candidate == signature)
+        };
+        let line_minimized = minimize_line_set(case.lines, &mut reproduces)
+            .ok_or_else(|| "artifact mismatch was not deterministic".to_string())?;
+        minimize_xy_coordinates(line_minimized, &mut reproduces)
+            .ok_or_else(|| "artifact mismatch changed during coordinate minimization".to_string())?
+    };
+
+    let (baseline_outcome, comparison_outcome) = compare(&minimized, &case.options)?;
+    if mismatch_signature(&baseline_outcome, &comparison_outcome) != Some(signature) {
+        return Err("minimized artifact changed the observed mismatch".to_string());
+    }
+    let candidate = DifferentialMismatchCandidateV1::new(
+        "adapter_differential",
+        &minimized,
+        &case.options,
+        BTreeMap::new(),
+        DifferentialRunV1 {
+            implementation: "one_shot".to_string(),
+            outcome: baseline_outcome,
+        },
+        DifferentialRunV1 {
+            implementation: "workspace".to_string(),
+            outcome: comparison_outcome,
+        },
+    )
+    .map_err(|error| error.to_string())?;
+
+    Ok(Some(PreparedDifferentialCandidate {
+        candidate,
+        original_line_count,
+        minimized_line_count: minimized.len(),
+    }))
 }
 
 #[cfg(test)]
@@ -101,5 +224,101 @@ mod tests {
             replay_adapter_differential(&artifact),
             Ok(ReplayOutcome::Matched)
         );
+    }
+
+    #[test]
+    fn preparation_minimizes_geometry_without_classifying_or_admitting() {
+        let coord = |x, y, z| Coord3D::new(x, y, z);
+        let case = AdapterDifferentialCase {
+            lines: vec![
+                Line3D::new(coord(0.0, 0.0, 10.0), coord(1.0, 0.0, 11.0), 10),
+                Line3D::new(coord(1.0, 0.0, 12.0), coord(1.0, 1.0, 13.0), 11),
+                Line3D::new(coord(1.0, 1.0, 14.0), coord(0.0, 1.0, 15.0), 12),
+                Line3D::new(coord(0.0, 1.0, 16.0), coord(0.0, 0.0, 17.0), 13),
+                Line3D::new(coord(8.0, 8.0, 18.0), coord(8.0, 8.0, 19.0), 99),
+            ],
+            options: PolygonizerOptions::default(),
+        };
+        let prepared = prepare_case_with(case, |lines, options| {
+            Ok((
+                DifferentialOutcomeV1::from_result(
+                    polygonize(lines.iter().copied(), options),
+                    options,
+                )
+                .unwrap(),
+                DifferentialOutcomeV1::from_result(
+                    polygonize(Vec::<Line3D>::new(), options),
+                    options,
+                )
+                .unwrap(),
+            ))
+        })
+        .unwrap()
+        .unwrap();
+        let ids: Vec<_> = prepared
+            .candidate
+            .input
+            .iter()
+            .map(|line| line.line_id.as_str())
+            .collect();
+
+        assert_eq!(prepared.original_line_count, 5);
+        assert_eq!(prepared.minimized_line_count, 4);
+        assert_eq!(
+            ids,
+            ["0x0000000a", "0x0000000b", "0x0000000c", "0x0000000d"]
+        );
+        assert_eq!(prepared.candidate.input[0].start.z, "0x4024000000000000");
+    }
+
+    #[test]
+    fn fingerprint_signature_preserves_values_at_the_same_path() {
+        let square = |offset, first_id| {
+            [
+                Line3D::new(
+                    Coord3D::new(offset, 0.0, 0.0),
+                    Coord3D::new(offset + 1.0, 0.0, 0.0),
+                    first_id,
+                ),
+                Line3D::new(
+                    Coord3D::new(offset + 1.0, 0.0, 0.0),
+                    Coord3D::new(offset + 1.0, 1.0, 0.0),
+                    first_id + 1,
+                ),
+                Line3D::new(
+                    Coord3D::new(offset + 1.0, 1.0, 0.0),
+                    Coord3D::new(offset, 1.0, 0.0),
+                    first_id + 2,
+                ),
+                Line3D::new(
+                    Coord3D::new(offset, 1.0, 0.0),
+                    Coord3D::new(offset, 0.0, 0.0),
+                    first_id + 3,
+                ),
+            ]
+        };
+        let options = PolygonizerOptions::default();
+        let one = square(0.0, 0).to_vec();
+        let shifted = square(3.0, 4).to_vec();
+        let outcome = |lines: &[Line3D]| {
+            DifferentialOutcomeV1::from_result(
+                polygonize(lines.iter().copied(), &options),
+                &options,
+            )
+            .unwrap()
+        };
+        let empty = outcome(&[]);
+        let one_signature = mismatch_signature(&outcome(&one), &empty).unwrap();
+        let shifted_signature = mismatch_signature(&outcome(&shifted), &empty).unwrap();
+        let (
+            MismatchSignature::Fingerprint(one_diff),
+            MismatchSignature::Fingerprint(shifted_diff),
+        ) = (&one_signature, &shifted_signature)
+        else {
+            panic!("expected fingerprint signatures");
+        };
+
+        assert_eq!(one_diff.path, shifted_diff.path);
+        assert_ne!(one_signature, shifted_signature);
     }
 }

--- a/crates/geo-polygonize-core/src/differential.rs
+++ b/crates/geo-polygonize-core/src/differential.rs
@@ -2,7 +2,8 @@
 
 use crate::fingerprint::{coordinate_fingerprint, float_bits};
 use crate::{
-    CoordinateFingerprintV1, FingerprintDiffV1, Line3D, PolygonizerOptions, TopologyFingerprintV1,
+    normalize_polygonize_error, CoordinateFingerprintV1, FingerprintDiffV1, Line3D,
+    NormalizedPolygonizeErrorV1, PolygonizerOptions, PolygonizerResult, TopologyFingerprintV1,
 };
 use serde::Serialize;
 use std::collections::BTreeMap;
@@ -11,6 +12,8 @@ use std::collections::BTreeMap;
 pub const REPRO_BUNDLE_V1_SCHEMA_VERSION: u32 = 1;
 /// The persisted differential fixture schema version.
 pub const PERSISTED_DIFFERENTIAL_FIXTURE_V1_SCHEMA_VERSION: u32 = 1;
+/// The two-sided differential mismatch candidate schema version.
+pub const DIFFERENTIAL_MISMATCH_CANDIDATE_V1_SCHEMA_VERSION: u32 = 1;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -77,6 +80,94 @@ pub struct PersistedDifferentialFixtureV1 {
     pub golden: ReproBundleV1,
 }
 
+/// One exact side of a differential comparison.
+#[derive(Clone, Debug, PartialEq, Serialize)]
+#[serde(tag = "status", content = "value", rename_all = "snake_case")]
+pub enum DifferentialOutcomeV1 {
+    Success(TopologyFingerprintV1),
+    Error(NormalizedPolygonizeErrorV1),
+}
+
+impl DifferentialOutcomeV1 {
+    pub fn from_result(
+        result: crate::Result<PolygonizerResult>,
+        options: &PolygonizerOptions,
+    ) -> crate::Result<Self> {
+        match result {
+            Ok(result) => Ok(Self::Success(TopologyFingerprintV1::try_from_result(
+                &result, options,
+            )?)),
+            Err(error) => Ok(Self::Error(normalize_polygonize_error(&error))),
+        }
+    }
+}
+
+/// A named implementation and its exact normalized outcome.
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct DifferentialRunV1 {
+    pub implementation: String,
+    pub outcome: DifferentialOutcomeV1,
+}
+
+/// Reviewable evidence emitted before compatibility classification or corpus admission.
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct DifferentialMismatchCandidateV1 {
+    pub schema_version: u32,
+    pub producer: String,
+    pub input: Vec<ReproLineV1>,
+    pub options: serde_json::Value,
+    pub versions: BTreeMap<String, String>,
+    pub baseline: DifferentialRunV1,
+    pub comparison: DifferentialRunV1,
+}
+
+impl DifferentialMismatchCandidateV1 {
+    pub fn new(
+        producer: impl Into<String>,
+        input: &[Line3D],
+        options: &PolygonizerOptions,
+        mut versions: BTreeMap<String, String>,
+        baseline: DifferentialRunV1,
+        comparison: DifferentialRunV1,
+    ) -> crate::Result<Self> {
+        let producer = producer.into();
+        if producer.is_empty()
+            || baseline.implementation.is_empty()
+            || comparison.implementation.is_empty()
+            || baseline.implementation == comparison.implementation
+        {
+            return Err(crate::PolygonizeError::InvalidArgumentType {
+                field: "differential_candidate".to_string(),
+                expected: "nonempty producer and distinct implementation labels".to_string(),
+                actual: producer,
+            });
+        }
+        if baseline.outcome == comparison.outcome {
+            return Err(crate::PolygonizeError::InvalidArgumentType {
+                field: "differential_candidate".to_string(),
+                expected: "different normalized outcomes".to_string(),
+                actual: "matching outcomes".to_string(),
+            });
+        }
+        versions
+            .entry("geo-polygonize-core".to_string())
+            .or_insert_with(|| env!("CARGO_PKG_VERSION").to_string());
+        Ok(Self {
+            schema_version: DIFFERENTIAL_MISMATCH_CANDIDATE_V1_SCHEMA_VERSION,
+            producer,
+            input: repro_lines(input)?,
+            options: serde_json::to_value(options).expect("validated options serialize"),
+            versions,
+            baseline,
+            comparison,
+        })
+    }
+
+    pub fn to_pretty_json(&self) -> serde_json::Result<String> {
+        serde_json::to_string_pretty(self)
+    }
+}
+
 impl PersistedDifferentialFixtureV1 {
     pub fn new(
         case_id: impl Into<String>,
@@ -122,16 +213,7 @@ impl ReproBundleV1 {
             .or_insert_with(|| env!("CARGO_PKG_VERSION").to_string());
         Ok(Self {
             schema_version: REPRO_BUNDLE_V1_SCHEMA_VERSION,
-            input: input
-                .iter()
-                .map(|line| {
-                    Ok(ReproLineV1 {
-                        start: coordinate_fingerprint(line.start)?,
-                        end: coordinate_fingerprint(line.end)?,
-                        line_id: format!("0x{:08x}", line.line_id),
-                    })
-                })
-                .collect::<crate::Result<_>>()?,
+            input: repro_lines(input)?,
             options: serde_json::to_value(options).expect("validated options serialize"),
             versions,
             fingerprint,
@@ -143,6 +225,19 @@ impl ReproBundleV1 {
     pub fn to_pretty_json(&self) -> serde_json::Result<String> {
         serde_json::to_string_pretty(self)
     }
+}
+
+fn repro_lines(input: &[Line3D]) -> crate::Result<Vec<ReproLineV1>> {
+    input
+        .iter()
+        .map(|line| {
+            Ok(ReproLineV1 {
+                start: coordinate_fingerprint(line.start)?,
+                end: coordinate_fingerprint(line.end)?,
+                line_id: format!("0x{:08x}", line.line_id),
+            })
+        })
+        .collect()
 }
 
 /// Delta-debug a line set while the caller's exact mismatch predicate holds.
@@ -424,6 +519,61 @@ mod tests {
             "Unsafe Name",
             CompatibilityClassificationV1::InvalidAmbiguous,
             persisted.golden,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn exports_two_sided_candidates_without_classifying_them() {
+        let lines = vec![line(7, 12.5)];
+        let options = PolygonizerOptions::default();
+        let success = DifferentialOutcomeV1::from_result(
+            polygonize(Vec::<Line3D>::new(), &options),
+            &options,
+        )
+        .unwrap();
+        let error = DifferentialOutcomeV1::Error(normalize_polygonize_error(
+            &crate::PolygonizeError::InvalidArgumentType {
+                field: "example".to_string(),
+                expected: "valid".to_string(),
+                actual: "invalid".to_string(),
+            },
+        ));
+        let baseline = DifferentialRunV1 {
+            implementation: "one_shot".to_string(),
+            outcome: success,
+        };
+        let comparison = DifferentialRunV1 {
+            implementation: "workspace".to_string(),
+            outcome: error,
+        };
+        let candidate = DifferentialMismatchCandidateV1::new(
+            "adapter_differential",
+            &lines,
+            &options,
+            BTreeMap::new(),
+            baseline.clone(),
+            comparison,
+        )
+        .unwrap();
+        let json: serde_json::Value =
+            serde_json::from_str(&candidate.to_pretty_json().unwrap()).unwrap();
+
+        assert_eq!(json["schema_version"], 1);
+        assert_eq!(json["producer"], "adapter_differential");
+        assert_eq!(json["input"][0]["line_id"], "0x00000007");
+        assert_eq!(json["input"][0]["start"]["z"], "0x4029000000000000");
+        assert_eq!(json["baseline"]["outcome"]["status"], "success");
+        assert_eq!(json["comparison"]["outcome"]["status"], "error");
+        assert!(json.get("case_id").is_none());
+        assert!(json.get("classification").is_none());
+        assert!(DifferentialMismatchCandidateV1::new(
+            "adapter_differential",
+            &lines,
+            &options,
+            BTreeMap::new(),
+            baseline.clone(),
+            baseline,
         )
         .is_err());
     }


### PR DESCRIPTION
## Stack

Parent:
- #1083

This PR:
- minimize raw adapter-differential artifacts into review-only mismatch candidates

Children:
- not opened yet

## Delivered

- Reuse the physical adapter fuzz decoder and comparator for replay and candidate preparation.
- Preserve the complete observed mismatch signature through line and coordinate minimization.
- Add a standalone example that writes exclusively-created review artifacts and never admits them automatically.
- Report ignored, matched, and prepared outcomes explicitly.

## Contract impact

- Fuzz/review tooling only; polygonization semantics and persisted fixture V1 are unchanged.
- Candidate files have no case ID or compatibility classification and cannot overwrite an existing path.

## Validation

- `cargo test --manifest-path crates/geo-polygonize-core/fuzz/Cargo.toml --lib` — 3 passed
- `cargo clippy --manifest-path crates/geo-polygonize-core/fuzz/Cargo.toml --all-targets -- -D warnings` — passed
- `cargo build --manifest-path crates/geo-polygonize-core/fuzz/Cargo.toml --example prepare_adapter_differential_candidate` — passed
- `cargo test -p geo-polygonize-core --no-default-features differential` — 5 unit tests and persisted corpus passed
- touched-file `rustfmt --edition 2021 --check` — passed
- `git diff --check` — passed

## Agent handoff

Remaining:
- Human review must assign compatibility truth and a stable case ID before the existing admission command runs.
- Benchmark/external-reference producers need separate wiring; Python mismatch explanations lack exact original input and cannot emit honestly yet.

Next dependency-ready slice:
- Add an explicit reviewed conversion from this candidate to the existing persisted fixture only when reference truth is supplied.