### PR TITLE
feat(wasm): minimize debugger profile differences

### DIFF
--- a/playground/src/main.tsx
+++ b/playground/src/main.tsx
@@ -28,6 +28,13 @@ import { appendLineString, parseGeojsonInput } from './input';
 import { comparePlaygroundProfiles, type ProfileComparison } from './compare';
 import { extractNormalizedError } from './error';
 import { createDebuggerEvidenceBundle, downloadDebuggerEvidence } from './evidence';
+import {
+  extractExactInputSegments,
+  segmentsToGeojson,
+  type FingerprintDifference,
+  type MinimizationReduction,
+} from './minimize';
+import { minimizeProfileDifference } from './minimize_client';
 import { buildPlaygroundOptions } from './options';
 import { decodePlaygroundRepro, encodePlaygroundRepro } from './repro';
 import {
@@ -154,12 +161,18 @@ function App() {
   const [comparisonBusy, setComparisonBusy] = useState(false);
   const [comparisonError, setComparisonError] = useState<string | null>(null);
   const [normalizedError, setNormalizedError] = useState<NormalizedPolygonizeErrorV1 | null>(null);
+  const [minimizationBusy, setMinimizationBusy] = useState(false);
+  const [minimizationError, setMinimizationError] = useState<string | null>(null);
+  const [minimizationSignature, setMinimizationSignature] = useState<FingerprintDifference | null>(null);
+  const [reductions, setReductions] = useState<MinimizationReduction[]>([]);
+  const [selectedReductionIndex, setSelectedReductionIndex] = useState(0);
   const [selectedFeature, setSelectedFeature] = useState<SelectedFeature | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [drawEnabled, setDrawEnabled] = useState(false);
   const [drawnPoints, setDrawnPoints] = useState<number[][]>([]);
   const drawnPointsRef = useRef<number[][]>([]);
   const svgRef = useRef<SVGSVGElement>(null);
+  const minimizationControllerRef = useRef<AbortController | null>(null);
 
   // Options
   const [nodeInput, setNodeInput] = useState(false);
@@ -361,6 +374,13 @@ function App() {
       return;
     }
     const controller = new AbortController();
+    minimizationControllerRef.current?.abort();
+    minimizationControllerRef.current = null;
+    setMinimizationBusy(false);
+    setMinimizationError(null);
+    setMinimizationSignature(null);
+    setReductions([]);
+    setSelectedReductionIndex(0);
     const options: Partial<PolygonizerOptions> = buildPlaygroundOptions(
       nodeInput,
       snapGridSize,
@@ -395,6 +415,8 @@ function App() {
     return () => controller.abort();
   }, [wasmReady, inputGeojson, nodeInput, snapGridSize, nodingGuarantee]);
 
+  useEffect(() => () => minimizationControllerRef.current?.abort(), []);
+
   useEffect(() => {
     if (!wasmReady || !inputGeojson) {
       setComparisonBusy(false);
@@ -420,11 +442,59 @@ function App() {
   }, [wasmReady, inputGeojson]);
 
 
+  const selectedReduction = reductions[selectedReductionIndex] ?? null;
+  const reductionGeojson = useMemo(
+    () => selectedReduction ? segmentsToGeojson(selectedReduction.segments) : null,
+    [selectedReduction],
+  );
+
+  const startMinimization = () => {
+    if (!trace || !comparison?.diverged) return;
+    const segments = extractExactInputSegments(trace);
+    if (!segments) {
+      setMinimizationError('The bounded trace does not contain every normalized input segment.');
+      return;
+    }
+    const controller = new AbortController();
+    minimizationControllerRef.current = controller;
+    setMinimizationBusy(true);
+    setMinimizationError(null);
+    setMinimizationSignature(null);
+    setReductions([{ phase: 'input', segments }]);
+    setSelectedReductionIndex(0);
+    void minimizeProfileDifference({
+      segments,
+      baselineOptions: comparison.results[0].report.topology.options as Partial<PolygonizerOptions>,
+      comparisonOptions: comparison.results[1].report.topology.options as Partial<PolygonizerOptions>,
+    }, {
+      signal: controller.signal,
+      onReduction: (reduction) => {
+        setReductions((current) => [...current, reduction]);
+        setSelectedReductionIndex((index) => index + 1);
+      },
+    }).then((result) => {
+      setMinimizationSignature(result.signature);
+    }).catch((e: Error) => {
+      if (e.name !== 'AbortError') setMinimizationError(e.message);
+    }).finally(() => {
+      if (minimizationControllerRef.current === controller) {
+        minimizationControllerRef.current = null;
+        setMinimizationBusy(false);
+      }
+    });
+  };
+
   // SVG Viewport calculation
   const bbox = useMemo(() => {
     if (!inputGeojson) return null;
-    return computeBoundingBox(inputGeojson);
-  }, [inputGeojson]);
+    if (!reductionGeojson || !Array.isArray(inputGeojson.features)) {
+      return computeBoundingBox(inputGeojson);
+    }
+    return computeBoundingBox({
+      type: 'FeatureCollection',
+      features: [...inputGeojson.features, ...reductionGeojson.features],
+    });
+  }, [inputGeojson, reductionGeojson]);
   const traceLayers = useMemo(() => trace ? extractTraceLayers(trace) : null, [trace]);
   const zDecisions = useMemo(
     () => trace ? extractZReconciliationDecisions(trace) : [],
@@ -758,6 +828,49 @@ function App() {
                   </Grid>
                 ))}
               </Grid>
+              {comparison.diverged && (
+                <>
+                  <Button
+                    variant="outlined"
+                    sx={{ mt: 2 }}
+                    onClick={() => {
+                      if (minimizationBusy) minimizationControllerRef.current?.abort();
+                      else startMinimization();
+                    }}
+                  >
+                    {minimizationBusy ? 'Stop minimization' : 'Minimize difference'}
+                  </Button>
+                  {minimizationError && <Alert severity="error" sx={{ mt: 1 }}>{minimizationError}</Alert>}
+                  {reductions.length > 0 && (
+                    <FormControl fullWidth sx={{ mt: 2 }}>
+                      <InputLabel id="reduction-label">Reduction</InputLabel>
+                      <Select
+                        labelId="reduction-label"
+                        label="Reduction"
+                        value={selectedReductionIndex}
+                        onChange={(event) => setSelectedReductionIndex(Number(event.target.value))}
+                      >
+                        {reductions.map((reduction, index) => (
+                          <MenuItem key={`${reduction.phase}-${index}`} value={index}>
+                            {index}: {reduction.phase} ({reduction.segments.length} segments)
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    </FormControl>
+                  )}
+                  {minimizationSignature && (
+                    <TextField
+                      fullWidth
+                      multiline
+                      minRows={3}
+                      label="Preserved profile-difference witness"
+                      value={JSON.stringify(minimizationSignature, null, 2)}
+                      InputProps={{ readOnly: true }}
+                      sx={{ mt: 2 }}
+                    />
+                  )}
+                </>
+              )}
             </Paper>
           )}
         </Grid>
@@ -819,13 +932,25 @@ function App() {
                      })}
 
                      {/* Draw Input Lines (dashed) */}
-                   {layers.rawLines && inputGeojson?.features.map((f: any, i: number) => {
+                     {layers.rawLines && inputGeojson?.features.map((f: any, i: number) => {
                         if (f.geometry?.type === 'LineString') {
                            const pts = f.geometry.coordinates.map((c: any) => `${c[0]},${c[1]}`).join(" ");
                            return <polyline key={`line-${i}`} points={pts} fill="none" stroke="#ff0000" strokeWidth={bbox.width * 0.003} strokeDasharray={`${bbox.width * 0.01},${bbox.width * 0.01}`} />;
                         }
                         return null;
                      })}
+
+                     {reductionGeojson?.features.map((feature, index) => (
+                       <polyline
+                         key={`reduction-${index}`}
+                         points={feature.geometry.coordinates.map((coordinate) => (
+                           `${coordinate[0]},${coordinate[1]}`
+                         )).join(' ')}
+                         fill="none"
+                         stroke="#00c853"
+                         strokeWidth={bbox.width * 0.006}
+                       />
+                     ))}
 
                      {layers.snappedLines && traceLayers?.snappedLines.map((line) => (
                        <line

--- a/playground/src/minimize.test.ts
+++ b/playground/src/minimize.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  decodeExactFloat,
+  extractExactInputSegments,
+  fingerprintDifference,
+  minimizeExactSegments,
+  type ExactInputSegment,
+} from './minimize';
+import type { TopologyTraceV1 } from 'geo-polygonize';
+
+const view = new DataView(new ArrayBuffer(8));
+const bits = (value: number) => {
+  view.setFloat64(0, value);
+  return `0x${view.getBigUint64(0).toString(16).padStart(16, '0')}`;
+};
+const segment = (x: number, sourceId: string, z: number): ExactInputSegment => ({
+  start: { x: bits(x), y: bits(5.5), z: bits(z) },
+  end: { x: bits(x + 1), y: bits(5.5), z: bits(z + 1) },
+  sourceId,
+});
+
+describe('profile minimization', () => {
+  it('extracts only a complete exact normalized input trace', () => {
+    const segments = [segment(0, '0x00000007', 10), segment(2, '0x00000009', 20)];
+    const trace: TopologyTraceV1 = {
+      schema_version: 1,
+      library_version: 'test',
+      level: 'full',
+      byte_limit: 4096,
+      bytes_used: 0,
+      truncated: false,
+      options: {},
+      events: [
+        ...segments.map((value, index) => ({
+          sequence: index,
+          stage: 'noding' as const,
+          kind: 'normalized_input_segment',
+          payload: { index, start: value.start, end: value.end, source_ids: [value.sourceId] },
+        })),
+        {
+          sequence: 2,
+          stage: 'summary',
+          kind: 'polygonizer_summary',
+          payload: { diagnostics: { input_segment_count: 2 } },
+        },
+      ],
+    };
+    expect(extractExactInputSegments(trace)).toEqual(segments);
+    (trace.events[2].payload as { diagnostics: { input_segment_count: number } })
+      .diagnostics.input_segment_count = 3;
+    expect(extractExactInputSegments(trace)).toBeNull();
+  });
+
+  it('matches deterministic first structural difference ordering', () => {
+    expect(fingerprintDifference(
+      { polygons: [{ exterior: ['a'] }] },
+      { polygons: [{ exterior: ['b'] }] },
+    )).toEqual({ path: '$.polygons[0].exterior[0]', expected: 'a', actual: 'b' });
+  });
+
+  it('removes segments and simplifies shared XY without changing source IDs or Z', async () => {
+    const input = [
+      segment(10.25, '0x00000007', 100),
+      segment(20.25, '0x00000009', 200),
+      segment(30.25, '0x0000000b', 300),
+    ];
+    const reductions = vi.fn();
+    const result = await minimizeExactSegments(
+      input,
+      async (candidate) => candidate.some(({ sourceId }) => sourceId === '0x00000009'),
+      reductions,
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result?.[0].sourceId).toBe('0x00000009');
+    expect(result?.[0].start.z).toBe(bits(200));
+    expect(result?.[0].end.z).toBe(bits(201));
+    expect(decodeExactFloat(result![0].start.x)).toBe(0);
+    expect(reductions.mock.calls.some(([reduction]) => reduction.phase === 'segments')).toBe(true);
+    expect(reductions.mock.calls.some(([reduction]) => reduction.phase === 'coordinates')).toBe(true);
+  });
+});

--- a/playground/src/minimize.ts
+++ b/playground/src/minimize.ts
@@ -1,0 +1,166 @@
+import type { TopologyTraceV1 } from 'geo-polygonize';
+
+export type ExactCoordinate = { x: string; y: string; z: string };
+export type ExactInputSegment = {
+  start: ExactCoordinate;
+  end: ExactCoordinate;
+  sourceId: string;
+};
+export type FingerprintDifference = { path: string; expected: unknown; actual: unknown };
+export type MinimizationReduction = {
+  phase: 'input' | 'segments' | 'coordinates';
+  segments: ExactInputSegment[];
+};
+export type MinimizationResult = {
+  signature: FingerprintDifference;
+  segments: ExactInputSegment[];
+};
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function coordinate(value: unknown): ExactCoordinate | null {
+  if (!isObject(value) || typeof value.x !== 'string'
+    || typeof value.y !== 'string' || typeof value.z !== 'string') return null;
+  return { x: value.x, y: value.y, z: value.z };
+}
+
+export function extractExactInputSegments(trace: TopologyTraceV1): ExactInputSegment[] | null {
+  const summary = trace.events.find(({ kind }) => kind === 'polygonizer_summary');
+  const diagnostics = isObject(summary?.payload) ? summary.payload.diagnostics : null;
+  const expectedCount = isObject(diagnostics) ? diagnostics.input_segment_count : null;
+  if (typeof expectedCount !== 'number' || !Number.isSafeInteger(expectedCount)) return null;
+
+  const segments: ExactInputSegment[] = [];
+  for (const event of trace.events) {
+    if (event.kind !== 'normalized_input_segment' || !isObject(event.payload)) continue;
+    const start = coordinate(event.payload.start);
+    const end = coordinate(event.payload.end);
+    const sourceIds = event.payload.source_ids;
+    if (event.payload.index !== segments.length || !start || !end
+      || !Array.isArray(sourceIds) || sourceIds.length !== 1
+      || typeof sourceIds[0] !== 'string') return null;
+    segments.push({ start, end, sourceId: sourceIds[0] });
+  }
+  return segments.length === expectedCount ? segments : null;
+}
+
+export function fingerprintDifference(
+  expected: unknown,
+  actual: unknown,
+  path = '$',
+): FingerprintDifference | null {
+  if (Array.isArray(expected) && Array.isArray(actual)) {
+    for (let index = 0; index < Math.max(expected.length, actual.length); index += 1) {
+      if (index >= expected.length || index >= actual.length) {
+        return { path: `${path}[${index}]`, expected: expected[index] ?? null, actual: actual[index] ?? null };
+      }
+      const difference = fingerprintDifference(expected[index], actual[index], `${path}[${index}]`);
+      if (difference) return difference;
+    }
+    return null;
+  }
+  if (isObject(expected) && isObject(actual) && !Array.isArray(expected) && !Array.isArray(actual)) {
+    const keys = [...new Set([...Object.keys(expected), ...Object.keys(actual)])]
+      .sort((left, right) => (left < right ? -1 : left > right ? 1 : 0));
+    for (const key of keys) {
+      if (!(key in expected) || !(key in actual)) {
+        return { path: `${path}.${key}`, expected: expected[key] ?? null, actual: actual[key] ?? null };
+      }
+      const difference = fingerprintDifference(expected[key], actual[key], `${path}.${key}`);
+      if (difference) return difference;
+    }
+    return null;
+  }
+  return Object.is(expected, actual) ? null : { path, expected, actual };
+}
+
+const floatView = new DataView(new ArrayBuffer(8));
+export function decodeExactFloat(bits: string) {
+  floatView.setBigUint64(0, BigInt(bits));
+  return floatView.getFloat64(0);
+}
+function encodeExactFloat(value: number) {
+  floatView.setFloat64(0, value);
+  return `0x${floatView.getBigUint64(0).toString(16).padStart(16, '0')}`;
+}
+
+function snapshot(segments: ExactInputSegment[]) {
+  return segments.map(({ start, end, sourceId }) => ({
+    start: { ...start },
+    end: { ...end },
+    sourceId,
+  }));
+}
+
+export async function minimizeExactSegments(
+  input: ExactInputSegment[],
+  reproduces: (candidate: ExactInputSegment[]) => Promise<boolean>,
+  onReduction: (reduction: MinimizationReduction) => void = () => {},
+): Promise<ExactInputSegment[] | null> {
+  if (!await reproduces(input)) return null;
+  if (await reproduces([])) return [];
+
+  let current = snapshot(input);
+  let partitions = 2;
+  while (current.length >= 2) {
+    const chunkSize = Math.ceil(current.length / partitions);
+    let reduced = false;
+    for (let start = 0; start < current.length; start += chunkSize) {
+      const candidate = [...current.slice(0, start), ...current.slice(start + chunkSize)];
+      if (await reproduces(candidate)) {
+        current = candidate;
+        partitions = Math.max(2, partitions - 1);
+        reduced = true;
+        onReduction({ phase: 'segments', segments: snapshot(current) });
+        break;
+      }
+    }
+    if (!reduced) {
+      if (partitions >= current.length) break;
+      partitions = Math.min(current.length, partitions * 2);
+    }
+  }
+
+  for (const axis of ['x', 'y'] as const) {
+    const values = [...new Set(current.flatMap(({ start, end }) => [start[axis], end[axis]]))]
+      .sort((left, right) => (BigInt(left) < BigInt(right) ? -1 : BigInt(left) > BigInt(right) ? 1 : 0));
+    for (const bits of values) {
+      const value = decodeExactFloat(bits);
+      const sign = value < 0 || Object.is(value, -0) ? -1 : 1;
+      for (const replacement of [0, sign, Math.trunc(value)]) {
+        const replacementBits = encodeExactFloat(replacement);
+        if (!Number.isFinite(replacement) || replacementBits === bits) continue;
+        const candidate = snapshot(current);
+        for (const segment of candidate) {
+          for (const endpoint of [segment.start, segment.end]) {
+            if (endpoint[axis] === bits) endpoint[axis] = replacementBits;
+          }
+        }
+        if (await reproduces(candidate)) {
+          current = candidate;
+          onReduction({ phase: 'coordinates', segments: snapshot(current) });
+          break;
+        }
+      }
+    }
+  }
+  return current;
+}
+
+export function segmentsToGeojson(segments: ExactInputSegment[]) {
+  return {
+    type: 'FeatureCollection',
+    features: segments.map(({ start, end, sourceId }) => ({
+      type: 'Feature',
+      properties: { source_id: sourceId },
+      geometry: {
+        type: 'LineString',
+        coordinates: [start, end].map(({ x, y, z }) => (
+          [decodeExactFloat(x), decodeExactFloat(y), decodeExactFloat(z)]
+        )),
+      },
+    })),
+  };
+}

--- a/playground/src/minimize_client.test.ts
+++ b/playground/src/minimize_client.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { minimizeProfileDifference } from './minimize_client';
+
+const request = {
+  segments: [],
+  baselineOptions: {},
+  comparisonOptions: {},
+};
+
+describe('minimization worker client', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('terminates its dedicated worker when aborted', async () => {
+    const terminate = vi.fn();
+    const constructed = vi.fn();
+    const postMessage = vi.fn();
+    class WorkerMock {
+      onmessage = null;
+      onerror = null;
+      constructor() { constructed(); }
+      postMessage = postMessage;
+      terminate = terminate;
+    }
+    vi.stubGlobal('Worker', WorkerMock);
+    const controller = new AbortController();
+
+    const result = minimizeProfileDifference(request, { signal: controller.signal });
+    controller.abort();
+
+    await expect(result).rejects.toMatchObject({ name: 'AbortError' });
+    expect(constructed).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith(request);
+    expect(terminate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/playground/src/minimize_client.ts
+++ b/playground/src/minimize_client.ts
@@ -1,0 +1,52 @@
+import type { PolygonizerOptions } from 'geo-polygonize';
+import type {
+  ExactInputSegment,
+  MinimizationReduction,
+  MinimizationResult,
+} from './minimize';
+
+type WorkerRequest = {
+  segments: ExactInputSegment[];
+  baselineOptions: Partial<PolygonizerOptions>;
+  comparisonOptions: Partial<PolygonizerOptions>;
+};
+type WorkerReply =
+  | { type: 'reduction'; reduction: MinimizationReduction }
+  | { type: 'result'; result: MinimizationResult }
+  | { type: 'error'; message: string };
+
+export function minimizeProfileDifference(
+  request: WorkerRequest,
+  { signal, onReduction }: {
+    signal?: AbortSignal;
+    onReduction?: (reduction: MinimizationReduction) => void;
+  } = {},
+): Promise<MinimizationResult> {
+  if (signal?.aborted) return Promise.reject(new DOMException('Minimization cancelled', 'AbortError'));
+  return new Promise((resolve, reject) => {
+    const worker = new Worker(new URL('./minimize_worker.ts', import.meta.url), { type: 'module' });
+    const cleanup = () => {
+      signal?.removeEventListener('abort', abort);
+      worker.terminate();
+    };
+    const abort = () => {
+      cleanup();
+      reject(new DOMException('Minimization cancelled', 'AbortError'));
+    };
+    worker.onmessage = ({ data }: MessageEvent<WorkerReply>) => {
+      if (data.type === 'reduction') {
+        onReduction?.(data.reduction);
+      } else {
+        cleanup();
+        if (data.type === 'result') resolve(data.result);
+        else reject(new Error(data.message));
+      }
+    };
+    worker.onerror = ({ message }) => {
+      cleanup();
+      reject(new Error(message));
+    };
+    signal?.addEventListener('abort', abort, { once: true });
+    worker.postMessage(request);
+  });
+}

--- a/playground/src/minimize_worker.ts
+++ b/playground/src/minimize_worker.ts
@@ -1,0 +1,90 @@
+import init, { polygonizeWithOptionsBuffer, type PolygonizerOptions } from 'geo-polygonize';
+import {
+  decodeExactFloat,
+  fingerprintDifference,
+  minimizeExactSegments,
+  type ExactInputSegment,
+  type FingerprintDifference,
+} from './minimize';
+
+type Request = {
+  segments: ExactInputSegment[];
+  baselineOptions: Partial<PolygonizerOptions>;
+  comparisonOptions: Partial<PolygonizerOptions>;
+};
+
+function pack(segments: ExactInputSegment[]) {
+  if (segments.length > Math.floor(0xffff_ffff / 2)) {
+    throw new Error('Too many trace segments for u32 offsets');
+  }
+  const coordinates = new Float64Array(segments.length * 6);
+  const offsets = new Uint32Array(segments.length + 1);
+  const sourceIds = new Uint32Array(segments.length);
+  for (let index = 0; index < segments.length; index += 1) {
+    const segment = segments[index];
+    coordinates.set([
+      decodeExactFloat(segment.start.x),
+      decodeExactFloat(segment.start.y),
+      decodeExactFloat(segment.start.z),
+      decodeExactFloat(segment.end.x),
+      decodeExactFloat(segment.end.y),
+      decodeExactFloat(segment.end.z),
+    ], index * 6);
+    offsets[index] = index * 2;
+    const sourceId = BigInt(segment.sourceId);
+    if (sourceId < 0n || sourceId > 0xffff_ffffn) throw new Error('Invalid trace source ID');
+    sourceIds[index] = Number(sourceId);
+  }
+  offsets[segments.length] = segments.length * 2;
+  return { coordinates, offsets, sourceIds };
+}
+
+function topologyWithoutOptions(value: unknown) {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error('Buffer result did not contain a topology fingerprint');
+  }
+  const { options: _, ...topology } = value as Record<string, unknown>;
+  return topology;
+}
+
+function run(segments: ExactInputSegment[], options: Partial<PolygonizerOptions>) {
+  const { coordinates, offsets, sourceIds } = pack(segments);
+  const result = polygonizeWithOptionsBuffer(coordinates, offsets, 3, options, sourceIds);
+  try {
+    return topologyWithoutOptions(result.topology_fingerprint);
+  } finally {
+    result.free();
+  }
+}
+
+self.addEventListener('message', async ({ data }: MessageEvent<Request>) => {
+  try {
+    await init();
+    const signature = fingerprintDifference(
+      run(data.segments, data.baselineOptions),
+      run(data.segments, data.comparisonOptions),
+    );
+    if (!signature) throw new Error('Profile difference no longer reproduces');
+    const reproduces = async (candidate: ExactInputSegment[]) => {
+      try {
+        const candidateSignature = fingerprintDifference(
+          run(candidate, data.baselineOptions),
+          run(candidate, data.comparisonOptions),
+        );
+        return JSON.stringify(candidateSignature) === JSON.stringify(signature);
+      } catch {
+        return false;
+      }
+    };
+    const minimized = await minimizeExactSegments(data.segments, reproduces, (reduction) => {
+      self.postMessage({ type: 'reduction', reduction });
+    });
+    if (!minimized) throw new Error('Profile difference was not deterministic');
+    self.postMessage({ type: 'result', result: { signature, segments: minimized } });
+  } catch (error) {
+    self.postMessage({
+      type: 'error',
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+});


### PR DESCRIPTION
## Stack
- Parent: #1089
- This PR: abortable worker minimization and reduction visualization
- Children: none

## Delivered
- Runs each minimization request in a dedicated, abortable module worker.
- Reconstructs exact normalized input segments from trace coordinate bits.
- Mirrors the Rust ddmin and global X/Y simplification order for deterministic reductions.
- Preserves resolved profile options, source IDs, and Z-coordinate bits.
- Visualizes the original input and every accepted reduction while retaining the first structural profile-difference witness.
- Limits minimization to reproducible successful profile divergences.

## Contract impact
Playground-only worker and UI behavior. No core schema, option, pooling, ROADMAP, or workflow changes.

## Validation
- Focused Vitest: 4 minimizer/client tests passed; combined debugger-focused run: 12 passed.
- Strict playground TypeScript check passed.
- `npm run build --prefix playground` passed and emitted a separate minimization worker bundle.
- Full `npm test`: 44 tests passed, including 21 Wasm tests.
- `git diff --cached --check` passed before commit.
- The worker uses the package default `init()`, retaining the shared scalar/SIMD runtime selection path.

## Agent handoff
- Error-vs-success and error-vs-error minimization remain unavailable because the merged profile comparison retains only paired successful reports.
- External reference truth is still absent, so exported evidence remains an evidence bundle rather than a persisted golden.
- Review after #1089.