### PR TITLE
test(core): expand tiled topology fixtures

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -703,6 +703,9 @@ coverage-detection rows remain open.
 - [ ] Expand exact tiled/untiled fixtures for nested disconnected rings, long
   faces, narrow concavities, holes crossing boundaries, dangles, cut edges,
   overlaps, and dirty boundary intersections.
+  - [x] Cover nested disconnected rings, long faces, narrow concavities,
+    boundary-crossing holes, overlaps, and dirty crossings under sufficient
+    halos; exact retained-family evidence for dangles and cut edges remains open.
 
 ### P3.2 Deterministic recovery
 

--- a/crates/geo-polygonize-core/tests/tiling_equivalence.rs
+++ b/crates/geo-polygonize-core/tests/tiling_equivalence.rs
@@ -111,6 +111,23 @@ fn tiled_output_matches_untiled_when_the_halo_contains_each_owned_face() {
         line((10.0, 0.0), (10.0, 20.0)),
     ]);
 
+    let mut disconnected_nested = ring(&[(2.0, 2.0), (28.0, 2.0), (28.0, 28.0), (2.0, 28.0)]);
+    disconnected_nested.extend(ring(&[(6.0, 6.0), (24.0, 6.0), (24.0, 24.0), (6.0, 24.0)]));
+    disconnected_nested.extend(ring(&[
+        (10.0, 10.0),
+        (20.0, 10.0),
+        (20.0, 20.0),
+        (10.0, 20.0),
+    ]));
+
+    let mut overlaps = ring(&[(2.0, 3.0), (17.0, 3.0), (17.0, 18.0), (2.0, 18.0)]);
+    overlaps.extend(ring(&[
+        (11.0, 9.0),
+        (26.0, 9.0),
+        (26.0, 24.0),
+        (11.0, 24.0),
+    ]));
+
     let cases = [
         Case {
             name: "one boundary",
@@ -169,6 +186,20 @@ fn tiled_output_matches_untiled_when_the_halo_contains_each_owned_face() {
             bbox: world(20.0),
             tile_size: 10.0,
             buffer: 20.0,
+        },
+        Case {
+            name: "disconnected nested rings",
+            lines: disconnected_nested,
+            bbox: world(30.0),
+            tile_size: 10.0,
+            buffer: 30.0,
+        },
+        Case {
+            name: "overlapping boundaries",
+            lines: overlaps,
+            bbox: world(30.0),
+            tile_size: 10.0,
+            buffer: 30.0,
         },
     ];
 


### PR DESCRIPTION
## Stack

Parent:
- #1135

This PR:
- Expands exact tiled/untiled topology fixtures under sufficient halos.

Children:
- not opened yet

## Delivered

- Added three-level disconnected nested-ring coverage.
- Added overlapping-boundary coverage that requires noding before polygonization.
- Retained the existing exact polygon coordinate and hole comparisons.
- Recorded the remaining retained-family evidence gap separately.

## Contract impact

- Test-only evidence; no production behavior or API changes.
- These fixtures establish sufficient-halo baselines for later recovery work.
- Dangle and cut-edge retained-family equivalence remains open because tiled output currently exposes counts, not those geometries.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo clippy --locked -p geo-polygonize-core --all-targets -- -D warnings` — passed
- `cargo test --locked -p geo-polygonize-core --test tiling_equivalence` — passed (2 tests)
- `cargo test --locked -p geo-polygonize-core --no-default-features --test tiling_equivalence` — passed (2 tests)
- `git diff --check` — passed

## Agent handoff

Remaining:
- Add exact tiled retained-family evidence for dangles and cut edges.
- Detect regions absent from every local face set.
- Implement deterministic bounded halo retry only after that detection contract is defined.

Next dependency-ready slice:
- Start a new stack from refreshed `main` after this five-PR stack advances, targeting missing-region coverage detection rather than adding recovery heuristics prematurely.
