### PR TITLE
fix(wasm): parse noding iteration evidence

### DIFF
--- a/playground/src/trace.test.ts
+++ b/playground/src/trace.test.ts
@@ -147,7 +147,7 @@ describe('execution evidence', () => {
           diagnostics: {
             phase_times: phaseTimes,
             noding_work_stats: workStats,
-            noding_iterations: 2,
+            noding_iterations: [{ iteration: 0, output_segments: 7 }],
           },
           trace_budget: traceBudget,
         },
@@ -155,7 +155,7 @@ describe('execution evidence', () => {
     ]))).toEqual({
       phase_times: phaseTimes,
       noding_work_stats: workStats,
-      noding_iterations: 2,
+      noding_iterations: [{ iteration: 0, output_segments: 7 }],
       trace_budget: traceBudget,
     });
   });

--- a/playground/src/trace.ts
+++ b/playground/src/trace.ts
@@ -31,7 +31,7 @@ export type ZReconciliationDecision = {
 export type ExecutionEvidence = {
   phase_times: Record<string, unknown>;
   noding_work_stats: Record<string, unknown>;
-  noding_iterations: number;
+  noding_iterations: unknown[];
   trace_budget: Record<string, unknown>;
 };
 
@@ -174,7 +174,7 @@ export function extractExecutionEvidence(trace: TopologyTraceV1): ExecutionEvide
   const { diagnostics, trace_budget: traceBudget } = summary.payload;
   if (!isObject(diagnostics) || !isObject(traceBudget)
     || !isObject(diagnostics.phase_times) || !isObject(diagnostics.noding_work_stats)
-    || typeof diagnostics.noding_iterations !== 'number') return null;
+    || !Array.isArray(diagnostics.noding_iterations)) return null;
   return {
     phase_times: diagnostics.phase_times,
     noding_work_stats: diagnostics.noding_work_stats,


### PR DESCRIPTION
## Stack

- Parent: `main`
- This PR: parse noding iteration evidence
- Child: #1089

## Delivered

- Match the actual `polygonizer_summary` contract where `noding_iterations` is an array of iteration records.
- Restore the execution-evidence panel for real traces.
- Update focused parser coverage to use the wire shape.

## Contract impact

Playground parser correction only. No Rust core, trace schema, workflow, or option changes.

## Validation

- `npx vitest run playground/src/trace.test.ts` — 7 passed
- strict source `tsc --noEmit`
- `npm run build --prefix playground`
- `npm test` — 38 passed, including 21 Wasm tests
- `git diff --check`

## Agent handoff

- #1085 was merged into this still-open branch during restacking; the branch was restored with force-with-lease to this parser-only commit, and replacement export child #1089 supersedes it.
- Remaining: none in this slice.
- Next: review #1089 after this root.