### PR TITLE
ci(core): add selective Miri coverage

### DIFF
--- a/.github/workflows/unsafe-boundaries.yml
+++ b/.github/workflows/unsafe-boundaries.yml
@@ -1,0 +1,32 @@
+name: Unsafe boundary checks
+
+on:
+  schedule:
+    - cron: "30 6 * * 1"
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/unsafe-boundaries.yml"
+      - "crates/geo-polygonize-core/**"
+      - "tests/test_ci_workflow.py"
+
+permissions:
+  contents: read
+
+jobs:
+  miri-core:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: "nightly-2026-07-15"
+          components: miri, rust-src
+
+      - name: Check bounded core execution with Miri
+        run: |
+          cargo miri setup
+          cargo miri test --locked -p geo-polygonize-core \
+            --no-default-features --test execution_policy

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -769,7 +769,10 @@ zero residual noding failures. Scheduled differential fuzzing now converts every
 retained adapter-differential failure into a deterministic minimized candidate,
 uploads the raw input and review candidate together for 30 days, and leaves
 classification and checked-in admission to the existing reviewed command. The
-error construction matrix is exhaustive, but
+selective Miri job runs the bounded-execution core tests without default
+parallel features under a pinned nightly; filesystem-backed corpus tests remain
+outside Miri rather than disabling its isolation. The error construction matrix
+is exhaustive, but
 the public-family row remains open: `TopologyFailure` and `NullPointer` have no
 production constructor, `InternalInvariantViolation` is a bug sentinel, and
 `Panic` is boundary-only.

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -48,3 +48,12 @@ def test_scheduled_differential_fuzzing_retains_review_candidates():
     assert "fuzz/artifacts/adapter_differential/*" in workflow
     assert "target/differential-fuzz-candidates/" in workflow
     assert "retention-days: 30" in workflow
+
+
+def test_miri_uses_a_pinned_no_default_feature_slice():
+    workflow = (ROOT / ".github/workflows/unsafe-boundaries.yml").read_text()
+
+    assert 'toolchain: "nightly-2026-07-15"' in workflow
+    assert "components: miri, rust-src" in workflow
+    assert "cargo miri test --locked -p geo-polygonize-core" in workflow
+    assert "--no-default-features --test execution_policy" in workflow


### PR DESCRIPTION
## Stack

Parent:
- #1115

This PR:
- adds a pinned selective Miri job for bounded core execution

Children:
- #1117

## Delivered

- added scheduled, manual, and path-filtered Miri coverage
- runs the no-default-feature execution-policy integration tests under pinned nightly
- keeps Miri filesystem isolation enabled and excludes unsupported filesystem-backed corpus tests
- records the exact supported scope in the roadmap

## Contract impact

- CI-only verification; runtime behavior is unchanged
- the broader Miri/sanitizer roadmap row remains open pending FFI sanitizer coverage

## Validation

- cargo +nightly-2026-07-15 miri test --locked -p geo-polygonize-core --no-default-features --test execution_policy — passed (9 tests)
- pytest -q tests/test_ci_workflow.py — passed (5 tests)
- actionlint .github/workflows/unsafe-boundaries.yml — passed
- git diff --check — passed
- attempted persisted_differential under Miri — unsupported because opendir is unavailable with isolation enabled; deliberately excluded

## Agent handoff

Remaining:
- add AddressSanitizer coverage for the Arrow C ABI ownership boundary
- retain the public-error-family row until honest production constructors exist

Next dependency-ready slice:
- extend this workflow with a pinned Linux AddressSanitizer FFI test job
