### PR TITLE
docs(python): define memory and GIL contract

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -738,7 +738,7 @@ Add or finish dedicated guides for:
 - [x] compatibility profiles and known divergences;
 - [x] tiling guarantees and fallback behavior;
 - [x] Wasm memory lifetime, workers, threads, and cancellation;
-- [ ] Python memory/GIL behavior;
+- [x] Python memory/GIL behavior;
 - [ ] Arrow C ABI ownership and error retrieval;
 - [ ] benchmark methodology and how to reproduce claims.
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
           { text: 'Compatibility', link: '/guide/compatibility' },
           { text: 'Tiling', link: '/guide/tiling' },
           { text: 'WASM Integration', link: '/guide/wasm' },
+          { text: 'Python Integration', link: '/guide/python' },
         ]
       },
       {

--- a/docs/guide/python.md
+++ b/docs/guide/python.md
@@ -1,0 +1,63 @@
+# Python memory and GIL behavior
+
+The `geo-polygonize-py` package accepts coordinate iterables or contiguous
+NumPy buffers and returns one of three output projections. The default remains
+`report` during the compatibility window.
+
+## Input ownership
+
+The Python wrapper converts `lines` into contiguous `float64` coordinates and
+`uint32` offsets. Existing arrays are normalized with `numpy.ascontiguousarray`,
+which reuses them when their dtype and layout already match and copies them
+otherwise.
+
+The native extension validates those borrowed NumPy slices and copies their
+segments into owned Rust linework while holding the GIL. Polygonization then
+runs on a dedicated Rust worker with the GIL released. Independent calls own
+independent geometry and may execute concurrently; thread creation is currently
+paid once per call.
+
+## Output modes
+
+Request only the representation the caller needs:
+
+| Mode | Flat NumPy buffers | `SimplePolygon` objects | Fingerprint and timings |
+| --- | --- | --- | --- |
+| `buffers` | yes | no | no |
+| `objects` | no | yes | no |
+| `report` | yes | yes | yes |
+
+Buffer flattening and fingerprint generation run on the Rust worker without the
+GIL. Python object construction necessarily holds the GIL. The native binding
+checks Python signals every 256 converted items while constructing polygon,
+dangle, cut-edge, and invalid-ring objects.
+
+`return_polygons=True` is a wrapper projection over `objects` or `report`: it
+imports Shapely and converts each `SimplePolygon` after the native call. It is
+incompatible with `buffers`, does not preserve the binding's provenance object
+on Shapely geometries, and adds Python/GIL-bound conversion cost. Prefer
+`buffers` for bulk numeric consumers and `report` only when complete conformance
+evidence is required.
+
+Report mode exposes `thread_spawn_ms`, `buffer_conversion_ms`,
+`fingerprint_ms`, and `python_objects_ms`. These are phase observations, not a
+stable performance promise.
+
+## Signals, cancellation, and limits
+
+Before starting work, the binding checks pending Python signals. While the GIL
+is released it wakes every 10 ms to check again. A signal cancels the core's
+cooperative `CancellationToken`, waits for the Rust worker to stop, and then
+raises the Python signal exception. The 10 ms wake interval is not a hard
+cancellation-latency bound: the worker stops only at core polling points, and an
+individual standard-library sort cannot be interrupted.
+
+The optional `execution_limits` dictionary maps to `ExecutionPolicy` and is
+kept separate from semantic polygonizer options. Limits stop work with a
+normalized `ResourceLimitExceeded` error; they are logical work and output
+guards, not a process-memory sandbox. Unknown limit names are rejected.
+
+Flat ring and polygon offsets are checked before conversion to `uint32`. Python
+exceptions retain the normalized structural error JSON on their `normalized`
+attribute; callers should inspect that contract instead of matching message
+text.


### PR DESCRIPTION
## Stack

Parent:
- #1110

This PR:
- documents Python ownership, output projections, GIL, signals, cancellation, and execution limits

Children:
- #1112

## Delivered

- added a dedicated Python runtime-boundary guide and navigation entry
- distinguished GIL-held input/object conversion from worker-side core, buffer, and fingerprint work
- documented buffers, objects, report, and Shapely projection costs
- defined the cooperative signal/cancellation boundary and non-semantic execution-limit contract
- updated the P3.6 guide checklist

## Contract impact

- documentation only; no runtime or public API behavior changes
- makes the per-call worker and conversion ownership boundaries explicit

## Validation

- npx --no-install markdown-link-check docs/guide/python.md — passed (0 links)
- python3 -m maturin build --release --out target/wheels — passed
- pytest --import-mode=importlib python/test_wrapper.py against the built wheel in an isolated virtualenv — passed (15 tests)
- python3 -m pytest python/test_wrapper.py in the source checkout — blocked as expected because the native extension is not installed there (5 passed, 10 import failures)
- git diff --check — passed
- npm run docs:build — passed; existing npm audit and bundle-size warnings remain

## Agent handoff

Remaining:
- document Arrow C ABI ownership and error retrieval
- define correctness-gated benchmark methodology after this stack shrinks

Next dependency-ready slice:
- document Arrow C Data Interface ownership, status, last-error, and concurrency rules
