### PR TITLE
test(core): gate certified corpus noding

### DIFF
--- a/crates/geo-polygonize-core/tests/workload_manifest.rs
+++ b/crates/geo-polygonize-core/tests/workload_manifest.rs
@@ -1,8 +1,10 @@
-use geo_polygonize_core::{polygonize, Coord3D, Line3D, NodingGuarantee, PolygonizerOptions};
+use geo_polygonize_core::{
+    normalize_polygonize_error, polygonize, Coord3D, Line3D, NodingGuarantee, PolygonizerOptions,
+};
 use geojson::{GeoJson, Value as GeoJsonValue};
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
 
 #[derive(Deserialize)]
@@ -199,6 +201,56 @@ fn already_noded_workloads_pass_full_noding_validation() {
         polygonize(load_segments(&root.join(path)), &options)
             .unwrap_or_else(|error| panic!("{} is not fully noded: {error}", workload.id));
     }
+}
+
+#[test]
+fn certified_fixed_workloads_have_zero_residual_noding_failures() {
+    let root = workload_root();
+    let manifest: Manifest =
+        serde_json::from_slice(&std::fs::read(root.join("manifest-v1.json")).unwrap()).unwrap();
+    let mut certified_workloads = 0;
+    let mut failures = BTreeMap::new();
+    for workload in manifest.workloads.iter().filter(|workload| {
+        workload
+            .permitted_profiles
+            .iter()
+            .any(|profile| matches!(profile, Profile::CertifiedFixed))
+    }) {
+        certified_workloads += 1;
+        let options = workload
+            .options
+            .iter()
+            .find(|options| {
+                matches!(
+                    options.noding.guarantee,
+                    NodingGuarantee::CertifiedFixedPrecision
+                )
+            })
+            .unwrap_or_else(|| {
+                panic!(
+                    "{} permits certified-fixed but has no explicit certified options",
+                    workload.id
+                )
+            });
+        let path = workload.artifact.clip_path.as_ref().unwrap_or_else(|| {
+            panic!(
+                "{} certified workload must have a checked-in clip",
+                workload.id
+            )
+        });
+        if let Err(error) = polygonize(load_segments(&root.join(path)), options) {
+            failures.insert(workload.id.clone(), normalize_polygonize_error(&error));
+        }
+    }
+    assert!(
+        certified_workloads > 0,
+        "public manifest must retain at least one certified-fixed workload"
+    );
+    assert!(
+        failures.is_empty(),
+        "certified-fixed public workloads retained residual noding failures:\n{}",
+        serde_json::to_string_pretty(&failures).unwrap()
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Context

The public workload manifest already identifies certified-compatible cases, but the core test suite had no manifest-driven aggregate assertion that all of them complete CertifiedFixedPrecision noding without residual validator failures. The benchmark workflow covers the same two current workloads with JTS references, while the separate CFB fixture test is not the public workload corpus.

## Scope

- Filter the existing public manifest to workloads that explicitly permit the certified-fixed profile.
- Select each workload existing explicit CertifiedFixedPrecision options without rewriting or loosening them.
- Run the checked-in clips through polygonize, which includes certified post-noding validation.
- Collect every failure in a workload-ID-keyed BTreeMap using NormalizedPolygonizeErrorV1 so regression output is stable and complete.
- Fail if the manifest has no certified workloads, a permitted workload lacks explicit certified options, or its clip is not checked in.

## Validation

- cargo fmt --all -- --check
- cargo test -p geo-polygonize-core --test workload_manifest certified_fixed_workloads_have_zero_residual_noding_failures
- cargo test -p geo-polygonize-core --no-default-features --test workload_manifest certified_fixed_workloads_have_zero_residual_noding_failures
- cargo test -p geo-polygonize-core --test workload_manifest
- cargo test -p geo-polygonize-core --no-default-features --test workload_manifest
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- git diff --check

## Cross-platform

The gate passes in both default and no-default native builds and uses only checked-in manifest artifacts. It introduces no platform-specific path or public API.

## Not included

- No manifest schema, workload corpus, CI, roadmap, documentation, or noding-option changes.
- No performance or JTS parity claim; the existing benchmark evidence workflow owns reference parity.
- No scheduled differential-fuzzing claim.

## Handoff

This is an independent root from main at 5d7c24d. The current public certified set is dense-crossings-v1 and overlaps-duplicates-v1; both complete with zero recorded failures.