### PR TITLE
feat(core): enforce tiled owned-face coverage

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -696,6 +696,8 @@ coverage-detection rows remain open.
   observed.
 - [ ] Add explicit guarantee levels such as `BestEffort` and
   `ValidateCoverage`; do not rename best effort as certified.
+  - [x] Add `BestEffort` and `ValidateOwnedFaces` for the reconstructed-face
+    subset; missing-region coverage certification remains open.
 - [ ] Randomize tile origins, sizes, and traversal orders in metamorphic tests.
 - [ ] Expand exact tiled/untiled fixtures for nested disconnected rings, long
   faces, narrow concavities, holes crossing boundaries, dangles, cut edges,

--- a/crates/geo-polygonize-core/src/lib.rs
+++ b/crates/geo-polygonize-core/src/lib.rs
@@ -65,7 +65,7 @@ pub use polygonizer::{
 };
 #[doc(hidden)]
 pub use tiling::{
-    StitchingReport, TileBoundarySide, TileCoverageIssue, TileReport, TiledPolygonizeResult,
-    TiledPolygonizer, TracedTiledPolygonizeResultV1,
+    StitchingReport, TileBoundarySide, TileCoverageGuarantee, TileCoverageIssue, TileReport,
+    TiledPolygonizeError, TiledPolygonizeResult, TiledPolygonizer, TracedTiledPolygonizeResultV1,
 };
 pub use types::{Coord3D, Line3D, Polygon3D, PolygonProvenance};

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -13,6 +13,7 @@ use geo_types::{Coord, Geometry, Point, Rect};
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 use std::collections::HashSet;
+use thiserror::Error;
 
 fn canonical_ring_key(ring: &[Coord3D]) -> Vec<[u64; 3]> {
     let key = |mut ring: Vec<Coord3D>| {
@@ -88,6 +89,34 @@ pub struct TiledPolygonizeResult {
     pub polygons: Vec<Polygon3D>,
     pub tile_reports: Vec<TileReport>,
     pub stitching_report: StitchingReport,
+}
+
+/// Coverage contract requested for experimental tiled polygonization.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum TileCoverageGuarantee {
+    /// Return output with any detected coverage issues in the tile reports.
+    #[default]
+    BestEffort,
+    /// Reject output when an owned face reaches an internal buffered-tile boundary.
+    ///
+    /// This validates reconstructed owned faces only. It cannot detect a region
+    /// that is absent because its closing linework fell outside every tile halo.
+    ValidateOwnedFaces,
+}
+
+/// Failure from experimental tiled polygonization with coverage validation.
+#[derive(Debug, Error)]
+pub enum TiledPolygonizeError {
+    #[error(transparent)]
+    Polygonize(#[from] PolygonizeError),
+    #[error(
+        "tiled owned-face coverage validation failed for {unresolved_owned_polygon_count} polygons across {unresolved_tile_count} tiles"
+    )]
+    CoverageIncomplete {
+        unresolved_tile_count: usize,
+        unresolved_owned_polygon_count: usize,
+        tile_reports: Vec<TileReport>,
+    },
 }
 
 /// Experimental tiled output paired with a bounded topology trace.
@@ -344,6 +373,25 @@ impl<'a> TiledPolygonizer<'a> {
 
     pub fn polygonize(&self) -> Result<TiledPolygonizeResult> {
         self.polygonize_impl(None)
+    }
+
+    pub fn polygonize_with_coverage_guarantee(
+        &self,
+        guarantee: TileCoverageGuarantee,
+    ) -> std::result::Result<TiledPolygonizeResult, TiledPolygonizeError> {
+        let result = self.polygonize_impl(None)?;
+        if guarantee == TileCoverageGuarantee::ValidateOwnedFaces
+            && result.stitching_report.unresolved_owned_polygon_count != 0
+        {
+            return Err(TiledPolygonizeError::CoverageIncomplete {
+                unresolved_tile_count: result.stitching_report.unresolved_tile_count,
+                unresolved_owned_polygon_count: result
+                    .stitching_report
+                    .unresolved_owned_polygon_count,
+                tile_reports: result.tile_reports,
+            });
+        }
+        Ok(result)
     }
 
     pub fn polygonize_with_trace(

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -3,7 +3,8 @@
 mod tests {
     use crate::{
         trace::TraceLevelV1, Coord3D, DedupPolicy, PolygonizeError, PolygonizerOptions,
-        ProvenanceOptions, TileBoundarySide, TiledPolygonizer,
+        ProvenanceOptions, TileBoundarySide, TileCoverageGuarantee, TiledPolygonizeError,
+        TiledPolygonizer,
     };
     use geo::{Contains, Coord, Geometry, LineString, Rect};
 
@@ -344,6 +345,41 @@ mod tests {
             .next()
             .unwrap();
         assert!(!issue.aggregate_source_line_ids.is_empty());
+    }
+
+    #[test]
+    fn validated_owned_face_coverage_rejects_reported_halo_escape() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 10.0 });
+        let face = Geometry::LineString(LineString::new(vec![
+            Coord { x: 1.0, y: 2.0 },
+            Coord { x: 19.0, y: 2.0 },
+            Coord { x: 19.0, y: 8.0 },
+            Coord { x: 1.0, y: 8.0 },
+            Coord { x: 1.0, y: 2.0 },
+        ]));
+        let mut tiler = TiledPolygonizer::new(bbox, 10.0).with_buffer(2.0);
+        tiler.add_geometry(&face);
+
+        assert!(tiler
+            .polygonize_with_coverage_guarantee(TileCoverageGuarantee::BestEffort)
+            .is_ok());
+        let error = tiler
+            .polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateOwnedFaces)
+            .unwrap_err();
+        assert!(matches!(
+            &error,
+            TiledPolygonizeError::CoverageIncomplete {
+                unresolved_tile_count: 1,
+                unresolved_owned_polygon_count: 1,
+                tile_reports,
+            } if tile_reports.iter().any(|report| !report.coverage_issues.is_empty())
+        ));
+
+        let mut sufficient = TiledPolygonizer::new(bbox, 10.0).with_buffer(10.0);
+        sufficient.add_geometry(&face);
+        assert!(sufficient
+            .polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateOwnedFaces)
+            .is_ok());
     }
 
     #[test]

--- a/docs/guide/tiling.md
+++ b/docs/guide/tiling.md
@@ -59,10 +59,17 @@ The implementation validates the tile size, buffer, bounding box, and semantic
 polygonizer options. A per-tile polygonization error stops the whole call and is
 returned to the caller.
 
-There is currently no opt-in coverage validator, halo retry, unresolved-region
-retry, untiled fallback, retry budget, or typed coverage-exhaustion error. No
-retry or fallback trace event is emitted because those execution paths do not
-exist.
+`polygonize_with_coverage_guarantee` provides two explicit modes:
+
+- `BestEffort` preserves the existing output behavior and reports detected issues.
+- `ValidateOwnedFaces` returns `TiledPolygonizeError::CoverageIncomplete` instead
+  of polygons when a reconstructed owned face reaches an internal halo boundary.
+
+The validation is deliberately scoped to reconstructed owned faces. It cannot
+certify missing regions whose closing linework was excluded from every halo.
+There is currently no halo retry, unresolved-region retry, untiled fallback, or
+retry budget. No retry or fallback trace event is emitted because those execution
+paths do not exist.
 Applications that require correctness must run an untiled equivalence check for
 their input class or choose untiled polygonization directly when sufficiency is
 unknown.


### PR DESCRIPTION
## Stack

Parent:
- #1131

This PR:
- Add explicit best-effort and reconstructed-owned-face validation contracts.

Children:
- #1134

## Delivered

- Added `TileCoverageGuarantee::BestEffort` and `ValidateOwnedFaces`.
- Added an additive validated entrypoint that rejects detected halo escapes.
- Added a typed tiled-only coverage error that retains per-tile evidence.
- Preserved the existing `polygonize()` best-effort behavior.

## Contract impact

- `ValidateOwnedFaces` rejects polygons only when a reconstructed owned face reaches an internal buffered-tile boundary.
- It does not claim to detect regions absent because closing linework fell outside every halo.
- The normalized core error V1 schema and binding adapters are unchanged.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo clippy --locked -p geo-polygonize-core --all-targets -- -D warnings` — passed
- `cargo test --locked -p geo-polygonize-core` — passed (213 unit tests plus integrations)
- `cargo test --locked -p geo-polygonize-core --no-default-features` — passed (213 unit tests plus integrations)
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked -p geo-polygonize-core --no-deps` — passed
- `git diff --check` — passed

## Agent handoff

Remaining:
- Detect missing connected regions that produce no local face.
- Add deterministic retry/fallback with explicit budgets.
- Expand metamorphic tiled/untiled evidence.

Next dependency-ready slice:
- #1134 varies tile grids and input order under sufficient halos.
