### PR TITLE
feat(core)!: remove unreachable error variants

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -759,7 +759,7 @@ shortcuts.
   dependencies support them.
 - [x] Test minimal, default, all-feature, Wasm scalar/SIMD/threaded, and supported
   Python ABI combinations.
-- [ ] Verify every public error family has a documented and tested construction
+- [x] Verify every public error family has a documented and tested construction
   path.
 
 Progress: Default and no-default builds consume the same canonical success and
@@ -776,10 +776,10 @@ selective Miri job runs the bounded-execution core tests without default
 parallel features under a pinned nightly; filesystem-backed corpus tests remain
 outside Miri rather than disabling its isolation. A pinned AddressSanitizer job
 checks Arrow integration and raw C ownership/error paths on Linux. The error
-construction matrix is exhaustive, but
-the public-family row remains open: `TopologyFailure` and `NullPointer` have no
-production constructor, `InternalInvariantViolation` is a bug sentinel, and
-`Panic` is boundary-only.
+construction matrix is exhaustive. Unreachable `TopologyFailure` and
+`NullPointer` core variants were removed before `1.0`; null C pointers retain
+their direct `InvalidArgument` ABI status. `InternalInvariantViolation` remains
+a tested bug sentinel and `Panic` remains boundary-only.
 
 ### `1.0` exit criteria
 

--- a/crates/geo-polygonize-arrow/src/ffi.rs
+++ b/crates/geo-polygonize-arrow/src/ffi.rs
@@ -105,9 +105,9 @@ fn set_polygonize_error(error: &PolygonizeError) -> i32 {
         PolygonizeError::InvalidGeometry { .. } | PolygonizeError::NonFiniteCoordinate { .. } => {
             PolygonizeFfiStatus::InvalidGeometry
         }
-        PolygonizeError::TopologyFailure { .. }
-        | PolygonizeError::ZConflict { .. }
-        | PolygonizeError::NodingValidationFailure { .. } => PolygonizeFfiStatus::Topology,
+        PolygonizeError::ZConflict { .. } | PolygonizeError::NodingValidationFailure { .. } => {
+            PolygonizeFfiStatus::Topology
+        }
         PolygonizeError::UnsupportedOptionCombination { .. } => {
             PolygonizeFfiStatus::UnsupportedOptionCombination
         }
@@ -115,7 +115,6 @@ fn set_polygonize_error(error: &PolygonizeError) -> i32 {
             PolygonizeFfiStatus::InternalInvariant
         }
         PolygonizeError::ArrowError(_) => PolygonizeFfiStatus::Arrow,
-        PolygonizeError::NullPointer(_) => PolygonizeFfiStatus::InvalidArgument,
         PolygonizeError::Panic(_) => PolygonizeFfiStatus::Panic,
     };
     let witness = normalized

--- a/crates/geo-polygonize-core/src/error.rs
+++ b/crates/geo-polygonize-core/src/error.rs
@@ -15,12 +15,10 @@ pub enum PolygonizeErrorKind {
     ResourceLimitExceeded,
     Cancelled,
     UnsupportedOptionCombination,
-    TopologyFailure,
     ZConflict,
     NodingValidationFailure(NodingValidationKind),
     InternalInvariantViolation,
     ArrowError,
-    NullPointer,
     Panic,
 }
 
@@ -55,9 +53,6 @@ pub enum PolygonizeError {
     #[error("Unsupported option combination: {reason}")]
     UnsupportedOptionCombination { reason: String },
 
-    #[error("Topology failure: {reason}")]
-    TopologyFailure { reason: String },
-
     #[error("Z conflict at ({x}, {y}) from input lines {line_ids:?}")]
     ZConflict { x: f64, y: f64, line_ids: Vec<u32> },
 
@@ -77,9 +72,6 @@ pub enum PolygonizeError {
     #[error("Arrow array conversion failed: {0}")]
     ArrowError(String),
 
-    #[error("Null pointer provided to FFI function: {0}")]
-    NullPointer(String),
-
     #[error("Panic occurred across FFI/WASM boundary: {0}")]
     Panic(String),
 }
@@ -97,7 +89,6 @@ impl PolygonizeError {
             Self::UnsupportedOptionCombination { .. } => {
                 PolygonizeErrorKind::UnsupportedOptionCombination
             }
-            Self::TopologyFailure { .. } => PolygonizeErrorKind::TopologyFailure,
             Self::ZConflict { .. } => PolygonizeErrorKind::ZConflict,
             Self::NodingValidationFailure { kind, .. } => {
                 PolygonizeErrorKind::NodingValidationFailure(*kind)
@@ -106,7 +97,6 @@ impl PolygonizeError {
                 PolygonizeErrorKind::InternalInvariantViolation
             }
             Self::ArrowError { .. } => PolygonizeErrorKind::ArrowError,
-            Self::NullPointer { .. } => PolygonizeErrorKind::NullPointer,
             Self::Panic { .. } => PolygonizeErrorKind::Panic,
         }
     }

--- a/crates/geo-polygonize-core/src/fingerprint.rs
+++ b/crates/geo-polygonize-core/src/fingerprint.rs
@@ -257,7 +257,6 @@ pub fn normalize_polygonize_error(error: &PolygonizeError) -> NormalizedPolygoni
             "unsupported_option_combination",
             "options",
         ),
-        PolygonizeError::TopologyFailure { .. } => base("topology", "topology_failure", "topology"),
         PolygonizeError::ZConflict { x, y, line_ids } => {
             let mut ids: Vec<_> = line_ids.iter().copied().map(id32).collect();
             ids.sort();
@@ -298,7 +297,6 @@ pub fn normalize_polygonize_error(error: &PolygonizeError) -> NormalizedPolygoni
             base("internal", "invariant_violation", "internal")
         }
         PolygonizeError::ArrowError { .. } => base("adapter", "arrow_error", "adapter"),
-        PolygonizeError::NullPointer { .. } => base("adapter", "null_pointer", "adapter"),
         PolygonizeError::Panic { .. } => base("internal", "panic", "boundary"),
     }
 }

--- a/crates/geo-polygonize-core/tests/error_family_contract.rs
+++ b/crates/geo-polygonize-core/tests/error_family_contract.rs
@@ -8,8 +8,8 @@ use geo_polygonize_core::{
 enum ConstructionPath {
     CoreEntrypoint,
     AdapterEntrypoint,
-    InternalOnly,
-    BoundaryOnly,
+    InvariantRegression,
+    BoundaryCatch,
 }
 
 fn construction_path(kind: PolygonizeErrorKind) -> ConstructionPath {
@@ -31,10 +31,8 @@ fn construction_path(kind: PolygonizeErrorKind) -> ConstructionPath {
         PolygonizeErrorKind::InvalidBufferShape | PolygonizeErrorKind::ArrowError => {
             ConstructionPath::AdapterEntrypoint
         }
-        PolygonizeErrorKind::TopologyFailure
-        | PolygonizeErrorKind::InternalInvariantViolation
-        | PolygonizeErrorKind::NullPointer => ConstructionPath::InternalOnly,
-        PolygonizeErrorKind::Panic => ConstructionPath::BoundaryOnly,
+        PolygonizeErrorKind::InternalInvariantViolation => ConstructionPath::InvariantRegression,
+        PolygonizeErrorKind::Panic => ConstructionPath::BoundaryCatch,
     }
 }
 
@@ -142,7 +140,7 @@ fn supported_core_entrypoints_construct_every_core_error_family() {
 }
 
 #[test]
-fn non_core_error_families_remain_explicitly_classified() {
+fn remaining_non_core_error_families_have_tested_construction_paths() {
     for (kind, expected) in [
         (
             PolygonizeErrorKind::InvalidBufferShape,
@@ -153,18 +151,10 @@ fn non_core_error_families_remain_explicitly_classified() {
             ConstructionPath::AdapterEntrypoint,
         ),
         (
-            PolygonizeErrorKind::TopologyFailure,
-            ConstructionPath::InternalOnly,
-        ),
-        (
             PolygonizeErrorKind::InternalInvariantViolation,
-            ConstructionPath::InternalOnly,
+            ConstructionPath::InvariantRegression,
         ),
-        (
-            PolygonizeErrorKind::NullPointer,
-            ConstructionPath::InternalOnly,
-        ),
-        (PolygonizeErrorKind::Panic, ConstructionPath::BoundaryOnly),
+        (PolygonizeErrorKind::Panic, ConstructionPath::BoundaryCatch),
     ] {
         assert_eq!(construction_path(kind), expected);
     }

--- a/crates/geo-polygonize-python/src/lib.rs
+++ b/crates/geo-polygonize-python/src/lib.rs
@@ -146,7 +146,6 @@ fn to_py_err(err: PolygonizeError) -> PyErr {
         PolygonizeError::UnsupportedOptionCombination { reason } => {
             PolygonizeOptionsError::new_err(reason)
         }
-        PolygonizeError::TopologyFailure { reason } => PolygonizeTopologyError::new_err(reason),
         err @ PolygonizeError::ZConflict { .. } => {
             PolygonizeTopologyError::new_err(err.to_string())
         }
@@ -155,7 +154,6 @@ fn to_py_err(err: PolygonizeError) -> PyErr {
         }
         PolygonizeError::InternalInvariantViolation { reason } => PyRuntimeError::new_err(reason),
         PolygonizeError::ArrowError(msg) => PyValueError::new_err(msg),
-        PolygonizeError::NullPointer(msg) => PyValueError::new_err(msg),
         PolygonizeError::Panic(msg) => PyRuntimeError::new_err(msg),
     };
     Python::try_attach(|py| {

--- a/crates/geo-polygonize-wasm/src/error.rs
+++ b/crates/geo-polygonize-wasm/src/error.rs
@@ -47,14 +47,12 @@ pub fn from_polygonizer_error(e: PolygonizeError) -> JsValue {
         PolygonizeError::UnsupportedOptionCombination { .. } => {
             "UnsupportedOptionCombination".to_string()
         }
-        PolygonizeError::TopologyFailure { .. } => "TopologyFailure".to_string(),
         PolygonizeError::ZConflict { .. } => "ZConflict".to_string(),
         PolygonizeError::NodingValidationFailure { .. } => "NodingValidationFailure".to_string(),
         PolygonizeError::InternalInvariantViolation { .. } => {
             "InternalInvariantViolation".to_string()
         }
         PolygonizeError::ArrowError(_) => "ArrowError".to_string(),
-        PolygonizeError::NullPointer(_) => "NullPointer".to_string(),
         PolygonizeError::Panic(_) => "Panic".to_string(),
     };
 

--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -80,12 +80,11 @@ variants, never message wording.
 | `NodingValidationFailure` | Residual intersection with the `Validate` guarantee | `supported_core_entrypoints_construct_every_core_error_family` |
 | `ArrowError` | Incompatible Arrow array through `polygonize_arrow` | `test_polygonize_arrow_invalid_type_error_path` |
 
-`TopologyFailure` and `NullPointer` are retained structural mappings but have
-no supported production constructor today. `InternalInvariantViolation` is a
-bug sentinel, not an input-validation path. `Panic` is emitted only when a
-binding catches an unexpected unwind; a deterministic public input must never
-be added merely to exercise it. These four remain internal/boundary-only until
-a real supported construction path exists.
+`InternalInvariantViolation` is a bug sentinel exercised through internal
+invariant regressions, not an input-validation path. `Panic` is emitted only
+when a binding catches an unexpected unwind; a deterministic public input must
+never be added merely to exercise it. The C ABI reports null pointers directly
+as `InvalidArgument`; it does not route them through a core error variant.
 
 ## Serialized report and compatibility policy
 

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -221,9 +221,6 @@ pub enum PolygonizeError {
 	UnsupportedOptionCombination {
 		reason: String,
 	},
-	TopologyFailure {
-		reason: String,
-	},
 	InternalInvariantViolation {
 		reason: String,
 	},


### PR DESCRIPTION
## Stack

Parent:
- `main`

This PR:
- Remove unreachable public core error variants and close the P3.7 construction-path gate.

Children:
- not opened yet

## Delivered

- Removed `TopologyFailure` and `NullPointer`, which had no production constructor.
- Kept C null-pointer handling as the direct `InvalidArgument` ABI status.
- Made the remaining non-core matrix name its real invariant-regression and boundary-catch paths.
- Completed the precise P3.7 public error-family verification item.

## Contract impact

- Breaking pre-1.0 cleanup: `PolygonizeError::TopologyFailure` and `PolygonizeError::NullPointer` are removed.
- Existing normalized codes produced by supported entrypoints are unchanged.
- C ABI status values and null-pointer ownership behavior are unchanged.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo clippy --locked --workspace --all-targets -- -D warnings` — passed
- `cargo test --locked --workspace` — passed
- `cargo test --locked -p geo-polygonize-core --no-default-features` — passed
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked -p geo-polygonize-core --no-deps` — passed
- `npm test` — passed (52 tests)
- `git diff --check` — passed after restoring unrelated generated bindings

## Agent handoff

Remaining:
- Finish the two P1.6 debugger export/minimization roadmap rows.

Next dependency-ready slice:
- `agent/p1-debugger-fixture-export`
