### PR TITLE
test(core): persist two-sided differential outcomes

### DIFF
--- a/crates/geo-polygonize-core/src/differential.rs
+++ b/crates/geo-polygonize-core/src/differential.rs
@@ -12,6 +12,8 @@ use std::collections::BTreeMap;
 pub const REPRO_BUNDLE_V1_SCHEMA_VERSION: u32 = 1;
 /// The persisted differential fixture schema version.
 pub const PERSISTED_DIFFERENTIAL_FIXTURE_V1_SCHEMA_VERSION: u32 = 1;
+/// The two-sided persisted differential fixture schema version.
+pub const PERSISTED_DIFFERENTIAL_FIXTURE_V2_SCHEMA_VERSION: u32 = 2;
 /// The two-sided differential mismatch candidate schema version.
 pub const DIFFERENTIAL_MISMATCH_CANDIDATE_V1_SCHEMA_VERSION: u32 = 1;
 
@@ -78,6 +80,15 @@ pub struct PersistedDifferentialFixtureV1 {
     pub case_id: String,
     pub classification: CompatibilityClassificationV1,
     pub golden: ReproBundleV1,
+}
+
+/// A reviewed two-sided mismatch retained without changing the V1 fixture shape.
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct PersistedDifferentialFixtureV2 {
+    pub schema_version: u32,
+    pub case_id: String,
+    pub classification: CompatibilityClassificationV1,
+    pub candidate: DifferentialMismatchCandidateV1,
 }
 
 /// One exact side of a differential comparison.
@@ -175,11 +186,7 @@ impl PersistedDifferentialFixtureV1 {
         golden: ReproBundleV1,
     ) -> crate::Result<Self> {
         let case_id = case_id.into();
-        if case_id.is_empty()
-            || !case_id.bytes().all(|byte| {
-                byte.is_ascii_lowercase() || byte.is_ascii_digit() || b"-._".contains(&byte)
-            })
-        {
+        if !valid_case_id(&case_id) {
             return Err(crate::PolygonizeError::InvalidArgumentType {
                 field: "case_id".to_string(),
                 expected: "a nonempty lowercase fixture identifier".to_string(),
@@ -191,6 +198,47 @@ impl PersistedDifferentialFixtureV1 {
             case_id,
             classification,
             golden,
+        })
+    }
+
+    pub fn to_pretty_json(&self) -> serde_json::Result<String> {
+        serde_json::to_string_pretty(self)
+    }
+}
+
+impl PersistedDifferentialFixtureV2 {
+    pub fn new(
+        case_id: impl Into<String>,
+        classification: CompatibilityClassificationV1,
+        candidate: DifferentialMismatchCandidateV1,
+    ) -> crate::Result<Self> {
+        let case_id = case_id.into();
+        if !valid_case_id(&case_id) {
+            return Err(crate::PolygonizeError::InvalidArgumentType {
+                field: "case_id".to_string(),
+                expected: "a nonempty lowercase fixture identifier".to_string(),
+                actual: case_id,
+            });
+        }
+        if candidate.schema_version != DIFFERENTIAL_MISMATCH_CANDIDATE_V1_SCHEMA_VERSION
+            || candidate.producer != "adapter_differential"
+            || candidate.baseline.implementation != "one_shot"
+            || candidate.comparison.implementation != "workspace"
+            || candidate.baseline.outcome == candidate.comparison.outcome
+            || candidate.versions.is_empty()
+        {
+            return Err(crate::PolygonizeError::InvalidArgumentType {
+                field: "candidate".to_string(),
+                expected: "an adapter_differential V1 mismatch from one_shot to workspace"
+                    .to_string(),
+                actual: candidate.producer,
+            });
+        }
+        Ok(Self {
+            schema_version: PERSISTED_DIFFERENTIAL_FIXTURE_V2_SCHEMA_VERSION,
+            case_id,
+            classification,
+            candidate,
         })
     }
 
@@ -238,6 +286,13 @@ fn repro_lines(input: &[Line3D]) -> crate::Result<Vec<ReproLineV1>> {
             })
         })
         .collect()
+}
+
+fn valid_case_id(case_id: &str) -> bool {
+    !case_id.is_empty()
+        && case_id.bytes().all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || b"-._".contains(&byte)
+        })
 }
 
 /// Delta-debug a line set while the caller's exact mismatch predicate holds.
@@ -567,6 +622,35 @@ mod tests {
         assert_eq!(json["comparison"]["outcome"]["status"], "error");
         assert!(json.get("case_id").is_none());
         assert!(json.get("classification").is_none());
+        let persisted = PersistedDifferentialFixtureV2::new(
+            "adapter-mixed-v2",
+            CompatibilityClassificationV1::InvalidAmbiguous,
+            candidate.clone(),
+        )
+        .unwrap();
+        let persisted_json: serde_json::Value =
+            serde_json::from_str(&persisted.to_pretty_json().unwrap()).unwrap();
+        assert_eq!(persisted_json["schema_version"], 2);
+        assert_eq!(persisted_json["case_id"], "adapter-mixed-v2");
+        assert_eq!(persisted_json["classification"], "invalid_ambiguous");
+        assert_eq!(persisted_json["candidate"], json);
+
+        let mut unknown = candidate.clone();
+        unknown.producer = "benchmark_record".to_string();
+        assert!(PersistedDifferentialFixtureV2::new(
+            "unsupported-producer",
+            CompatibilityClassificationV1::ExpectedDivergence,
+            unknown,
+        )
+        .is_err());
+        let mut matching = candidate.clone();
+        matching.comparison.outcome = matching.baseline.outcome.clone();
+        assert!(PersistedDifferentialFixtureV2::new(
+            "matching-outcomes",
+            CompatibilityClassificationV1::ExpectedParity,
+            matching,
+        )
+        .is_err());
         assert!(DifferentialMismatchCandidateV1::new(
             "adapter_differential",
             &lines,

--- a/crates/geo-polygonize-core/tests/persisted_differential_v2.rs
+++ b/crates/geo-polygonize-core/tests/persisted_differential_v2.rs
@@ -1,0 +1,184 @@
+use geo_polygonize_core::{
+    differential::DifferentialOutcomeV1, polygonize, polygonize_with_workspace, Coord3D, Line3D,
+    PolygonizerOptions, PolygonizerWorkspace,
+};
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn exact_keys(value: &Value, expected: &[&str]) -> Result<(), String> {
+    let mut actual: Vec<_> = value
+        .as_object()
+        .ok_or("expected an object")?
+        .keys()
+        .map(String::as_str)
+        .collect();
+    actual.sort_unstable();
+    let mut expected = expected.to_vec();
+    expected.sort_unstable();
+    (actual == expected)
+        .then_some(())
+        .ok_or_else(|| format!("expected keys {expected:?}, found {actual:?}"))
+}
+
+fn decode_bits(value: &Value) -> Result<f64, String> {
+    let bits = value
+        .as_str()
+        .and_then(|value| value.strip_prefix("0x"))
+        .ok_or("expected a hexadecimal float")?;
+    u64::from_str_radix(bits, 16)
+        .map(f64::from_bits)
+        .map_err(|error| error.to_string())
+}
+
+fn lines(value: &Value) -> Result<Vec<Line3D>, String> {
+    value
+        .as_array()
+        .ok_or("input must be an array")?
+        .iter()
+        .map(|line| {
+            let coordinate = |value: &Value| -> Result<Coord3D, String> {
+                Ok(Coord3D::new(
+                    decode_bits(&value["x"])?,
+                    decode_bits(&value["y"])?,
+                    decode_bits(&value["z"])?,
+                ))
+            };
+            let line_id = line["line_id"]
+                .as_str()
+                .and_then(|value| value.strip_prefix("0x"))
+                .ok_or("expected a hexadecimal line_id")?;
+            Ok(Line3D::new(
+                coordinate(&line["start"])?,
+                coordinate(&line["end"])?,
+                u32::from_str_radix(line_id, 16).map_err(|error| error.to_string())?,
+            ))
+        })
+        .collect()
+}
+
+fn validate(path: &Path, fixture: &Value) -> Result<(), String> {
+    exact_keys(
+        fixture,
+        &["candidate", "case_id", "classification", "schema_version"],
+    )?;
+    if fixture["schema_version"] != 2 {
+        return Err("expected persisted differential schema 2".to_string());
+    }
+    if fixture["case_id"].as_str() != path.file_stem().and_then(|value| value.to_str()) {
+        return Err("case_id must match the fixture filename".to_string());
+    }
+    if !matches!(
+        fixture["classification"].as_str(),
+        Some("expected_parity" | "expected_divergence" | "invalid_ambiguous")
+    ) {
+        return Err("unknown compatibility classification".to_string());
+    }
+
+    let candidate = &fixture["candidate"];
+    exact_keys(
+        candidate,
+        &[
+            "baseline",
+            "comparison",
+            "input",
+            "options",
+            "producer",
+            "schema_version",
+            "versions",
+        ],
+    )?;
+    if candidate["schema_version"] != 1
+        || candidate["producer"] != "adapter_differential"
+        || candidate["baseline"]["implementation"] != "one_shot"
+        || candidate["comparison"]["implementation"] != "workspace"
+    {
+        return Err("unknown producer or implementation labels".to_string());
+    }
+    if candidate["baseline"]["outcome"] == candidate["comparison"]["outcome"] {
+        return Err("persisted outcomes must differ".to_string());
+    }
+    if candidate["versions"]
+        .as_object()
+        .is_none_or(|versions| versions.is_empty())
+    {
+        return Err("candidate versions are required".to_string());
+    }
+
+    let options: PolygonizerOptions =
+        serde_json::from_value(candidate["options"].clone()).map_err(|error| error.to_string())?;
+    let lines = lines(&candidate["input"])?;
+    let baseline =
+        DifferentialOutcomeV1::from_result(polygonize(lines.iter().copied(), &options), &options)
+            .map_err(|error| error.to_string())?;
+    let comparison = DifferentialOutcomeV1::from_result(
+        polygonize_with_workspace(&lines, &options, &mut PolygonizerWorkspace::new()),
+        &options,
+    )
+    .map_err(|error| error.to_string())?;
+    if serde_json::to_value(baseline).unwrap() != candidate["baseline"]["outcome"] {
+        return Err("baseline outcome changed on rerun".to_string());
+    }
+    if serde_json::to_value(comparison).unwrap() != candidate["comparison"]["outcome"] {
+        return Err("comparison outcome changed on rerun".to_string());
+    }
+    Ok(())
+}
+
+#[test]
+fn persisted_two_sided_differential_corpus_reruns_exact_outcomes() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../fixtures/differential-v2");
+    let mut paths: Vec<PathBuf> = if root.exists() {
+        fs::read_dir(root)
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .filter(|path| {
+                path.extension()
+                    .is_some_and(|extension| extension == "json")
+            })
+            .collect()
+    } else {
+        Vec::new()
+    };
+    if let Some(candidate) = std::env::var_os("PERSISTED_DIFFERENTIAL_V2_CANDIDATE") {
+        paths.push(candidate.into());
+    }
+    paths.sort();
+
+    for path in paths {
+        let fixture: Value = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        validate(&path, &fixture).unwrap_or_else(|error| panic!("{}: {error}", path.display()));
+    }
+}
+
+#[test]
+fn rerun_validation_rejects_a_changed_full_outcome() {
+    let options = PolygonizerOptions::default();
+    let input = serde_json::json!([{
+        "start": {"x": "0x0000000000000000", "y": "0x0000000000000000", "z": "0x4024000000000000"},
+        "end": {"x": "0x0000000000000000", "y": "0x0000000000000000", "z": "0x4026000000000000"},
+        "line_id": "0x00000007"
+    }]);
+    let lines = lines(&input).unwrap();
+    let baseline =
+        DifferentialOutcomeV1::from_result(polygonize(lines, &options), &options).unwrap();
+    let fixture = serde_json::json!({
+        "schema_version": 2,
+        "case_id": "changed-outcome",
+        "classification": "invalid_ambiguous",
+        "candidate": {
+            "schema_version": 1,
+            "producer": "adapter_differential",
+            "input": input,
+            "options": options,
+            "versions": {"geo-polygonize-core": env!("CARGO_PKG_VERSION")},
+            "baseline": {"implementation": "one_shot", "outcome": baseline},
+            "comparison": {"implementation": "workspace", "outcome": {"status": "error", "value": null}}
+        }
+    });
+
+    assert_eq!(
+        validate(Path::new("changed-outcome.json"), &fixture),
+        Err("comparison outcome changed on rerun".to_string())
+    );
+}


### PR DESCRIPTION
## Stack

- Parent: `main`
- This PR: `agent/p1-differential-persisted-v2`
- Children: #1091

## Delivered

- Adds `PersistedDifferentialFixtureV2` as a reviewed wrapper around the unchanged two-sided candidate payload.
- Retains explicit compatibility classification and exact input, options, versions, implementation labels, and normalized outcomes.
- Adds a separate V2 corpus runner that reruns known `adapter_differential` one-shot/workspace labels and compares both complete outcomes.
- Keeps the V1 fixture bytes, corpus directory, and integration test unchanged.

## Contract impact

This is additive schema version 2. V2 accepts success/success, error/error, and mixed mismatches, but only for the known adapter producer labels. It does not classify candidates, invent external truth, or support the reduced benchmark reference format. V2 fixtures use `fixtures/differential-v2`, so V1 and V2 loading is unambiguous.

## Validation

- `cargo test -p geo-polygonize-core differential::tests::exports_two_sided_candidates_without_classifying_them`
- `cargo test -p geo-polygonize-core --test persisted_differential --test persisted_differential_v2`
- `cargo test -p geo-polygonize-core --no-default-features --test persisted_differential --test persisted_differential_v2`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `git diff --check`

## Agent handoff

- Remaining: convert a human-reviewed candidate into V2 with an explicit stable case ID and classification.
- Next: #1091 adds exclusive-create reviewed admission.