### PR TITLE
feat(core): trace tiled input boundary evidence

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -689,8 +689,9 @@ with internal boundary sides, polygon envelopes, representative edge source IDs,
 and complete aggregate source IDs when provenance is enabled. Conservative
 input-boundary evidence now retains stable input geometry indexes, envelopes,
 and internal halo sides even when no local face was reconstructed. Missing
-connected regions are not yet classified conclusively, so the coverage-detection
-rows remain open.
+connected regions are not yet classified conclusively. Bounded full traces reuse
+that physical-pass evidence as `tile_input_boundary` events, so the
+coverage-detection rows remain open.
 
 - [ ] Detect owned faces or connected regions that touch an unresolved halo or
   partition boundary.

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -511,6 +511,11 @@ impl<'a> TiledPolygonizer<'a> {
                 let (polygons, report, ownership_decisions, capture_truncated) =
                     self.process_tile(tile, capture_byte_limit)?;
                 let trace = trace.as_deref_mut().expect("tile trace exists");
+                for issue in &report.input_boundary_issues {
+                    if !trace.record_tile_input_boundary(tile_index, issue)? {
+                        break;
+                    }
+                }
                 for (polygon_index, ownership_point, owned) in ownership_decisions {
                     trace.record_tile_ownership(
                         tile_index,

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -407,6 +407,29 @@ mod tests {
                 ..
             })
         ));
+        let traced = tiled
+            .polygonize_with_trace(TraceLevelV1::Full, usize::MAX)
+            .unwrap();
+        let boundary_events: Vec<_> = traced
+            .trace
+            .events
+            .iter()
+            .filter(|event| event.kind == "tile_input_boundary")
+            .collect();
+        assert_eq!(boundary_events.len(), 4);
+        assert_eq!(boundary_events[0].payload["tile_index"], 0);
+        assert_eq!(boundary_events[0].payload["input_geometry_index"], 0);
+        assert_eq!(boundary_events[0].payload["unresolved_sides"][0], "max_x");
+        let bounded = tiled.polygonize_with_trace(TraceLevelV1::Full, 0).unwrap();
+        assert!(bounded.trace.events.is_empty());
+        assert!(bounded.trace.truncated);
+        assert_eq!(
+            bounded
+                .result
+                .stitching_report
+                .unresolved_input_geometry_count,
+            4
+        );
     }
 
     #[test]

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -280,6 +280,15 @@ pub struct TileOwnershipTraceV1 {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct TileInputBoundaryTraceV1 {
+    pub tile_index: usize,
+    pub input_geometry_index: usize,
+    pub geometry_min: CoordinateFingerprintV1,
+    pub geometry_max: CoordinateFingerprintV1,
+    pub unresolved_sides: Vec<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct TileDedupTraceV1 {
     pub polygon_index: usize,
     pub retained: bool,
@@ -1018,6 +1027,39 @@ impl TraceRecorderV1 {
             .expect("tile ownership trace event serializes"),
         );
         Ok(())
+    }
+
+    pub(crate) fn record_tile_input_boundary(
+        &mut self,
+        tile_index: usize,
+        issue: &crate::tiling::TileInputBoundaryIssue,
+    ) -> crate::Result<bool> {
+        let side = |side| match side {
+            crate::tiling::TileBoundarySide::MinX => "min_x",
+            crate::tiling::TileBoundarySide::MaxX => "max_x",
+            crate::tiling::TileBoundarySide::MinY => "min_y",
+            crate::tiling::TileBoundarySide::MaxY => "max_y",
+        };
+        let min = issue.geometry_bbox.min();
+        let max = issue.geometry_bbox.max();
+        Ok(self.record(
+            TraceStageV1::Output,
+            "tile_input_boundary",
+            serde_json::to_value(TileInputBoundaryTraceV1 {
+                tile_index,
+                input_geometry_index: issue.input_geometry_index,
+                geometry_min: coordinate_fingerprint(crate::Coord3D::new(min.x, min.y, 0.0))?,
+                geometry_max: coordinate_fingerprint(crate::Coord3D::new(max.x, max.y, 0.0))?,
+                unresolved_sides: issue
+                    .unresolved_sides
+                    .iter()
+                    .copied()
+                    .map(side)
+                    .map(str::to_string)
+                    .collect(),
+            })
+            .expect("tile input-boundary trace event serializes"),
+        ))
     }
 
     pub(crate) fn record_tile_dedup(&mut self, polygon_index: usize, retained: bool) {

--- a/docs/guide/tiling.md
+++ b/docs/guide/tiling.md
@@ -38,7 +38,8 @@ reaches beyond that halo. This conservative witness remains available when no
 local face is reconstructed, so it catches split-boundary cases that face-only
 evidence cannot see. It reports unresolved connectivity, not a confirmed missing
 face: whole input geometries are replicated and may already contain everything
-needed locally.
+needed locally. Full output traces record the same evidence as bounded
+`tile_input_boundary` events without rescanning inputs.
 
 ## Ownership and deduplication
 


### PR DESCRIPTION
## Stack

Parent:
- #1138

This PR:
- Records physical tiled input-boundary evidence in bounded topology traces.

Children:
- #1141

## Delivered

- Added deterministic `tile_input_boundary` output events.
- Records tile index, stable input geometry index, exact envelope coordinates, and ordered boundary sides.
- Reuses tile-report evidence from the physical pass without rescanning inputs.
- Stops event emission when the existing trace byte budget is exhausted.
- Added exact event-order/payload and zero-byte-budget regressions.

## Contract impact

- Additive event kind in the experimental topology trace.
- Polygon results and tile reports are unchanged.
- Trace truncation does not alter coverage diagnostics.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo clippy --locked -p geo-polygonize-core --all-targets -- -D warnings` — passed
- Input-boundary trace regression with default features — passed
- Input-boundary trace regression with `--no-default-features` — passed
- Existing tile ownership/dedup trace regression — passed
- `git diff --check` — passed

## Agent handoff

Remaining:
- Classify connected input regions excluded from every halo.
- Add retry/fallback events only after those execution paths exist.
- Preserve the current bounded trace behavior when recovery is introduced.

Next dependency-ready slice:
- #1141 adds the matching bounded owned-face boundary event family.
