### PR TITLE
docs(core): define noding guarantee contracts

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -733,7 +733,7 @@ This milestone supersedes the broad intent of issue #672.
 Add or finish dedicated guides for:
 
 - [x] topology and output semantics;
-- [ ] floating, fixed, validated, and certified noding guarantees;
+- [x] floating, fixed, validated, and certified noding guarantees;
 - [ ] Z and provenance behavior;
 - [ ] compatibility profiles and known divergences;
 - [ ] tiling guarantees and fallback behavior;

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -732,7 +732,7 @@ This milestone supersedes the broad intent of issue #672.
 
 Add or finish dedicated guides for:
 
-- [ ] topology and output semantics;
+- [x] topology and output semantics;
 - [ ] floating, fixed, validated, and certified noding guarantees;
 - [ ] Z and provenance behavior;
 - [ ] compatibility profiles and known divergences;

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
         text: 'Guide',
         items: [
           { text: 'Getting Started', link: '/guide/getting-started' },
+          { text: 'Topology and output', link: '/guide/topology-output' },
           { text: 'WASM Integration', link: '/guide/wasm' },
         ]
       },

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
         items: [
           { text: 'Getting Started', link: '/guide/getting-started' },
           { text: 'Topology and output', link: '/guide/topology-output' },
+          { text: 'Noding guarantees', link: '/guide/noding-guarantees' },
           { text: 'WASM Integration', link: '/guide/wasm' },
         ]
       },

--- a/docs/guide/noding-guarantees.md
+++ b/docs/guide/noding-guarantees.md
@@ -1,0 +1,73 @@
+# Noding and precision guarantees
+
+Noding makes every topological intersection an endpoint on every incident
+segment and normalizes collinear overlap before graph construction. Precision
+controls which XY coordinates participate in that topology. They are separate
+choices: a fixed grid can round coordinates without noding, and floating noding
+can insert intersections without rounding to a grid.
+
+## Choosing a guarantee
+
+| Configuration | Work performed | Contract |
+| --- | --- | --- |
+| `node_input = false`, `Unchecked` | No intersection insertion. Fixed precision still rounds endpoints. | The caller asserts that the resulting linework is already noded. |
+| `node_input = false`, `Validate` | No intersection insertion, followed by the independent validator. | Returns a typed error if the supplied or rounded linework is not fully noded. |
+| `node_input = true`, `Unchecked` | Iterative floating or grid candidate noding. | Produces the noder's result without certifying its postcondition. |
+| `node_input = true`, `Validate` | Ordinary noding, followed by the independent validator. | Succeeds only when the produced segments pass the full-noding checks. |
+| `CertifiedFixedPrecision` | Hot-pixel snap rounding, followed by the independent validator. | Succeeds only for a validated fixed-grid result. |
+
+`CertifiedFixedPrecision` requires all of the following:
+
+- `node_input = true`;
+- `PrecisionModel::FixedGrid` with a finite positive `grid_size`;
+- the `Snap` backend; and
+- `SnapStrategy::Grid`.
+
+Other combinations return `UnsupportedOptionCombination` before geometry work.
+Certification is a postcondition for the selected grid, not a claim that the
+grid preserves the application's intended narrow features or distinct points.
+
+## Validator postcondition
+
+The independent validator rejects the first deterministic segment pair that
+contains:
+
+- a zero-length segment;
+- an intersection that is not an endpoint of both segments; or
+- an unnormalized collinear overlap.
+
+Failures use the structured noding-validation error family and retain segment
+indices plus the failure kind. Validation checks the segments produced by
+noding, precision rounding, coordinate restoration, and Z reconciliation; it
+does not merely re-check the original input.
+
+## Floating and fixed precision
+
+`PrecisionModel::Floating` preserves source endpoints and computes inserted
+intersection coordinates in `f64`. It avoids intentional quantization, but it
+does not make floating predicates or constructed coordinates exact real-number
+arithmetic.
+
+`PrecisionModel::FixedGrid { grid_size }` maps topology coordinates to integer
+grid indices separated by `grid_size` in the input coordinate units. A smaller
+grid retains more coordinate detail but may require larger exact grid indices;
+a larger grid is more aggressive and can collapse short segments, narrow gaps,
+or nearby vertices. Certified inputs must fit the supported integer grid range.
+
+Use `SnapStrategy::Grid` when grid coordinates are the desired output contract.
+`GeosCompat` uses the grid for topology and then restores one deterministic
+nearest source XY per snapped node. That improves source-coordinate fidelity for
+compatibility work, but it is not `set_precision` emulation and is intentionally
+ineligible for `CertifiedFixedPrecision`.
+
+## Pre-snap and execution controls
+
+`pre_snap_tolerance` optionally moves endpoints to nearby reference vertices
+before noding and therefore requires `node_input = true`. It changes semantic
+geometry and should use a tolerance expressed in the same units as the input.
+
+Execution budgets and cancellation are non-semantic controls. They can stop
+noding or validation with a structured resource/cancellation error, but raising
+a budget does not change the selected precision or guarantee. Diagnostics and
+bounded traces report physical candidate, predicate, split, and validation work
+without selecting a different algorithm through public semantic options.

--- a/docs/guide/topology-output.md
+++ b/docs/guide/topology-output.md
@@ -1,0 +1,71 @@
+# Topology and output semantics
+
+Polygonization builds polygonal faces from linework. It does not repair every
+invalid geometry, infer missing boundaries, or return the input lines unchanged.
+Topology is computed in XY; Z and source provenance are attributes reconstructed
+after the XY topology is established.
+
+## Input contract
+
+With `node_input = false`, every intersection that should participate in the
+graph must already be an endpoint on both incident lines. Crossing lines without
+a shared vertex are not implicitly connected. Enable noding, and select an
+appropriate guarantee, when that precondition is not known to hold.
+
+Coincident and overlapping segments are dissolved into topology edges. Their
+source IDs remain available for provenance, but duplicate boundaries do not
+create duplicate faces. Zero-length segments and rings that cannot bound a
+positive finite area do not produce polygons.
+
+## Result families
+
+`PolygonizerResult` keeps four topology result families:
+
+- `polygons` are positive-area faces assembled from valid shell and hole cycles.
+- `dangles` are dead-end line chains removed recursively from the graph.
+- `cut_edges` remain connected after dangle removal but do not bound a retained
+  ring.
+- `invalid_rings` are closed ring candidates rejected during ring validation or
+  face assembly.
+
+These classifications describe this polygonization run. They are not a general
+validity verdict for the original dataset. In particular, a line may be useful
+to another operation even when it is a dangle or cut edge here.
+
+`PolygonizerResult::into_multi_polygon()` intentionally discards dangles, cut
+edges, invalid rings, diagnostics, representative edge IDs, provenance, and Z.
+Keep the full result or a binding's report output when those values matter.
+
+## Shells, holes, and filtering
+
+Closed cycles are classified by deterministic containment. The configured
+`TouchPolicy` decides how touching candidates participate in containment;
+changing it may intentionally change shell/hole assignment. Nested shells and
+holes are retained when their boundaries satisfy the selected policy.
+
+`extract_only_polygonal` removes shells that are not part of the selected
+polygonal subset. `output_filter.minimum_face_area` is applied only after
+topology and provenance are established. It keeps faces whose unsigned area is
+at least the configured value; it does not alter noding or graph construction.
+
+## Deterministic output
+
+The default determinism options canonicalize ring starts, orientations, holes,
+polygons, and non-polygon result families. Representative edge IDs rotate and
+reverse with their coordinates, while aggregate boundary provenance is sorted
+and deduplicated. `-0.0` is normalized only in the versioned conformance
+encoding; ordinary coordinate values remain `f64` values.
+
+Canonical ordering makes equivalent runs comparable. It does not make two
+different precision, noding, containment, Z, or filtering profiles semantically
+equivalent. Use the versioned topology fingerprint or normalized error contract
+for exact cross-binding conformance rather than comparing polygon counts alone.
+
+## Failure boundary
+
+Invalid options, non-finite coordinates, unsupported option combinations,
+noding validation failures, topology failures, resource limits, and
+cancellation return typed errors. A successful call means the selected pipeline
+completed; unchecked noding does not certify that the input or produced segments
+are fully noded. The [getting-started guide](./getting-started.md) summarizes the
+available validation levels and precision contracts.

--- a/docs/guide/topology-output.md
+++ b/docs/guide/topology-output.md
@@ -67,5 +67,5 @@ Invalid options, non-finite coordinates, unsupported option combinations,
 noding validation failures, topology failures, resource limits, and
 cancellation return typed errors. A successful call means the selected pipeline
 completed; unchecked noding does not certify that the input or produced segments
-are fully noded. The [getting-started guide](./getting-started.md) summarizes the
-available validation levels and precision contracts.
+are fully noded. The [noding guide](./noding-guarantees.md) defines the available
+validation levels and precision contracts.


### PR DESCRIPTION
## Stack

Parent:
- #1095

This PR:
- Publishes the floating, fixed, validated, and certified noding contract.

Children:
- #1102

## Delivered

- Defines the noding/guarantee matrix for already-noded input, ordinary noding, independent validation, and certified fixed precision.
- Documents the validator postcondition, floating versus fixed precision, Grid versus GeosCompat output, pre-snap semantics, and non-semantic execution controls.
- Links the topology guide to the new contract, adds navigation, and marks only the corresponding P3.6 roadmap row complete.

## Contract impact

- Documentation only; no runtime, public API, schema, output, provenance, Z, or error change.
- Explicitly limits certification to a validated result on the selected grid; it does not promise preservation of application-intended narrow features.

## Validation

- `npm run docs:build` — passed; generated scalar/SIMD packages, VitePress, and playground. Existing MUI directive, runtime Wasm URL, dependency audit, and large-chunk warnings remain.
- `npx --no-install markdown-link-check docs/guide/noding-guarantees.md docs/guide/topology-output.md` — topology link passed; the noding guide contains no links.
- `git diff --check` — passed.

## Agent handoff

Remaining:
- Publish Z/provenance behavior and binding-specific production guides.
- Keep compatibility-profile divergences separate from the base guarantee contract.

Next dependency-ready slice:
- Add the Z reconstruction and source-provenance guide.

