### PR TITLE
test(core): verify cross-binding conformance

### DIFF
--- a/crates/geo-polygonize-arrow/tests/arrow_integration.rs
+++ b/crates/geo-polygonize-arrow/tests/arrow_integration.rs
@@ -1,8 +1,11 @@
 use arrow::array::Array;
 use arrow::datatypes::Field;
 use arrow::ffi::{FFI_ArrowArray, FFI_ArrowSchema};
-use geo_polygonize_arrow::ffi::{polygonize_ffi, polygonize_with_options_ffi, PolygonizerOptions};
+use geo_polygonize_arrow::ffi::{
+    polygonize_ffi, polygonize_ffi_last_error, polygonize_with_options_ffi, PolygonizerOptions,
+};
 use geo_polygonize_arrow::{polygonize_arrow, PolygonizerOptions as CoreOptions};
+use geo_polygonize_core::normalize_polygonize_error;
 use geo_traits::{CoordTrait, LineStringTrait, PolygonTrait};
 use geoarrow::array::{
     GeoArrowArray, GeoArrowArrayAccessor, LineStringArray, LineStringBuilder, PolygonArray,
@@ -10,6 +13,7 @@ use geoarrow::array::{
 use geoarrow::datatypes::{Crs, Dimension, LineStringType, Metadata};
 use serde_json::Value;
 use std::convert::TryFrom;
+use std::ffi::CStr;
 use std::sync::Arc;
 
 #[allow(dead_code)]
@@ -102,6 +106,16 @@ fn assert_conformance_polygon(fixture: &Value, polygons: &PolygonArray) {
     assert_eq!(canonical_ring(actual), canonical_ring(expected));
 }
 
+fn import_ffi_polygons(
+    output_array: FFI_ArrowArray,
+    output_schema: &FFI_ArrowSchema,
+) -> PolygonArray {
+    let output = unsafe { arrow::ffi::from_ffi(output_array, output_schema).unwrap() };
+    let output = arrow::array::make_array(output);
+    let field = Field::try_from(output_schema).unwrap();
+    PolygonArray::try_from((output.as_ref(), &field)).unwrap()
+}
+
 #[test]
 fn arrow_and_c_data_retain_the_shared_conformance_polygon() {
     let fixture = conformance_fixture();
@@ -123,6 +137,32 @@ fn arrow_and_c_data_retain_the_shared_conformance_polygon() {
     let mut input_schema = std::mem::ManuallyDrop::new(input_schema);
     let mut output_array = FFI_ArrowArray::empty();
     let mut output_schema = FFI_ArrowSchema::empty();
+    let legacy_options = PolygonizerOptions {
+        node_input: 0,
+        snap_grid_size: 1e-10,
+        extract_only_polygonal: 0,
+        report_mode: 0,
+    };
+    let status = unsafe {
+        polygonize_ffi(
+            &mut *input_array,
+            &mut *input_schema,
+            &mut output_array,
+            &mut output_schema,
+            &legacy_options,
+        )
+    };
+    assert_eq!(status, 0);
+    assert_conformance_polygon(&fixture, &import_ffi_polygons(output_array, &output_schema));
+
+    let (input, field) = conformance_input(&fixture);
+    let input = input.into_array_ref();
+    let (input_array, _) = arrow::ffi::to_ffi(&input.to_data()).unwrap();
+    let input_schema = FFI_ArrowSchema::try_from(&field).unwrap();
+    let mut input_array = std::mem::ManuallyDrop::new(input_array);
+    let mut input_schema = std::mem::ManuallyDrop::new(input_schema);
+    let mut output_array = FFI_ArrowArray::empty();
+    let mut output_schema = FFI_ArrowSchema::empty();
     let options = serde_json::to_vec(&canonical_options_fixture()["options"]).unwrap();
     let status = unsafe {
         polygonize_with_options_ffi(
@@ -135,11 +175,91 @@ fn arrow_and_c_data_retain_the_shared_conformance_polygon() {
         )
     };
     assert_eq!(status, 0);
-    let output = unsafe { arrow::ffi::from_ffi(output_array, &output_schema).unwrap() };
-    let output = arrow::array::make_array(output);
-    let field = Field::try_from(&output_schema).unwrap();
-    let polygons = PolygonArray::try_from((output.as_ref(), &field)).unwrap();
-    assert_conformance_polygon(&fixture, &polygons);
+    assert_conformance_polygon(&fixture, &import_ffi_polygons(output_array, &output_schema));
+}
+
+#[test]
+fn arrow_and_c_data_expose_normalized_non_finite_errors_without_message_equality() {
+    let mut builder = LineStringBuilder::new(LineStringType::new(
+        Dimension::XY,
+        Arc::new(Default::default()),
+    ));
+    builder
+        .push_line_string(Some(&geo::LineString::from(vec![
+            (0.0, 0.0),
+            (f64::NAN, 1.0),
+        ])))
+        .unwrap();
+    let input = builder.finish();
+    let field = input.data_type().to_field("geometry", true);
+    let input = input.into_array_ref();
+    let normalized = normalize_polygonize_error(
+        &polygonize_arrow(input.as_ref(), &field, CoreOptions::default()).unwrap_err(),
+    );
+    assert_eq!(normalized.family, "invalid_geometry");
+    assert_eq!(normalized.code, "non_finite_coordinate");
+    assert_eq!(normalized.stage, "input_validation");
+
+    for canonical_options in [false, true] {
+        let mut builder = LineStringBuilder::new(LineStringType::new(
+            Dimension::XY,
+            Arc::new(Default::default()),
+        ));
+        builder
+            .push_line_string(Some(&geo::LineString::from(vec![
+                (0.0, 0.0),
+                (f64::NAN, 1.0),
+            ])))
+            .unwrap();
+        let input = builder.finish();
+        let field = input.data_type().to_field("geometry", true);
+        let input = input.into_array_ref();
+        let (input_array, _) = arrow::ffi::to_ffi(&input.to_data()).unwrap();
+        let input_schema = FFI_ArrowSchema::try_from(&field).unwrap();
+        let mut input_array = std::mem::ManuallyDrop::new(input_array);
+        let mut input_schema = std::mem::ManuallyDrop::new(input_schema);
+        let mut output_array = FFI_ArrowArray::empty();
+        let mut output_schema = FFI_ArrowSchema::empty();
+        let status = if canonical_options {
+            let options = serde_json::to_vec(&CoreOptions::default()).unwrap();
+            unsafe {
+                polygonize_with_options_ffi(
+                    &mut *input_array,
+                    &mut *input_schema,
+                    &mut output_array,
+                    &mut output_schema,
+                    options.as_ptr(),
+                    options.len(),
+                )
+            }
+        } else {
+            let options = PolygonizerOptions {
+                node_input: 0,
+                snap_grid_size: 1e-10,
+                extract_only_polygonal: 0,
+                report_mode: 0,
+            };
+            unsafe {
+                polygonize_ffi(
+                    &mut *input_array,
+                    &mut *input_schema,
+                    &mut output_array,
+                    &mut output_schema,
+                    &options,
+                )
+            }
+        };
+        assert_eq!(status, 7);
+        let error = polygonize_ffi_last_error();
+        assert!(!error.is_null());
+        let error = unsafe { &*error };
+        let family = unsafe { CStr::from_ptr(error.family) }.to_str().unwrap();
+        let stage = unsafe { CStr::from_ptr(error.stage) }.to_str().unwrap();
+        let witness = unsafe { CStr::from_ptr(error.witness) }.to_str().unwrap();
+        assert_eq!(family, normalized.family);
+        assert_eq!(stage, normalized.stage);
+        assert!(witness.is_empty());
+    }
 }
 
 #[test]

--- a/crates/geo-polygonize-core/tests/conformance_fingerprint.rs
+++ b/crates/geo-polygonize-core/tests/conformance_fingerprint.rs
@@ -1,6 +1,9 @@
 use geo_polygonize_core::{
-    normalize_polygonize_error, polygonize, polygonize_line_strings, polygonize_with_workspace,
-    Coord3D, DeterminismOptions, DiagnosticsOptions, Line3D, NodingGuarantee, NodingOptions,
+    normalize_polygonize_error, polygonize, polygonize_line_strings,
+    polygonize_line_strings_with_execution_policy, polygonize_to_multi_polygon,
+    polygonize_with_execution_policy, polygonize_with_workspace,
+    polygonize_with_workspace_and_execution_policy, Coord3D, DeterminismOptions,
+    DiagnosticsOptions, ExecutionPolicy, Line3D, NodingGuarantee, NodingOptions,
     NodingValidationKind, Polygon3D, PolygonizeError, PolygonizerOptions, PolygonizerResult,
     PolygonizerWorkspace, ProvenanceOptions, TopologyFingerprintV1,
 };
@@ -241,16 +244,38 @@ fn one_shot_and_workspace_share_the_same_fingerprint() {
 }
 
 #[test]
-fn shared_adapter_fixture_matches_owned_workspace_and_borrowed_paths() {
+fn shared_adapter_fixture_matches_every_full_result_entrypoint() {
     let (lines, options, expected) = adapter_fixture();
-    let one_shot = fingerprint(&polygonize(lines.clone(), &options).unwrap(), &options);
+    let policy = ExecutionPolicy::default();
+    let one_shot_result = polygonize(lines.clone(), &options).unwrap();
+    let one_shot = fingerprint(&one_shot_result, &options);
     assert_eq!(serde_json::to_value(&one_shot).unwrap(), expected);
+    assert_eq!(
+        one_shot,
+        fingerprint(
+            &polygonize_with_execution_policy(lines.clone(), &options, &policy).unwrap(),
+            &options,
+        )
+    );
 
     let mut workspace = PolygonizerWorkspace::new();
     assert_eq!(
         one_shot,
         fingerprint(
             &polygonize_with_workspace(&lines, &options, &mut workspace).unwrap(),
+            &options,
+        )
+    );
+    assert_eq!(
+        one_shot,
+        fingerprint(
+            &polygonize_with_workspace_and_execution_policy(
+                &lines,
+                &options,
+                &mut workspace,
+                &policy,
+            )
+            .unwrap(),
             &options,
         )
     );
@@ -268,6 +293,19 @@ fn shared_adapter_fixture_matches_owned_workspace_and_borrowed_paths() {
             &polygonize_line_strings([&ring], &options).unwrap(),
             &options
         )
+    );
+    assert_eq!(
+        one_shot,
+        fingerprint(
+            &polygonize_line_strings_with_execution_policy([&ring], &options, &policy).unwrap(),
+            &options,
+        )
+    );
+
+    // This convenience entrypoint intentionally retains polygons in XY only.
+    assert_eq!(
+        polygonize_to_multi_polygon(lines, &options).unwrap(),
+        one_shot_result.into_multi_polygon(),
     );
 }
 

--- a/crates/geo-polygonize-wasm/src/lib.rs
+++ b/crates/geo-polygonize-wasm/src/lib.rs
@@ -701,37 +701,78 @@ mod tests {
     #[wasm_bindgen_test]
     fn test_polygonize_geoarrow_valid() {
         let ipc_bytes = geoarrow_reference::square_ipc(Arc::new(Default::default()));
-        let result = polygonize_geoarrow(&ipc_bytes, false, 0.0, false);
+        let outputs = [
+            polygonize_geoarrow(&ipc_bytes, false, 0.0, false),
+            polygonize_geoarrow_with_options_js(
+                &ipc_bytes,
+                serde_wasm_bindgen::to_value(&PolygonizerOptions::default()).unwrap(),
+            ),
+        ];
 
-        // Ensure success without unwrapping directly which can panic
-        let out_bytes = result.unwrap_or_else(|e| {
-            panic!(
-                "Error from polygonize_geoarrow: {:?}",
-                js_sys::JSON::stringify(&e).unwrap().as_string()
-            );
-        });
+        for result in outputs {
+            let out_bytes = result.unwrap_or_else(|e| {
+                panic!(
+                    "Error from polygonize_geoarrow: {:?}",
+                    js_sys::JSON::stringify(&e).unwrap().as_string()
+                );
+            });
 
-        assert!(!out_bytes.is_empty());
+            assert!(!out_bytes.is_empty());
+            let reader =
+                arrow_ipc::reader::StreamReader::try_new(std::io::Cursor::new(&out_bytes), None)
+                    .unwrap();
+            let schema = reader.schema();
+            let geom_field = schema.field(0);
+            let batches = reader.collect::<Result<Vec<_>, _>>().unwrap();
 
-        let reader =
-            arrow_ipc::reader::StreamReader::try_new(std::io::Cursor::new(&out_bytes), None)
-                .unwrap();
-
-        let schema = reader.schema();
-        let geom_field = schema.field(0);
-
-        let mut batches = vec![];
-        for batch in reader {
-            batches.push(batch.unwrap());
+            assert_eq!(batches.len(), 1);
+            let geom_col = batches[0].column(0);
+            let poly_array = PolygonArray::try_from((geom_col.as_ref(), geom_field)).unwrap();
+            geoarrow_reference::assert_square(&poly_array);
         }
+    }
 
-        assert_eq!(batches.len(), 1);
-        let batch = &batches[0];
-        let geom_col = batch.column(0);
+    #[wasm_bindgen_test]
+    fn test_polygonize_geoarrow_errors_keep_normalized_fields() {
+        let ipc_bytes = geoarrow_reference::square_ipc(Arc::new(Default::default()));
+        let options = PolygonizerOptions {
+            node_input: true,
+            precision_model: geo_polygonize_core::PrecisionModel::FixedGrid { grid_size: -1.0 },
+            ..Default::default()
+        };
+        let errors = [
+            polygonize_geoarrow(&ipc_bytes, true, -1.0, false).unwrap_err(),
+            polygonize_geoarrow_with_options_js(
+                &ipc_bytes,
+                serde_wasm_bindgen::to_value(&options).unwrap(),
+            )
+            .unwrap_err(),
+        ];
 
-        use std::convert::TryFrom;
-        let poly_array = PolygonArray::try_from((geom_col.as_ref(), geom_field)).unwrap();
-        geoarrow_reference::assert_square(&poly_array);
+        for error in errors {
+            let normalized = js_sys::Reflect::get(&error, &"normalized".into()).unwrap();
+            assert_eq!(
+                js_sys::Reflect::get(&normalized, &"family".into())
+                    .unwrap()
+                    .as_string()
+                    .as_deref(),
+                Some("invalid_argument")
+            );
+            assert_eq!(
+                js_sys::Reflect::get(&normalized, &"code".into())
+                    .unwrap()
+                    .as_string()
+                    .as_deref(),
+                Some("invalid_argument_type")
+            );
+            assert_eq!(
+                js_sys::Reflect::get(&normalized, &"stage".into())
+                    .unwrap()
+                    .as_string()
+                    .as_deref(),
+                Some("options")
+            );
+        }
     }
 
     #[wasm_bindgen_test]

--- a/crates/geo-polygonize-wasm/tests/wasm.test.js
+++ b/crates/geo-polygonize-wasm/tests/wasm.test.js
@@ -4,6 +4,15 @@ import { join, resolve } from 'node:path';
 import init, { polygonize, cfbRobustOptions } from '../../../dist/standard/es/index.js';
 import { selectRuntime } from '../../../pkg-wrapper/runtime.ts';
 
+function normalizedError(call) {
+    try {
+        call();
+        throw new Error('entrypoint unexpectedly succeeded');
+    } catch (error) {
+        return JSON.parse(JSON.stringify(error.normalized));
+    }
+}
+
 describe('WASM Polygonizer', () => {
     it('should publish declaration paths referenced by wrapper types', () => {
         expect(existsSync(resolve('dist/standard/pkg-scalar/geo_polygonize.d.ts'))).toBe(true);
@@ -52,6 +61,48 @@ describe('WASM Polygonizer', () => {
                 traceLevel: 'graph',
                 byteLimit: 4096,
             });
+        } finally {
+            if (originalWorker === undefined) delete globalThis.Worker;
+            else globalThis.Worker = originalWorker;
+        }
+    });
+
+    it('should preserve conformance through all async worker entrypoints', async () => {
+        const wasm = await import('../../../dist/standard/es/index.js');
+        await wasm.default();
+        const fixture = JSON.parse(readFileSync(
+            resolve('crates/geo-polygonize-core/tests/fixtures/conformance/axis_aligned_ring_v1.json'),
+            'utf8',
+        ));
+        const input = JSON.stringify(fixture.geojson);
+        const originalWorker = globalThis.Worker;
+        class TestWorker {
+            postMessage(request) {
+                queueMicrotask(() => {
+                    const calls = {
+                        polygons: () => wasm.polygonizeWithOptions(request.geojson, request.options),
+                        report: () => wasm.polygonizeReportWithOptions(request.geojson, request.options),
+                        trace: () => wasm.polygonizeTraceWithOptions(
+                            request.geojson,
+                            request.options,
+                            request.traceLevel,
+                            request.byteLimit,
+                        ),
+                    };
+                    this.onmessage({ data: { id: request.id, result: calls[request.operation]() } });
+                });
+            }
+            terminate() {}
+        }
+        globalThis.Worker = TestWorker;
+        try {
+            expect(JSON.parse(await wasm.polygonizeWithOptionsAsync(input, fixture.options)))
+                .toEqual(JSON.parse(wasm.polygonizeWithOptions(input, fixture.options)));
+            expect(JSON.parse(await wasm.polygonizeReportWithOptionsAsync(input, fixture.options)))
+                .toEqual(fixture.expected_fingerprint);
+            expect(JSON.parse(await wasm.polygonizeTraceWithOptionsAsync(
+                input, fixture.options, 'summary', 0,
+            )).topology).toEqual(fixture.expected_fingerprint);
         } finally {
             if (originalWorker === undefined) delete globalThis.Worker;
             else globalThis.Worker = originalWorker;
@@ -217,8 +268,12 @@ describe('WASM Polygonizer', () => {
     it('should match the shared canonical fixture through GeoJSON and buffers', async () => {
         const {
             default: initModule,
+            polygonize: polygonizeLegacy,
+            polygonize_buffers: polygonizeBuffersLegacy,
             polygonizeFingerprintWithOptions,
             polygonizeReportWithOptions,
+            polygonizeTraceWithOptions,
+            polygonizeWithOptions,
             polygonizeWithOptionsBuffer,
         } = await import('../../../dist/standard/es/index.js');
         await initModule();
@@ -229,10 +284,15 @@ describe('WASM Polygonizer', () => {
 
         const input = JSON.stringify(fixture.geojson);
         const report = JSON.parse(polygonizeReportWithOptions(input, fixture.options));
+        const retained = JSON.parse(polygonizeWithOptions(input, fixture.options));
         expect(JSON.parse(polygonizeFingerprintWithOptions(input, fixture.options))).toEqual(
             fixture.expected_fingerprint,
         );
         expect(report).toEqual(fixture.expected_fingerprint);
+        expect(JSON.parse(
+            polygonizeTraceWithOptions(input, fixture.options, 'summary', 0),
+        ).topology).toEqual(fixture.expected_fingerprint);
+        expect(JSON.parse(polygonizeLegacy(input))).toEqual(retained);
         expect(
             polygonizeWithOptionsBuffer(
                 new Float64Array(fixture.coords),
@@ -242,6 +302,102 @@ describe('WASM Polygonizer', () => {
                 new Uint32Array(fixture.line_ids),
             ).topology_fingerprint,
         ).toEqual(fixture.expected_fingerprint);
+        expect(
+            polygonizeBuffersLegacy(
+                new Float64Array(fixture.coords),
+                new Uint32Array(fixture.offsets),
+                fixture.stride,
+                false,
+                0,
+                new Uint32Array(fixture.line_ids),
+            ).topology_fingerprint,
+        ).toEqual(fixture.expected_fingerprint);
+    });
+
+    it('should expose normalized core errors through every canonical Wasm shape', async () => {
+        const {
+            default: initModule,
+            polygonizeFingerprintWithOptions,
+            polygonizeReportWithOptions,
+            polygonizeTraceWithOptions,
+            polygonizeWithOptions,
+            polygonizeWithOptionsBuffer,
+        } = await import('../../../dist/standard/es/index.js');
+        await initModule();
+
+        const crossing = {
+            type: 'FeatureCollection',
+            features: [
+                { type: 'Feature', geometry: { type: 'LineString', coordinates: [[-1, 0], [1, 0]] } },
+                { type: 'Feature', geometry: { type: 'LineString', coordinates: [[0, -1], [0, 1]] } },
+            ],
+        };
+        const options = { noding: { guarantee: 'Validate' } };
+        const expected = {
+            schema_version: 1,
+            family: 'topology',
+            code: 'interior_intersection',
+            stage: 'noding_validation',
+            witness: {
+                ids: ['0x0000000000000000', '0x0000000000000001'],
+            },
+        };
+        for (const entrypoint of [
+            polygonizeWithOptions,
+            polygonizeFingerprintWithOptions,
+            polygonizeReportWithOptions,
+        ]) {
+            expect(normalizedError(
+                () => entrypoint(JSON.stringify(crossing), options),
+            )).toEqual(expected);
+        }
+        expect(normalizedError(() => polygonizeTraceWithOptions(
+            JSON.stringify(crossing), options, 'summary', 0,
+        ))).toEqual(expected);
+        expect(normalizedError(() => polygonizeWithOptionsBuffer(
+            new Float64Array([-1, 0, 1, 0, 0, -1, 0, 1]),
+            new Uint32Array([0, 2]),
+            2,
+            options,
+            new Uint32Array([0, 1]),
+        ))).toEqual(expected);
+    });
+
+    it('should retain normalized option failures through legacy Wasm entrypoints', async () => {
+        const {
+            default: initModule,
+            polygonize: polygonizeLegacy,
+            polygonize_buffers: polygonizeBuffersLegacy,
+        } = await import('../../../dist/standard/es/index.js');
+        await initModule();
+        const input = JSON.stringify({
+            type: 'FeatureCollection',
+            features: [{
+                type: 'Feature',
+                geometry: {
+                    type: 'LineString',
+                    coordinates: [[0, 0], [1, 0], [1, 1], [0, 0]],
+                },
+            }],
+        });
+        const expected = {
+            schema_version: 1,
+            family: 'invalid_argument',
+            code: 'invalid_argument_type',
+            stage: 'options',
+            field: 'precision_model.grid_size',
+            expected: 'a finite positive number',
+            actual: '-1',
+        };
+
+        expect(normalizedError(() => polygonizeLegacy(input, true, -1))).toEqual(expected);
+        expect(normalizedError(() => polygonizeBuffersLegacy(
+            new Float64Array([0, 0, 1, 0, 1, 1, 0, 0]),
+            new Uint32Array([0]),
+            2,
+            true,
+            -1,
+        ))).toEqual(expected);
     });
 
     it('should round-trip every canonical option through report APIs', async () => {

--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -27,6 +27,31 @@ Direct `MultiPolygon` conversion is intentionally lossy: it discards dangles,
 cut edges, invalid rings, diagnostics, representative IDs, provenance, and Z.
 Adapter tests for such APIs compare only the polygon subset they can retain.
 
+## Stable entrypoint matrix
+
+Conformance fixtures are exercised at the strongest contract each supported
+entrypoint retains:
+
+| Surface | Stable entrypoints | Compared contract |
+| --- | --- | --- |
+| Rust | `polygonize`, `polygonize_with_execution_policy`, `polygonize_with_workspace`, `polygonize_with_workspace_and_execution_policy`, `polygonize_line_strings`, `polygonize_line_strings_with_execution_policy` | Exact `TopologyFingerprintV1` |
+| Rust XY projection | `polygonize_to_multi_polygon` | Polygon structure only; non-polygon outputs, IDs, provenance, diagnostics, and Z are discarded |
+| Python | `polygonize_with_options`, legacy `polygonize` with `output="report"` | Exact `topology_fingerprint` serialized by Rust |
+| Python projections | `output="buffers"`, `output="objects"`, and `return_polygons=True` | Only their exposed buffers or objects; these modes do not carry a topology fingerprint |
+| Wasm full-result | `polygonizeFingerprintWithOptions`, `polygonizeReportWithOptions`, `polygonizeTraceWithOptions`, `polygonizeWithOptionsBuffer`, legacy `polygonize_buffers`, and the async report/trace wrappers | Exact fingerprint, or the exact `topology` member for traces |
+| Wasm polygon projections | `polygonizeWithOptions`, legacy `polygonize`, and the async polygon wrapper | Polygon GeoJSON only |
+| Wasm Arrow IPC | `polygonizeGeoArrowWithOptions`, legacy `polygonize_geoarrow` | XY polygon structure only |
+| Arrow Rust API | `polygonize_arrow` | XY polygon structure only |
+| Arrow C Data Interface | `polygonize_with_options_ffi`, legacy `polygonize_ffi` | XY polygon structure only |
+
+Python and Wasm core failures expose the complete
+`NormalizedPolygonizeErrorV1`. The Rust Arrow API returns the core error, which
+is normalized by the conformance test. The version-1 C ABI last-error record is
+more limited: tests compare its stable status, family, stage, and witness and
+deliberately ignore `message`; it does not expose the normalized code or schema
+version. Adapter parsing failures that never reach the core are likewise
+binding-specific rather than cross-binding equality candidates.
+
 Future incompatible additions use `V2` rather than changing V1. Adapters must
 declare the highest schema they consume and retain V1 comparisons during a
 supported migration window.

--- a/tests/test_adapter_conformance.py
+++ b/tests/test_adapter_conformance.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 import geo_polygonize
 
@@ -12,13 +13,54 @@ FIXTURE = (
 )
 
 
-def test_python_canonical_options_matches_shared_fingerprint_fixture():
+def test_python_report_entrypoints_match_shared_fingerprint_fixture():
     fixture = json.loads(FIXTURE.read_text())
-    result = geo_polygonize.polygonize_with_options(
+    canonical = geo_polygonize.polygonize_with_options(
         coords=np.asarray(fixture["coords"], dtype=np.float64),
         offsets=np.asarray(fixture["offsets"], dtype=np.uint32),
         stride=fixture["stride"],
         line_ids=np.asarray(fixture["line_ids"], dtype=np.uint32),
         options=fixture["options"],
     )
-    assert result["topology_fingerprint"] == fixture["expected_fingerprint"]
+    legacy = geo_polygonize.polygonize(
+        coords=np.asarray(fixture["coords"], dtype=np.float64),
+        offsets=np.asarray(fixture["offsets"], dtype=np.uint32),
+        stride=fixture["stride"],
+        line_ids=np.asarray(fixture["line_ids"], dtype=np.uint32),
+    )
+
+    assert canonical["topology_fingerprint"] == fixture["expected_fingerprint"]
+    assert legacy["topology_fingerprint"] == fixture["expected_fingerprint"]
+
+
+def test_python_entrypoints_expose_the_same_normalized_core_error():
+    fixture = json.loads(FIXTURE.read_text())
+    arguments = {
+        "coords": np.asarray(fixture["coords"], dtype=np.float64),
+        "offsets": np.asarray(fixture["offsets"], dtype=np.uint32),
+        "stride": fixture["stride"],
+        "line_ids": np.asarray(fixture["line_ids"], dtype=np.uint32),
+        "execution_limits": {"max_input_segments": 0},
+    }
+
+    normalized = []
+    for entrypoint in (
+        geo_polygonize.polygonize_with_options,
+        geo_polygonize.polygonize,
+    ):
+        with pytest.raises(RuntimeError) as caught:
+            entrypoint(**arguments)
+        normalized.append(json.loads(caught.value.normalized))
+
+    assert normalized[0] == normalized[1] == {
+        "schema_version": 1,
+        "family": "resource_limit",
+        "code": "resource_limit_exceeded",
+        "stage": "input_segments",
+        "field": None,
+        "expected": None,
+        "actual": None,
+        "limit": "0",
+        "observed": "1",
+        "witness": None,
+    }


### PR DESCRIPTION
## Stack

- Parent: `main`
- This branch: `agent/p3-cross-binding-conformance`
- Children: none

## Delivered

- runs the shared topology fingerprint through every supported full-result Rust, Python, and Wasm entrypoint
- verifies canonical and legacy Arrow C Data Interface paths against the retained polygon contract
- compares normalized Rust/Python/Wasm/Arrow errors structurally, while excluding human message wording
- records the exact retained contract for intentionally lossy Python, Wasm, Arrow, and C ABI projections

## Contract impact

No production API changes. Full-result bindings continue to serialize Rust's `TopologyFingerprintV1` directly. Polygon-only surfaces remain intentionally lossy, and C ABI v1 error equality is limited to status, family, stage, and witness because it does not expose the normalized code or schema version.

## Validation

- `cargo test --locked -p geo-polygonize-core --test conformance_fingerprint` — 12 passed
- `cargo test --locked -p geo-polygonize-arrow --test arrow_integration` — 4 passed
- `CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=wasm-bindgen-test-runner cargo test --locked --target wasm32-unknown-unknown -p geo-polygonize-wasm --lib` — 4 passed
- rebuilt the Python extension with `maturin develop --locked`, then `python -m pytest -q tests/test_adapter_conformance.py` — 2 passed
- `SITE_BUILD=1 SKIP_SIMD=1 ./scripts/build_wasm.sh` — passed
- `npm test` — 47 passed
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed

## Agent handoff

Draft PR only. No CI polling was performed. The site-mode Wasm validation intentionally reused the scalar binary for the SIMD bundle; independent scalar/SIMD/threaded build coverage remains in the existing CI matrix.
