### PR TITLE
refactor(core): make builder options construction-only

### DIFF
--- a/crates/geo-polygonize-core/benches/iai_bench.rs
+++ b/crates/geo-polygonize-core/benches/iai_bench.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use common::generate_grid;
-use geo_polygonize_core::Polygonizer;
+use geo_polygonize_core::{Polygonizer, PolygonizerOptions};
 use geo_types::LineString;
 use iai_callgrind::{library_benchmark, library_benchmark_group, main};
 use rand::rngs::StdRng;
@@ -24,11 +24,13 @@ fn generate_random_lines(n: usize, seed: u64) -> Vec<LineString<f64>> {
 #[bench::grid_10(generate_grid(10))]
 #[bench::grid_20(generate_grid(20))]
 fn bench_polygonize_grid(lines: Vec<LineString<f64>>) {
-    let mut poly = Polygonizer::new();
+    let mut poly = Polygonizer::with_options(PolygonizerOptions {
+        node_input: true,
+        ..Default::default()
+    });
     for line in lines {
         poly.add_geometry(line.into());
     }
-    poly.options_mut().node_input = true;
     let _ = poly.polygonize();
 }
 
@@ -36,11 +38,13 @@ fn bench_polygonize_grid(lines: Vec<LineString<f64>>) {
 #[bench::random_50(generate_random_lines(50, 42))]
 #[bench::random_100(generate_random_lines(100, 42))]
 fn bench_polygonize_random(lines: Vec<LineString<f64>>) {
-    let mut poly = Polygonizer::new();
+    let mut poly = Polygonizer::with_options(PolygonizerOptions {
+        node_input: true,
+        ..Default::default()
+    });
     for line in lines {
         poly.add_geometry(line.into());
     }
-    poly.options_mut().node_input = true;
     let _ = poly.polygonize();
 }
 

--- a/crates/geo-polygonize-core/benches/polygonize_bench.rs
+++ b/crates/geo-polygonize-core/benches/polygonize_bench.rs
@@ -62,11 +62,13 @@ fn bench_grid_scenarios<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
         group.bench_with_input(BenchmarkId::new("grid", size), &size, |b, &size| {
             let lines = generate_grid(size);
             b.iter(|| {
-                let mut poly = Polygonizer::new();
+                let mut poly = Polygonizer::with_options(PolygonizerOptions {
+                    node_input: true,
+                    ..Default::default()
+                });
                 for line in &lines {
                     poly.add_geometry(line.clone().into());
                 }
-                poly.options_mut().node_input = true;
                 poly.polygonize().unwrap();
             });
         });
@@ -169,11 +171,13 @@ fn bench_random_scenarios<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
         group.bench_with_input(BenchmarkId::new("random", count), &count, |b, &count| {
             let lines = generate_random_lines(count, 42);
             b.iter(|| {
-                let mut poly = Polygonizer::new();
+                let mut poly = Polygonizer::with_options(PolygonizerOptions {
+                    node_input: true,
+                    ..Default::default()
+                });
                 for line in &lines {
                     poly.add_geometry(line.clone().into());
                 }
-                poly.options_mut().node_input = true;
                 poly.polygonize().unwrap();
             });
         });

--- a/crates/geo-polygonize-core/benches/wasm_bench/src/lib.rs
+++ b/crates/geo-polygonize-core/benches/wasm_bench/src/lib.rs
@@ -42,11 +42,13 @@ pub fn polygonize(lines: JsValue) -> Result<JsValue, JsValue> {
     let lines = parse_input(lines)?;
 
     // Core Logic
-    let mut polygonizer = Polygonizer::new();
+    let mut polygonizer = Polygonizer::with_options(geo_polygonize_core::PolygonizerOptions {
+        node_input: true,
+        ..Default::default()
+    });
     for line in lines {
         polygonizer.add_geometry(Geometry::LineString(line));
     }
-    polygonizer.options_mut().node_input = true;
     let results = polygonizer.polygonize();
 
     let results_vec = results.map_err(|e| JsValue::from_str(&format!("{:?}", e)))?;
@@ -84,8 +86,10 @@ pub fn polygonize_random(lines: JsValue) -> Result<JsValue, JsValue> {
     let lines = parse_input(lines)?;
 
     // Core Logic
-    let mut polygonizer = Polygonizer::new();
-    polygonizer.options_mut().node_input = true;
+    let mut polygonizer = Polygonizer::with_options(geo_polygonize_core::PolygonizerOptions {
+        node_input: true,
+        ..Default::default()
+    });
     for line in lines {
         polygonizer.add_geometry(Geometry::LineString(line));
     }
@@ -99,12 +103,13 @@ pub fn polygonize_random(lines: JsValue) -> Result<JsValue, JsValue> {
 pub fn polygonize_robust(lines: JsValue, grid_size: Option<f64>) -> Result<JsValue, JsValue> {
     let lines = parse_input(lines)?;
 
-    let mut polygonizer = Polygonizer::new();
-    polygonizer.options_mut().node_input = true;
-    if let Some(g) = grid_size {
-        polygonizer.options_mut().precision_model =
-            geo_polygonize_core::PrecisionModel::FixedGrid { grid_size: g };
-    }
+    let mut polygonizer = Polygonizer::with_options(geo_polygonize_core::PolygonizerOptions {
+        node_input: true,
+        precision_model: grid_size.map_or(geo_polygonize_core::PrecisionModel::Floating, |g| {
+            geo_polygonize_core::PrecisionModel::FixedGrid { grid_size: g }
+        }),
+        ..Default::default()
+    });
 
     for line in lines {
         polygonizer.add_geometry(Geometry::LineString(line));

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -354,7 +354,8 @@ impl Polygonizer {
         &self.options
     }
 
-    pub fn options_mut(&mut self) -> &mut PolygonizerOptions {
+    #[cfg(test)]
+    pub(crate) fn options_mut(&mut self) -> &mut PolygonizerOptions {
         &mut self.options
     }
 

--- a/crates/geo-polygonize-core/tests/determinism.rs
+++ b/crates/geo-polygonize-core/tests/determinism.rs
@@ -1,6 +1,6 @@
 use geo_polygonize_core::DeterminismOptions;
 use geo_polygonize_core::Polygonizer;
-use geo_polygonize_core::{Coord3D, Line3D};
+use geo_polygonize_core::{Coord3D, Line3D, PolygonizerOptions};
 
 #[test]
 fn test_determinism_canonical_sort_and_rotation() {
@@ -10,15 +10,20 @@ fn test_determinism_canonical_sort_and_rotation() {
     // 3. polygons are ordered consistently.
 
     let create_polygons_from_lines = |lines: Vec<Line3D>, use_determinism: bool| {
-        let mut poly = Polygonizer::new();
-        poly.options_mut().node_input = true;
-        if use_determinism {
-            poly.options_mut().determinism = DeterminismOptions {
+        let determinism = if use_determinism {
+            DeterminismOptions {
                 canonical_sort: true,
                 canonical_ring_rotation: true,
                 stable_tie_breaks: true,
-            };
-        }
+            }
+        } else {
+            DeterminismOptions::default()
+        };
+        let mut poly = Polygonizer::with_options(PolygonizerOptions {
+            node_input: true,
+            determinism,
+            ..Default::default()
+        });
         poly.add_lines(lines);
         poly.polygonize().unwrap()
     };
@@ -95,15 +100,20 @@ fn test_determinism_canonical_sort_and_rotation() {
 fn test_determinism_byte_identical_serialization() {
     // 1. the same input produces byte-identical serialized output across repeated runs.
     let create_polygons_from_lines = |lines: Vec<Line3D>, use_determinism: bool| {
-        let mut poly = Polygonizer::new();
-        poly.options_mut().node_input = true;
-        if use_determinism {
-            poly.options_mut().determinism = DeterminismOptions {
+        let determinism = if use_determinism {
+            DeterminismOptions {
                 canonical_sort: true,
                 canonical_ring_rotation: true,
                 stable_tie_breaks: true,
-            };
-        }
+            }
+        } else {
+            DeterminismOptions::default()
+        };
+        let mut poly = Polygonizer::with_options(PolygonizerOptions {
+            node_input: true,
+            determinism,
+            ..Default::default()
+        });
         poly.add_lines(lines);
         poly.polygonize().unwrap()
     };
@@ -156,13 +166,15 @@ fn test_determinism_segment_order_permutation() {
     use rand::SeedableRng;
 
     let create_polygons_from_lines = |lines: Vec<Line3D>| {
-        let mut poly = Polygonizer::new();
-        poly.options_mut().node_input = true;
-        poly.options_mut().determinism = DeterminismOptions {
-            canonical_sort: true,
-            canonical_ring_rotation: true,
-            stable_tie_breaks: true,
-        };
+        let mut poly = Polygonizer::with_options(PolygonizerOptions {
+            node_input: true,
+            determinism: DeterminismOptions {
+                canonical_sort: true,
+                canonical_ring_rotation: true,
+                stable_tie_breaks: true,
+            },
+            ..Default::default()
+        });
         poly.add_lines(lines);
         poly.polygonize().unwrap()
     };

--- a/crates/geo-polygonize-core/tests/integration_tests.rs
+++ b/crates/geo-polygonize-core/tests/integration_tests.rs
@@ -1,7 +1,15 @@
 use geo::Area;
-use geo_polygonize_core::Polygonizer;
+use geo_polygonize_core::{Polygonizer, PolygonizerOptions, PrecisionModel};
 use geo_types::{Coord, LineString};
 use std::f64::consts::PI;
+
+fn noding_polygonizer(precision_model: PrecisionModel) -> Polygonizer {
+    Polygonizer::with_options(PolygonizerOptions {
+        node_input: true,
+        precision_model,
+        ..Default::default()
+    })
+}
 
 #[test]
 fn test_nested_holes() {
@@ -74,8 +82,7 @@ fn test_nested_holes() {
 #[test]
 
 fn test_touching_polygons() {
-    let mut poly = Polygonizer::new();
-    poly.options_mut().node_input = true; // Required to deduplicate the shared edge
+    let mut poly = noding_polygonizer(PrecisionModel::Floating);
 
     // Square 1: (0,0)-(50,0)-(50,50)-(0,50)
     poly.add_geometry(
@@ -144,8 +151,7 @@ fn test_dangles() {
 
 #[test]
 fn test_bowtie() {
-    let mut poly = Polygonizer::new();
-    poly.options_mut().node_input = true;
+    let mut poly = noding_polygonizer(PrecisionModel::Floating);
 
     // Bowtie: (0,0)->(10,10)->(0,10)->(10,0)->(0,0)
     // Intersects at (5,5)
@@ -191,10 +197,7 @@ fn create_circle(x: f64, y: f64, r: f64, points: usize) -> LineString<f64> {
 
 #[test]
 fn test_overlapping_circles() {
-    let mut poly = Polygonizer::new();
-    poly.options_mut().node_input = true;
-    poly.options_mut().precision_model =
-        geo_polygonize_core::PrecisionModel::FixedGrid { grid_size: 1e-10 };
+    let mut poly = noding_polygonizer(PrecisionModel::FixedGrid { grid_size: 1e-10 });
 
     // 1. Overlapping Circles
     let c1 = create_circle(30.0, 30.0, 30.0, 100);
@@ -220,10 +223,7 @@ fn test_overlapping_circles() {
 
 #[test]
 fn test_curved_holes() {
-    let mut poly = Polygonizer::new();
-    poly.options_mut().node_input = true;
-    poly.options_mut().precision_model =
-        geo_polygonize_core::PrecisionModel::FixedGrid { grid_size: 1e-10 };
+    let mut poly = noding_polygonizer(PrecisionModel::FixedGrid { grid_size: 1e-10 });
 
     // 2. Curved Holes
     let outer = create_circle(50.0, 50.0, 50.0, 200);
@@ -251,8 +251,7 @@ fn test_touching_full_edge() {
     // Square 2: (10,0)-(20,0)-(20,10)-(10,10)-(10,0)
     // Shared edge: (10,0)-(10,10)
 
-    let mut poly = Polygonizer::new();
-    poly.options_mut().node_input = true;
+    let mut poly = noding_polygonizer(PrecisionModel::Floating);
 
     poly.add_geometry(
         LineString::from(vec![
@@ -291,8 +290,7 @@ fn test_touching_partial_edge() {
     // (10,5)-(20,5)-(20,15)-(10,15)-(10,5)
     // Shared segment: (10,5)-(10,10)
 
-    let mut poly = Polygonizer::new();
-    poly.options_mut().node_input = true;
+    let mut poly = noding_polygonizer(PrecisionModel::Floating);
 
     poly.add_geometry(
         LineString::from(vec![
@@ -334,8 +332,7 @@ fn test_touching_vertex() {
     // Square 1: (0,0)-(10,0)-(10,10)-(0,10)-(0,0)
     // Square 2: (10,10)-(20,10)-(20,20)-(10,20)-(10,10)
 
-    let mut poly = Polygonizer::new();
-    poly.options_mut().node_input = true;
+    let mut poly = noding_polygonizer(PrecisionModel::Floating);
 
     poly.add_geometry(
         LineString::from(vec![
@@ -370,8 +367,7 @@ fn test_touching_t_junction() {
     // (2, -10)-(8, -10)-(8, 0)-(2, 0)-(2, -10)
     // Touches at segment (2,0)-(8,0) which is part of S1's bottom edge (0,0)-(10,0)
 
-    let mut poly = Polygonizer::new();
-    poly.options_mut().node_input = true;
+    let mut poly = noding_polygonizer(PrecisionModel::Floating);
 
     poly.add_geometry(
         LineString::from(vec![
@@ -417,8 +413,7 @@ fn test_grid_2x2() {
     // Split at x=10, y=10
     // Lines provided as 4 separate squares to force deduplication/noding
 
-    let mut poly = Polygonizer::new();
-    poly.options_mut().node_input = true;
+    let mut poly = noding_polygonizer(PrecisionModel::Floating);
 
     // Bottom-Left
     poly.add_geometry(

--- a/crates/geo-polygonize-core/tests/robustness.rs
+++ b/crates/geo-polygonize-core/tests/robustness.rs
@@ -1,6 +1,14 @@
 use geo::Geometry;
-use geo_polygonize_core::{Coord3D, Line3D, Polygonizer};
+use geo_polygonize_core::{Coord3D, Line3D, Polygonizer, PolygonizerOptions, PrecisionModel};
 use geo_types::{Coord, LineString};
+
+fn fixed_noding_polygonizer() -> Polygonizer {
+    Polygonizer::with_options(PolygonizerOptions {
+        node_input: true,
+        precision_model: PrecisionModel::FixedGrid { grid_size: 1e-6 },
+        ..Default::default()
+    })
+}
 
 #[test]
 fn test_bowtie_noding() {
@@ -14,10 +22,7 @@ fn test_bowtie_noding() {
         Coord { x: 0.0, y: 0.0 },
     ]);
 
-    let mut poly = Polygonizer::new();
-    poly.options_mut().node_input = true;
-    poly.options_mut().precision_model =
-        geo_polygonize_core::PrecisionModel::FixedGrid { grid_size: 1e-6 };
+    let mut poly = fixed_noding_polygonizer();
     poly.add_geometry(Geometry::LineString(ls));
 
     let results = poly.polygonize().expect("Polygonization failed").polygons;
@@ -32,10 +37,7 @@ fn test_bowtie_noding() {
 
 #[test]
 fn test_duplicate_edge_removal() {
-    let mut poly = Polygonizer::new();
-    poly.options_mut().node_input = true;
-    poly.options_mut().precision_model =
-        geo_polygonize_core::PrecisionModel::FixedGrid { grid_size: 1e-6 };
+    let mut poly = fixed_noding_polygonizer();
 
     // Triangle edge 1
     poly.add_geometry(Geometry::LineString(LineString(vec![


### PR DESCRIPTION
## Stack

Parent:
- #1119

This PR:
- removes post-construction option mutation from the hidden builder surface

Children:
- #1121

## Delivered

- restricts `Polygonizer::options_mut` to unit-test builds inside the core crate
- migrates integration tests and benchmarks to construct `PolygonizerOptions` before creating a builder
- preserves all prior semantic option values and benchmark workloads

## Contract impact

- supported one-shot and workspace APIs are unchanged
- hidden mutable-builder users must pass complete options to `Polygonizer::with_options`
- no semantic defaults, topology, provenance, Z, or deterministic ordering behavior changes

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo clippy --locked -p geo-polygonize-core --all-targets -- -D warnings` — passed
- `cargo test --locked -p geo-polygonize-core` — passed
- `cargo test --locked -p geo-polygonize-core --no-default-features` — passed
- `cargo check --manifest-path crates/geo-polygonize-core/benches/wasm_bench/Cargo.toml` — passed; the standalone benchmark lockfile is stale, so `--locked` failed before compilation and its generated lockfile update was restored
- `git diff --check` — passed after restoring binding files generated by tests

## Agent handoff

Remaining:
- remove retired noding and tile-ownership aliases

Next dependency-ready slice:
- remove `NodingBackend::Advanced` and the exact-snap compatibility wrapper
