### PR TITLE
test(core): verify public error family paths

### DIFF
--- a/crates/geo-polygonize-arrow/tests/arrow_api_tests.rs
+++ b/crates/geo-polygonize-arrow/tests/arrow_api_tests.rs
@@ -1,7 +1,8 @@
-use arrow::array::{Array, Float64Array, LargeListArray, StructArray};
+use arrow::array::{Array, Float64Array, LargeListArray, ListArray, StructArray};
 use arrow::buffer::OffsetBuffer;
 use arrow::datatypes::{DataType, Field};
 use geo_polygonize_arrow::{polygonize_arrow, PolygonizerOptions};
+use geo_polygonize_core::PolygonizeErrorKind;
 use geo_traits::{LineStringTrait, PolygonTrait};
 use geoarrow::array::{GeoArrowArray, GeoArrowArrayAccessor, LineStringBuilder};
 use geoarrow::datatypes::{Crs, Dimension, Edges, LineStringType, Metadata};
@@ -21,14 +22,19 @@ fn test_polygonize_arrow_invalid_type_error_path() {
     let field = Field::new("geometry", DataType::Float64, true);
     let options = PolygonizerOptions::default();
 
-    let result = polygonize_arrow(&array, &field, options);
-    assert!(result.is_err());
-    let err = result.unwrap_err().to_string();
-    assert!(
-        err.contains("Failed to convert input array to LineStringArray and fallback failed")
-            && err.contains("DataType: Float64")
-            && err.contains("Field { name: \"geometry\", data_type: Float64, nullable: true")
-    );
+    let error = polygonize_arrow(&array, &field, options).unwrap_err();
+    assert_eq!(error.kind(), PolygonizeErrorKind::ArrowError);
+}
+
+#[test]
+fn test_polygonize_arrow_invalid_buffer_shape_error_path() {
+    let values = Arc::new(Float64Array::from(vec![0.0, 1.0])) as Arc<dyn Array>;
+    let item = Arc::new(Field::new("item", DataType::Float64, false));
+    let array = ListArray::try_new(item, OffsetBuffer::from_lengths([2]), values, None).unwrap();
+    let field = Field::new("geometry", array.data_type().clone(), true);
+
+    let error = polygonize_arrow(&array, &field, PolygonizerOptions::default()).unwrap_err();
+    assert_eq!(error.kind(), PolygonizeErrorKind::InvalidBufferShape);
 }
 
 #[test]

--- a/crates/geo-polygonize-core/tests/error_family_contract.rs
+++ b/crates/geo-polygonize-core/tests/error_family_contract.rs
@@ -1,0 +1,171 @@
+use geo_polygonize_core::{
+    polygonize, polygonize_with_execution_policy, CancellationToken, Coord3D, ExecutionPolicy,
+    Line3D, NodingGuarantee, NodingOptions, NodingValidationKind, PolygonizeErrorKind,
+    PolygonizerOptions, ZOptions, ZPolicy,
+};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ConstructionPath {
+    CoreEntrypoint,
+    AdapterEntrypoint,
+    InternalOnly,
+    BoundaryOnly,
+}
+
+fn construction_path(kind: PolygonizeErrorKind) -> ConstructionPath {
+    match kind {
+        PolygonizeErrorKind::InvalidArgumentType
+        | PolygonizeErrorKind::InvalidGeometry
+        | PolygonizeErrorKind::ResourceLimitExceeded
+        | PolygonizeErrorKind::Cancelled
+        | PolygonizeErrorKind::UnsupportedOptionCombination
+        | PolygonizeErrorKind::ZConflict => ConstructionPath::CoreEntrypoint,
+        PolygonizeErrorKind::NodingValidationFailure(kind) => {
+            match kind {
+                NodingValidationKind::ZeroLengthSegment
+                | NodingValidationKind::CollinearOverlap
+                | NodingValidationKind::InteriorIntersection => {}
+            }
+            ConstructionPath::CoreEntrypoint
+        }
+        PolygonizeErrorKind::InvalidBufferShape | PolygonizeErrorKind::ArrowError => {
+            ConstructionPath::AdapterEntrypoint
+        }
+        PolygonizeErrorKind::TopologyFailure
+        | PolygonizeErrorKind::InternalInvariantViolation
+        | PolygonizeErrorKind::NullPointer => ConstructionPath::InternalOnly,
+        PolygonizeErrorKind::Panic => ConstructionPath::BoundaryOnly,
+    }
+}
+
+fn line(start: (f64, f64, f64), end: (f64, f64, f64), id: u32) -> Line3D {
+    Line3D::new(
+        Coord3D::new(start.0, start.1, start.2),
+        Coord3D::new(end.0, end.1, end.2),
+        id,
+    )
+}
+
+#[test]
+fn supported_core_entrypoints_construct_every_core_error_family() {
+    let invalid_argument = PolygonizerOptions {
+        pre_snap_tolerance: -1.0,
+        ..Default::default()
+    }
+    .validate()
+    .unwrap_err();
+    let unsupported_options = PolygonizerOptions {
+        pre_snap_tolerance: 1.0,
+        ..Default::default()
+    }
+    .validate()
+    .unwrap_err();
+    let invalid_geometry = polygonize(
+        [line((f64::NAN, 0.0, 0.0), (1.0, 0.0, 0.0), 1)],
+        &PolygonizerOptions::default(),
+    )
+    .unwrap_err();
+    let resource_limit = polygonize_with_execution_policy(
+        [line((0.0, 0.0, 0.0), (1.0, 0.0, 0.0), 1)],
+        &PolygonizerOptions::default(),
+        &ExecutionPolicy {
+            max_input_segments: Some(0),
+            ..Default::default()
+        },
+    )
+    .unwrap_err();
+
+    let token = CancellationToken::new();
+    token.cancel();
+    let cancelled = polygonize_with_execution_policy(
+        [],
+        &PolygonizerOptions::default(),
+        &ExecutionPolicy {
+            cancellation_token: Some(token),
+            ..Default::default()
+        },
+    )
+    .unwrap_err();
+
+    let z_conflict = polygonize(
+        [
+            line((0.0, 0.0, 0.0), (1.0, 0.0, 0.0), 1),
+            line((1.0, 0.0, 1.0), (1.0, 1.0, 1.0), 2),
+        ],
+        &PolygonizerOptions {
+            z: ZOptions {
+                policy: ZPolicy::ErrorOnConflict,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    )
+    .unwrap_err();
+    let noding_validation = polygonize(
+        [
+            line((-1.0, 0.0, 0.0), (1.0, 0.0, 0.0), 1),
+            line((0.0, -1.0, 0.0), (0.0, 1.0, 0.0), 2),
+        ],
+        &PolygonizerOptions {
+            noding: NodingOptions {
+                guarantee: NodingGuarantee::Validate,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    )
+    .unwrap_err();
+
+    let actual = [
+        invalid_argument.kind(),
+        invalid_geometry.kind(),
+        resource_limit.kind(),
+        cancelled.kind(),
+        unsupported_options.kind(),
+        z_conflict.kind(),
+        noding_validation.kind(),
+    ];
+    let expected = [
+        PolygonizeErrorKind::InvalidArgumentType,
+        PolygonizeErrorKind::InvalidGeometry,
+        PolygonizeErrorKind::ResourceLimitExceeded,
+        PolygonizeErrorKind::Cancelled,
+        PolygonizeErrorKind::UnsupportedOptionCombination,
+        PolygonizeErrorKind::ZConflict,
+        PolygonizeErrorKind::NodingValidationFailure(NodingValidationKind::InteriorIntersection),
+    ];
+
+    assert_eq!(actual, expected);
+    assert!(actual
+        .into_iter()
+        .all(|kind| construction_path(kind) == ConstructionPath::CoreEntrypoint));
+}
+
+#[test]
+fn non_core_error_families_remain_explicitly_classified() {
+    for (kind, expected) in [
+        (
+            PolygonizeErrorKind::InvalidBufferShape,
+            ConstructionPath::AdapterEntrypoint,
+        ),
+        (
+            PolygonizeErrorKind::ArrowError,
+            ConstructionPath::AdapterEntrypoint,
+        ),
+        (
+            PolygonizeErrorKind::TopologyFailure,
+            ConstructionPath::InternalOnly,
+        ),
+        (
+            PolygonizeErrorKind::InternalInvariantViolation,
+            ConstructionPath::InternalOnly,
+        ),
+        (
+            PolygonizeErrorKind::NullPointer,
+            ConstructionPath::InternalOnly,
+        ),
+        (PolygonizeErrorKind::Panic, ConstructionPath::BoundaryOnly),
+    ] {
+        assert_eq!(construction_path(kind), expected);
+    }
+}

--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -36,6 +36,32 @@ The Python canonical-options result exposes this value as
 `topology_fingerprint`; both are serialized directly by Rust rather than
 reconstructed in the adapter.
 
+## Error construction matrix
+
+`PolygonizeErrorKind` is the structural error-family contract. The exhaustive
+match in `error_family_contract.rs` makes adding a family a compile failure
+until its construction class is chosen. Construction tests compare structural
+variants, never message wording.
+
+| Error kind | Supported construction path | Regression |
+| --- | --- | --- |
+| `InvalidArgumentType` | Invalid `PolygonizerOptions` through `validate` or polygonization | `supported_core_entrypoints_construct_every_core_error_family` |
+| `InvalidGeometry` | Non-finite input through `polygonize` | `supported_core_entrypoints_construct_every_core_error_family` |
+| `InvalidBufferShape` | Malformed Arrow list buffers through `polygonize_arrow` | `test_polygonize_arrow_invalid_buffer_shape_error_path` |
+| `ResourceLimitExceeded` | Any exceeded `ExecutionPolicy` budget | `supported_core_entrypoints_construct_every_core_error_family` |
+| `Cancelled` | A cancelled `ExecutionPolicy` token | `supported_core_entrypoints_construct_every_core_error_family` |
+| `UnsupportedOptionCombination` | Incompatible semantic options through `validate` or polygonization | `supported_core_entrypoints_construct_every_core_error_family` |
+| `ZConflict` | Conflicting source Z values with `ErrorOnConflict` | `supported_core_entrypoints_construct_every_core_error_family` |
+| `NodingValidationFailure` | Residual intersection with the `Validate` guarantee | `supported_core_entrypoints_construct_every_core_error_family` |
+| `ArrowError` | Incompatible Arrow array through `polygonize_arrow` | `test_polygonize_arrow_invalid_type_error_path` |
+
+`TopologyFailure` and `NullPointer` are retained structural mappings but have
+no supported production constructor today. `InternalInvariantViolation` is a
+bug sentinel, not an input-validation path. `Panic` is emitted only when a
+binding catches an unexpected unwind; a deterministic public input must never
+be added merely to exercise it. These four remain internal/boundary-only until
+a real supported construction path exists.
+
 ## Serialized report and compatibility policy
 
 Topology fingerprints, normalized errors, and serialized diagnostics expose a


### PR DESCRIPTION
## Stack

Parent:
- main

This PR:
- Exhaustively classifies each public structural error family by supported core entrypoint, adapter entrypoint, internal-only sentinel, or boundary-only sentinel.

Children:
- not opened yet

## Delivered

- Added public-entrypoint regressions for every intentionally constructible core error family.
- Added structural Arrow adapter regressions for ArrowError and InvalidBufferShape without matching message text.
- Documented the construction matrix and the four families that intentionally lack safe production constructors.

## Contract impact

- No error enum, normalized schema, status code, or user-facing message changes.
- New error kinds now make the exhaustive construction classifier fail to compile until their path is classified.
- TopologyFailure, InternalInvariantViolation, NullPointer, and Panic remain internal or boundary-only; this PR does not fabricate public triggers for them.

## Validation

- cargo fmt --all -- --check — passed
- cargo test -p geo-polygonize-core --test error_family_contract — 2 passed
- cargo test -p geo-polygonize-core --no-default-features --test error_family_contract — 2 passed
- cargo test -p geo-polygonize-arrow --test arrow_api_tests — 7 passed
- cargo clippy --workspace --all-targets -- -D warnings — passed
- RUSTDOCFLAGS=-D warnings cargo doc -p geo-polygonize-core --no-deps — passed
- git diff --check — passed

## Agent handoff

Remaining:
- ROADMAP P3.7 must stay open until every internal or boundary family that becomes intentionally public gains a real construction path.
- TopologyFailure and NullPointer currently have no production constructor; InternalInvariantViolation and Panic are not safe user-triggered paths.

Next dependency-ready slice:
- Decide whether the unreachable TopologyFailure and NullPointer variants should remain public compatibility sentinels or be deprecated in a separate API review.