### PR TITLE
test(core): prepare benchmark mismatch candidates

### DIFF
--- a/benchmarks/benchmark-mismatch-candidate-v1.schema.json
+++ b/benchmarks/benchmark-mismatch-candidate-v1.schema.json
@@ -1,0 +1,180 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/graydonpleasants/geo-polygonize/benchmarks/benchmark-mismatch-candidate-v1.schema.json",
+  "title": "geo-polygonize benchmark mismatch candidate V1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "producer",
+    "workload_id",
+    "lane",
+    "input",
+    "options",
+    "versions",
+    "baseline",
+    "comparison"
+  ],
+  "properties": {
+    "schema_version": {"const": 1},
+    "producer": {"const": "benchmark_record"},
+    "workload_id": {"type": "string", "minLength": 1},
+    "lane": {
+      "enum": [
+        "already-noded-polygonization",
+        "floating-noding-plus-polygonization",
+        "certified-fixed-precision-noding-plus-polygonization"
+      ]
+    },
+    "input": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/input_line"}
+    },
+    "options": {"type": "object"},
+    "versions": {
+      "type": "object",
+      "minProperties": 2,
+      "additionalProperties": {"type": "string", "minLength": 1}
+    },
+    "baseline": {"$ref": "#/$defs/run"},
+    "comparison": {"$ref": "#/$defs/run"}
+  },
+  "$defs": {
+    "coordinate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["x", "y", "z"],
+      "properties": {
+        "x": {"type": "string", "pattern": "^0x[0-9a-f]{16}$"},
+        "y": {"type": "string", "pattern": "^0x[0-9a-f]{16}$"},
+        "z": {"type": "string", "pattern": "^0x[0-9a-f]{16}$"}
+      }
+    },
+    "input_line": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["start", "end", "line_id"],
+      "properties": {
+        "start": {"$ref": "#/$defs/coordinate"},
+        "end": {"$ref": "#/$defs/coordinate"},
+        "line_id": {"type": "string", "pattern": "^0x[0-9a-f]{8}$"}
+      }
+    },
+    "run": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["implementation", "outcome"],
+      "properties": {
+        "implementation": {"type": "string", "minLength": 1},
+        "outcome": {"$ref": "#/$defs/outcome"}
+      }
+    },
+    "outcome": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status", "value"],
+          "properties": {
+            "status": {"const": "success"},
+            "value": {"$ref": "#/$defs/topology"}
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status", "value"],
+          "properties": {
+            "status": {"const": "error"},
+            "value": {"$ref": "#/$defs/failure"}
+          }
+        }
+      ]
+    },
+    "failure": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["stage", "error"],
+      "properties": {
+        "stage": {"type": "string", "minLength": 1},
+        "error": {"$ref": "#/$defs/normalized_error"}
+      }
+    },
+    "normalized_error": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema_version",
+        "family",
+        "code",
+        "stage",
+        "field",
+        "expected",
+        "actual",
+        "limit",
+        "observed",
+        "witness"
+      ],
+      "properties": {
+        "schema_version": {"const": 1},
+        "family": {"type": "string", "minLength": 1},
+        "code": {"type": "string", "minLength": 1},
+        "stage": {"type": "string", "minLength": 1},
+        "field": {"type": ["string", "null"]},
+        "expected": {"type": ["string", "null"]},
+        "actual": {"type": ["string", "null"]},
+        "limit": {"type": ["string", "null"]},
+        "observed": {"type": ["string", "null"]},
+        "witness": {"type": ["object", "null"]}
+      }
+    },
+    "xy_coordinate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["x", "y"],
+      "properties": {
+        "x": {"type": "string", "pattern": "^0x[0-9a-f]{16}$"},
+        "y": {"type": "string", "pattern": "^0x[0-9a-f]{16}$"}
+      }
+    },
+    "line": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/xy_coordinate"}
+    },
+    "polygon": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["exterior", "interiors"],
+      "properties": {
+        "exterior": {"$ref": "#/$defs/line"},
+        "interiors": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/line"}
+        }
+      }
+    },
+    "topology": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["polygons", "dangles", "cut_edges", "invalid_rings"],
+      "properties": {
+        "polygons": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/polygon"}
+        },
+        "dangles": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/line"}
+        },
+        "cut_edges": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/line"}
+        },
+        "invalid_rings": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/line"}
+        }
+      }
+    }
+  }
+}

--- a/crates/geo-polygonize-core/examples/benchmark_record.rs
+++ b/crates/geo-polygonize-core/examples/benchmark_record.rs
@@ -3,15 +3,17 @@ static ALLOC: dhat::Alloc = dhat::Alloc;
 
 use clap::{Parser, ValueEnum};
 use geo_polygonize_core::{
-    normalize_polygonize_error, polygonize, Coord3D, Line3D, NodingGuarantee,
-    NormalizedPolygonizeErrorV1, PolygonizerOptions, PolygonizerResult, PrecisionModel,
-    TopologyFingerprintV1,
+    normalize_polygonize_error, polygonize, Coord3D, CoordinateFingerprintV1, Line3D,
+    NodingGuarantee, NormalizedPolygonizeErrorV1, PolygonizerOptions, PolygonizerResult,
+    PrecisionModel, TopologyFingerprintV1,
 };
 use geojson::{GeoJson, Value as GeoJsonValue};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
+use std::fs::OpenOptions;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{Duration, Instant};
@@ -37,6 +39,8 @@ struct Args {
     check_only: bool,
     #[arg(long)]
     output: Option<PathBuf>,
+    #[arg(long)]
+    mismatch_candidate: Option<PathBuf>,
 }
 
 #[derive(Clone, Copy, ValueEnum)]
@@ -171,6 +175,68 @@ struct BenchmarkFailureV1 {
     error: NormalizedPolygonizeErrorV1,
 }
 
+#[derive(Clone, Debug, PartialEq, Serialize)]
+struct BenchmarkRunV1 {
+    implementation: String,
+    outcome: BenchmarkReducedOutcomeV1,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+struct BenchmarkInputLineV1 {
+    start: CoordinateFingerprintV1,
+    end: CoordinateFingerprintV1,
+    line_id: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+struct BenchmarkMismatchCandidateV1 {
+    schema_version: u32,
+    producer: String,
+    workload_id: String,
+    lane: String,
+    input: Vec<BenchmarkInputLineV1>,
+    options: serde_json::Value,
+    versions: BTreeMap<String, String>,
+    baseline: BenchmarkRunV1,
+    comparison: BenchmarkRunV1,
+}
+
+impl BenchmarkMismatchCandidateV1 {
+    fn new(
+        workload_id: &str,
+        lane: Lane,
+        input: &[Line3D],
+        options: &PolygonizerOptions,
+        versions: &BTreeMap<String, String>,
+        baseline: BenchmarkRunV1,
+        comparison: BenchmarkRunV1,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        if baseline.implementation == comparison.implementation
+            || baseline.outcome == comparison.outcome
+        {
+            return Err("benchmark mismatch candidates require distinct runs and outcomes".into());
+        }
+        Ok(Self {
+            schema_version: 1,
+            producer: "benchmark_record".to_string(),
+            workload_id: workload_id.to_string(),
+            lane: lane.record_name().to_string(),
+            input: input
+                .iter()
+                .map(|line| BenchmarkInputLineV1 {
+                    start: exact_coordinate(line.start),
+                    end: exact_coordinate(line.end),
+                    line_id: format!("0x{:08x}", line.line_id),
+                })
+                .collect(),
+            options: serde_json::to_value(options)?,
+            versions: versions.clone(),
+            baseline,
+            comparison,
+        })
+    }
+}
+
 #[derive(Default)]
 struct Samples {
     elapsed: Vec<Duration>,
@@ -235,6 +301,37 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     options.provenance.enabled = true;
     options.provenance.include_boundary_line_ids = true;
 
+    let reference: ReferenceResult =
+        serde_json::from_slice(&std::fs::read(&args.reference_result)?)?;
+    validate_reference(&reference, &workload.id, args.lane)?;
+    let reference_outcome = reduced_reference_outcome(&reference);
+    let expected = parse_sha256(&reference.fingerprint_sha256)?;
+    let reference_hash = benchmark_fingerprint_sha256(&reference.topology);
+    if reference_hash != expected {
+        return Err("reference result fingerprint does not match its topology payload".into());
+    }
+    let versions = dependencies(&reference)?;
+    let write_candidate = |candidate_options: &PolygonizerOptions,
+                           comparison: &BenchmarkReducedOutcomeV1|
+     -> Result<(), Box<dyn std::error::Error>> {
+        let candidate = BenchmarkMismatchCandidateV1::new(
+            &workload.id,
+            args.lane,
+            &lines,
+            candidate_options,
+            &versions,
+            BenchmarkRunV1 {
+                implementation: reference.implementation.name.clone(),
+                outcome: reference_outcome.clone(),
+            },
+            BenchmarkRunV1 {
+                implementation: "geo-polygonize-core".to_string(),
+                outcome: comparison.clone(),
+            },
+        )?;
+        write_mismatch_candidate(args.mismatch_candidate.as_deref(), &candidate)
+    };
+
     let mut validation_options = options.clone();
     validation_options.noding.guarantee = args.lane.validation_guarantee();
     let (validation_outcome, _) = reduced_rust_outcome(
@@ -243,6 +340,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "validation",
     );
     if matches!(validation_outcome, BenchmarkReducedOutcomeV1::Error(_)) {
+        write_candidate(&validation_options, &validation_outcome)?;
         return Err(format!(
             "benchmark validation failed: {}",
             serde_json::to_string(&validation_outcome)?
@@ -254,25 +352,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     correctness_options.diagnostics.enabled = true;
     let (actual_outcome, correctness) = reduced_rust_outcome(
         polygonize(lines.clone(), &correctness_options),
-        &options,
+        &correctness_options,
         "correctness",
     );
     let Some(correctness) = correctness else {
+        write_candidate(&correctness_options, &actual_outcome)?;
         return Err(format!(
             "correctness gate failed: {}",
             serde_json::to_string(&actual_outcome)?
         )
         .into());
     };
-    let reference: ReferenceResult =
-        serde_json::from_slice(&std::fs::read(&args.reference_result)?)?;
-    validate_reference(&reference, &workload.id, args.lane)?;
-    let reference_outcome = reduced_reference_outcome(&reference);
-    let expected = parse_sha256(&reference.fingerprint_sha256)?;
-    let reference_hash = benchmark_fingerprint_sha256(&reference.topology);
-    if reference_hash != expected {
-        return Err("reference result fingerprint does not match its topology payload".into());
-    }
     let BenchmarkReducedOutcomeV1::Success(actual_topology) = &actual_outcome else {
         unreachable!("successful correctness result has a success outcome");
     };
@@ -281,6 +371,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         unreachable!("validated reference result has a success outcome");
     };
     if actual_topology != reference_topology {
+        write_candidate(&correctness_options, &actual_outcome)?;
         return Err(format!(
             "correctness gate failed: expected {}, observed {}",
             hex(&expected),
@@ -332,7 +423,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .ok_or("correctness run omitted diagnostics")?;
     let p50 = percentile(&samples.elapsed, 50);
     let p95 = percentile(&samples.elapsed, 95);
-    let dependencies = dependencies(&reference)?;
     let commit = command("git", &["rev-parse", "HEAD"])?;
     let output_coordinates = output_coordinates(&correctness);
     let record_id = format!("{}-{}-{}", workload.id, &commit[..12], args.lane.profile());
@@ -410,7 +500,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 "name": "rustc",
                 "version": command("rustc", &["--version"])?,
             },
-            "dependencies": dependencies,
+            "dependencies": versions,
             "commit_sha": commit,
         },
     });
@@ -521,6 +611,28 @@ fn reduced_rust_outcome(
 
 fn reduced_reference_outcome(reference: &ReferenceResult) -> BenchmarkReducedOutcomeV1 {
     BenchmarkReducedOutcomeV1::Success(reference.topology.clone())
+}
+
+fn exact_coordinate(coordinate: Coord3D) -> CoordinateFingerprintV1 {
+    let bits = |value: f64| format!("0x{:016x}", value.to_bits());
+    CoordinateFingerprintV1 {
+        x: bits(coordinate.x),
+        y: bits(coordinate.y),
+        z: bits(coordinate.z),
+    }
+}
+
+fn write_mismatch_candidate(
+    path: Option<&Path>,
+    candidate: &BenchmarkMismatchCandidateV1,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let Some(path) = path else {
+        return Ok(());
+    };
+    let mut output = OpenOptions::new().write(true).create_new(true).open(path)?;
+    serde_json::to_writer_pretty(&mut output, candidate)?;
+    writeln!(output)?;
+    Ok(())
 }
 
 fn xy(
@@ -785,6 +897,79 @@ mod tests {
         assert_eq!(failure["status"], "error");
         assert_eq!(failure["value"]["stage"], "validation");
         assert_eq!(failure["value"]["error"]["family"], "invalid_argument");
+    }
+
+    #[test]
+    fn mismatch_candidates_keep_exact_input_and_reduced_outcomes() {
+        let mut options = PolygonizerOptions::default();
+        options.diagnostics.enabled = true;
+        let lines = [Line3D::new(
+            Coord3D::new(-0.0, 1.0, 10.0),
+            Coord3D::new(2.0, 3.0, 11.0),
+            7,
+        )];
+        let baseline = BenchmarkRunV1 {
+            implementation: "shapely".to_string(),
+            outcome: reduced_rust_outcome(
+                polygonize(Vec::<Line3D>::new(), &options),
+                &options,
+                "reference",
+            )
+            .0,
+        };
+        let comparison = BenchmarkRunV1 {
+            implementation: "geo-polygonize-core".to_string(),
+            outcome: reduced_rust_outcome(
+                Err(geo_polygonize_core::PolygonizeError::InvalidArgumentType {
+                    field: "example".to_string(),
+                    expected: "valid".to_string(),
+                    actual: "invalid".to_string(),
+                }),
+                &options,
+                "correctness",
+            )
+            .0,
+        };
+        let versions = BTreeMap::from([
+            (
+                "geo-polygonize-core".to_string(),
+                env!("CARGO_PKG_VERSION").to_string(),
+            ),
+            ("shapely".to_string(), "2.1.2".to_string()),
+        ]);
+        let candidate = BenchmarkMismatchCandidateV1::new(
+            "example-workload",
+            Lane::Floating,
+            &lines,
+            &options,
+            &versions,
+            baseline.clone(),
+            comparison,
+        )
+        .unwrap();
+        let json = serde_json::to_value(candidate).unwrap();
+
+        assert_eq!(json["producer"], "benchmark_record");
+        assert_eq!(json["input"][0]["start"]["x"], "0x8000000000000000");
+        assert_eq!(json["input"][0]["start"]["z"], "0x4024000000000000");
+        assert_eq!(json["input"][0]["line_id"], "0x00000007");
+        assert_eq!(json["baseline"]["outcome"]["status"], "success");
+        assert!(json["baseline"]["outcome"]["value"]
+            .get("schema_version")
+            .is_none());
+        assert_eq!(json["comparison"]["outcome"]["status"], "error");
+        assert!(json.get("case_id").is_none());
+        assert!(json.get("classification").is_none());
+        assert!(BenchmarkMismatchCandidateV1::new(
+            "example-workload",
+            Lane::Floating,
+            &lines,
+            &options,
+            &versions,
+            baseline.clone(),
+            baseline,
+        )
+        .is_err());
     }
 
     #[test]

--- a/crates/geo-polygonize-core/tests/benchmark_record_schema.rs
+++ b/crates/geo-polygonize-core/tests/benchmark_record_schema.rs
@@ -160,3 +160,34 @@ fn decision_policy_separates_diagnostics_from_publishable_evidence() {
         true
     );
 }
+
+#[test]
+fn mismatch_candidate_schema_keeps_exact_input_and_reduced_outcomes() {
+    let schema = benchmark_file("benchmark-mismatch-candidate-v1.schema.json");
+    assert_eq!(schema["additionalProperties"], false);
+    assert!(required(&schema).is_superset(&HashSet::from([
+        "producer",
+        "workload_id",
+        "lane",
+        "input",
+        "options",
+        "versions",
+        "baseline",
+        "comparison",
+    ])));
+    assert_eq!(
+        schema["properties"]["producer"]["const"],
+        "benchmark_record"
+    );
+    assert!(required(&schema["$defs"]["coordinate"]).contains("z"));
+    assert_eq!(
+        schema["$defs"]["outcome"]["oneOf"][0]["properties"]["value"]["$ref"],
+        "#/$defs/topology"
+    );
+    assert_eq!(
+        schema["$defs"]["outcome"]["oneOf"][1]["properties"]["value"]["$ref"],
+        "#/$defs/failure"
+    );
+    assert!(schema["properties"].get("classification").is_none());
+    assert!(schema["properties"].get("case_id").is_none());
+}


### PR DESCRIPTION
## Stack

- Parent: #1099
- This PR: `agent/p1-benchmark-mismatch-candidates`
- Children: none

## Delivered

- Adds a standalone V1 schema for benchmark mismatch review candidates.
- Adds `--mismatch-candidate` to emit exact input coordinate bits, source IDs, the actual Rust run options, pinned implementation/dependency versions, and both reduced outcomes.
- Emits only for validation errors, Rust correctness errors, or reduced topology mismatches; matching references produce no file.
- Uses exclusive create and refuses overwrite.
- Keeps case ID and compatibility classification out of review candidates.

## Contract impact

The candidate is benchmark-specific and explicitly reduced. It does not reuse the full differential candidate type, coerce the external XY topology into `TopologyFingerprintV1`, invent Z/provenance/reference fields, auto-classify, or mutate existing schemas.

## Validation

- Default and no-default benchmark example tests: 6 passed each
- Default and no-default benchmark schema tests: 4 passed each
- `pytest -q tests/test_reference_geos.py tests/test_benchmark_artifacts.py`: 5 passed with an unrelated pytest-asyncio deprecation warning
- Workspace all-target Clippy with warnings denied
- Real matching GEOS check-only run emitted no candidate
- Real valid topology mismatch emitted one schema-valid candidate and refused overwrite on retry
- JSON Schema Draft 2020-12 structure check
- Revalidated after rebasing onto live `origin/main`
- `git diff --check origin/main...HEAD`

## Agent handoff

- Remaining: human review and an explicit compatibility classification are still required before corpus admission.
- Next: feed reviewed benchmark evidence into a future benchmark-specific admission path only after its reduced semantics are accepted.