### PR TITLE
feat(wasm): minimize debugger error differences

### DIFF
--- a/playground/src/compare.test.ts
+++ b/playground/src/compare.test.ts
@@ -45,8 +45,37 @@ describe('profile comparison', () => {
     expect(run.mock.calls.map((call) => call[1].noding.guarantee))
       .toEqual(['Validate', 'CertifiedFixedPrecision']);
     expect(run.mock.calls.every((call) => call[4].signal === signal)).toBe(true);
-    expect(comparison.results.map((result) => result.report.topology.polygons.length))
+    expect(comparison.results.map((result) => (
+      result.status === 'success' ? result.report.topology.polygons.length : null
+    )))
       .toEqual([1, 2]);
+    expect(comparison.diverged).toBe(true);
+  });
+
+  it('retains normalized profile errors without comparing their message wording', async () => {
+    const normalized = {
+      schema_version: 1,
+      family: 'topology',
+      code: 'z_conflict',
+      stage: 'z_reconciliation',
+      field: null,
+      expected: null,
+      actual: null,
+      limit: null,
+      observed: null,
+      witness: null,
+    } as const;
+    const run = vi.fn()
+      .mockResolvedValueOnce(JSON.stringify(report(1)))
+      .mockRejectedValueOnce(Object.assign(new Error('unstable human wording'), { normalized }));
+
+    const comparison = await comparePlaygroundProfiles(
+      '{}',
+      new AbortController().signal,
+      run,
+    );
+
+    expect(comparison.results[1]).toMatchObject({ status: 'error', error: normalized });
     expect(comparison.diverged).toBe(true);
   });
 });

--- a/playground/src/compare.ts
+++ b/playground/src/compare.ts
@@ -1,8 +1,14 @@
 import type {
+  NormalizedPolygonizeErrorV1,
   PolygonizeTraceReportV1,
   PolygonizerOptions,
   polygonizeTraceWithOptionsAsync,
 } from 'geo-polygonize';
+import { extractNormalizedError } from './error';
+import {
+  profileDifferenceSignature,
+  type ProfileOutcome,
+} from './minimize';
 import { buildPlaygroundOptions } from './options';
 import { parsePlaygroundTraceReport, PLAYGROUND_TRACE_BYTE_LIMIT } from './trace';
 
@@ -17,18 +23,24 @@ const profiles = [
   },
 ] satisfies { label: string; options: Partial<PolygonizerOptions> }[];
 
-export type ProfileResult = {
+type ProfileResultBase = {
   label: string;
-  report: PolygonizeTraceReportV1;
+  options: Partial<PolygonizerOptions>;
 };
+export type ProfileResult = ProfileResultBase & (
+  | { status: 'success'; report: PolygonizeTraceReportV1 }
+  | { status: 'error'; error: NormalizedPolygonizeErrorV1 }
+);
 
 export type ProfileComparison = {
   results: ProfileResult[];
   diverged: boolean;
 };
 
-function fingerprint({ options: _, ...topology }: PolygonizeTraceReportV1['topology']) {
-  return JSON.stringify(topology);
+function outcome(result: ProfileResult): ProfileOutcome {
+  if (result.status === 'error') return { status: 'error', value: result.error };
+  const { options: _, ...topology } = result.report.topology;
+  return { status: 'success', value: topology };
 }
 
 export async function comparePlaygroundProfiles(
@@ -36,18 +48,32 @@ export async function comparePlaygroundProfiles(
   signal: AbortSignal,
   run: typeof polygonizeTraceWithOptionsAsync,
 ): Promise<ProfileComparison> {
-  const results = await Promise.all(profiles.map(async ({ label, options }) => ({
-    label,
-    report: parsePlaygroundTraceReport(await run(
-      input,
-      options,
-      'summary',
-      PLAYGROUND_TRACE_BYTE_LIMIT,
-      { signal },
-    )),
-  })));
+  const results = await Promise.all(profiles.map(async ({ label, options }): Promise<ProfileResult> => {
+    try {
+      const report = parsePlaygroundTraceReport(await run(
+        input,
+        options,
+        'summary',
+        PLAYGROUND_TRACE_BYTE_LIMIT,
+        { signal },
+      ));
+      return {
+        label,
+        options: report.topology.options as Partial<PolygonizerOptions>,
+        status: 'success',
+        report,
+      };
+    } catch (error) {
+      if (typeof error === 'object' && error !== null && 'name' in error
+        && error.name === 'AbortError') throw error;
+      const normalized = extractNormalizedError(error);
+      if (!normalized) throw new Error('Profile comparison failed without a normalized V1 error');
+      return { label, options, status: 'error', error: normalized };
+    }
+  }));
+  const signature = profileDifferenceSignature(outcome(results[0]), outcome(results[1]));
   return {
     results,
-    diverged: fingerprint(results[0].report.topology) !== fingerprint(results[1].report.topology),
+    diverged: signature !== null,
   };
 }

--- a/playground/src/evidence.test.ts
+++ b/playground/src/evidence.test.ts
@@ -47,7 +47,15 @@ describe('debugger evidence bundles', () => {
       requestedOptions: { node_input: true },
       topology: report.topology,
       trace: report.trace,
-      comparison: { results: [{ label: 'test', report }], diverged: false },
+      comparison: {
+        results: [{
+          label: 'test',
+          options: { node_input: true },
+          status: 'success',
+          report,
+        }],
+        diverged: false,
+      },
       normalizedError: null,
     });
 

--- a/playground/src/main.tsx
+++ b/playground/src/main.tsx
@@ -31,8 +31,8 @@ import { createDebuggerEvidenceBundle, downloadDebuggerEvidence } from './eviden
 import {
   extractExactInputSegments,
   segmentsToGeojson,
-  type FingerprintDifference,
   type MinimizationReduction,
+  type ProfileDifferenceSignature,
 } from './minimize';
 import { minimizeProfileDifference } from './minimize_client';
 import { buildPlaygroundOptions } from './options';
@@ -163,7 +163,7 @@ function App() {
   const [normalizedError, setNormalizedError] = useState<NormalizedPolygonizeErrorV1 | null>(null);
   const [minimizationBusy, setMinimizationBusy] = useState(false);
   const [minimizationError, setMinimizationError] = useState<string | null>(null);
-  const [minimizationSignature, setMinimizationSignature] = useState<FingerprintDifference | null>(null);
+  const [minimizationSignature, setMinimizationSignature] = useState<ProfileDifferenceSignature | null>(null);
   const [reductions, setReductions] = useState<MinimizationReduction[]>([]);
   const [selectedReductionIndex, setSelectedReductionIndex] = useState(0);
   const [selectedFeature, setSelectedFeature] = useState<SelectedFeature | null>(null);
@@ -447,6 +447,7 @@ function App() {
     () => selectedReduction ? segmentsToGeojson(selectedReduction.segments) : null,
     [selectedReduction],
   );
+  const comparisonIncludesError = comparison?.results.some(({ status }) => status === 'error') ?? false;
 
   const startMinimization = () => {
     if (!trace || !comparison?.diverged) return;
@@ -464,8 +465,8 @@ function App() {
     setSelectedReductionIndex(0);
     void minimizeProfileDifference({
       segments,
-      baselineOptions: comparison.results[0].report.topology.options as Partial<PolygonizerOptions>,
-      comparisonOptions: comparison.results[1].report.topology.options as Partial<PolygonizerOptions>,
+      baselineOptions: comparison.results[0].options,
+      comparisonOptions: comparison.results[1].options,
     }, {
       signal: controller.signal,
       onReduction: (reduction) => {
@@ -804,24 +805,44 @@ function App() {
             <Paper sx={{ p: 2, mt: 3 }}>
               <Typography variant="h6">Profile comparison</Typography>
               <Alert severity={comparison.diverged ? 'warning' : 'success'} sx={{ my: 1 }}>
-                Canonical topology fingerprints {comparison.diverged ? 'diverge' : 'match'}.
+                {comparisonIncludesError
+                  ? `Normalized profile outcomes ${comparison.diverged ? 'diverge' : 'match'}.`
+                  : `Canonical topology fingerprints ${comparison.diverged ? 'diverge' : 'match'}.`}
               </Alert>
               <Grid container spacing={2}>
-                {comparison.results.map(({ label, report: result }) => (
-                  <Grid key={label} size={{ xs: 12, sm: 6 }}>
-                    <Typography variant="subtitle1">{label}</Typography>
-                    <Typography>Polygons: {result.topology.polygons.length}</Typography>
-                    <Typography>Dangles: {result.topology.dangles.length}</Typography>
-                    <Typography>Cut edges: {result.topology.cut_edges.length}</Typography>
-                    <Typography>Invalid rings: {result.topology.invalid_rings.length}</Typography>
-                    <Typography>Trace events: {result.trace.events.length}</Typography>
-                    <Typography>Trace bytes: {result.trace.bytes_used.toLocaleString()}</Typography>
+                {comparison.results.map((result) => (
+                  <Grid key={result.label} size={{ xs: 12, sm: 6 }}>
+                    <Typography variant="subtitle1">{result.label}</Typography>
+                    {result.status === 'success' ? (
+                      <>
+                        <Typography>Outcome: success</Typography>
+                        <Typography>Polygons: {result.report.topology.polygons.length}</Typography>
+                        <Typography>Dangles: {result.report.topology.dangles.length}</Typography>
+                        <Typography>Cut edges: {result.report.topology.cut_edges.length}</Typography>
+                        <Typography>Invalid rings: {result.report.topology.invalid_rings.length}</Typography>
+                        <Typography>Trace events: {result.report.trace.events.length}</Typography>
+                        <Typography>Trace bytes: {result.report.trace.bytes_used.toLocaleString()}</Typography>
+                      </>
+                    ) : (
+                      <>
+                        <Typography>Outcome: error</Typography>
+                        <TextField
+                          fullWidth
+                          multiline
+                          minRows={6}
+                          label="Normalized error outcome"
+                          value={JSON.stringify(result.error, null, 2)}
+                          InputProps={{ readOnly: true }}
+                          sx={{ mt: 1 }}
+                        />
+                      </>
+                    )}
                     <TextField
                       fullWidth
                       multiline
                       minRows={4}
-                      label="Canonical options"
-                      value={JSON.stringify(result.topology.options, null, 2)}
+                      label="Canonical profile options"
+                      value={JSON.stringify(result.options, null, 2)}
                       InputProps={{ readOnly: true }}
                       sx={{ mt: 1 }}
                     />
@@ -833,13 +854,21 @@ function App() {
                   <Button
                     variant="outlined"
                     sx={{ mt: 2 }}
+                    disabled={!trace && !minimizationBusy}
                     onClick={() => {
                       if (minimizationBusy) minimizationControllerRef.current?.abort();
                       else startMinimization();
                     }}
                   >
-                    {minimizationBusy ? 'Stop minimization' : 'Minimize difference'}
+                    {minimizationBusy
+                      ? 'Stop minimization'
+                      : comparisonIncludesError ? 'Minimize error difference' : 'Minimize difference'}
                   </Button>
+                  {!trace && (
+                    <Alert severity="info" sx={{ mt: 1 }}>
+                      Minimization requires a successful full trace with exact normalized input segments.
+                    </Alert>
+                  )}
                   {minimizationError && <Alert severity="error" sx={{ mt: 1 }}>{minimizationError}</Alert>}
                   {reductions.length > 0 && (
                     <FormControl fullWidth sx={{ mt: 2 }}>
@@ -863,7 +892,9 @@ function App() {
                       fullWidth
                       multiline
                       minRows={3}
-                      label="Preserved profile-difference witness"
+                      label={comparisonIncludesError
+                        ? 'Preserved normalized-error signature'
+                        : 'Preserved profile-difference witness'}
                       value={JSON.stringify(minimizationSignature, null, 2)}
                       InputProps={{ readOnly: true }}
                       sx={{ mt: 2 }}

--- a/playground/src/minimize.test.ts
+++ b/playground/src/minimize.test.ts
@@ -4,6 +4,8 @@ import {
   extractExactInputSegments,
   fingerprintDifference,
   minimizeExactSegments,
+  profileDifferenceSignature,
+  sameProfileDifferenceSignature,
   type ExactInputSegment,
 } from './minimize';
 import type { TopologyTraceV1 } from 'geo-polygonize';
@@ -17,6 +19,18 @@ const segment = (x: number, sourceId: string, z: number): ExactInputSegment => (
   start: { x: bits(x), y: bits(5.5), z: bits(z) },
   end: { x: bits(x + 1), y: bits(5.5), z: bits(z + 1) },
   sourceId,
+});
+const normalizedError = (code: string, ids: string[] = []) => ({
+  schema_version: 1,
+  family: 'topology',
+  code,
+  stage: 'noding_validation',
+  field: null,
+  expected: null,
+  actual: null,
+  limit: null,
+  observed: null,
+  witness: ids.length > 0 ? { ids, coordinate: null } : null,
 });
 
 describe('profile minimization', () => {
@@ -56,6 +70,26 @@ describe('profile minimization', () => {
       { polygons: [{ exterior: ['a'] }] },
       { polygons: [{ exterior: ['b'] }] },
     )).toEqual({ path: '$.polygons[0].exterior[0]', expected: 'a', actual: 'b' });
+  });
+
+  it('keeps successful signatures unchanged and preserves complete normalized error pairs', () => {
+    expect(profileDifferenceSignature(
+      { status: 'success', value: { polygons: ['a'] } },
+      { status: 'success', value: { polygons: ['b'] } },
+    )).toEqual({ path: '$.polygons[0]', expected: 'a', actual: 'b' });
+
+    const baseline = normalizedError('interior_intersection', ['0x01', '0x02']);
+    const comparison = normalizedError('collinear_overlap', ['0x03', '0x04']);
+    const signature = profileDifferenceSignature(
+      { status: 'error', value: baseline },
+      { status: 'error', value: comparison },
+    );
+    expect(signature).toEqual({ kind: 'normalized_errors', baseline, comparison });
+    expect(sameProfileDifferenceSignature(signature!, { ...signature! })).toBe(true);
+    expect(profileDifferenceSignature(
+      { status: 'error', value: baseline },
+      { status: 'error', value: baseline },
+    )).toBeNull();
   });
 
   it('removes segments and simplifies shared XY without changing source IDs or Z', async () => {

--- a/playground/src/minimize.ts
+++ b/playground/src/minimize.ts
@@ -1,4 +1,4 @@
-import type { TopologyTraceV1 } from 'geo-polygonize';
+import type { NormalizedPolygonizeErrorV1, TopologyTraceV1 } from 'geo-polygonize';
 
 export type ExactCoordinate = { x: string; y: string; z: string };
 export type ExactInputSegment = {
@@ -7,12 +7,24 @@ export type ExactInputSegment = {
   sourceId: string;
 };
 export type FingerprintDifference = { path: string; expected: unknown; actual: unknown };
+export type ProfileOutcome =
+  | { status: 'success'; value: unknown }
+  | { status: 'error'; value: NormalizedPolygonizeErrorV1 };
+export type ProfileDifferenceSignature = FingerprintDifference | {
+  kind: 'normalized_errors';
+  baseline: NormalizedPolygonizeErrorV1;
+  comparison: NormalizedPolygonizeErrorV1;
+} | {
+  kind: 'outcome_kinds';
+  baseline: ProfileOutcome['status'];
+  comparison: ProfileOutcome['status'];
+};
 export type MinimizationReduction = {
   phase: 'input' | 'segments' | 'coordinates';
   segments: ExactInputSegment[];
 };
 export type MinimizationResult = {
-  signature: FingerprintDifference;
+  signature: ProfileDifferenceSignature;
   segments: ExactInputSegment[];
 };
 
@@ -74,6 +86,28 @@ export function fingerprintDifference(
     return null;
   }
   return Object.is(expected, actual) ? null : { path, expected, actual };
+}
+
+export function profileDifferenceSignature(
+  baseline: ProfileOutcome,
+  comparison: ProfileOutcome,
+): ProfileDifferenceSignature | null {
+  if (baseline.status === 'success' && comparison.status === 'success') {
+    return fingerprintDifference(baseline.value, comparison.value);
+  }
+  if (baseline.status === 'error' && comparison.status === 'error') {
+    return fingerprintDifference(baseline.value, comparison.value)
+      ? { kind: 'normalized_errors', baseline: baseline.value, comparison: comparison.value }
+      : null;
+  }
+  return { kind: 'outcome_kinds', baseline: baseline.status, comparison: comparison.status };
+}
+
+export function sameProfileDifferenceSignature(
+  expected: ProfileDifferenceSignature,
+  actual: ProfileDifferenceSignature | null,
+) {
+  return actual !== null && fingerprintDifference(expected, actual) === null;
 }
 
 const floatView = new DataView(new ArrayBuffer(8));

--- a/playground/src/minimize_worker.test.ts
+++ b/playground/src/minimize_worker.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ExactInputSegment } from './minimize';
+
+const wasm = vi.hoisted(() => ({
+  init: vi.fn(async () => {}),
+  polygonizeWithOptionsBuffer: vi.fn(),
+}));
+
+vi.mock('geo-polygonize', () => ({
+  default: wasm.init,
+  polygonizeWithOptionsBuffer: wasm.polygonizeWithOptionsBuffer,
+}));
+
+const view = new DataView(new ArrayBuffer(8));
+const bits = (value: number) => {
+  view.setFloat64(0, value);
+  return `0x${view.getBigUint64(0).toString(16).padStart(16, '0')}`;
+};
+const segments: ExactInputSegment[] = [{
+  start: { x: bits(1), y: bits(2), z: bits(30) },
+  end: { x: bits(3), y: bits(4), z: bits(40) },
+  sourceId: '0x0000002a',
+}];
+const normalized = {
+  schema_version: 1,
+  family: 'topology',
+  code: 'z_conflict',
+  stage: 'z_reconciliation',
+  field: null,
+  expected: null,
+  actual: null,
+  limit: null,
+  observed: null,
+  witness: { ids: ['0x0000002a'], coordinate: null },
+};
+
+type WorkerHandler = (event: { data: unknown }) => Promise<void>;
+
+async function loadWorker() {
+  let handler: WorkerHandler | undefined;
+  const postMessage = vi.fn();
+  vi.stubGlobal('self', {
+    addEventListener: vi.fn((_type: string, listener: WorkerHandler) => { handler = listener; }),
+    postMessage,
+  });
+  await import('./minimize_worker');
+  if (!handler) throw new Error('worker handler was not registered');
+  return { handler, postMessage };
+}
+
+describe('profile minimization worker outcomes', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('minimizes success-vs-error using only the normalized structural signature', async () => {
+    const free = vi.fn();
+    wasm.polygonizeWithOptionsBuffer.mockImplementation(
+      (_coordinates, _offsets, _stride, options) => {
+        if (options.input_profile_id === 'comparison') {
+          throw { message: 'wording may change', normalized };
+        }
+        return {
+          topology_fingerprint: { options, polygons: [] },
+          free,
+        };
+      },
+    );
+    const { handler, postMessage } = await loadWorker();
+
+    await handler({
+      data: {
+        segments,
+        baselineOptions: { input_profile_id: 'baseline' },
+        comparisonOptions: { input_profile_id: 'comparison' },
+      },
+    });
+
+    expect(wasm.init).toHaveBeenCalledTimes(1);
+    expect(wasm.polygonizeWithOptionsBuffer.mock.calls[0][0])
+      .toEqual(new Float64Array([1, 2, 30, 3, 4, 40]));
+    expect(wasm.polygonizeWithOptionsBuffer.mock.calls[0][1])
+      .toEqual(new Uint32Array([0, 2]));
+    expect(wasm.polygonizeWithOptionsBuffer.mock.calls[0][2]).toBe(3);
+    expect(wasm.polygonizeWithOptionsBuffer.mock.calls[0][4])
+      .toEqual(new Uint32Array([42]));
+    expect(wasm.polygonizeWithOptionsBuffer.mock.calls.map((call) => call[3].input_profile_id))
+      .toEqual(['baseline', 'comparison', 'baseline', 'comparison', 'baseline', 'comparison']);
+    expect(free).toHaveBeenCalledTimes(3);
+    expect(postMessage).toHaveBeenLastCalledWith({
+      type: 'result',
+      result: {
+        signature: {
+          kind: 'outcome_kinds',
+          baseline: 'success',
+          comparison: 'error',
+        },
+        segments: [],
+      },
+    });
+  });
+
+  it('stops when the buffer API does not provide a normalized error', async () => {
+    wasm.polygonizeWithOptionsBuffer.mockImplementation(
+      (_coordinates, _offsets, _stride, options) => {
+        if (options.input_profile_id === 'comparison') throw new Error('do not parse this wording');
+        return { topology_fingerprint: { options, polygons: [] }, free: vi.fn() };
+      },
+    );
+    const { handler, postMessage } = await loadWorker();
+
+    await handler({
+      data: {
+        segments,
+        baselineOptions: { input_profile_id: 'baseline' },
+        comparisonOptions: { input_profile_id: 'comparison' },
+      },
+    });
+
+    expect(postMessage).toHaveBeenLastCalledWith({
+      type: 'error',
+      message: 'Buffer API failure did not include a normalized V1 error',
+    });
+  });
+
+  it('preserves both complete normalized errors when their structures differ', async () => {
+    const comparisonError = {
+      ...normalized,
+      code: 'interior_intersection',
+      witness: { ids: ['0x0000002a', '0x0000002b'], coordinate: null },
+    };
+    wasm.polygonizeWithOptionsBuffer.mockImplementation(
+      (_coordinates, _offsets, _stride, options) => {
+        throw {
+          message: options.input_profile_id === 'baseline' ? 'first wording' : 'second wording',
+          normalized: options.input_profile_id === 'baseline' ? normalized : comparisonError,
+        };
+      },
+    );
+    const { handler, postMessage } = await loadWorker();
+
+    await handler({
+      data: {
+        segments,
+        baselineOptions: { input_profile_id: 'baseline' },
+        comparisonOptions: { input_profile_id: 'comparison' },
+      },
+    });
+
+    expect(postMessage).toHaveBeenLastCalledWith({
+      type: 'result',
+      result: {
+        signature: {
+          kind: 'normalized_errors',
+          baseline: normalized,
+          comparison: comparisonError,
+        },
+        segments: [],
+      },
+    });
+  });
+});

--- a/playground/src/minimize_worker.ts
+++ b/playground/src/minimize_worker.ts
@@ -1,10 +1,12 @@
 import init, { polygonizeWithOptionsBuffer, type PolygonizerOptions } from 'geo-polygonize';
+import { extractNormalizedError } from './error';
 import {
   decodeExactFloat,
-  fingerprintDifference,
   minimizeExactSegments,
+  profileDifferenceSignature,
+  sameProfileDifferenceSignature,
   type ExactInputSegment,
-  type FingerprintDifference,
+  type ProfileOutcome,
 } from './minimize';
 
 type Request = {
@@ -47,11 +49,20 @@ function topologyWithoutOptions(value: unknown) {
   return topology;
 }
 
-function run(segments: ExactInputSegment[], options: Partial<PolygonizerOptions>) {
+function run(segments: ExactInputSegment[], options: Partial<PolygonizerOptions>): ProfileOutcome {
   const { coordinates, offsets, sourceIds } = pack(segments);
-  const result = polygonizeWithOptionsBuffer(coordinates, offsets, 3, options, sourceIds);
+  let result;
   try {
-    return topologyWithoutOptions(result.topology_fingerprint);
+    result = polygonizeWithOptionsBuffer(coordinates, offsets, 3, options, sourceIds);
+  } catch (error) {
+    const normalized = extractNormalizedError(error);
+    if (!normalized) {
+      throw new Error('Buffer API failure did not include a normalized V1 error');
+    }
+    return { status: 'error', value: normalized };
+  }
+  try {
+    return { status: 'success', value: topologyWithoutOptions(result.topology_fingerprint) };
   } finally {
     result.free();
   }
@@ -60,18 +71,18 @@ function run(segments: ExactInputSegment[], options: Partial<PolygonizerOptions>
 self.addEventListener('message', async ({ data }: MessageEvent<Request>) => {
   try {
     await init();
-    const signature = fingerprintDifference(
+    const signature = profileDifferenceSignature(
       run(data.segments, data.baselineOptions),
       run(data.segments, data.comparisonOptions),
     );
     if (!signature) throw new Error('Profile difference no longer reproduces');
     const reproduces = async (candidate: ExactInputSegment[]) => {
       try {
-        const candidateSignature = fingerprintDifference(
+        const candidateSignature = profileDifferenceSignature(
           run(candidate, data.baselineOptions),
           run(candidate, data.comparisonOptions),
         );
-        return JSON.stringify(candidateSignature) === JSON.stringify(signature);
+        return sameProfileDifferenceSignature(signature, candidateSignature);
       } catch {
         return false;
       }


### PR DESCRIPTION
## Stack

- Merged parent: #1093
- This PR: normalized error-outcome minimization
- Children: none

The parent merged and its remote branch was deleted during implementation, so this child was rebased onto current `main` before publishing.

## Delivered

- Retains successful topology comparison behavior while extending profile comparison to normalized success/error outcomes.
- Mirrors the Rust differential mismatch signature: first topology witness for success-success, both complete normalized errors for error-error, and outcome kinds for success-error.
- Never compares or persists human error message wording.
- Stops with a fixed diagnostic when the buffer API does not provide a normalized V1 error.
- Preserves exact trace segments, source IDs, Z bits, checked u32 offsets, and both profile option objects through deterministic minimization.
- Keeps the dedicated worker termination-on-abort behavior and package default scalar/SIMD runtime selection.
- Distinguishes successful and normalized-error outcomes in the debugger UI, including error-specific minimization labels and signatures.

## Contract impact

Playground-only comparison, worker, evidence, and UI behavior. Successful comparison results gain explicit outcome status/profile options; normalized error results are additive. No Rust core schema, option, workflow, or ROADMAP changes.

## Validation

- `npm test` — 49 passed across 11 files, including 21 Wasm tests
- strict playground `tsc --noEmit` — passed
- `npm run build --prefix playground` — passed and emitted the separate minimization worker
- focused comparator/minimizer/client/worker/evidence tests — 12 passed
- `git diff --check origin/main..HEAD` — passed

The build retains existing MUI `use client`, runtime Wasm URL, output-directory, and large-chunk warnings.

## Agent handoff

- Exact minimization still requires a successful full trace containing every normalized input segment; the UI now reports and disables minimization when that evidence is unavailable.
- Buffer/API failures without normalized V1 data intentionally stop instead of parsing messages.
- Review independently on top of merged #1093.