### PR TITLE
docs(core): define tiling fallback contract

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -736,7 +736,7 @@ Add or finish dedicated guides for:
 - [x] floating, fixed, validated, and certified noding guarantees;
 - [x] Z and provenance behavior;
 - [x] compatibility profiles and known divergences;
-- [ ] tiling guarantees and fallback behavior;
+- [x] tiling guarantees and fallback behavior;
 - [ ] Wasm memory lifetime, workers, threads, and cancellation;
 - [ ] Python memory/GIL behavior;
 - [ ] Arrow C ABI ownership and error retrieval;

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
           { text: 'Noding guarantees', link: '/guide/noding-guarantees' },
           { text: 'Z and provenance', link: '/guide/z-provenance' },
           { text: 'Compatibility', link: '/guide/compatibility' },
+          { text: 'Tiling', link: '/guide/tiling' },
           { text: 'WASM Integration', link: '/guide/wasm' },
         ]
       },

--- a/docs/guide/tiling.md
+++ b/docs/guide/tiling.md
@@ -1,0 +1,68 @@
+# Tiling guarantees and fallback behavior
+
+`TiledPolygonizer` is an experimental Rust-only replicate-and-own pipeline. It
+partitions an ownership bounding box into rectangular tiles, expands each tile
+by a caller-selected buffer, polygonizes the intersecting input geometries, and
+keeps each face in exactly the tile selected by its ownership point.
+
+It is not boundary-graph stitching, streaming ingest, or a certified coverage
+algorithm. The tiled API remains outside the stable facade before `1.0`.
+
+## Current equivalence contract
+
+Tiled output is equivalent to untiled output only when the caller can establish
+that every face owned by a tile can be reconstructed from the complete input
+geometries whose bounding boxes intersect that tile's buffered extent. Input
+geometries are replicated whole; they are not clipped at tile borders.
+
+The checked-in equivalence gate covers faces crossing one, two, four, and many
+tile boundaries, plus a narrow concavity, a boundary-crossing hole, dirty
+intersections, and exterior dangles. Those fixtures use:
+
+- `RepresentativePointInsidePolygon` ownership;
+- `CanonicalRingHash` deduplication; and
+- a buffer chosen large enough for the complete owned face.
+
+This is evidence for that input class, not a general proof that an arbitrary
+buffer is sufficient. `TileReport` and `StitchingReport` contain observed counts;
+they do not detect missing boundary evidence or certify coverage.
+
+## Ownership and deduplication
+
+Tiles use half-open `[min, max)` ownership intervals, except that the final row
+and column include the outer maximum. Ownership policy determines the point used
+for that test:
+
+- `RepresentativePointInsidePolygon` uses a point guaranteed to intersect the
+  polygon interior when one exists and is the safest current choice.
+- `Centroid` is the default but may lie outside a concave polygon.
+- `LexicographicMinVertex` is deterministic but chooses a boundary vertex.
+- `CanonicalBoundaryHash` is a compatibility name that currently uses the same
+  interior-point behavior as `RepresentativePointInsidePolygon`.
+
+`KeepAll` performs no duplicate removal. `CanonicalRingHash` removes exact
+duplicate polygon geometry after canonicalizing ring direction and start; its
+key contains exact XYZ bits, not a tolerance. It does not merge distinct
+provenance payloads, so callers requiring provenance equivalence must verify the
+retained polygon against untiled output.
+
+Canonical output options apply the normal final ordering pass after tile merge.
+The untraced path may process tiles in parallel, while bounded tracing processes
+them in tile order so ownership and deduplication events remain deterministic.
+
+## Failure and fallback boundary
+
+The implementation validates the tile size, buffer, bounding box, and semantic
+polygonizer options. A per-tile polygonization error stops the whole call and is
+returned to the caller.
+
+There is currently no coverage validator, halo retry, unresolved-region retry,
+untiled fallback, retry budget, or typed coverage-exhaustion error. No retry or
+fallback trace event is emitted because those execution paths do not exist.
+Applications that require correctness must run an untiled equivalence check for
+their input class or choose untiled polygonization directly when sufficiency is
+unknown.
+
+The tiled implementation materializes its tile list and per-tile results; it is
+not a bounded-memory or out-of-core subsystem. Streaming work begins only after
+coverage detection and deterministic recovery exist.


### PR DESCRIPTION
## Stack

Parent:
- #1108

This PR:
- documents the current tiled equivalence, ownership, deduplication, and failure boundary

Children:
- #1110

## Delivered

- added a dedicated tiling contract guide
- distinguished tested equivalence evidence from general coverage guarantees
- documented the absence of retry, fallback, and bounded-memory behavior
- updated the P3.6 guide checklist and navigation

## Contract impact

- documentation only; no runtime or public API behavior changes
- makes the experimental Rust-only tiling boundary explicit

## Validation

- npx --no-install markdown-link-check docs/guide/tiling.md — passed (0 links)
- cargo test -p geo-polygonize-core --test tiling_equivalence — passed (1 test)
- cargo test -p geo-polygonize-core --no-default-features --test tiling_equivalence — passed (1 test)
- git diff --check — passed
- npm run docs:build — passed; existing npm audit and bundle-size warnings remain

## Agent handoff

Remaining:
- document Wasm, Python, and Arrow C ABI runtime boundaries
- define correctness-gated benchmark methodology after this stack shrinks

Next dependency-ready slice:
- document Wasm memory lifetime, runtime selection, workers, threads, and cancellation
