### PR TITLE
ci(core): retain minimized fuzz candidates

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -36,9 +36,25 @@ jobs:
 
       - name: Retain minimized fuzz failures
         if: failure()
+        working-directory: crates/geo-polygonize-core
+        run: |
+          mkdir -p ../../target/differential-fuzz-candidates
+          cargo build --locked --manifest-path fuzz/Cargo.toml \
+            --example prepare_adapter_differential_candidate
+          for artifact in fuzz/artifacts/adapter_differential/*; do
+            [ -f "$artifact" ] || continue
+            name=$(basename "$artifact")
+            fuzz/target/debug/examples/prepare_adapter_differential_candidate \
+              "$artifact" "../../target/differential-fuzz-candidates/${name}.json"
+          done
+
+      - name: Upload fuzz review candidates
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: differential-fuzz-failures-${{ github.run_id }}
-          path: crates/geo-polygonize-core/fuzz/artifacts/
+          path: |
+            crates/geo-polygonize-core/fuzz/artifacts/
+            target/differential-fuzz-candidates/
           if-no-files-found: ignore
           retention-days: 30

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -751,7 +751,7 @@ shortcuts.
 - [x] Run canonical equality across serial and parallel native builds.
 - [x] Run cross-binding conformance on every stable entrypoint.
 - [x] Run the certified corpus with zero residual noding failures.
-- [ ] Run scheduled differential fuzzing and persist novel minimized cases.
+- [x] Run scheduled differential fuzzing and persist novel minimized cases.
 - [ ] Add selective Miri and sanitizer jobs for unsafe/FFI boundaries where the
   dependencies support them.
 - [x] Test minimal, default, all-feature, Wasm scalar/SIMD/threaded, and supported
@@ -765,7 +765,11 @@ build enters Rayon graph construction. Stable Rust, Python, Wasm, Arrow, and C
 entrypoints now compare the complete fingerprint/error contract or an explicit
 retained-field projection for lossy APIs. Every manifest workload permitting the
 certified-fixed profile runs its declared certified options and currently has
-zero residual noding failures. The error construction matrix is exhaustive, but
+zero residual noding failures. Scheduled differential fuzzing now converts every
+retained adapter-differential failure into a deterministic minimized candidate,
+uploads the raw input and review candidate together for 30 days, and leaves
+classification and checked-in admission to the existing reviewed command. The
+error construction matrix is exhaustive, but
 the public-family row remains open: `TopologyFailure` and `NullPointer` have no
 production constructor, `InternalInvariantViolation` is a bug sentinel, and
 `Panic` is boundary-only.

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -38,3 +38,13 @@ def test_supported_feature_and_python_abi_matrix_is_required():
     assert "from geo_polygonize.geo_polygonize_core import polygonize_with_options" in workflow
     assert "needs.python-abi-build.result" in workflow
     assert "needs.python-abi.result" in workflow
+
+
+def test_scheduled_differential_fuzzing_retains_review_candidates():
+    workflow = (ROOT / ".github/workflows/fuzz.yml").read_text()
+
+    assert 'cron: "0 6 * * 1"' in workflow
+    assert "prepare_adapter_differential_candidate" in workflow
+    assert "fuzz/artifacts/adapter_differential/*" in workflow
+    assert "target/differential-fuzz-candidates/" in workflow
+    assert "retention-days: 30" in workflow


### PR DESCRIPTION
## Stack

Parent:
- #1114

This PR:
- converts scheduled adapter-differential failures into minimized review candidates

Children:
- #1116

## Delivered

- builds the existing deterministic candidate preparer after a scheduled fuzz failure
- converts retained adapter-differential inputs without auto-classifying or admitting them
- uploads raw failures and minimized JSON candidates together for 30 days
- closes the scheduled differential-fuzz evidence row in P3.7

## Contract impact

- workflow-only evidence handling; polygonization behavior is unchanged
- novel fixtures still require explicit human classification and reviewed admission

## Validation

- pytest -q tests/test_ci_workflow.py — passed (4 tests)
- cargo test --locked --manifest-path crates/geo-polygonize-core/fuzz/Cargo.toml --lib — passed (3 tests)
- cargo build --locked --manifest-path crates/geo-polygonize-core/fuzz/Cargo.toml --example prepare_adapter_differential_candidate — passed
- actionlint .github/workflows/fuzz.yml — passed
- git diff --check — passed

## Agent handoff

Remaining:
- add selective Miri and sanitizer coverage for supported unsafe/FFI boundaries
- retain the public-error-family row until honest production constructors exist

Next dependency-ready slice:
- add a pinned, selective Miri job for core unsafe-free invariants before introducing sanitizer coverage
