### PR TITLE
feat(wasm): export debugger evidence bundles

### DIFF
--- a/playground/src/evidence.test.ts
+++ b/playground/src/evidence.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import type { PolygonizeTraceReportV1 } from 'geo-polygonize';
+import {
+  createDebuggerEvidenceBundle,
+  serializeDebuggerEvidence,
+} from './evidence';
+
+const report: PolygonizeTraceReportV1 = {
+  schema_version: 1,
+  topology: {
+    schema_version: 1,
+    options: { node_input: true },
+    polygons: [],
+    dangles: [],
+    cut_edges: [],
+    invalid_rings: [],
+    diagnostics: null,
+  },
+  trace: {
+    schema_version: 1,
+    library_version: 'test',
+    level: 'full',
+    byte_limit: 4096,
+    bytes_used: 200,
+    truncated: false,
+    options: { node_input: true },
+    events: [{
+      sequence: 0,
+      stage: 'noding',
+      kind: 'normalized_input_segment',
+      payload: { start: { x: '0x0', y: '0x0', z: '0x4024000000000000' } },
+    }],
+  },
+};
+
+describe('debugger evidence bundles', () => {
+  it('serializes current evidence deterministically without claiming golden truth', () => {
+    const bundle = createDebuggerEvidenceBundle({
+      input: {
+        type: 'FeatureCollection',
+        features: [{
+          properties: { source_id: 7 },
+          geometry: { coordinates: [[0, 0, 10], [1, 0, 20]], type: 'LineString' },
+          type: 'Feature',
+        }],
+      },
+      requestedOptions: { node_input: true },
+      topology: report.topology,
+      trace: report.trace,
+      comparison: { results: [{ label: 'test', report }], diverged: false },
+      normalizedError: null,
+    });
+
+    const encoded = serializeDebuggerEvidence(bundle);
+    const decoded = JSON.parse(encoded);
+    expect(decoded).toMatchObject({
+      schema_version: 1,
+      kind: 'geo_polygonize_debugger_evidence',
+      input: { features: [{ properties: { source_id: 7 } }] },
+      requested_options: { node_input: true },
+      trace_run: { trace: { library_version: 'test' } },
+    });
+    expect(decoded.input.features[0].geometry.coordinates[0][2]).toBe(10);
+    expect(encoded).not.toContain('golden');
+    expect(encoded).not.toContain('reference_metrics');
+    expect(serializeDebuggerEvidence(decoded)).toBe(encoded);
+  });
+
+  it('rejects an unpaired topology or trace', () => {
+    expect(() => createDebuggerEvidenceBundle({
+      input: {},
+      requestedOptions: {},
+      topology: report.topology,
+      trace: null,
+      comparison: null,
+      normalizedError: null,
+    })).toThrow('requires topology and trace together');
+  });
+});

--- a/playground/src/evidence.ts
+++ b/playground/src/evidence.ts
@@ -1,0 +1,77 @@
+import type {
+  NormalizedPolygonizeErrorV1,
+  PolygonizerOptions,
+  TopologyFingerprintV1,
+  TopologyTraceV1,
+} from 'geo-polygonize';
+import type { ProfileComparison } from './compare';
+
+export const DEBUGGER_EVIDENCE_FILENAME = 'geo-polygonize-debugger-evidence-v1.json';
+
+export type DebuggerEvidenceBundleV1 = {
+  schema_version: 1;
+  kind: 'geo_polygonize_debugger_evidence';
+  input: unknown;
+  requested_options: Partial<PolygonizerOptions>;
+  trace_run: {
+    topology: TopologyFingerprintV1;
+    trace: TopologyTraceV1;
+  } | null;
+  profile_comparison: ProfileComparison | null;
+  normalized_error: NormalizedPolygonizeErrorV1 | null;
+};
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (typeof value !== 'object' || value === null) return value;
+  return Object.fromEntries(
+    Object.entries(value)
+      .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+      .map(([key, child]) => [key, canonicalize(child)]),
+  );
+}
+
+export function createDebuggerEvidenceBundle({
+  input,
+  requestedOptions,
+  topology,
+  trace,
+  comparison,
+  normalizedError,
+}: {
+  input: unknown;
+  requestedOptions: Partial<PolygonizerOptions>;
+  topology: TopologyFingerprintV1 | null;
+  trace: TopologyTraceV1 | null;
+  comparison: ProfileComparison | null;
+  normalizedError: NormalizedPolygonizeErrorV1 | null;
+}): DebuggerEvidenceBundleV1 {
+  if ((topology === null) !== (trace === null)) {
+    throw new Error('Debugger evidence requires topology and trace together');
+  }
+  return {
+    schema_version: 1,
+    kind: 'geo_polygonize_debugger_evidence',
+    input,
+    requested_options: requestedOptions,
+    trace_run: topology && trace ? { topology, trace } : null,
+    profile_comparison: comparison,
+    normalized_error: normalizedError,
+  };
+}
+
+export function serializeDebuggerEvidence(bundle: DebuggerEvidenceBundleV1): string {
+  return `${JSON.stringify(canonicalize(bundle), null, 2)}\n`;
+}
+
+export function downloadDebuggerEvidence(bundle: DebuggerEvidenceBundleV1) {
+  const url = URL.createObjectURL(new Blob(
+    [serializeDebuggerEvidence(bundle)],
+    { type: 'application/json' },
+  ));
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = DEBUGGER_EVIDENCE_FILENAME;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}

--- a/playground/src/main.tsx
+++ b/playground/src/main.tsx
@@ -27,6 +27,7 @@ import {
 import { appendLineString, parseGeojsonInput } from './input';
 import { comparePlaygroundProfiles, type ProfileComparison } from './compare';
 import { extractNormalizedError } from './error';
+import { createDebuggerEvidenceBundle, downloadDebuggerEvidence } from './evidence';
 import { buildPlaygroundOptions } from './options';
 import { decodePlaygroundRepro, encodePlaygroundRepro } from './repro';
 import {
@@ -554,6 +555,31 @@ function App() {
                   }}
                 >
                   Copy repro URL
+                </Button>
+                <Button
+                  variant="outlined"
+                  disabled={!inputGeojson || (!trace && !comparison && !normalizedError)}
+                  onClick={() => {
+                    try {
+                      downloadDebuggerEvidence(createDebuggerEvidenceBundle({
+                        input: inputGeojson,
+                        requestedOptions: buildPlaygroundOptions(
+                          nodeInput,
+                          snapGridSize,
+                          nodingGuarantee,
+                        ),
+                        topology: report,
+                        trace,
+                        comparison,
+                        normalizedError,
+                      }));
+                      setError(null);
+                    } catch (e) {
+                      setError(`Export Error: ${e instanceof Error ? e.message : String(e)}`);
+                    }
+                  }}
+                >
+                  Export evidence
                 </Button>
               </Box>
               <Typography variant="caption" color="text.secondary">

--- a/playground/src/trace.test.ts
+++ b/playground/src/trace.test.ts
@@ -147,7 +147,7 @@ describe('execution evidence', () => {
           diagnostics: {
             phase_times: phaseTimes,
             noding_work_stats: workStats,
-            noding_iterations: 2,
+            noding_iterations: [{ iteration: 0, output_segments: 7 }],
           },
           trace_budget: traceBudget,
         },
@@ -155,7 +155,7 @@ describe('execution evidence', () => {
     ]))).toEqual({
       phase_times: phaseTimes,
       noding_work_stats: workStats,
-      noding_iterations: 2,
+      noding_iterations: [{ iteration: 0, output_segments: 7 }],
       trace_budget: traceBudget,
     });
   });

--- a/playground/src/trace.ts
+++ b/playground/src/trace.ts
@@ -31,7 +31,7 @@ export type ZReconciliationDecision = {
 export type ExecutionEvidence = {
   phase_times: Record<string, unknown>;
   noding_work_stats: Record<string, unknown>;
-  noding_iterations: number;
+  noding_iterations: unknown[];
   trace_budget: Record<string, unknown>;
 };
 
@@ -174,7 +174,7 @@ export function extractExecutionEvidence(trace: TopologyTraceV1): ExecutionEvide
   const { diagnostics, trace_budget: traceBudget } = summary.payload;
   if (!isObject(diagnostics) || !isObject(traceBudget)
     || !isObject(diagnostics.phase_times) || !isObject(diagnostics.noding_work_stats)
-    || typeof diagnostics.noding_iterations !== 'number') return null;
+    || !Array.isArray(diagnostics.noding_iterations)) return null;
   return {
     phase_times: diagnostics.phase_times,
     noding_work_stats: diagnostics.noding_work_stats,


### PR DESCRIPTION
## Stack

- Logical prerequisite: #1087
- This PR: export debugger evidence bundles
- Child: #1093

## Delivered

- Export a deterministic versioned `geo_polygonize_debugger_evidence` V1 JSON bundle.
- Preserve the current parsed input, requested options, successful topology and bounded trace, profile comparison reports, and normalized worker error as represented by the debugger.
- Keep the export honest: it is debugger evidence, not a persisted golden or compatibility fixture.

## Contract impact

Additive playground-only download format. No Rust core, persisted differential schema, workflow, or semantic option changes.

## Validation

- `npx vitest run playground/src/evidence.test.ts` — 2 passed
- strict source `tsc --noEmit`
- `npm run build --prefix playground`
- `npm test` — 40 passed, including 21 Wasm tests
- `git diff --check`

## Agent handoff

- Supersedes merged #1085 after its ancestry was accidentally absorbed into the still-open prerequisite branch and repaired with force-with-lease.
- Remaining: parsed GeoJSON cannot retain original JSON spelling or every numeric bit spelling; external reference metrics, a comparison witness, and compatibility classification are also absent. This bundle must not be treated as a persisted golden.
- Next: review #1093 for abortable minimization of an already-observed profile divergence using exact normalized trace segments.