### PR TITLE
feat(core): report tiled halo coverage evidence

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -684,6 +684,12 @@ Treat two different algorithms separately:
 
 ### P3.1 Coverage validation for replicate-and-own tiling
 
+Progress: tile and stitching reports now retain definite owned-face halo escapes
+with internal boundary sides, polygon envelopes, representative edge source IDs,
+and complete aggregate source IDs when provenance is enabled. This does not yet
+detect missing connected regions that produced no local face, so the
+coverage-detection rows remain open.
+
 - [ ] Detect owned faces or connected regions that touch an unresolved halo or
   partition boundary.
 - [ ] Report source IDs and boundary evidence that were required but not fully

--- a/crates/geo-polygonize-core/src/lib.rs
+++ b/crates/geo-polygonize-core/src/lib.rs
@@ -65,7 +65,7 @@ pub use polygonizer::{
 };
 #[doc(hidden)]
 pub use tiling::{
-    StitchingReport, TileReport, TiledPolygonizeResult, TiledPolygonizer,
-    TracedTiledPolygonizeResultV1,
+    StitchingReport, TileBoundarySide, TileCoverageIssue, TileReport, TiledPolygonizeResult,
+    TiledPolygonizer, TracedTiledPolygonizeResultV1,
 };
 pub use types::{Coord3D, Line3D, Polygon3D, PolygonProvenance};

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -34,6 +34,26 @@ fn canonical_polygon_key(poly: &Polygon3D) -> (Vec<[u64; 3]>, Vec<Vec<[u64; 3]>>
     (canonical_ring_key(&poly.exterior), interiors)
 }
 
+/// An internal buffered-tile boundary reached by an owned face.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TileBoundarySide {
+    MinX,
+    MaxX,
+    MinY,
+    MaxY,
+}
+
+/// Evidence that an owned face extends to an unresolved buffered-tile boundary.
+#[derive(Clone, Debug)]
+pub struct TileCoverageIssue {
+    pub polygon_index: usize,
+    pub polygon_bbox: Rect<f64>,
+    pub unresolved_sides: Vec<TileBoundarySide>,
+    pub representative_source_line_ids: Vec<u32>,
+    /// Complete source IDs when aggregate provenance was requested.
+    pub aggregate_source_line_ids: Vec<u32>,
+}
+
 /// Observed work and topology output for one tile.
 #[derive(Debug)]
 pub struct TileReport {
@@ -46,6 +66,8 @@ pub struct TileReport {
     pub dangle_count: usize,
     pub cut_edge_count: usize,
     pub invalid_ring_count: usize,
+    /// Definite halo insufficiency observed for owned faces in this tile.
+    pub coverage_issues: Vec<TileCoverageIssue>,
 }
 
 /// Counts from merging and deduplicating owned tile polygons.
@@ -56,6 +78,8 @@ pub struct StitchingReport {
     pub merged_polygon_count: usize,
     pub duplicate_polygon_count: usize,
     pub output_polygon_count: usize,
+    pub unresolved_tile_count: usize,
+    pub unresolved_owned_polygon_count: usize,
 }
 
 /// Experimental tiled output with per-tile and merge diagnostics.
@@ -168,6 +192,7 @@ impl<'a> TiledPolygonizer<'a> {
             dangle_count: 0,
             cut_edge_count: 0,
             invalid_ring_count: 0,
+            coverage_issues: Vec::new(),
         };
         if relevant_lines == 0 {
             return Ok((Vec::new(), report, Vec::new(), false));
@@ -214,6 +239,9 @@ impl<'a> TiledPolygonizer<'a> {
                 );
             }
             if owned {
+                if let Some(issue) = self.coverage_issue(polygon_index, &poly, buffered_bbox) {
+                    report.coverage_issues.push(issue);
+                }
                 valid_polys.push(poly);
             }
         }
@@ -238,6 +266,57 @@ impl<'a> TiledPolygonizer<'a> {
                 .min_by(|a, b| a.x.total_cmp(&b.x).then(a.y.total_cmp(&b.y)))
                 .map(|coord| Point::new(coord.x, coord.y)),
         }
+    }
+
+    fn coverage_issue(
+        &self,
+        polygon_index: usize,
+        poly: &Polygon3D,
+        buffered_bbox: Rect<f64>,
+    ) -> Option<TileCoverageIssue> {
+        let first = poly.exterior.first()?;
+        let mut min_x = first.x;
+        let mut min_y = first.y;
+        let mut max_x = first.x;
+        let mut max_y = first.y;
+        for coordinate in &poly.exterior[1..] {
+            min_x = min_x.min(coordinate.x);
+            min_y = min_y.min(coordinate.y);
+            max_x = max_x.max(coordinate.x);
+            max_y = max_y.max(coordinate.y);
+        }
+        let polygon_bbox = Rect::new(Coord { x: min_x, y: min_y }, Coord { x: max_x, y: max_y });
+        let mut unresolved_sides = Vec::new();
+        if buffered_bbox.min().x > self.bbox.min().x && min_x <= buffered_bbox.min().x {
+            unresolved_sides.push(TileBoundarySide::MinX);
+        }
+        if buffered_bbox.max().x < self.bbox.max().x && max_x >= buffered_bbox.max().x {
+            unresolved_sides.push(TileBoundarySide::MaxX);
+        }
+        if buffered_bbox.min().y > self.bbox.min().y && min_y <= buffered_bbox.min().y {
+            unresolved_sides.push(TileBoundarySide::MinY);
+        }
+        if buffered_bbox.max().y < self.bbox.max().y && max_y >= buffered_bbox.max().y {
+            unresolved_sides.push(TileBoundarySide::MaxY);
+        }
+        if unresolved_sides.is_empty() {
+            return None;
+        }
+        let mut representative_source_line_ids = poly
+            .exterior_ids
+            .iter()
+            .chain(poly.interiors_ids.iter().flatten())
+            .copied()
+            .collect::<Vec<_>>();
+        representative_source_line_ids.sort_unstable();
+        representative_source_line_ids.dedup();
+        Some(TileCoverageIssue {
+            polygon_index,
+            polygon_bbox,
+            unresolved_sides,
+            representative_source_line_ids,
+            aggregate_source_line_ids: poly.boundary_source_line_ids.clone(),
+        })
     }
 
     fn generate_tiles(&self) -> Vec<Rect<f64>> {
@@ -386,6 +465,14 @@ impl<'a> TiledPolygonizer<'a> {
         )
         .expect("default execution policy cannot cancel");
         let output_polygon_count = polygons.len();
+        let unresolved_tile_count = tile_reports
+            .iter()
+            .filter(|report| !report.coverage_issues.is_empty())
+            .count();
+        let unresolved_owned_polygon_count = tile_reports
+            .iter()
+            .map(|report| report.coverage_issues.len())
+            .sum();
         Ok(TiledPolygonizeResult {
             polygons,
             tile_reports,
@@ -393,6 +480,8 @@ impl<'a> TiledPolygonizer<'a> {
                 merged_polygon_count,
                 duplicate_polygon_count: merged_polygon_count - output_polygon_count,
                 output_polygon_count,
+                unresolved_tile_count,
+                unresolved_owned_polygon_count,
             },
         })
     }

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -3,7 +3,7 @@
 mod tests {
     use crate::{
         trace::TraceLevelV1, Coord3D, DedupPolicy, PolygonizeError, PolygonizerOptions,
-        TiledPolygonizer,
+        ProvenanceOptions, TileBoundarySide, TiledPolygonizer,
     };
     use geo::{Contains, Coord, Geometry, LineString, Rect};
 
@@ -295,6 +295,55 @@ mod tests {
         assert_eq!(result.stitching_report.merged_polygon_count, 1);
         assert_eq!(result.stitching_report.duplicate_polygon_count, 0);
         assert_eq!(result.stitching_report.output_polygon_count, 1);
+    }
+
+    #[test]
+    fn reports_owned_faces_that_escape_an_internal_halo() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 10.0 });
+        let face = Geometry::LineString(LineString::new(vec![
+            Coord { x: 1.0, y: 2.0 },
+            Coord { x: 19.0, y: 2.0 },
+            Coord { x: 19.0, y: 8.0 },
+            Coord { x: 1.0, y: 8.0 },
+            Coord { x: 1.0, y: 2.0 },
+        ]));
+        let mut tiler = TiledPolygonizer::new(bbox, 10.0).with_buffer(2.0);
+        tiler.add_geometry(&face);
+
+        let result = tiler.polygonize().unwrap();
+        let issues: Vec<_> = result
+            .tile_reports
+            .iter()
+            .flat_map(|report| &report.coverage_issues)
+            .collect();
+
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].unresolved_sides, vec![TileBoundarySide::MinX]);
+        assert_eq!(issues[0].polygon_bbox.min().x, 1.0);
+        assert_eq!(issues[0].polygon_bbox.max().x, 19.0);
+        assert!(!issues[0].representative_source_line_ids.is_empty());
+        assert!(issues[0].aggregate_source_line_ids.is_empty());
+        assert_eq!(result.stitching_report.unresolved_tile_count, 1);
+        assert_eq!(result.stitching_report.unresolved_owned_polygon_count, 1);
+
+        let mut tiler = TiledPolygonizer::new(bbox, 10.0)
+            .with_buffer(2.0)
+            .with_options(PolygonizerOptions {
+                provenance: ProvenanceOptions {
+                    enabled: true,
+                    include_boundary_line_ids: true,
+                },
+                ..Default::default()
+            });
+        tiler.add_geometry(&face);
+        let result = tiler.polygonize().unwrap();
+        let issue = result
+            .tile_reports
+            .iter()
+            .flat_map(|report| &report.coverage_issues)
+            .next()
+            .unwrap();
+        assert!(!issue.aggregate_source_line_ids.is_empty());
     }
 
     #[test]

--- a/docs/guide/tiling.md
+++ b/docs/guide/tiling.md
@@ -24,8 +24,13 @@ intersections, and exterior dangles. Those fixtures use:
 - a buffer chosen large enough for the complete owned face.
 
 This is evidence for that input class, not a general proof that an arbitrary
-buffer is sufficient. `TileReport` and `StitchingReport` contain observed counts;
-they do not detect missing boundary evidence or certify coverage.
+buffer is sufficient. `TileReport::coverage_issues` reports an owned face whose
+envelope reaches an internal buffered-tile boundary, including the affected
+sides, face envelope, representative edge source IDs, and complete aggregate
+source IDs when provenance was requested. `StitchingReport` summarizes the
+affected tiles and faces. Absence of this definite witness does not certify
+coverage because missing external linework may leave no reconstructed face to
+inspect.
 
 ## Ownership and deduplication
 
@@ -54,9 +59,10 @@ The implementation validates the tile size, buffer, bounding box, and semantic
 polygonizer options. A per-tile polygonization error stops the whole call and is
 returned to the caller.
 
-There is currently no coverage validator, halo retry, unresolved-region retry,
-untiled fallback, retry budget, or typed coverage-exhaustion error. No retry or
-fallback trace event is emitted because those execution paths do not exist.
+There is currently no opt-in coverage validator, halo retry, unresolved-region
+retry, untiled fallback, retry budget, or typed coverage-exhaustion error. No
+retry or fallback trace event is emitted because those execution paths do not
+exist.
 Applications that require correctness must run an untiled equivalence check for
 their input class or choose untiled polygonization directly when sufficiency is
 unknown.


### PR DESCRIPTION
## Stack

Parent:
- `main`

This PR:
- Reports definite owned-face escapes at internal buffered-tile boundaries.

Children:
- #1132

## Delivered

- Adds deterministic boundary-side and polygon-envelope witnesses to each affected tile report.
- Retains representative edge source IDs unconditionally and complete aggregate source IDs when provenance is enabled.
- Summarizes affected tiles and owned faces in the stitching report.
- Documents that absence of this witness is not a coverage certificate.

## Contract impact

- Additive fields on the experimental Rust-only tiled reporting API.
- Existing best-effort output and ownership behavior are unchanged.
- P3.1 remains open for missing connected regions and opt-in enforcement.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo clippy --locked -p geo-polygonize-core --all-targets -- -D warnings` — passed
- `cargo test --locked -p geo-polygonize-core` — passed, 212 unit tests plus integration tests
- `cargo test --locked -p geo-polygonize-core --no-default-features` — passed, 212 unit tests plus integration tests
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked -p geo-polygonize-core --no-deps` — passed
- `cargo test --locked -p geo-polygonize-core --test tiling_equivalence` — passed
- `git diff --check` — passed after restoring generated bindings

## Agent handoff

Remaining:
- Missing connected regions can produce no local face and therefore no face-envelope witness.
- Coverage evidence is reported but does not yet change success behavior.

Next dependency-ready slice:
- #1132 adds explicit best-effort and reconstructed-owned-face validation contracts.
