### PR TITLE
refactor(core): remove snap-grid builder alias

### DIFF
--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -358,17 +358,6 @@ impl Polygonizer {
         &mut self.options
     }
 
-    /// Compatibility shorthand for setting floating or fixed precision.
-    ///
-    /// # Arguments
-    ///
-    /// * `grid_size` - Zero selects floating precision; a positive value selects a fixed grid.
-    #[deprecated(note = "use with_precision_model")]
-    pub fn with_snap_grid(mut self, grid_size: f64) -> Self {
-        self.options.precision_model = PrecisionModel::from_grid_size(grid_size);
-        self
-    }
-
     pub fn with_precision_model(mut self, precision_model: PrecisionModel) -> Self {
         self.options.precision_model = precision_model;
         self


### PR DESCRIPTION
## Stack

Parent:
- `main`

This PR:
- removes the deprecated `Polygonizer::with_snap_grid` compatibility builder

Children:
- #1120

## Delivered

- removes the expired snap-grid builder alias
- retains `with_precision_model` as the single explicit precision builder

## Contract impact

- the stable root facade is unchanged because `Polygonizer` is a hidden mutable-builder API
- hidden builder users migrate to `with_precision_model(PrecisionModel::...)`

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo clippy --locked -p geo-polygonize-core --all-targets -- -D warnings` — passed
- `cargo test --locked -p geo-polygonize-core --no-default-features` — passed
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked -p geo-polygonize-core --no-deps` — passed
- `git diff --check` — passed after restoring unrelated binding files generated by tests

## Agent handoff

Remaining:
- remove the mutable `options_mut` builder path
- remove retired noding and tile-ownership aliases

Next dependency-ready slice:
- make hidden builder options construction-only and migrate repository callers
