### PR TITLE
feat(wasm): export exact debugger fixtures

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -510,8 +510,14 @@ directly into the worker-backed debugger.
 - [x] Show phase timings, work counters, resource budgets, and validator witnesses.
 - [x] Compare two option profiles side by side.
 - [x] Encode small deterministic repros in shareable URLs.
-- [ ] Export an exact golden/compatibility fixture bundle.
-- [ ] Run differential minimization in a worker and visualize each reduction.
+- [x] Export an exact golden/compatibility fixture bundle.
+- [x] Run differential minimization in a worker and visualize each reduction.
+
+Exact minimized segments retain coordinate bit strings and source IDs in the
+downloaded fixture, together with both canonical profile outcomes, the preserved
+witness, and an explicit compatibility classification. The existing disposable
+worker streams every accepted segment/coordinate reduction to the selectable map
+overlay and terminates on completion or abort.
 
 **Done when:** a user can move from a failing input to a minimized, exportable
 fixture while seeing which topology stage changed the result.

--- a/playground/src/evidence.test.ts
+++ b/playground/src/evidence.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from 'vitest';
 import type { PolygonizeTraceReportV1 } from 'geo-polygonize';
 import {
   createDebuggerEvidenceBundle,
+  createDebuggerFixtureBundle,
   serializeDebuggerEvidence,
+  serializeDebuggerFixture,
 } from './evidence';
+import type { ExactInputSegment } from './minimize';
 
 const report: PolygonizeTraceReportV1 = {
   schema_version: 1,
@@ -83,5 +86,65 @@ describe('debugger evidence bundles', () => {
       comparison: null,
       normalizedError: null,
     })).toThrow('requires topology and trace together');
+  });
+
+  it('exports exact minimized compatibility fixtures deterministically', () => {
+    const segments: ExactInputSegment[] = [{
+      start: { x: '0x0000000000000000', y: '0x0000000000000000', z: '0x4024000000000000' },
+      end: { x: '0x3ff0000000000000', y: '0x0000000000000000', z: '0x4034000000000000' },
+      sourceId: '7',
+    }];
+    const comparison = {
+      results: [
+        { label: 'baseline', options: { node_input: true }, status: 'success' as const, report },
+        {
+          label: 'comparison',
+          options: { node_input: true },
+          status: 'error' as const,
+          error: {
+            schema_version: 1,
+            family: 'topology',
+            code: 'interior_intersection',
+            stage: 'noding_validation',
+          },
+        },
+      ],
+      diverged: true,
+    };
+    const bundle = createDebuggerFixtureBundle({
+      caseId: 'profile-crossing-001',
+      classification: 'expected_divergence',
+      segments,
+      profileComparison: comparison,
+      witness: { kind: 'outcome_kinds', baseline: 'success', comparison: 'error' },
+    });
+
+    const encoded = serializeDebuggerFixture(bundle);
+    expect(JSON.parse(encoded)).toMatchObject({
+      schema_version: 1,
+      kind: 'geo_polygonize_compatibility_fixture',
+      case_id: 'profile-crossing-001',
+      classification: 'expected_divergence',
+      input: [{ sourceId: '7', start: { z: '0x4024000000000000' } }],
+      baseline: { status: 'success' },
+      comparison: { status: 'error' },
+    });
+    expect(encoded).not.toContain('trace_run');
+    expect(encoded).not.toContain('normalized_input_segment');
+    expect(serializeDebuggerFixture(JSON.parse(encoded))).toBe(encoded);
+  });
+
+  it('rejects unsafe fixture IDs and non-differences', () => {
+    expect(() => createDebuggerFixtureBundle({
+      caseId: '../fixture',
+      classification: 'invalid_ambiguous',
+      segments: [{
+        start: { x: '0x0', y: '0x0', z: '0x0' },
+        end: { x: '0x0', y: '0x0', z: '0x0' },
+        sourceId: '1',
+      }],
+      profileComparison: { results: [], diverged: false },
+      witness: { kind: 'outcome_kinds', baseline: 'success', comparison: 'error' },
+    })).toThrow('lowercase and filesystem-safe');
   });
 });

--- a/playground/src/evidence.ts
+++ b/playground/src/evidence.ts
@@ -5,8 +5,33 @@ import type {
   TopologyTraceV1,
 } from 'geo-polygonize';
 import type { ProfileComparison } from './compare';
+import type { ExactInputSegment, ProfileDifferenceSignature } from './minimize';
 
 export const DEBUGGER_EVIDENCE_FILENAME = 'geo-polygonize-debugger-evidence-v1.json';
+
+export type CompatibilityClassification =
+  | 'expected_parity'
+  | 'expected_divergence'
+  | 'invalid_ambiguous';
+
+type FixtureProfileOutcome = {
+  label: string;
+  options: Partial<PolygonizerOptions>;
+} & (
+  | { status: 'success'; topology: TopologyFingerprintV1 }
+  | { status: 'error'; error: NormalizedPolygonizeErrorV1 }
+);
+
+export type DebuggerFixtureBundleV1 = {
+  schema_version: 1;
+  kind: 'geo_polygonize_compatibility_fixture';
+  case_id: string;
+  classification: CompatibilityClassification;
+  input: ExactInputSegment[];
+  baseline: FixtureProfileOutcome;
+  comparison: FixtureProfileOutcome;
+  witness: ProfileDifferenceSignature;
+};
 
 export type DebuggerEvidenceBundleV1 = {
   schema_version: 1;
@@ -64,14 +89,59 @@ export function serializeDebuggerEvidence(bundle: DebuggerEvidenceBundleV1): str
   return `${JSON.stringify(canonicalize(bundle), null, 2)}\n`;
 }
 
-export function downloadDebuggerEvidence(bundle: DebuggerEvidenceBundleV1) {
-  const url = URL.createObjectURL(new Blob(
-    [serializeDebuggerEvidence(bundle)],
-    { type: 'application/json' },
-  ));
+export function createDebuggerFixtureBundle({
+  caseId,
+  classification,
+  segments,
+  profileComparison,
+  witness,
+}: {
+  caseId: string;
+  classification: CompatibilityClassification;
+  segments: ExactInputSegment[];
+  profileComparison: ProfileComparison;
+  witness: ProfileDifferenceSignature;
+}): DebuggerFixtureBundleV1 {
+  if (!/^[a-z0-9]+(?:[._-][a-z0-9]+)*$/.test(caseId)) {
+    throw new Error('Fixture case ID must be lowercase and filesystem-safe');
+  }
+  if (!profileComparison.diverged || profileComparison.results.length !== 2 || segments.length === 0) {
+    throw new Error('Fixture export requires a minimized two-profile difference');
+  }
+  const outcome = (result: ProfileComparison['results'][number]): FixtureProfileOutcome => (
+    result.status === 'success'
+      ? { label: result.label, options: result.options, status: 'success', topology: result.report.topology }
+      : { label: result.label, options: result.options, status: 'error', error: result.error }
+  );
+  return {
+    schema_version: 1,
+    kind: 'geo_polygonize_compatibility_fixture',
+    case_id: caseId,
+    classification,
+    input: segments,
+    baseline: outcome(profileComparison.results[0]),
+    comparison: outcome(profileComparison.results[1]),
+    witness,
+  };
+}
+
+export function serializeDebuggerFixture(bundle: DebuggerFixtureBundleV1): string {
+  return `${JSON.stringify(canonicalize(bundle), null, 2)}\n`;
+}
+
+function downloadJson(filename: string, value: string) {
+  const url = URL.createObjectURL(new Blob([value], { type: 'application/json' }));
   const anchor = document.createElement('a');
   anchor.href = url;
-  anchor.download = DEBUGGER_EVIDENCE_FILENAME;
+  anchor.download = filename;
   anchor.click();
   URL.revokeObjectURL(url);
+}
+
+export function downloadDebuggerEvidence(bundle: DebuggerEvidenceBundleV1) {
+  downloadJson(DEBUGGER_EVIDENCE_FILENAME, serializeDebuggerEvidence(bundle));
+}
+
+export function downloadDebuggerFixture(bundle: DebuggerFixtureBundleV1) {
+  downloadJson(`${bundle.case_id}.json`, serializeDebuggerFixture(bundle));
 }

--- a/playground/src/main.tsx
+++ b/playground/src/main.tsx
@@ -27,10 +27,17 @@ import {
 import { appendLineString, parseGeojsonInput } from './input';
 import { comparePlaygroundProfiles, type ProfileComparison } from './compare';
 import { extractNormalizedError } from './error';
-import { createDebuggerEvidenceBundle, downloadDebuggerEvidence } from './evidence';
+import {
+  createDebuggerEvidenceBundle,
+  createDebuggerFixtureBundle,
+  downloadDebuggerEvidence,
+  downloadDebuggerFixture,
+  type CompatibilityClassification,
+} from './evidence';
 import {
   extractExactInputSegments,
   segmentsToGeojson,
+  type ExactInputSegment,
   type MinimizationReduction,
   type ProfileDifferenceSignature,
 } from './minimize';
@@ -164,8 +171,12 @@ function App() {
   const [minimizationBusy, setMinimizationBusy] = useState(false);
   const [minimizationError, setMinimizationError] = useState<string | null>(null);
   const [minimizationSignature, setMinimizationSignature] = useState<ProfileDifferenceSignature | null>(null);
+  const [minimizedSegments, setMinimizedSegments] = useState<ExactInputSegment[] | null>(null);
   const [reductions, setReductions] = useState<MinimizationReduction[]>([]);
   const [selectedReductionIndex, setSelectedReductionIndex] = useState(0);
+  const [fixtureCaseId, setFixtureCaseId] = useState('');
+  const [fixtureClassification, setFixtureClassification]
+    = useState<CompatibilityClassification>('expected_divergence');
   const [selectedFeature, setSelectedFeature] = useState<SelectedFeature | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [drawEnabled, setDrawEnabled] = useState(false);
@@ -426,6 +437,9 @@ function App() {
     setComparisonBusy(true);
     setComparison(null);
     setComparisonError(null);
+    setMinimizationSignature(null);
+    setMinimizedSegments(null);
+    setReductions([]);
     void comparePlaygroundProfiles(
       JSON.stringify(inputGeojson),
       controller.signal,
@@ -461,6 +475,7 @@ function App() {
     setMinimizationBusy(true);
     setMinimizationError(null);
     setMinimizationSignature(null);
+    setMinimizedSegments(null);
     setReductions([{ phase: 'input', segments }]);
     setSelectedReductionIndex(0);
     void minimizeProfileDifference({
@@ -475,6 +490,7 @@ function App() {
       },
     }).then((result) => {
       setMinimizationSignature(result.signature);
+      setMinimizedSegments(result.segments);
     }).catch((e: Error) => {
       if (e.name !== 'AbortError') setMinimizationError(e.message);
     }).finally(() => {
@@ -888,17 +904,63 @@ function App() {
                     </FormControl>
                   )}
                   {minimizationSignature && (
-                    <TextField
-                      fullWidth
-                      multiline
-                      minRows={3}
-                      label={comparisonIncludesError
-                        ? 'Preserved normalized-error signature'
-                        : 'Preserved profile-difference witness'}
-                      value={JSON.stringify(minimizationSignature, null, 2)}
-                      InputProps={{ readOnly: true }}
-                      sx={{ mt: 2 }}
-                    />
+                    <>
+                      <TextField
+                        fullWidth
+                        multiline
+                        minRows={3}
+                        label={comparisonIncludesError
+                          ? 'Preserved normalized-error signature'
+                          : 'Preserved profile-difference witness'}
+                        value={JSON.stringify(minimizationSignature, null, 2)}
+                        InputProps={{ readOnly: true }}
+                        sx={{ mt: 2 }}
+                      />
+                      <TextField
+                        fullWidth
+                        label="Fixture case ID"
+                        value={fixtureCaseId}
+                        onChange={(event) => setFixtureCaseId(event.target.value)}
+                        sx={{ mt: 2 }}
+                      />
+                      <FormControl fullWidth sx={{ mt: 2 }}>
+                        <InputLabel id="fixture-classification-label">Classification</InputLabel>
+                        <Select
+                          labelId="fixture-classification-label"
+                          label="Classification"
+                          value={fixtureClassification}
+                          onChange={(event) => setFixtureClassification(
+                            event.target.value as CompatibilityClassification,
+                          )}
+                        >
+                          <MenuItem value="expected_parity">Expected parity</MenuItem>
+                          <MenuItem value="expected_divergence">Expected divergence</MenuItem>
+                          <MenuItem value="invalid_ambiguous">Invalid or ambiguous</MenuItem>
+                        </Select>
+                      </FormControl>
+                      <Button
+                        variant="outlined"
+                        sx={{ mt: 2 }}
+                        disabled={!minimizedSegments || !fixtureCaseId}
+                        onClick={() => {
+                          if (!comparison || !minimizedSegments) return;
+                          try {
+                            downloadDebuggerFixture(createDebuggerFixtureBundle({
+                              caseId: fixtureCaseId,
+                              classification: fixtureClassification,
+                              segments: minimizedSegments,
+                              profileComparison: comparison,
+                              witness: minimizationSignature,
+                            }));
+                            setMinimizationError(null);
+                          } catch (e) {
+                            setMinimizationError(e instanceof Error ? e.message : String(e));
+                          }
+                        }}
+                      >
+                        Export exact fixture
+                      </Button>
+                    </>
                   )}
                 </>
               )}


### PR DESCRIPTION
## Stack

Parent:
- `main`

This PR:
- Finish the P1.6 debugger export and reduction workflow.

Children:
- #1126

## Delivered

- Export minimized compatibility fixtures with exact coordinate bits and source IDs.
- Retain both canonical profile outcomes and the preserved difference witness without embedding trace bulk.
- Require a filesystem-safe case ID and explicit compatibility classification.
- Clear stale minimization state whenever the compared input changes.
- Reconcile the already-delivered disposable worker and selectable reduction visualization.

## Contract impact

- Adds a debugger-only fixture schema; canonical fingerprint and semantic option schemas are unchanged.
- Export requires a completed deterministic two-profile minimization.
- Existing evidence export remains unchanged.

## Validation

- `npm test -- playground/src/evidence.test.ts` — passed (4 tests)
- `npm --prefix playground run build` — passed
- `npm test` — passed (54 tests)
- `npm run docs:build` — passed; npm reported 5 existing audit vulnerabilities
- `git diff --check` — passed after restoring generated bindings and lockfile churn

## Agent handoff

Remaining:
- Wire every retained mismatch producer to emit a review candidate.

Next dependency-ready slice:
- `agent/p1-mismatch-candidate-emission`
