### PR TITLE
ci(core): sanitize Arrow FFI boundaries

### DIFF
--- a/.github/workflows/unsafe-boundaries.yml
+++ b/.github/workflows/unsafe-boundaries.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - ".github/workflows/unsafe-boundaries.yml"
       - "crates/geo-polygonize-core/**"
+      - "crates/geo-polygonize-arrow/**"
       - "tests/test_ci_workflow.py"
 
 permissions:
@@ -30,3 +31,22 @@ jobs:
           cargo miri setup
           cargo miri test --locked -p geo-polygonize-core \
             --no-default-features --test execution_policy
+
+  address-sanitizer-arrow-ffi:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: "nightly-2026-07-15"
+          components: rust-src
+
+      - name: Check Arrow C ownership with AddressSanitizer
+        run: |
+          cargo test -Zbuild-std --locked \
+            --target x86_64-unknown-linux-gnu \
+            --config 'build.rustflags=["-Zsanitizer=address"]' \
+            -p geo-polygonize-arrow \
+            --test arrow_integration --test test_ffi_errors

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -752,7 +752,7 @@ shortcuts.
 - [x] Run cross-binding conformance on every stable entrypoint.
 - [x] Run the certified corpus with zero residual noding failures.
 - [x] Run scheduled differential fuzzing and persist novel minimized cases.
-- [ ] Add selective Miri and sanitizer jobs for unsafe/FFI boundaries where the
+- [x] Add selective Miri and sanitizer jobs for unsafe/FFI boundaries where the
   dependencies support them.
 - [x] Test minimal, default, all-feature, Wasm scalar/SIMD/threaded, and supported
   Python ABI combinations.
@@ -771,8 +771,9 @@ uploads the raw input and review candidate together for 30 days, and leaves
 classification and checked-in admission to the existing reviewed command. The
 selective Miri job runs the bounded-execution core tests without default
 parallel features under a pinned nightly; filesystem-backed corpus tests remain
-outside Miri rather than disabling its isolation. The error construction matrix
-is exhaustive, but
+outside Miri rather than disabling its isolation. A pinned AddressSanitizer job
+checks Arrow integration and raw C ownership/error paths on Linux. The error
+construction matrix is exhaustive, but
 the public-family row remains open: `TopologyFailure` and `NullPointer` have no
 production constructor, `InternalInvariantViolation` is a bug sentinel, and
 `Panic` is boundary-only.

--- a/crates/geo-polygonize-arrow/src/ffi.rs
+++ b/crates/geo-polygonize-arrow/src/ffi.rs
@@ -469,9 +469,8 @@ mod tests {
         let input_arrow_array = builder.finish();
 
         let array_ref = input_arrow_array.into_array_ref();
-        let (input_array, input_schema) = arrow::ffi::to_ffi(&array_ref.to_data()).unwrap();
+        let (input_array, mut input_schema_ffi) = arrow::ffi::to_ffi(&array_ref.to_data()).unwrap();
         let mut input_array_ffi = std::mem::ManuallyDrop::new(input_array);
-        let mut input_schema_ffi = std::mem::ManuallyDrop::new(input_schema);
 
         let mut output_array = FFI_ArrowArray::empty();
         let mut output_schema = FFI_ArrowSchema::empty();
@@ -487,7 +486,7 @@ mod tests {
         let status = unsafe {
             polygonize_ffi(
                 &mut *input_array_ffi,
-                &mut *input_schema_ffi,
+                &mut input_schema_ffi,
                 &mut output_array,
                 &mut output_schema,
                 &options,

--- a/crates/geo-polygonize-arrow/tests/arrow_integration.rs
+++ b/crates/geo-polygonize-arrow/tests/arrow_integration.rs
@@ -132,9 +132,8 @@ fn arrow_and_c_data_retain_the_shared_conformance_polygon() {
     let (input, field) = conformance_input(&fixture);
     let input = input.into_array_ref();
     let (input_array, _) = arrow::ffi::to_ffi(&input.to_data()).unwrap();
-    let input_schema = FFI_ArrowSchema::try_from(&field).unwrap();
+    let mut input_schema = FFI_ArrowSchema::try_from(&field).unwrap();
     let mut input_array = std::mem::ManuallyDrop::new(input_array);
-    let mut input_schema = std::mem::ManuallyDrop::new(input_schema);
     let mut output_array = FFI_ArrowArray::empty();
     let mut output_schema = FFI_ArrowSchema::empty();
     let legacy_options = PolygonizerOptions {
@@ -146,7 +145,7 @@ fn arrow_and_c_data_retain_the_shared_conformance_polygon() {
     let status = unsafe {
         polygonize_ffi(
             &mut *input_array,
-            &mut *input_schema,
+            &mut input_schema,
             &mut output_array,
             &mut output_schema,
             &legacy_options,
@@ -158,16 +157,15 @@ fn arrow_and_c_data_retain_the_shared_conformance_polygon() {
     let (input, field) = conformance_input(&fixture);
     let input = input.into_array_ref();
     let (input_array, _) = arrow::ffi::to_ffi(&input.to_data()).unwrap();
-    let input_schema = FFI_ArrowSchema::try_from(&field).unwrap();
+    let mut input_schema = FFI_ArrowSchema::try_from(&field).unwrap();
     let mut input_array = std::mem::ManuallyDrop::new(input_array);
-    let mut input_schema = std::mem::ManuallyDrop::new(input_schema);
     let mut output_array = FFI_ArrowArray::empty();
     let mut output_schema = FFI_ArrowSchema::empty();
     let options = serde_json::to_vec(&canonical_options_fixture()["options"]).unwrap();
     let status = unsafe {
         polygonize_with_options_ffi(
             &mut *input_array,
-            &mut *input_schema,
+            &mut input_schema,
             &mut output_array,
             &mut output_schema,
             options.as_ptr(),
@@ -215,9 +213,8 @@ fn arrow_and_c_data_expose_normalized_non_finite_errors_without_message_equality
         let field = input.data_type().to_field("geometry", true);
         let input = input.into_array_ref();
         let (input_array, _) = arrow::ffi::to_ffi(&input.to_data()).unwrap();
-        let input_schema = FFI_ArrowSchema::try_from(&field).unwrap();
+        let mut input_schema = FFI_ArrowSchema::try_from(&field).unwrap();
         let mut input_array = std::mem::ManuallyDrop::new(input_array);
-        let mut input_schema = std::mem::ManuallyDrop::new(input_schema);
         let mut output_array = FFI_ArrowArray::empty();
         let mut output_schema = FFI_ArrowSchema::empty();
         let status = if canonical_options {
@@ -225,7 +222,7 @@ fn arrow_and_c_data_expose_normalized_non_finite_errors_without_message_equality
             unsafe {
                 polygonize_with_options_ffi(
                     &mut *input_array,
-                    &mut *input_schema,
+                    &mut input_schema,
                     &mut output_array,
                     &mut output_schema,
                     options.as_ptr(),
@@ -242,7 +239,7 @@ fn arrow_and_c_data_expose_normalized_non_finite_errors_without_message_equality
             unsafe {
                 polygonize_ffi(
                     &mut *input_array,
-                    &mut *input_schema,
+                    &mut input_schema,
                     &mut output_array,
                     &mut output_schema,
                     &options,
@@ -275,11 +272,10 @@ fn test_ffi_arrow_integration_square() {
     let arrow_array = input_array.into_array_ref();
     let (input_array_ffi, _) =
         arrow::ffi::to_ffi(&arrow_array.to_data()).expect("Failed to export input array to FFI");
-    let input_schema_ffi =
+    let mut input_schema_ffi =
         FFI_ArrowSchema::try_from(&input_field).expect("Failed to export GeoArrow input field");
 
     let mut input_array_ffi = std::mem::ManuallyDrop::new(input_array_ffi);
-    let mut input_schema_ffi = std::mem::ManuallyDrop::new(input_schema_ffi);
 
     let mut output_array = FFI_ArrowArray::empty();
     let mut output_schema = FFI_ArrowSchema::empty();
@@ -295,7 +291,7 @@ fn test_ffi_arrow_integration_square() {
     let status = unsafe {
         polygonize_ffi(
             &mut *input_array_ffi,
-            &mut *input_schema_ffi,
+            &mut input_schema_ffi,
             &mut output_array,
             &mut output_schema,
             &options,
@@ -332,11 +328,10 @@ fn test_ffi_arrow_integration_empty() {
     let input_array = builder.finish();
 
     let arrow_array = input_array.into_array_ref();
-    let (input_array_ffi, input_schema_ffi) =
+    let (input_array_ffi, mut input_schema_ffi) =
         arrow::ffi::to_ffi(&arrow_array.to_data()).expect("Failed to export input array to FFI");
 
     let mut input_array_ffi = std::mem::ManuallyDrop::new(input_array_ffi);
-    let mut input_schema_ffi = std::mem::ManuallyDrop::new(input_schema_ffi);
 
     let mut output_array = FFI_ArrowArray::empty();
     let mut output_schema = FFI_ArrowSchema::empty();
@@ -351,7 +346,7 @@ fn test_ffi_arrow_integration_empty() {
     let status = unsafe {
         polygonize_ffi(
             &mut *input_array_ffi,
-            &mut *input_schema_ffi,
+            &mut input_schema_ffi,
             &mut output_array,
             &mut output_schema,
             &options,

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -57,3 +57,12 @@ def test_miri_uses_a_pinned_no_default_feature_slice():
     assert "components: miri, rust-src" in workflow
     assert "cargo miri test --locked -p geo-polygonize-core" in workflow
     assert "--no-default-features --test execution_policy" in workflow
+
+
+def test_address_sanitizer_covers_the_arrow_c_ownership_boundary():
+    workflow = (ROOT / ".github/workflows/unsafe-boundaries.yml").read_text()
+
+    assert "address-sanitizer-arrow-ffi:" in workflow
+    assert "-Zsanitizer=address" in workflow
+    assert "--target x86_64-unknown-linux-gnu" in workflow
+    assert "--test arrow_integration --test test_ffi_errors" in workflow


### PR DESCRIPTION
## Stack

Parent:
- #1116

This PR:
- adds pinned Linux AddressSanitizer coverage for Arrow C ownership and error paths

Children:
- not opened yet

## Delivered

- extends the unsafe-boundary workflow with a Linux AddressSanitizer job
- instruments the standard library and Arrow/core dependencies with the pinned nightly
- exercises Arrow integration, C input consumption, output ownership, normalized failures, and null-pointer handling
- closes the selective Miri/sanitizer verification row in P3.7

## Contract impact

- CI-only verification; runtime and ABI behavior are unchanged
- sanitizer scope is intentionally limited to the supported Arrow C boundary tests

## Validation

- cargo +nightly-2026-07-15 test -Zbuild-std --target aarch64-apple-darwin --config build.rustflags=[-Zsanitizer=address] -p geo-polygonize-arrow --test arrow_integration --test test_ffi_errors — passed locally under AddressSanitizer (5 tests)
- cargo test --locked -p geo-polygonize-arrow --test arrow_integration --test test_ffi_errors — passed (5 tests)
- pytest -q tests/test_ci_workflow.py — passed (6 tests)
- actionlint .github/workflows/unsafe-boundaries.yml — passed
- git diff --check — passed
- Linux x86_64 sanitizer execution is delegated to the new workflow; it was not run on this macOS host
- cargo fmt --all -- --check — passed
- cargo clippy --workspace --all-targets -- -D warnings — passed
- cargo test --workspace — passed
- cargo test -p geo-polygonize-core --no-default-features — passed
- RUSTDOCFLAGS=-D warnings cargo doc -p geo-polygonize-core --no-deps — passed
- npm test — passed (11 files, 52 tests)

## Agent handoff

Remaining:
- public error kinds without supported production constructors keep the final P3.7 row open
- P3.5 alias removal and P3 tiling coverage/recovery remain separate future stacks

Next dependency-ready slice:
- audit expired aliases and transitional mutable configuration paths from refreshed main after this stack begins merging
