### PR TITLE
feat(core): validate observed tiled coverage

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -700,6 +700,8 @@ rows remain open.
   `ValidateCoverage`; do not rename best effort as certified.
   - [x] Add `BestEffort` and `ValidateOwnedFaces` for the reconstructed-face
     subset; missing-region coverage certification remains open.
+  - [x] Add `ValidateObservedCoverage` to reject either owned-face or
+    conservative input-boundary evidence without claiming certification.
 - [x] Randomize tile origins, sizes, input orders, and tile traversal order in
   deterministic metamorphic tests with sufficient halos.
 - [ ] Expand exact tiled/untiled fixtures for nested disconnected rings, long

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -118,6 +118,11 @@ pub enum TileCoverageGuarantee {
     /// This validates reconstructed owned faces only. It cannot detect a region
     /// that is absent because its closing linework fell outside every tile halo.
     ValidateOwnedFaces,
+    /// Reject output when either owned-face or input-boundary evidence is present.
+    ///
+    /// This validates the observed evidence only. It does not certify connected
+    /// regions whose geometry never intersected a tile halo.
+    ValidateObservedCoverage,
 }
 
 /// Failure from experimental tiled polygonization with coverage validation.
@@ -126,11 +131,13 @@ pub enum TiledPolygonizeError {
     #[error(transparent)]
     Polygonize(#[from] PolygonizeError),
     #[error(
-        "tiled owned-face coverage validation failed for {unresolved_owned_polygon_count} polygons across {unresolved_tile_count} tiles"
+        "tiled coverage validation failed for {unresolved_owned_polygon_count} owned polygons and {unresolved_input_geometry_count} input boundary instances"
     )]
     CoverageIncomplete {
         unresolved_tile_count: usize,
         unresolved_owned_polygon_count: usize,
+        unresolved_input_tile_count: usize,
+        unresolved_input_geometry_count: usize,
         tile_reports: Vec<TileReport>,
     },
 }
@@ -426,14 +433,26 @@ impl<'a> TiledPolygonizer<'a> {
         guarantee: TileCoverageGuarantee,
     ) -> std::result::Result<TiledPolygonizeResult, TiledPolygonizeError> {
         let result = self.polygonize_impl(None)?;
-        if guarantee == TileCoverageGuarantee::ValidateOwnedFaces
-            && result.stitching_report.unresolved_owned_polygon_count != 0
-        {
+        let reject = match guarantee {
+            TileCoverageGuarantee::BestEffort => false,
+            TileCoverageGuarantee::ValidateOwnedFaces => {
+                result.stitching_report.unresolved_owned_polygon_count != 0
+            }
+            TileCoverageGuarantee::ValidateObservedCoverage => {
+                result.stitching_report.unresolved_owned_polygon_count != 0
+                    || result.stitching_report.unresolved_input_geometry_count != 0
+            }
+        };
+        if reject {
             return Err(TiledPolygonizeError::CoverageIncomplete {
                 unresolved_tile_count: result.stitching_report.unresolved_tile_count,
                 unresolved_owned_polygon_count: result
                     .stitching_report
                     .unresolved_owned_polygon_count,
+                unresolved_input_tile_count: result.stitching_report.unresolved_input_tile_count,
+                unresolved_input_geometry_count: result
+                    .stitching_report
+                    .unresolved_input_geometry_count,
                 tile_reports: result.tile_reports,
             });
         }

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -397,6 +397,16 @@ mod tests {
             .all(|issue| issue.unresolved_sides == vec![TileBoundarySide::MinX]));
         assert_eq!(result.stitching_report.unresolved_input_tile_count, 2);
         assert_eq!(result.stitching_report.unresolved_input_geometry_count, 4);
+        assert!(matches!(
+            tiled.polygonize_with_coverage_guarantee(
+                TileCoverageGuarantee::ValidateObservedCoverage
+            ),
+            Err(TiledPolygonizeError::CoverageIncomplete {
+                unresolved_input_tile_count: 2,
+                unresolved_input_geometry_count: 4,
+                ..
+            })
+        ));
     }
 
     #[test]
@@ -424,13 +434,14 @@ mod tests {
                 unresolved_tile_count: 1,
                 unresolved_owned_polygon_count: 1,
                 tile_reports,
+                ..
             } if tile_reports.iter().any(|report| !report.coverage_issues.is_empty())
         ));
 
         let mut sufficient = TiledPolygonizer::new(bbox, 10.0).with_buffer(10.0);
         sufficient.add_geometry(&face);
         assert!(sufficient
-            .polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateOwnedFaces)
+            .polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateObservedCoverage)
             .is_ok());
     }
 

--- a/docs/guide/tiling.md
+++ b/docs/guide/tiling.md
@@ -72,9 +72,12 @@ returned to the caller.
 - `BestEffort` preserves the existing output behavior and reports detected issues.
 - `ValidateOwnedFaces` returns `TiledPolygonizeError::CoverageIncomplete` instead
   of polygons when a reconstructed owned face reaches an internal halo boundary.
+- `ValidateObservedCoverage` returns that typed error when either owned-face or
+  conservative input-boundary evidence is present.
 
-The validation is deliberately scoped to reconstructed owned faces. It cannot
-certify missing regions whose closing linework was excluded from every halo.
+Both validation modes are deliberately narrower than coverage certification.
+They cannot certify missing connected regions whose geometry was excluded from
+every halo.
 There is currently no halo retry, unresolved-region retry, untiled fallback, or
 retry budget. No retry or fallback trace event is emitted because those execution
 paths do not exist.


### PR DESCRIPTION
## Stack

Parent:
- #1137

This PR:
- Adds an opt-in strict mode over every currently observed tiled coverage issue.

Children:
- #1140

## Delivered

- Added `TileCoverageGuarantee::ValidateObservedCoverage`.
- Rejects output when either owned-face or conservative input-boundary evidence is present.
- Extended the typed tiled coverage error with both input-boundary counts.
- Preserved `BestEffort` and the narrower `ValidateOwnedFaces` behavior.
- Added failing and successful strict-mode regressions.

## Contract impact

- Additive variant on the experimental Rust-only tiled guarantee enum.
- `ValidateObservedCoverage` is explicitly not full coverage certification.
- Existing normalized core error schemas and binding adapters are unchanged.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo clippy --locked -p geo-polygonize-core --all-targets -- -D warnings` — passed
- `cargo test --locked -p geo-polygonize-core` — passed (215 unit tests plus integrations)
- `cargo test --locked -p geo-polygonize-core --no-default-features` — passed (215 unit tests plus integrations)
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked -p geo-polygonize-core --no-deps` — passed
- Focused observed-input and owned-face coverage tests — passed
- `git diff --check` — passed after restoring generated bindings

## Agent handoff

Remaining:
- Record observed coverage decisions in the bounded topology trace.
- Detect connected input regions excluded from every halo.
- Reserve the name `ValidateCoverage` for a genuinely certifying contract.

Next dependency-ready slice:
- #1140 records bounded input-boundary trace evidence from the physical pass.
