### PR TITLE
feat(core): report tiled input boundary evidence

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -686,9 +686,11 @@ Treat two different algorithms separately:
 
 Progress: tile and stitching reports now retain definite owned-face halo escapes
 with internal boundary sides, polygon envelopes, representative edge source IDs,
-and complete aggregate source IDs when provenance is enabled. This does not yet
-detect missing connected regions that produced no local face, so the
-coverage-detection rows remain open.
+and complete aggregate source IDs when provenance is enabled. Conservative
+input-boundary evidence now retains stable input geometry indexes, envelopes,
+and internal halo sides even when no local face was reconstructed. Missing
+connected regions are not yet classified conclusively, so the coverage-detection
+rows remain open.
 
 - [ ] Detect owned faces or connected regions that touch an unresolved halo or
   partition boundary.

--- a/crates/geo-polygonize-core/src/lib.rs
+++ b/crates/geo-polygonize-core/src/lib.rs
@@ -65,7 +65,8 @@ pub use polygonizer::{
 };
 #[doc(hidden)]
 pub use tiling::{
-    StitchingReport, TileBoundarySide, TileCoverageGuarantee, TileCoverageIssue, TileReport,
-    TiledPolygonizeError, TiledPolygonizeResult, TiledPolygonizer, TracedTiledPolygonizeResultV1,
+    StitchingReport, TileBoundarySide, TileCoverageGuarantee, TileCoverageIssue,
+    TileInputBoundaryIssue, TileReport, TiledPolygonizeError, TiledPolygonizeResult,
+    TiledPolygonizer, TracedTiledPolygonizeResultV1,
 };
 pub use types::{Coord3D, Line3D, Polygon3D, PolygonProvenance};

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -55,6 +55,17 @@ pub struct TileCoverageIssue {
     pub aggregate_source_line_ids: Vec<u32>,
 }
 
+/// Input geometry that reaches an internal buffered-tile boundary.
+///
+/// This is conservative evidence that topology may continue through linework
+/// outside the halo, including when no local face was reconstructed.
+#[derive(Clone, Debug)]
+pub struct TileInputBoundaryIssue {
+    pub input_geometry_index: usize,
+    pub geometry_bbox: Rect<f64>,
+    pub unresolved_sides: Vec<TileBoundarySide>,
+}
+
 /// Observed work and topology output for one tile.
 #[derive(Debug)]
 pub struct TileReport {
@@ -69,6 +80,8 @@ pub struct TileReport {
     pub invalid_ring_count: usize,
     /// Definite halo insufficiency observed for owned faces in this tile.
     pub coverage_issues: Vec<TileCoverageIssue>,
+    /// Inputs that may connect to linework beyond this tile's halo.
+    pub input_boundary_issues: Vec<TileInputBoundaryIssue>,
 }
 
 /// Counts from merging and deduplicating owned tile polygons.
@@ -81,6 +94,9 @@ pub struct StitchingReport {
     pub output_polygon_count: usize,
     pub unresolved_tile_count: usize,
     pub unresolved_owned_polygon_count: usize,
+    pub unresolved_input_tile_count: usize,
+    /// Input-boundary issue instances across tiles; a geometry may occur more than once.
+    pub unresolved_input_geometry_count: usize,
 }
 
 /// Experimental tiled output with per-tile and merge diagnostics.
@@ -206,10 +222,22 @@ impl<'a> TiledPolygonizer<'a> {
 
         // Filter geometries intersecting the BUFFERED tile
         let mut relevant_lines = 0;
-        for (geom, bbox) in &self.geometries {
-            if bbox.map(|b| b.intersects(&buffered_bbox)).unwrap_or(false) {
+        let mut input_boundary_issues = Vec::new();
+        for (input_geometry_index, (geom, bbox)) in self.geometries.iter().enumerate() {
+            if let Some(geometry_bbox) = bbox
+                .as_ref()
+                .filter(|geometry_bbox| geometry_bbox.intersects(&buffered_bbox))
+            {
                 local_poly.add_borrowed_geometry(geom);
                 relevant_lines += 1;
+                let unresolved_sides = self.unresolved_sides(*geometry_bbox, buffered_bbox);
+                if !unresolved_sides.is_empty() {
+                    input_boundary_issues.push(TileInputBoundaryIssue {
+                        input_geometry_index,
+                        geometry_bbox: *geometry_bbox,
+                        unresolved_sides,
+                    });
+                }
             }
         }
 
@@ -222,6 +250,7 @@ impl<'a> TiledPolygonizer<'a> {
             cut_edge_count: 0,
             invalid_ring_count: 0,
             coverage_issues: Vec::new(),
+            input_boundary_issues,
         };
         if relevant_lines == 0 {
             return Ok((Vec::new(), report, Vec::new(), false));
@@ -315,19 +344,7 @@ impl<'a> TiledPolygonizer<'a> {
             max_y = max_y.max(coordinate.y);
         }
         let polygon_bbox = Rect::new(Coord { x: min_x, y: min_y }, Coord { x: max_x, y: max_y });
-        let mut unresolved_sides = Vec::new();
-        if buffered_bbox.min().x > self.bbox.min().x && min_x <= buffered_bbox.min().x {
-            unresolved_sides.push(TileBoundarySide::MinX);
-        }
-        if buffered_bbox.max().x < self.bbox.max().x && max_x >= buffered_bbox.max().x {
-            unresolved_sides.push(TileBoundarySide::MaxX);
-        }
-        if buffered_bbox.min().y > self.bbox.min().y && min_y <= buffered_bbox.min().y {
-            unresolved_sides.push(TileBoundarySide::MinY);
-        }
-        if buffered_bbox.max().y < self.bbox.max().y && max_y >= buffered_bbox.max().y {
-            unresolved_sides.push(TileBoundarySide::MaxY);
-        }
+        let unresolved_sides = self.unresolved_sides(polygon_bbox, buffered_bbox);
         if unresolved_sides.is_empty() {
             return None;
         }
@@ -346,6 +363,35 @@ impl<'a> TiledPolygonizer<'a> {
             representative_source_line_ids,
             aggregate_source_line_ids: poly.boundary_source_line_ids.clone(),
         })
+    }
+
+    fn unresolved_sides(
+        &self,
+        geometry_bbox: Rect<f64>,
+        buffered_bbox: Rect<f64>,
+    ) -> Vec<TileBoundarySide> {
+        let mut unresolved_sides = Vec::new();
+        if buffered_bbox.min().x > self.bbox.min().x
+            && geometry_bbox.min().x <= buffered_bbox.min().x
+        {
+            unresolved_sides.push(TileBoundarySide::MinX);
+        }
+        if buffered_bbox.max().x < self.bbox.max().x
+            && geometry_bbox.max().x >= buffered_bbox.max().x
+        {
+            unresolved_sides.push(TileBoundarySide::MaxX);
+        }
+        if buffered_bbox.min().y > self.bbox.min().y
+            && geometry_bbox.min().y <= buffered_bbox.min().y
+        {
+            unresolved_sides.push(TileBoundarySide::MinY);
+        }
+        if buffered_bbox.max().y < self.bbox.max().y
+            && geometry_bbox.max().y >= buffered_bbox.max().y
+        {
+            unresolved_sides.push(TileBoundarySide::MaxY);
+        }
+        unresolved_sides
     }
 
     fn generate_tiles(&self) -> Vec<Rect<f64>> {
@@ -529,6 +575,13 @@ impl<'a> TiledPolygonizer<'a> {
             .iter()
             .map(|report| report.coverage_issues.len())
             .sum();
+        let unresolved_input_tile_count = tile_reports
+            .iter()
+            .filter(|report| !report.input_boundary_issues.is_empty())
+            .count();
+        let unresolved_input_geometry_count = tile_reports.iter().fold(0usize, |total, report| {
+            total.saturating_add(report.input_boundary_issues.len())
+        });
         Ok(TiledPolygonizeResult {
             polygons,
             tile_reports,
@@ -538,6 +591,8 @@ impl<'a> TiledPolygonizer<'a> {
                 output_polygon_count,
                 unresolved_tile_count,
                 unresolved_owned_polygon_count,
+                unresolved_input_tile_count,
+                unresolved_input_geometry_count,
             },
         })
     }

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -2,9 +2,9 @@
 #[allow(clippy::module_inception)]
 mod tests {
     use crate::{
-        trace::TraceLevelV1, Coord3D, DedupPolicy, PolygonizeError, PolygonizerOptions,
-        ProvenanceOptions, TileBoundarySide, TileCoverageGuarantee, TiledPolygonizeError,
-        TiledPolygonizer,
+        trace::TraceLevelV1, Coord3D, DedupPolicy, PolygonizeError, Polygonizer,
+        PolygonizerOptions, ProvenanceOptions, TileBoundarySide, TileCoverageGuarantee,
+        TiledPolygonizeError, TiledPolygonizer,
     };
     use geo::{Contains, Coord, Geometry, LineString, Rect};
 
@@ -345,6 +345,58 @@ mod tests {
             .next()
             .unwrap();
         assert!(!issue.aggregate_source_line_ids.is_empty());
+    }
+
+    #[test]
+    fn reports_boundary_inputs_when_no_local_face_is_reconstructed() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 10.0 });
+        let boundaries = [
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 1.0, y: 2.0 },
+                Coord { x: 19.0, y: 2.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 19.0, y: 2.0 },
+                Coord { x: 19.0, y: 8.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 19.0, y: 8.0 },
+                Coord { x: 1.0, y: 8.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 1.0, y: 8.0 },
+                Coord { x: 1.0, y: 2.0 },
+            ])),
+        ];
+        let mut untiled = Polygonizer::new();
+        let mut tiled = TiledPolygonizer::new(bbox, 10.0).with_buffer(2.0);
+        for boundary in &boundaries {
+            untiled.add_borrowed_geometry(boundary);
+            tiled.add_geometry(boundary);
+        }
+
+        assert_eq!(untiled.polygonize().unwrap().polygons.len(), 1);
+        let result = tiled.polygonize().unwrap();
+        assert!(result.polygons.is_empty());
+        let issues: Vec<_> = result
+            .tile_reports
+            .iter()
+            .flat_map(|report| &report.input_boundary_issues)
+            .collect();
+        assert_eq!(issues.len(), 4);
+        assert!(issues
+            .iter()
+            .all(|issue| { issue.input_geometry_index == 0 || issue.input_geometry_index == 2 }));
+        assert!(result.tile_reports[0]
+            .input_boundary_issues
+            .iter()
+            .all(|issue| issue.unresolved_sides == vec![TileBoundarySide::MaxX]));
+        assert!(result.tile_reports[1]
+            .input_boundary_issues
+            .iter()
+            .all(|issue| issue.unresolved_sides == vec![TileBoundarySide::MinX]));
+        assert_eq!(result.stitching_report.unresolved_input_tile_count, 2);
+        assert_eq!(result.stitching_report.unresolved_input_geometry_count, 4);
     }
 
     #[test]

--- a/docs/guide/tiling.md
+++ b/docs/guide/tiling.md
@@ -32,6 +32,14 @@ affected tiles and faces. Absence of this definite witness does not certify
 coverage because missing external linework may leave no reconstructed face to
 inspect.
 
+`TileReport::input_boundary_issues` also records the stable input geometry index,
+envelope, and internal halo sides for each included geometry whose envelope
+reaches beyond that halo. This conservative witness remains available when no
+local face is reconstructed, so it catches split-boundary cases that face-only
+evidence cannot see. It reports unresolved connectivity, not a confirmed missing
+face: whole input geometries are replicated and may already contain everything
+needed locally.
+
 ## Ownership and deduplication
 
 Tiles use half-open `[min, max)` ownership intervals, except that the final row


### PR DESCRIPTION
## Stack

Parent:
- `main`

This PR:
- Reports conservative input-boundary evidence when tiled topology may continue outside a halo.

Children:
- #1138

## Delivered

- Added stable input geometry indexes, envelopes, and internal boundary sides to tile reports.
- Added stitching counts for affected tiles and input-geometry issue instances.
- Reused the existing boundary-side classifier for face and input evidence.
- Added a regression where untiled finds a face, tiled reconstructs none, and input evidence still identifies the unresolved boundaries.
- Documented that input evidence is conservative rather than a confirmed missing-face diagnosis.

## Contract impact

- Additive fields on the experimental Rust-only tiled reporting API.
- Existing best-effort polygon output is unchanged.
- Coverage remains uncertified: whole input geometries are replicated and an input-boundary witness may be conservative.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo clippy --locked -p geo-polygonize-core --all-targets -- -D warnings` — passed
- `cargo test --locked -p geo-polygonize-core` — passed (215 unit tests plus integrations)
- `cargo test --locked -p geo-polygonize-core --no-default-features` — passed (215 unit tests plus integrations)
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked -p geo-polygonize-core --no-deps` — passed
- `git diff --check` — passed after restoring generated bindings

## Agent handoff

Remaining:
- Make an opt-in strict contract reject both owned-face and conservative input-boundary evidence.
- Classify connected input regions to reduce conservative false positives.
- Add bounded retry only after the strict evidence contract is explicit.

Next dependency-ready slice:
- #1138 validates all currently observed coverage evidence without claiming certification.
