### PR TITLE
ci(github): verify supported feature combinations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       wasm: ${{ steps.filter.outputs.wasm }}
+      python: ${{ steps.filter.outputs.python }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -42,6 +43,12 @@ jobs:
             echo "wasm=true" >> "$GITHUB_OUTPUT"
           else
             echo "wasm=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if echo "$changed" | grep -Eq '^(Cargo\.(toml|lock)$|pyproject\.toml$|python/|crates/geo-polygonize-(core|python)/|\.github/workflows/ci\.yml$)'; then
+            echo "python=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "python=false" >> "$GITHUB_OUTPUT"
           fi
 
   rust:
@@ -73,6 +80,81 @@ jobs:
 
       - name: Run tests
         run: cargo test --locked --verbose
+
+      - name: Verify supported core feature combinations
+        run: |
+          cargo test --locked -p geo-polygonize-core --no-default-features --lib --tests
+          cargo check --locked -p geo-polygonize-core --all-targets --all-features
+
+  python-abi-build:
+    name: Python abi3 wheel
+    needs: changes
+    if: needs.changes.outputs.python == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: python-abi
+          workspaces: |
+            . -> target
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Build abi3 wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          command: build
+          args: --locked --release --out dist
+
+      - name: Upload abi3 wheel
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-abi3-wheel
+          path: dist/*.whl
+          if-no-files-found: error
+          retention-days: 3
+
+  python-abi:
+    name: Python ABI (${{ matrix.python-version }})
+    needs: [changes, python-abi-build]
+    if: needs.changes.outputs.python == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.8', '3.x']
+    steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: python-abi3-wheel
+          path: dist
+
+      - name: Install abi3 wheel
+        run: python -m pip install dist/*.whl
+
+      - name: Verify native ABI import
+        run: |
+          python - <<'PY'
+          import geo_polygonize
+          from geo_polygonize.geo_polygonize_core import polygonize_with_options
+
+          ok, error = geo_polygonize.import_probe()
+          assert ok, error
+          assert callable(polygonize_with_options)
+          PY
 
   release-tests:
     name: Release Tests
@@ -246,7 +328,7 @@ jobs:
 
   test:
     name: CI Required
-    needs: [changes, rust, release-tests, release-contract, supply-chain, wasm-build, js]
+    needs: [changes, rust, python-abi-build, python-abi, release-tests, release-contract, supply-chain, wasm-build, js]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -255,6 +337,8 @@ jobs:
         run: |
           [ "${{ needs.changes.result }}" = "success" ]
           [ "${{ needs.rust.result }}" = "success" ]
+          [[ "${{ needs.python-abi-build.result }}" =~ ^(success|skipped)$ ]]
+          [[ "${{ needs.python-abi.result }}" =~ ^(success|skipped)$ ]]
           [ "${{ needs.release-tests.result }}" = "success" ]
           [ "${{ needs.release-contract.result }}" = "success" ]
           [ "${{ needs.supply-chain.result }}" = "success" ]

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -20,3 +20,21 @@ def test_playground_changes_run_and_build_in_js_ci():
         "npm run build --prefix playground"
     )
     assert "npm run build --prefix playground" in workflow
+
+
+def test_supported_feature_and_python_abi_matrix_is_required():
+    workflow = (ROOT / ".github/workflows/ci.yml").read_text()
+
+    assert (
+        "cargo test --locked -p geo-polygonize-core --no-default-features --lib --tests"
+        in workflow
+    )
+    assert (
+        "cargo check --locked -p geo-polygonize-core --all-targets --all-features"
+        in workflow
+    )
+    assert "variant: [scalar, simd, threads]" in workflow
+    assert "python-version: ['3.8', '3.x']" in workflow
+    assert "from geo_polygonize.geo_polygonize_core import polygonize_with_options" in workflow
+    assert "needs.python-abi-build.result" in workflow
+    assert "needs.python-abi.result" in workflow


### PR DESCRIPTION
## Context

Stacks logically on the support policy from #1086, which merged while this child was being submitted. The child was rebased onto the resulting live `main`, so this PR now contains only the missing enforcement slice.

The existing Rust job already tests default workspace features, and the existing Wasm matrix already builds scalar, SIMD, and threads variants. This change reuses those gates rather than duplicating them.

## Scope

- run core tests with `--no-default-features` on the existing Rust runner
- compile all core targets with `--all-features` on that same runner
- build one PyO3 `abi3-py38` wheel when core/Python paths change
- install and import that wheel on the declared Python 3.8 minimum and latest stable Python
- make the Python ABI jobs part of the required CI aggregate
- add focused static workflow assertions for the supported matrix

## Validation

- `git diff --check`
- `actionlint .github/workflows/ci.yml`
- `python3 -m pytest -q tests/test_ci_workflow.py` (3 passed; unrelated local pytest-asyncio deprecation warning)
- `cargo test --locked -p geo-polygonize-core --no-default-features --lib --tests` (all unit and integration suites passed)
- `cargo check --locked -p geo-polygonize-core --all-targets --all-features`
- `maturin build --locked --release --out target/python-abi-wheels` (produced `cp38-abi3` wheel)
- local wheel install/import and native `polygonize_with_options` symbol check on CPython 3.11
- post-rebase `git range-diff` confirmed the child patch is unchanged

## Cross-platform

Validated locally on macOS with CPython 3.11. The Linux Python 3.8/latest endpoint matrix is defined here but has not been observed remotely; remote CI has not been polled.

## Not included

- duplicate default-feature or Wasm scalar/SIMD/threads jobs already present in CI
- a fixed numeric Rust MSRV or Cargo `rust-version`
- full cross-binding conformance, certified corpus, fuzz, Miri, or sanitizer work
- ROADMAP, graph implementation, playground, or differential changes