### PR TITLE
feat(core): trace tiled owned-face boundaries

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -690,8 +690,8 @@ and complete aggregate source IDs when provenance is enabled. Conservative
 input-boundary evidence now retains stable input geometry indexes, envelopes,
 and internal halo sides even when no local face was reconstructed. Missing
 connected regions are not yet classified conclusively. Bounded full traces reuse
-that physical-pass evidence as `tile_input_boundary` events, so the
-coverage-detection rows remain open.
+that physical-pass evidence as `tile_input_boundary` and
+`tile_owned_face_boundary` events, so the coverage-detection rows remain open.
 
 - [ ] Detect owned faces or connected regions that touch an unresolved halo or
   partition boundary.

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -516,6 +516,11 @@ impl<'a> TiledPolygonizer<'a> {
                         break;
                     }
                 }
+                for issue in &report.coverage_issues {
+                    if !trace.record_tile_owned_face_boundary(tile_index, issue)? {
+                        break;
+                    }
+                }
                 for (polygon_index, ownership_point, owned) in ownership_decisions {
                     trace.record_tile_ownership(
                         tile_index,

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -326,6 +326,21 @@ mod tests {
         assert!(issues[0].aggregate_source_line_ids.is_empty());
         assert_eq!(result.stitching_report.unresolved_tile_count, 1);
         assert_eq!(result.stitching_report.unresolved_owned_polygon_count, 1);
+        let traced = tiler
+            .polygonize_with_trace(TraceLevelV1::Full, usize::MAX)
+            .unwrap();
+        let event = traced
+            .trace
+            .events
+            .iter()
+            .find(|event| event.kind == "tile_owned_face_boundary")
+            .unwrap();
+        assert_eq!(event.payload["polygon_index"], 0);
+        assert_eq!(event.payload["unresolved_sides"][0], "min_x");
+        assert!(!event.payload["representative_source_line_ids"]
+            .as_array()
+            .unwrap()
+            .is_empty());
 
         let mut tiler = TiledPolygonizer::new(bbox, 10.0)
             .with_buffer(2.0)

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -289,6 +289,17 @@ pub struct TileInputBoundaryTraceV1 {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct TileOwnedFaceBoundaryTraceV1 {
+    pub tile_index: usize,
+    pub polygon_index: usize,
+    pub polygon_min: CoordinateFingerprintV1,
+    pub polygon_max: CoordinateFingerprintV1,
+    pub unresolved_sides: Vec<String>,
+    pub representative_source_line_ids: Vec<String>,
+    pub aggregate_source_line_ids: Vec<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct TileDedupTraceV1 {
     pub polygon_index: usize,
     pub retained: bool,
@@ -1034,12 +1045,6 @@ impl TraceRecorderV1 {
         tile_index: usize,
         issue: &crate::tiling::TileInputBoundaryIssue,
     ) -> crate::Result<bool> {
-        let side = |side| match side {
-            crate::tiling::TileBoundarySide::MinX => "min_x",
-            crate::tiling::TileBoundarySide::MaxX => "max_x",
-            crate::tiling::TileBoundarySide::MinY => "min_y",
-            crate::tiling::TileBoundarySide::MaxY => "max_y",
-        };
         let min = issue.geometry_bbox.min();
         let max = issue.geometry_bbox.max();
         Ok(self.record(
@@ -1054,11 +1059,41 @@ impl TraceRecorderV1 {
                     .unresolved_sides
                     .iter()
                     .copied()
-                    .map(side)
+                    .map(tile_boundary_side_name)
                     .map(str::to_string)
                     .collect(),
             })
             .expect("tile input-boundary trace event serializes"),
+        ))
+    }
+
+    pub(crate) fn record_tile_owned_face_boundary(
+        &mut self,
+        tile_index: usize,
+        issue: &crate::tiling::TileCoverageIssue,
+    ) -> crate::Result<bool> {
+        let min = issue.polygon_bbox.min();
+        let max = issue.polygon_bbox.max();
+        let source_ids = |ids: &[u32]| ids.iter().map(|id| format!("0x{id:08x}")).collect();
+        Ok(self.record(
+            TraceStageV1::Output,
+            "tile_owned_face_boundary",
+            serde_json::to_value(TileOwnedFaceBoundaryTraceV1 {
+                tile_index,
+                polygon_index: issue.polygon_index,
+                polygon_min: coordinate_fingerprint(crate::Coord3D::new(min.x, min.y, 0.0))?,
+                polygon_max: coordinate_fingerprint(crate::Coord3D::new(max.x, max.y, 0.0))?,
+                unresolved_sides: issue
+                    .unresolved_sides
+                    .iter()
+                    .copied()
+                    .map(tile_boundary_side_name)
+                    .map(str::to_string)
+                    .collect(),
+                representative_source_line_ids: source_ids(&issue.representative_source_line_ids),
+                aggregate_source_line_ids: source_ids(&issue.aggregate_source_line_ids),
+            })
+            .expect("tile owned-face boundary trace event serializes"),
         ))
     }
 
@@ -1080,6 +1115,15 @@ impl TraceRecorderV1 {
             kind,
             serde_json::to_value(ring).expect("ring trace event serializes"),
         )
+    }
+}
+
+fn tile_boundary_side_name(side: crate::tiling::TileBoundarySide) -> &'static str {
+    match side {
+        crate::tiling::TileBoundarySide::MinX => "min_x",
+        crate::tiling::TileBoundarySide::MaxX => "max_x",
+        crate::tiling::TileBoundarySide::MinY => "min_y",
+        crate::tiling::TileBoundarySide::MaxY => "max_y",
     }
 }
 

--- a/docs/guide/tiling.md
+++ b/docs/guide/tiling.md
@@ -38,8 +38,9 @@ reaches beyond that halo. This conservative witness remains available when no
 local face is reconstructed, so it catches split-boundary cases that face-only
 evidence cannot see. It reports unresolved connectivity, not a confirmed missing
 face: whole input geometries are replicated and may already contain everything
-needed locally. Full output traces record the same evidence as bounded
-`tile_input_boundary` events without rescanning inputs.
+needed locally. Full output traces record both evidence families as bounded
+`tile_input_boundary` and `tile_owned_face_boundary` events without rescanning
+inputs or reconstructed faces.
 
 ## Ownership and deduplication
 


### PR DESCRIPTION
## Stack

Parent:
- #1140

This PR:
- Records reconstructed owned-face boundary evidence in bounded topology traces.

Children:
- #1142

## Delivered

- Added deterministic `tile_owned_face_boundary` output events.
- Records tile/polygon indexes, exact polygon envelope, ordered sides, and representative/aggregate source IDs.
- Reuses the tile report from the physical pass without rescanning faces.
- Shares the boundary-side encoding with input-boundary trace events.
- Added exact payload regression coverage under default and no-default feature builds.

## Contract impact

- Additive event kind in the experimental topology trace.
- Polygon results, provenance, and tile reports are unchanged.
- Existing trace byte limits apply to the new event family.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo clippy --locked -p geo-polygonize-core --all-targets -- -D warnings` — passed
- Owned-face boundary trace regression with default features — passed
- Owned-face boundary trace regression with `--no-default-features` — passed
- `git diff --check` — passed

## Agent handoff

Remaining:
- Build a real connected-input classification before claiming missing-region coverage.
- Add bounded retry/fallback only after that classifier identifies a safe unresolved region.
- Record retry/fallback events only when those paths exist.

Next dependency-ready slice:
- #1142 pins the wholly excluded connected-component gap before classifier work.
