### PR TITLE
docs(wasm): define runtime lifetime contract

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -737,7 +737,7 @@ Add or finish dedicated guides for:
 - [x] Z and provenance behavior;
 - [x] compatibility profiles and known divergences;
 - [x] tiling guarantees and fallback behavior;
-- [ ] Wasm memory lifetime, workers, threads, and cancellation;
+- [x] Wasm memory lifetime, workers, threads, and cancellation;
 - [ ] Python memory/GIL behavior;
 - [ ] Arrow C ABI ownership and error retrieval;
 - [ ] benchmark methodology and how to reproduce claims.

--- a/docs/guide/wasm.md
+++ b/docs/guide/wasm.md
@@ -31,3 +31,65 @@ const result = wasm.polygonizeWithOptions(
 
 The default `geo-polygonize` import is convenient for quick demos, but it
 inlines the Wasm builds into the importing chunk.
+
+## Scalar and SIMD selection
+
+The default and slim entry points use the same feature test and prefer the SIMD
+binary when `WebAssembly.validate` accepts a small `simd128` module. Otherwise
+they load the scalar binary. Worker-backed calls run the same selection inside
+the worker, so direct and cancellable calls do not choose different runtimes.
+
+`initBest` accepts explicit scalar and SIMD modules or URLs. If the SIMD input
+is omitted, both outcomes load the scalar input. Initialization is cached by the
+default wrapper; do not initialize one wrapper with different binaries over its
+lifetime.
+
+## Buffer ownership and memory lifetime
+
+The typed-buffer entry points borrow their `Float64Array` and `Uint32Array`
+arguments only for the synchronous call. Rust parses them into owned linework
+before polygonization; callers may reuse the JavaScript input arrays after the
+call returns.
+
+`WasmPolygonResult` owns its flattened output vectors. Its pointer methods expose
+views into Wasm linear memory, not JavaScript-owned copies. Keep the result alive
+while reading those views, and recreate every view after any call that may grow
+Wasm memory because a growth can detach the previous buffer. Copy the arrays when
+they must outlive the result or cross an async boundary. Ring and polygon offsets
+are checked against the `u32` range before the result is returned.
+
+The GeoArrow entry points borrow the incoming IPC bytes only for the synchronous
+call and return a JavaScript-owned `Uint8Array`; they do not expose borrowed
+Arrow C Data Interface pointers.
+
+## Cancellation and workers
+
+Direct Wasm exports are synchronous and cannot consume an `AbortSignal`. The
+`polygonizeWithOptionsAsync`, `polygonizeReportWithOptionsAsync`, and
+`polygonizeTraceWithOptionsAsync` wrappers instead create one disposable browser
+worker per call. Aborting terminates that worker and rejects with `AbortError`;
+completion and failure also terminate it. This bounds caller-visible latency but
+does not resume or reuse partially computed state.
+
+A pre-aborted signal rejects before a worker is created. Worker APIs require a
+browser `Worker`; they reject in runtimes without one. Cold worker startup,
+module compilation, and initialization are part of each call, and the package
+does not currently provide a worker pool.
+
+## Threads
+
+The experimental `geo-polygonize/threads` entry point is a separate build. Call
+its default initializer, then `initThreadPool(count)`, before polygonization. It
+requires `SharedArrayBuffer`, atomics, a secure context, and cross-origin
+isolation headers:
+
+```text
+Cross-Origin-Opener-Policy: same-origin
+Cross-Origin-Embedder-Policy: require-corp
+```
+
+The threads package does not add `AbortSignal` support. The disposable-worker
+async helpers belong to the standard entry point, while the threads entry point
+owns a Rayon pool for its lifetime. Use the scalar fallback when SIMD is not
+available; use the standard package when shared memory or isolation is not
+available.


### PR DESCRIPTION
## Stack

Parent:
- #1109

This PR:
- documents Wasm runtime selection, memory lifetime, workers, threads, and cancellation

Children:
- #1111

## Delivered

- documented shared scalar/SIMD selection across direct and worker calls
- defined typed-buffer input and output-view lifetimes
- documented disposable-worker cancellation and cold-start costs
- separated the experimental threads package and its browser-isolation requirements
- updated the P3.6 guide checklist

## Contract impact

- documentation only; no runtime or public API behavior changes
- makes synchronous cancellation and Wasm-memory invalidation boundaries explicit

## Validation

- npx --no-install markdown-link-check docs/guide/wasm.md — passed (0 links)
- npm test — passed (11 files, 52 tests)
- git diff --check — passed
- npm run docs:build — passed; existing npm audit and bundle-size warnings remain

## Agent handoff

Remaining:
- document Python memory/GIL behavior and Arrow C ABI ownership/error retrieval
- define correctness-gated benchmark methodology after this stack shrinks

Next dependency-ready slice:
- document Python ownership, output conversion, GIL, cancellation, and signal behavior
