### PR TITLE
test(core): verify serial parallel conformance

### DIFF
--- a/crates/geo-polygonize-core/src/polygonizer_tests.rs
+++ b/crates/geo-polygonize-core/src/polygonizer_tests.rs
@@ -771,4 +771,199 @@ mod tests {
         assert_eq!(result.polygons.len(), 2);
         assert!(result.invalid_rings.is_empty());
     }
+
+    mod serial_parallel_conformance {
+        use crate::utils::parallel::{par_flat_map_dispatches, reset_par_flat_map_dispatches};
+        use crate::{
+            normalize_polygonize_error, polygonize, Coord3D, DiagnosticsOptions, Line3D,
+            NodingGuarantee, NodingOptions, NormalizedPolygonizeErrorV1, PolygonizerOptions,
+            ProvenanceOptions, TopologyFingerprintV1, ZOptions, ZPolicy,
+        };
+        use serde::{Deserialize, Serialize};
+        use sha2::{Digest, Sha256};
+
+        #[derive(Deserialize)]
+        struct Fixture {
+            options: Option<PolygonizerOptions>,
+            #[serde(default)]
+            profile_id: Option<String>,
+            inputs: Vec<FixtureLine>,
+        }
+
+        #[derive(Deserialize)]
+        struct FixtureLine {
+            start: FixtureCoordinate,
+            end: FixtureCoordinate,
+            id: u32,
+        }
+
+        #[derive(Deserialize)]
+        struct FixtureCoordinate {
+            x: f64,
+            y: f64,
+            z: f64,
+        }
+
+        #[derive(Debug, Serialize)]
+        struct ConformanceEvidenceV1 {
+            schema_version: u32,
+            cases: Vec<CaseEvidenceV1>,
+        }
+
+        #[derive(Debug, Serialize)]
+        struct CaseEvidenceV1 {
+            name: &'static str,
+            outcome: OutcomeV1,
+        }
+
+        #[derive(Debug, Serialize)]
+        #[serde(tag = "status", rename_all = "snake_case")]
+        enum OutcomeV1 {
+            Success {
+                fingerprint_sha256: String,
+            },
+            Error {
+                normalized: Box<NormalizedPolygonizeErrorV1>,
+            },
+        }
+
+        fn fixture(source: &str) -> (Vec<Line3D>, PolygonizerOptions) {
+            let fixture: Fixture = serde_json::from_str(source).unwrap();
+            let mut options = fixture.options.unwrap_or_default();
+            options.diagnostics = DiagnosticsOptions {
+                enabled: true,
+                ..Default::default()
+            };
+            options.provenance = ProvenanceOptions {
+                enabled: true,
+                include_boundary_line_ids: true,
+            };
+            options.input_profile_id = fixture.profile_id;
+            let lines = fixture
+                .inputs
+                .into_iter()
+                .map(|line| {
+                    Line3D::new(
+                        Coord3D::new(line.start.x, line.start.y, line.start.z),
+                        Coord3D::new(line.end.x, line.end.y, line.end.z),
+                        line.id,
+                    )
+                })
+                .collect();
+            (lines, options)
+        }
+
+        fn outcome(
+            name: &'static str,
+            lines: Vec<Line3D>,
+            options: PolygonizerOptions,
+        ) -> CaseEvidenceV1 {
+            let outcome = match polygonize(lines, &options) {
+                Ok(result) => {
+                    let fingerprint =
+                        TopologyFingerprintV1::try_from_result(&result, &options).unwrap();
+                    let bytes = serde_json::to_vec(&fingerprint).unwrap();
+                    OutcomeV1::Success {
+                        fingerprint_sha256: format!("{:x}", Sha256::digest(bytes)),
+                    }
+                }
+                Err(error) => OutcomeV1::Error {
+                    normalized: Box::new(normalize_polygonize_error(&error)),
+                },
+            };
+            CaseEvidenceV1 { name, outcome }
+        }
+
+        #[test]
+        fn representative_outcomes_match_the_shared_feature_build_snapshot() {
+            reset_par_flat_map_dispatches();
+
+            let mut cases = Vec::new();
+            for (name, source) in [
+                (
+                    "square_with_hole",
+                    include_str!("../tests/fixtures/basic/square_with_hole.json"),
+                ),
+                (
+                    "bowtie",
+                    include_str!("../tests/fixtures/dirty/bowtie.json"),
+                ),
+                (
+                    "reported_output_families",
+                    include_str!("../tests/fixtures/topology/reported_outputs.json"),
+                ),
+                (
+                    "provenance_with_profile",
+                    include_str!("../tests/fixtures/provenance/mixed_boundary_with_profile.json"),
+                ),
+                (
+                    "z_ignore_conflicts",
+                    include_str!("../tests/fixtures/z/ignore_conflicts.json"),
+                ),
+            ] {
+                let (lines, options) = fixture(source);
+                cases.push(outcome(name, lines, options));
+            }
+
+            let crossing = vec![
+                Line3D::new(Coord3D::new(-1.0, 0.0, 0.0), Coord3D::new(1.0, 0.0, 0.0), 1),
+                Line3D::new(Coord3D::new(0.0, -1.0, 0.0), Coord3D::new(0.0, 1.0, 0.0), 2),
+            ];
+            cases.push(outcome(
+                "noding_validation_failure",
+                crossing,
+                PolygonizerOptions {
+                    noding: NodingOptions {
+                        guarantee: NodingGuarantee::Validate,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            ));
+            cases.push(outcome(
+                "invalid_option",
+                Vec::new(),
+                PolygonizerOptions {
+                    pre_snap_tolerance: -1.0,
+                    ..Default::default()
+                },
+            ));
+            let (z_conflicts, mut z_options) =
+                fixture(include_str!("../tests/fixtures/z/ignore_conflicts.json"));
+            z_options.z = ZOptions {
+                policy: ZPolicy::ErrorOnConflict,
+                conflict_tolerance: 0.0,
+            };
+            cases.push(outcome("z_conflict", z_conflicts, z_options));
+
+            let actual = serde_json::to_value(ConformanceEvidenceV1 {
+                schema_version: 1,
+                cases,
+            })
+            .unwrap();
+            let expected: serde_json::Value = serde_json::from_str(include_str!(
+                "../tests/fixtures/conformance/serial_parallel_outcomes_v1.json"
+            ))
+            .unwrap();
+            assert_eq!(
+                actual,
+                expected,
+                "feature-build conformance evidence changed:\n{}",
+                serde_json::to_string_pretty(&actual).unwrap()
+            );
+
+            if cfg!(feature = "parallel") && !cfg!(target_arch = "wasm32") {
+                assert!(
+                    par_flat_map_dispatches() > 0,
+                    "parallel feature build did not exercise the Rayon graph-construction path"
+                );
+            } else {
+                assert_eq!(
+                    par_flat_map_dispatches(),
+                    0,
+                    "serial feature build unexpectedly exercised the Rayon graph-construction path"
+                );
+            }
+        }
+    }
 }

--- a/crates/geo-polygonize-core/src/utils/parallel.rs
+++ b/crates/geo-polygonize-core/src/utils/parallel.rs
@@ -1,5 +1,22 @@
 #[cfg(all(feature = "parallel", not(target_arch = "wasm32")))]
 use rayon::prelude::*;
+#[cfg(test)]
+use std::cell::Cell;
+
+#[cfg(test)]
+thread_local! {
+    static PAR_FLAT_MAP_DISPATCHES: Cell<usize> = const { Cell::new(0) };
+}
+
+#[cfg(test)]
+pub(crate) fn reset_par_flat_map_dispatches() {
+    PAR_FLAT_MAP_DISPATCHES.set(0);
+}
+
+#[cfg(test)]
+pub(crate) fn par_flat_map_dispatches() -> usize {
+    PAR_FLAT_MAP_DISPATCHES.get()
+}
 
 /// A trait to switch between parallel and sequential iterators
 pub trait MaybeParIter<T> {
@@ -62,6 +79,8 @@ where
 {
     #[cfg(all(feature = "parallel", not(target_arch = "wasm32")))]
     {
+        #[cfg(test)]
+        PAR_FLAT_MAP_DISPATCHES.with(|dispatches| dispatches.set(dispatches.get() + 1));
         slice.par_iter().flat_map_iter(f).collect()
     }
     #[cfg(any(not(feature = "parallel"), target_arch = "wasm32"))]

--- a/crates/geo-polygonize-core/tests/conformance_fingerprint.rs
+++ b/crates/geo-polygonize-core/tests/conformance_fingerprint.rs
@@ -303,7 +303,7 @@ fn borrowed_georust_input_retains_the_owned_contract() {
 }
 
 #[test]
-fn permutation_and_feature_builds_keep_the_canonical_fingerprint() {
+fn input_permutation_keeps_the_canonical_fingerprint() {
     let (lines, options) = fixture("topology/reported_outputs.json");
     let expected = fingerprint(&polygonize(lines.clone(), &options).unwrap(), &options);
     let mut permuted = lines;

--- a/crates/geo-polygonize-core/tests/fixtures/conformance/serial_parallel_outcomes_v1.json
+++ b/crates/geo-polygonize-core/tests/fixtures/conformance/serial_parallel_outcomes_v1.json
@@ -1,0 +1,110 @@
+{
+  "schema_version": 1,
+  "cases": [
+    {
+      "name": "square_with_hole",
+      "outcome": {
+        "status": "success",
+        "fingerprint_sha256": "371b55c677ba8840f4956f3fad392611bd8818d603a61a2488ca4c52958c1e30"
+      }
+    },
+    {
+      "name": "bowtie",
+      "outcome": {
+        "status": "success",
+        "fingerprint_sha256": "e009cab4b1c8a64557d72db6e726e1f51339794a011aa094054d43666811f477"
+      }
+    },
+    {
+      "name": "reported_output_families",
+      "outcome": {
+        "status": "success",
+        "fingerprint_sha256": "c7bb7a071462ece423548b7574fee94051150b02fe048866a5b17271f507ee81"
+      }
+    },
+    {
+      "name": "provenance_with_profile",
+      "outcome": {
+        "status": "success",
+        "fingerprint_sha256": "cf9a1fbc3c5394c30f9b77aa0e59bf64a69f3cadeae749d2f882d0b6dc275223"
+      }
+    },
+    {
+      "name": "z_ignore_conflicts",
+      "outcome": {
+        "status": "success",
+        "fingerprint_sha256": "8bd2301a7eff161f29bec5c935f8602f660a440ae6b8c6d419df443d11874a30"
+      }
+    },
+    {
+      "name": "noding_validation_failure",
+      "outcome": {
+        "status": "error",
+        "normalized": {
+          "schema_version": 1,
+          "family": "topology",
+          "code": "interior_intersection",
+          "stage": "noding_validation",
+          "field": null,
+          "expected": null,
+          "actual": null,
+          "limit": null,
+          "observed": null,
+          "witness": {
+            "ids": [
+              "0x0000000000000000",
+              "0x0000000000000001"
+            ],
+            "coordinate": null
+          }
+        }
+      }
+    },
+    {
+      "name": "invalid_option",
+      "outcome": {
+        "status": "error",
+        "normalized": {
+          "schema_version": 1,
+          "family": "invalid_argument",
+          "code": "invalid_argument_type",
+          "stage": "options",
+          "field": "pre_snap_tolerance",
+          "expected": "a finite non-negative number",
+          "actual": "-1",
+          "limit": null,
+          "observed": null,
+          "witness": null
+        }
+      }
+    },
+    {
+      "name": "z_conflict",
+      "outcome": {
+        "status": "error",
+        "normalized": {
+          "schema_version": 1,
+          "family": "topology",
+          "code": "z_conflict",
+          "stage": "z_reconciliation",
+          "field": null,
+          "expected": null,
+          "actual": null,
+          "limit": null,
+          "observed": null,
+          "witness": {
+            "ids": [
+              "0x0000000a",
+              "0x00000028"
+            ],
+            "coordinate": {
+              "x": "0x0000000000000000",
+              "y": "0x0000000000000000",
+              "z": "0x0000000000000000"
+            }
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Context

Serial versus parallel execution is selected at compile time, so one test binary cannot compare both paths directly. The prior permutation test name implied feature-build coverage but only permuted inputs within one build.

## Scope

- Add a shared v1 evidence snapshot consumed by both default and no-default core test builds.
- Cover representative noding, containment, reported output families, provenance/profile, Z handling, validation failure, option failure, and Z-conflict outcomes.
- Hash exact serialized TopologyFingerprintV1 values for successes and retain full NormalizedPolygonizeErrorV1 structures for failures.
- Add a cfg(test)-only thread-local marker proving the default native build reaches the Rayon graph-construction branch while the no-default build remains serial.
- Rename the prior permutation-only test so its name matches its actual coverage.

## Validation

- cargo fmt --all -- --check
- cargo test -p geo-polygonize-core representative_outcomes_match_the_shared_feature_build_snapshot --lib
- cargo test -p geo-polygonize-core --no-default-features representative_outcomes_match_the_shared_feature_build_snapshot --lib
- cargo test -p geo-polygonize-core --lib
- cargo test -p geo-polygonize-core --no-default-features --lib --tests
- cargo test -p geo-polygonize-core --all-features --lib --tests
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- git diff --check

## Cross-platform

The Rayon-path assertion applies only to native parallel builds. wasm32 continues through the serial implementation and is not given a new runtime option or public API.

## Not included

- No semantic serial/parallel option.
- No CI, roadmap, playground, differential schema, binding, or support-policy changes.
- No cross-binding expansion because the audit found no binding-specific execution-path gap.