### PR TITLE
test(core): verify tiled traversal invariance

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -698,10 +698,8 @@ coverage-detection rows remain open.
   `ValidateCoverage`; do not rename best effort as certified.
   - [x] Add `BestEffort` and `ValidateOwnedFaces` for the reconstructed-face
     subset; missing-region coverage certification remains open.
-- [ ] Randomize tile origins, sizes, and traversal orders in metamorphic tests.
-  - [x] Cover deterministic pseudo-random tile origins, sizes, and input orders
-    when the configured halo contains every owned face; tile traversal order
-    remains open.
+- [x] Randomize tile origins, sizes, input orders, and tile traversal order in
+  deterministic metamorphic tests with sufficient halos.
 - [ ] Expand exact tiled/untiled fixtures for nested disconnected rings, long
   faces, narrow concavities, holes crossing boundaries, dangles, cut edges,
   overlaps, and dirty boundary intersections.

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -418,10 +418,18 @@ impl<'a> TiledPolygonizer<'a> {
 
     fn polygonize_impl(
         &self,
-        mut trace: Option<&mut TraceRecorderV1>,
+        trace: Option<&mut TraceRecorderV1>,
     ) -> Result<TiledPolygonizeResult> {
         self.validate()?;
         let tiles = self.generate_tiles();
+        self.polygonize_tiles(tiles, trace)
+    }
+
+    fn polygonize_tiles(
+        &self,
+        tiles: Vec<Rect<f64>>,
+        mut trace: Option<&mut TraceRecorderV1>,
+    ) -> Result<TiledPolygonizeResult> {
         let trace_ownership = trace
             .as_ref()
             .is_some_and(|trace| trace.records_stage(TraceStageV1::Output));

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -383,6 +383,38 @@ mod tests {
     }
 
     #[test]
+    fn permuted_tile_traversal_preserves_canonical_output() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 20.0 });
+        let face = Geometry::LineString(LineString::new(vec![
+            Coord { x: 2.0, y: 2.0 },
+            Coord { x: 18.0, y: 2.0 },
+            Coord { x: 18.0, y: 18.0 },
+            Coord { x: 2.0, y: 18.0 },
+            Coord { x: 2.0, y: 2.0 },
+        ]));
+        let mut tiler = TiledPolygonizer::new(bbox, 7.0)
+            .with_buffer(20.0)
+            .with_dedup_policy(DedupPolicy::CanonicalRingHash);
+        tiler.add_geometry(&face);
+
+        let forward = tiler.polygonize().unwrap();
+        let mut tiles = tiler.generate_tiles();
+        let mut state = 0x71_1e_u64;
+        for upper in (1..tiles.len()).rev() {
+            state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
+            tiles.swap(upper, (state as usize) % (upper + 1));
+        }
+        let permuted = tiler.polygonize_tiles(tiles, None).unwrap();
+
+        assert_eq!(permuted.polygons.len(), forward.polygons.len());
+        assert_eq!(permuted.polygons[0].exterior, forward.polygons[0].exterior);
+        assert_eq!(
+            permuted.stitching_report.output_polygon_count,
+            forward.stitching_report.output_polygon_count
+        );
+    }
+
+    #[test]
     fn trace_records_physical_tile_ownership_and_dedup_decisions() {
         let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 10.0 });
         let square = Geometry::LineString(LineString::new(vec![


### PR DESCRIPTION
## Stack

Parent:
- #1134

This PR:
- Verifies canonical tiled output under a permuted physical tile order.

Children:
- #1136

## Delivered

- Factored the existing private tile execution body so tests can supply an alternate tile order.
- Added deterministic Fisher-Yates tile permutation coverage.
- Proved canonical polygon output and stitching counts match the normal order.
- Completed the roadmap's tile origin, size, input-order, and traversal-order metamorphic evidence row.

## Contract impact

- No public API or semantic option changes.
- Normal tile generation and execution continue through the same implementation.
- The no-default-features run exercises the permuted tile order serially.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo clippy --locked -p geo-polygonize-core --all-targets -- -D warnings` — passed
- `cargo test --locked -p geo-polygonize-core` — passed (214 unit tests plus integrations)
- `cargo test --locked -p geo-polygonize-core --no-default-features` — passed (214 unit tests plus integrations)
- `cargo test --locked -p geo-polygonize-core permuted_tile_traversal_preserves_canonical_output` — passed
- `cargo test --locked -p geo-polygonize-core --no-default-features permuted_tile_traversal_preserves_canonical_output` — passed
- `git diff --check` — passed after restoring generated bindings

## Agent handoff

Remaining:
- Detect missing connected regions that produce no local face.
- Add deterministic bounded halo retry and explicit exhaustion behavior.
- Expand exact tiled/untiled fixtures for remaining difficult topology classes.

Next dependency-ready slice:
- #1136 adds nested disconnected-ring and overlap equivalence baselines.
