### PR TITLE
test(core): admit reviewed differential candidates

### DIFF
--- a/scripts/admit_differential_fixture.py
+++ b/scripts/admit_differential_fixture.py
@@ -6,41 +6,122 @@ import json
 import os
 import re
 import subprocess
+import tempfile
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 CASE_ID = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
+CLASSIFICATIONS = ("expected_parity", "expected_divergence", "invalid_ambiguous")
+PRODUCERS = {"adapter_differential": ("one_shot", "workspace")}
+
+
+def reviewed_fixture(candidate, case_id, classification):
+    if not CASE_ID.fullmatch(case_id):
+        raise ValueError("candidate has an invalid case_id")
+    if classification not in CLASSIFICATIONS:
+        raise ValueError("candidate has an invalid classification")
+    expected_keys = {
+        "schema_version",
+        "producer",
+        "input",
+        "options",
+        "versions",
+        "baseline",
+        "comparison",
+    }
+    if set(candidate) != expected_keys or candidate["schema_version"] != 1:
+        raise ValueError("expected an exact DifferentialMismatchCandidateV1")
+    for run in (candidate["baseline"], candidate["comparison"]):
+        if not isinstance(run, dict) or set(run) != {"implementation", "outcome"}:
+            raise ValueError("expected exact differential runs")
+        outcome = run["outcome"]
+        if (
+            not isinstance(outcome, dict)
+            or set(outcome) != {"status", "value"}
+            or outcome["status"] not in ("success", "error")
+            or not isinstance(outcome["value"], dict)
+        ):
+            raise ValueError("expected exact normalized outcomes")
+    labels = PRODUCERS.get(candidate["producer"])
+    actual_labels = (
+        candidate["baseline"].get("implementation"),
+        candidate["comparison"].get("implementation"),
+    )
+    if labels is None or actual_labels != labels:
+        raise ValueError("unknown producer or implementation labels")
+    if candidate["baseline"].get("outcome") == candidate["comparison"].get("outcome"):
+        raise ValueError("candidate outcomes must differ")
+    if not isinstance(candidate["input"], list) or not isinstance(candidate["options"], dict):
+        raise ValueError("candidate input and options are required")
+    if not isinstance(candidate["versions"], dict) or not candidate["versions"]:
+        raise ValueError("candidate versions are required")
+    return {
+        "schema_version": 2,
+        "case_id": case_id,
+        "classification": classification,
+        "candidate": candidate,
+    }
+
+
+def write_fixture(path, payload):
+    with path.open("x") as output:
+        json.dump(payload, output, indent=2, allow_nan=False)
+        output.write("\n")
 
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("candidate", type=Path)
-    parser.add_argument("--output-dir", type=Path, default=ROOT / "fixtures/differential")
+    parser.add_argument("--case-id")
+    parser.add_argument("--classification", choices=CLASSIFICATIONS)
+    parser.add_argument("--output-dir", type=Path)
     parser.add_argument("--check-only", action="store_true")
     args = parser.parse_args()
 
     candidate = args.candidate.resolve(strict=True)
     payload = json.loads(candidate.read_text())
-    case_id = payload.get("case_id", "")
-    if not CASE_ID.fullmatch(case_id):
-        raise SystemExit("candidate has an invalid case_id")
+    if not isinstance(payload, dict):
+        raise SystemExit("candidate must be a JSON object")
+    is_mismatch_candidate = "producer" in payload
+    if is_mismatch_candidate:
+        if not args.case_id or not args.classification:
+            raise SystemExit("candidate review requires --case-id and --classification")
+        try:
+            payload = reviewed_fixture(payload, args.case_id, args.classification)
+        except (KeyError, TypeError, ValueError) as error:
+            raise SystemExit(str(error)) from error
+        case_id = args.case_id
+        test = "persisted_differential_v2"
+        env_name = "PERSISTED_DIFFERENTIAL_V2_CANDIDATE"
+        default_output_dir = ROOT / "fixtures/differential-v2"
+    else:
+        if args.case_id or args.classification:
+            raise SystemExit("review flags require a DifferentialMismatchCandidateV1")
+        case_id = payload.get("case_id", "")
+        if not CASE_ID.fullmatch(case_id):
+            raise SystemExit("candidate has an invalid case_id")
+        test = "persisted_differential"
+        env_name = "PERSISTED_DIFFERENTIAL_CANDIDATE"
+        default_output_dir = ROOT / "fixtures/differential"
 
-    env = os.environ.copy()
-    env["PERSISTED_DIFFERENTIAL_CANDIDATE"] = str(candidate)
-    subprocess.run(
-        ["cargo", "test", "-p", "geo-polygonize-core", "--test", "persisted_differential"],
-        cwd=ROOT,
-        env=env,
-        check=True,
-    )
+    with tempfile.TemporaryDirectory() as temporary:
+        reviewed = Path(temporary) / f"{case_id}.json"
+        reviewed.write_text(json.dumps(payload, indent=2, allow_nan=False) + "\n")
+        env = os.environ.copy()
+        env[env_name] = str(reviewed)
+        subprocess.run(
+            ["cargo", "test", "-p", "geo-polygonize-core", "--test", test],
+            cwd=ROOT,
+            env=env,
+            check=True,
+        )
     if args.check_only:
         return
 
-    args.output_dir.mkdir(parents=True, exist_ok=True)
-    destination = args.output_dir / f"{case_id}.json"
-    with destination.open("x") as output:
-        json.dump(payload, output, indent=2, allow_nan=False)
-        output.write("\n")
+    output_dir = args.output_dir or default_output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+    destination = output_dir / f"{case_id}.json"
+    write_fixture(destination, payload)
     print(destination)
 
 

--- a/tests/test_admit_differential_fixture.py
+++ b/tests/test_admit_differential_fixture.py
@@ -1,0 +1,83 @@
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts/admit_differential_fixture.py"
+SPEC = importlib.util.spec_from_file_location("admit_differential_fixture", SCRIPT)
+ADMISSION = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(ADMISSION)
+reviewed_fixture = ADMISSION.reviewed_fixture
+write_fixture = ADMISSION.write_fixture
+
+
+def candidate():
+    return {
+        "schema_version": 1,
+        "producer": "adapter_differential",
+        "input": [
+            {
+                "start": {
+                    "x": "0x0000000000000000",
+                    "y": "0x0000000000000000",
+                    "z": "0x4024000000000000",
+                },
+                "end": {
+                    "x": "0x3ff0000000000000",
+                    "y": "0x0000000000000000",
+                    "z": "0x4026000000000000",
+                },
+                "line_id": "0x00000007",
+            }
+        ],
+        "options": {"node_input": False},
+        "versions": {"geo-polygonize-core": "0.76.2"},
+        "baseline": {
+            "implementation": "one_shot",
+            "outcome": {"status": "success", "value": {"polygons": []}},
+        },
+        "comparison": {
+            "implementation": "workspace",
+            "outcome": {"status": "error", "value": {"kind": "topology"}},
+        },
+    }
+
+
+class ReviewedAdmissionTests(unittest.TestCase):
+    def test_review_preserves_the_exact_candidate_without_rewriting_it(self):
+        source = candidate()
+        fixture = reviewed_fixture(source, "adapter-mixed-v2", "invalid_ambiguous")
+
+        self.assertIs(fixture["candidate"], source)
+        self.assertEqual(fixture["schema_version"], 2)
+        self.assertEqual(fixture["case_id"], "adapter-mixed-v2")
+        self.assertEqual(fixture["classification"], "invalid_ambiguous")
+        self.assertEqual(fixture["candidate"]["input"][0]["line_id"], "0x00000007")
+        self.assertEqual(
+            fixture["candidate"]["input"][0]["start"]["z"],
+            "0x4024000000000000",
+        )
+
+    def test_review_rejects_unknown_producers_and_matching_outcomes(self):
+        unknown = candidate()
+        unknown["producer"] = "benchmark_record"
+        with self.assertRaisesRegex(ValueError, "unknown producer"):
+            reviewed_fixture(unknown, "unknown", "expected_divergence")
+
+        matching = candidate()
+        matching["comparison"]["outcome"] = matching["baseline"]["outcome"]
+        with self.assertRaisesRegex(ValueError, "outcomes must differ"):
+            reviewed_fixture(matching, "matching", "expected_parity")
+
+    def test_admission_refuses_to_overwrite_a_fixture(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "case.json"
+            write_fixture(path, {"schema_version": 2})
+            with self.assertRaises(FileExistsError):
+                write_fixture(path, {"schema_version": 2})
+            self.assertEqual(json.loads(path.read_text()), {"schema_version": 2})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Stack

- Parent: #1090
- This PR: `agent/p1-differential-reviewed-admission`
- Children: none

## Delivered

- Converts an exact `DifferentialMismatchCandidateV1` into persisted V2 only when `--case-id` and `--classification` are supplied.
- Preserves the candidate payload unchanged, including source IDs, Z bits, options, versions, and both full normalized outcomes.
- Rejects unknown producers or implementation labels, matching outcomes, malformed normalized outcomes, and overwrites.
- Reruns the reviewed temporary fixture through the strict Rust V2 corpus test before exclusive-create admission.
- Preserves the existing V1 admission path and stores V2 fixtures separately.

## Contract impact

Admission remains a human review boundary: there is no automatic classification or corpus mutation before rerun validation. Only `adapter_differential` one-shot/workspace candidates are supported. Reduced benchmark references and fabricated external outcomes are refused.

## Validation

- `python -m py_compile scripts/admit_differential_fixture.py tests/test_admit_differential_fixture.py`
- `pytest -q tests/test_admit_differential_fixture.py` (3 passed; unrelated pytest-asyncio deprecation warning)
- Legacy V1 `--check-only` admission against an existing fixture
- Default and no-default V1/V2 persisted corpus tests
- `cargo test --manifest-path crates/geo-polygonize-core/fuzz/Cargo.toml --lib` (3 passed)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `git diff --check`

## Agent handoff

- Remaining: a reviewer must choose the stable case ID and compatibility classification for each real mismatch candidate.
- Next: run `python scripts/admit_differential_fixture.py CANDIDATE --case-id CASE_ID --classification CLASSIFICATION`; the destination is created only after strict rerun validation.