### PR TITLE
test(core): pin excluded tiled component gap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -695,6 +695,8 @@ that physical-pass evidence as `tile_input_boundary` and
 
 - [ ] Detect owned faces or connected regions that touch an unresolved halo or
   partition boundary.
+  - [x] Pin the excluded-component gap where untiled output contains a face but
+    no member geometry intersects any tile halo.
 - [ ] Report source IDs and boundary evidence that were required but not fully
   observed.
 - [ ] Add explicit guarantee levels such as `BestEffort` and

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -448,6 +448,46 @@ mod tests {
     }
 
     #[test]
+    fn documents_component_excluded_from_every_halo() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 20.0 });
+        let boundaries = [
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: -10.0, y: -10.0 },
+                Coord { x: 30.0, y: -10.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 30.0, y: -10.0 },
+                Coord { x: 30.0, y: 30.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 30.0, y: 30.0 },
+                Coord { x: -10.0, y: 30.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: -10.0, y: 30.0 },
+                Coord { x: -10.0, y: -10.0 },
+            ])),
+        ];
+        let mut untiled = Polygonizer::new();
+        let mut tiled = TiledPolygonizer::new(bbox, 10.0).with_buffer(2.0);
+        for boundary in &boundaries {
+            untiled.add_borrowed_geometry(boundary);
+            tiled.add_geometry(boundary);
+        }
+
+        assert_eq!(untiled.polygonize().unwrap().polygons.len(), 1);
+        let observed = tiled.polygonize().unwrap();
+        assert!(observed.polygons.is_empty());
+        assert_eq!(observed.stitching_report.unresolved_input_geometry_count, 0);
+        assert_eq!(observed.stitching_report.unresolved_owned_polygon_count, 0);
+        assert!(tiled
+            .polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateObservedCoverage)
+            .unwrap()
+            .polygons
+            .is_empty());
+    }
+
+    #[test]
     fn validated_owned_face_coverage_rejects_reported_halo_escape() {
         let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 10.0 });
         let face = Geometry::LineString(LineString::new(vec![

--- a/docs/guide/tiling.md
+++ b/docs/guide/tiling.md
@@ -80,6 +80,9 @@ returned to the caller.
 Both validation modes are deliberately narrower than coverage certification.
 They cannot certify missing connected regions whose geometry was excluded from
 every halo.
+The checked-in excluded-component fixture demonstrates this boundary explicitly:
+untiled polygonization reconstructs an enclosing face while every tiled halo
+observes no member geometry, no face, and no coverage issue.
 There is currently no halo retry, unresolved-region retry, untiled fallback, or
 retry budget. No retry or fallback trace event is emitted because those execution
 paths do not exist.


### PR DESCRIPTION
## Stack

Parent:
- #1141

This PR:
- Pins the remaining wholly excluded connected-component coverage gap.

Children:
- not opened yet

## Delivered

- Added a fixture whose separate boundary geometries enclose the ownership grid but miss every configured halo.
- Proves untiled polygonization returns one face while tiled best-effort returns none.
- Proves neither owned-face nor input-boundary evidence fires.
- Proves `ValidateObservedCoverage` remains intentionally narrower than certification.
- Records the exact limitation in the roadmap and tiling guide.

## Contract impact

- Test and documentation only.
- No production behavior or API changes.
- Prevents future work from silently calling observed-evidence validation a coverage certificate.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo clippy --locked -p geo-polygonize-core --all-targets -- -D warnings` — passed
- Excluded-component fixture with default features — passed
- Excluded-component fixture with `--no-default-features` — passed
- `git diff --check` — passed

## Agent handoff

Remaining:
- Derive real input-component connectivity and envelopes.
- Surface excluded components conservatively without turning every global bbox into a false positive.
- Only then introduce `ValidateCoverage` and bounded recovery.

Next dependency-ready slice:
- Start from this fixture with exact endpoint-connected component classification; reuse existing geometry traversal and avoid introducing a second noder.
