### PR TITLE
docs(core): define Arrow C ABI ownership

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -739,7 +739,7 @@ Add or finish dedicated guides for:
 - [x] tiling guarantees and fallback behavior;
 - [x] Wasm memory lifetime, workers, threads, and cancellation;
 - [x] Python memory/GIL behavior;
-- [ ] Arrow C ABI ownership and error retrieval;
+- [x] Arrow C ABI ownership and error retrieval;
 - [ ] benchmark methodology and how to reproduce claims.
 
 Compile examples, run rustdoc with warnings denied, check links, and ensure the

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -36,6 +36,7 @@ export default defineConfig({
         items: [
           { text: 'Options', link: '/reference/options' },
           { text: 'WASM API', link: '/reference/wasm-api' },
+          { text: 'Arrow C ABI', link: '/C_ABI' },
         ]
       },
       {

--- a/docs/C_ABI.md
+++ b/docs/C_ABI.md
@@ -34,6 +34,11 @@ Statuses `13` and `14` are additive ABI v1 behavior: existing numeric values and
 request layouts are unchanged, so consumers may handle unknown future nonzero
 statuses conservatively without requiring an ABI v2 request.
 
+ABI v1 does not expose an `ExecutionPolicy` request or cancellation handle.
+Statuses `13` and `14` keep adapter mappings exhaustive and reserve stable
+results for calls that reach those core failures; their presence is not a claim
+that callers can configure budgets or cancellation through this ABI today.
+
 On a nonzero result, `polygonize_ffi_last_error()` returns a thread-local
 `PolygonizeFfiLastError` with the matching status plus NUL-terminated `family`,
 `stage`, `message`, and `witness` strings. `witness` is empty when unavailable;
@@ -51,14 +56,33 @@ After a valid input schema is accepted, `input_array` is consumed regardless
 of success or failure; callers must not release or reuse it afterwards. If
 schema validation fails before that point, both inputs remain caller-owned.
 
-`output_array` and `output_schema` are caller-provided, safe-to-overwrite
-destinations. They are unchanged on failure. On success, they receive Arrow C
-objects owned by the caller; release each through its Arrow C `release`
-callback exactly once. `polygonize_result_free` is a legacy no-op and must not
-be used for Arrow C outputs.
+`output_array` and `output_schema` are caller-provided empty or uninitialized
+destinations. Do not pass live Arrow objects: the function writes new structures
+without releasing previous contents. The destinations are unchanged on failure.
+On success, they receive Arrow C objects owned by the caller; release each
+through its Arrow C `release` callback exactly once. `polygonize_result_free` is
+a legacy no-op and must not be used for Arrow C outputs.
 
 Calls are thread-safe when every call uses separate Arrow objects. Last-error
 state is per-thread. Do not concurrently access, reuse, or release any request
 or output object while a call using it is in progress; the API makes no
 callbacks and requires no special reentrancy handling beyond that ownership
 rule.
+
+## Consumer call sequence
+
+1. Verify `polygonize_ffi_abi_version()` is an ABI version the consumer knows.
+2. Export one GeoArrow LineString array and schema. Initialize both output
+   destinations as empty Arrow C structures.
+3. Call `polygonize_with_options_ffi` with UTF-8 canonical options JSON.
+4. On failure, copy the last-error fields before any other polygonize call on
+   that thread. If the input array's `release` callback remains non-null, the
+   caller still owns it and must release it; a null callback means it was
+   consumed. Leave unchanged empty outputs alone.
+5. On success, treat the input array as consumed and release the returned output
+   array and schema exactly once through their callbacks.
+
+The current Arrow C result carries XY polygon structure only. It does not expose
+the full Rust result, Z, provenance, diagnostics, or topology fingerprint; use a
+binding report entry point when those retained fields are part of the
+conformance requirement.


### PR DESCRIPTION
## Stack

Parent:
- #1111

This PR:
- completes the Arrow C Data Interface ownership and error-retrieval contract

Children:
- not opened yet

## Delivered

- linked the existing Arrow C ABI reference from the documentation navigation
- documented the empty-output-destination requirement and release-callback ownership test
- added a complete consumer call sequence
- clarified retained XY-only output fields and the absence of an ABI v1 execution-policy handle
- updated the P3.6 guide checklist

## Contract impact

- documentation only; no runtime or ABI behavior changes
- prevents leaking a live destination object and avoids overstating cancellation/resource configuration

## Validation

- npx --no-install markdown-link-check docs/C_ABI.md — passed (0 links)
- cargo test -p geo-polygonize-arrow --all-features — passed (19 tests, 0 doc tests)
- git diff --check — passed
- npm run docs:build — passed; existing npm audit and bundle-size warnings remain

## Agent handoff

Remaining:
- define and automate correctness-gated benchmark methodology
- keep public error-family coverage open until production constructors exist for the remaining families

Next dependency-ready slice:
- after the stack root merges, start agent/p3-benchmark-methodology from current main