### PR TITLE
feat(core): report excluded tiled endpoint components

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -689,7 +689,10 @@ with internal boundary sides, polygon envelopes, representative edge source IDs,
 and complete aggregate source IDs when provenance is enabled. Conservative
 input-boundary evidence now retains stable input geometry indexes, envelopes,
 and internal halo sides even when no local face was reconstructed. Missing
-connected regions are not yet classified conclusively. Bounded full traces reuse
+regions formed by separate input geometries that share exact endpoints now
+produce conservative excluded-component evidence when their combined envelope
+intersects a halo but no member geometry does. Connections created at
+mid-segment intersections are not yet classified. Bounded full traces reuse
 that physical-pass evidence as `tile_input_boundary` and
 `tile_owned_face_boundary` events, so the coverage-detection rows remain open.
 
@@ -697,6 +700,9 @@ that physical-pass evidence as `tile_input_boundary` and
   partition boundary.
   - [x] Pin the excluded-component gap where untiled output contains a face but
     no member geometry intersects any tile halo.
+  - [x] Report conservative excluded-component evidence for separate input
+    geometries connected by exact shared endpoints; intersection-connected
+    components remain open.
 - [ ] Report source IDs and boundary evidence that were required but not fully
   observed.
 - [ ] Add explicit guarantee levels such as `BestEffort` and

--- a/crates/geo-polygonize-core/src/lib.rs
+++ b/crates/geo-polygonize-core/src/lib.rs
@@ -66,7 +66,7 @@ pub use polygonizer::{
 #[doc(hidden)]
 pub use tiling::{
     StitchingReport, TileBoundarySide, TileCoverageGuarantee, TileCoverageIssue,
-    TileInputBoundaryIssue, TileReport, TiledPolygonizeError, TiledPolygonizeResult,
-    TiledPolygonizer, TracedTiledPolygonizeResultV1,
+    TileExcludedComponentIssue, TileInputBoundaryIssue, TileReport, TiledPolygonizeError,
+    TiledPolygonizeResult, TiledPolygonizer, TracedTiledPolygonizeResultV1,
 };
 pub use types::{Coord3D, Line3D, Polygon3D, PolygonProvenance};

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -9,10 +9,10 @@ use crate::{PolygonizeError, Polygonizer, PolygonizerOptions, Result};
 use geo::bounding_rect::BoundingRect;
 use geo::intersects::Intersects;
 use geo::InteriorPoint;
-use geo_types::{Coord, Geometry, Point, Rect};
+use geo_types::{Coord, Geometry, LineString, Point, Rect};
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use thiserror::Error;
 
 fn canonical_ring_key(ring: &[Coord3D]) -> Vec<[u64; 3]> {
@@ -66,6 +66,17 @@ pub struct TileInputBoundaryIssue {
     pub unresolved_sides: Vec<TileBoundarySide>,
 }
 
+/// An exact-endpoint-connected input component excluded from a tile halo.
+///
+/// The component envelope intersects the buffered tile, but none of its member
+/// geometry envelopes do. This is conservative evidence, not proof that the
+/// component contains a face.
+#[derive(Clone, Debug)]
+pub struct TileExcludedComponentIssue {
+    pub input_geometry_indices: Vec<usize>,
+    pub component_bbox: Rect<f64>,
+}
+
 /// Observed work and topology output for one tile.
 #[derive(Debug)]
 pub struct TileReport {
@@ -82,6 +93,8 @@ pub struct TileReport {
     pub coverage_issues: Vec<TileCoverageIssue>,
     /// Inputs that may connect to linework beyond this tile's halo.
     pub input_boundary_issues: Vec<TileInputBoundaryIssue>,
+    /// Exact-endpoint-connected components excluded from this tile's halo.
+    pub excluded_component_issues: Vec<TileExcludedComponentIssue>,
 }
 
 /// Counts from merging and deduplicating owned tile polygons.
@@ -97,6 +110,9 @@ pub struct StitchingReport {
     pub unresolved_input_tile_count: usize,
     /// Input-boundary issue instances across tiles; a geometry may occur more than once.
     pub unresolved_input_geometry_count: usize,
+    pub unresolved_component_tile_count: usize,
+    /// Excluded-component issue instances across tiles; a component may occur more than once.
+    pub unresolved_component_count: usize,
 }
 
 /// Experimental tiled output with per-tile and merge diagnostics.
@@ -151,6 +167,82 @@ pub struct TracedTiledPolygonizeResultV1 {
 
 type TileOwnershipDecision = (usize, Option<Coord3D>, bool);
 type TileProcessResult = (Vec<Polygon3D>, TileReport, Vec<TileOwnershipDecision>, bool);
+
+#[derive(Debug)]
+struct EndpointComponent {
+    input_geometry_indices: Vec<usize>,
+    bbox: Rect<f64>,
+}
+
+fn endpoint_bits(value: f64) -> u64 {
+    if value == 0.0 {
+        0.0f64.to_bits()
+    } else {
+        value.to_bits()
+    }
+}
+
+fn line_string_endpoints(line: &LineString<f64>, endpoints: &mut Vec<Coord<f64>>) {
+    if let Some(first) = line.0.first() {
+        endpoints.push(*first);
+    }
+    if let Some(last) = line.0.last() {
+        endpoints.push(*last);
+    }
+}
+
+fn geometry_endpoints(geometry: &Geometry<f64>, endpoints: &mut Vec<Coord<f64>>) {
+    match geometry {
+        Geometry::LineString(line) => line_string_endpoints(line, endpoints),
+        Geometry::MultiLineString(lines) => {
+            for line in lines {
+                line_string_endpoints(line, endpoints);
+            }
+        }
+        Geometry::Polygon(polygon) => {
+            line_string_endpoints(polygon.exterior(), endpoints);
+            for ring in polygon.interiors() {
+                line_string_endpoints(ring, endpoints);
+            }
+        }
+        Geometry::MultiPolygon(polygons) => {
+            for polygon in polygons {
+                line_string_endpoints(polygon.exterior(), endpoints);
+                for ring in polygon.interiors() {
+                    line_string_endpoints(ring, endpoints);
+                }
+            }
+        }
+        Geometry::GeometryCollection(collection) => {
+            for member in collection {
+                geometry_endpoints(member, endpoints);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn component_root(parents: &mut [usize], index: usize) -> usize {
+    let mut root = index;
+    while parents[root] != root {
+        root = parents[root];
+    }
+    let mut current = index;
+    while parents[current] != current {
+        let next = parents[current];
+        parents[current] = root;
+        current = next;
+    }
+    root
+}
+
+fn join_components(parents: &mut [usize], left: usize, right: usize) {
+    let left = component_root(parents, left);
+    let right = component_root(parents, right);
+    if left != right {
+        parents[left.max(right)] = left.min(right);
+    }
+}
 
 /// Experimental tiled polygonization.
 ///
@@ -210,6 +302,7 @@ impl<'a> TiledPolygonizer<'a> {
     fn process_tile(
         &self,
         tile_bbox: Rect<f64>,
+        endpoint_components: &[EndpointComponent],
         capture_byte_limit: Option<usize>,
     ) -> Result<TileProcessResult> {
         let mut capture_budget = capture_byte_limit.map(TraceCaptureBudget::new);
@@ -247,6 +340,21 @@ impl<'a> TiledPolygonizer<'a> {
                 }
             }
         }
+        let excluded_component_issues = endpoint_components
+            .iter()
+            .filter(|component| {
+                component.bbox.intersects(&buffered_bbox)
+                    && component.input_geometry_indices.iter().all(|&index| {
+                        self.geometries[index]
+                            .1
+                            .is_none_or(|bbox| !bbox.intersects(&buffered_bbox))
+                    })
+            })
+            .map(|component| TileExcludedComponentIssue {
+                input_geometry_indices: component.input_geometry_indices.clone(),
+                component_bbox: component.bbox,
+            })
+            .collect();
 
         let mut report = TileReport {
             tile_bbox,
@@ -258,6 +366,7 @@ impl<'a> TiledPolygonizer<'a> {
             invalid_ring_count: 0,
             coverage_issues: Vec::new(),
             input_boundary_issues,
+            excluded_component_issues,
         };
         if relevant_lines == 0 {
             return Ok((Vec::new(), report, Vec::new(), false));
@@ -424,6 +533,56 @@ impl<'a> TiledPolygonizer<'a> {
         tiles
     }
 
+    fn endpoint_components(&self) -> Vec<EndpointComponent> {
+        let mut parents = (0..self.geometries.len()).collect::<Vec<_>>();
+        let mut endpoint_owners = HashMap::new();
+        let mut endpoints = Vec::new();
+        for (geometry_index, (geometry, _)) in self.geometries.iter().enumerate() {
+            endpoints.clear();
+            geometry_endpoints(geometry, &mut endpoints);
+            for endpoint in &endpoints {
+                let key = (endpoint_bits(endpoint.x), endpoint_bits(endpoint.y));
+                if let Some(previous) = endpoint_owners.insert(key, geometry_index) {
+                    join_components(&mut parents, previous, geometry_index);
+                }
+            }
+        }
+
+        let mut members = HashMap::<usize, Vec<usize>>::new();
+        for geometry_index in 0..self.geometries.len() {
+            let root = component_root(&mut parents, geometry_index);
+            members.entry(root).or_default().push(geometry_index);
+        }
+        let mut components = members
+            .into_values()
+            .filter(|indices| indices.len() > 1)
+            .filter_map(|input_geometry_indices| {
+                let mut bounds = input_geometry_indices
+                    .iter()
+                    .filter_map(|&index| self.geometries[index].1);
+                let first = bounds.next()?;
+                let bbox = bounds.fold(first, |bbox, next| {
+                    Rect::new(
+                        Coord {
+                            x: bbox.min().x.min(next.min().x),
+                            y: bbox.min().y.min(next.min().y),
+                        },
+                        Coord {
+                            x: bbox.max().x.max(next.max().x),
+                            y: bbox.max().y.max(next.max().y),
+                        },
+                    )
+                });
+                Some(EndpointComponent {
+                    input_geometry_indices,
+                    bbox,
+                })
+            })
+            .collect::<Vec<_>>();
+        components.sort_unstable_by_key(|component| component.input_geometry_indices[0]);
+        components
+    }
+
     pub fn polygonize(&self) -> Result<TiledPolygonizeResult> {
         self.polygonize_impl(None)
     }
@@ -487,12 +646,14 @@ impl<'a> TiledPolygonizer<'a> {
     ) -> Result<TiledPolygonizeResult> {
         self.validate()?;
         let tiles = self.generate_tiles();
-        self.polygonize_tiles(tiles, trace)
+        let endpoint_components = self.endpoint_components();
+        self.polygonize_tiles(tiles, &endpoint_components, trace)
     }
 
     fn polygonize_tiles(
         &self,
         tiles: Vec<Rect<f64>>,
+        endpoint_components: &[EndpointComponent],
         mut trace: Option<&mut TraceRecorderV1>,
     ) -> Result<TiledPolygonizeResult> {
         let trace_ownership = trace
@@ -509,7 +670,7 @@ impl<'a> TiledPolygonizer<'a> {
                         .then(|| trace.capture_byte_limit(TraceStageV1::Output))
                 });
                 let (polygons, report, ownership_decisions, capture_truncated) =
-                    self.process_tile(tile, capture_byte_limit)?;
+                    self.process_tile(tile, endpoint_components, capture_byte_limit)?;
                 let trace = trace.as_deref_mut().expect("tile trace exists");
                 for issue in &report.input_boundary_issues {
                     if !trace.record_tile_input_boundary(tile_index, issue)? {
@@ -539,12 +700,12 @@ impl<'a> TiledPolygonizer<'a> {
             #[cfg(feature = "parallel")]
             let tile_results: Vec<_> = tiles
                 .into_par_iter()
-                .map(|tile| self.process_tile(tile, None))
+                .map(|tile| self.process_tile(tile, endpoint_components, None))
                 .collect();
             #[cfg(not(feature = "parallel"))]
             let tile_results: Vec<_> = tiles
                 .into_iter()
-                .map(|tile| self.process_tile(tile, None))
+                .map(|tile| self.process_tile(tile, endpoint_components, None))
                 .collect();
 
             for result in tile_results {
@@ -611,6 +772,13 @@ impl<'a> TiledPolygonizer<'a> {
         let unresolved_input_geometry_count = tile_reports.iter().fold(0usize, |total, report| {
             total.saturating_add(report.input_boundary_issues.len())
         });
+        let unresolved_component_tile_count = tile_reports
+            .iter()
+            .filter(|report| !report.excluded_component_issues.is_empty())
+            .count();
+        let unresolved_component_count = tile_reports.iter().fold(0usize, |total, report| {
+            total.saturating_add(report.excluded_component_issues.len())
+        });
         Ok(TiledPolygonizeResult {
             polygons,
             tile_reports,
@@ -622,6 +790,8 @@ impl<'a> TiledPolygonizer<'a> {
                 unresolved_owned_polygon_count,
                 unresolved_input_tile_count,
                 unresolved_input_geometry_count,
+                unresolved_component_tile_count,
+                unresolved_component_count,
             },
         })
     }

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -480,6 +480,15 @@ mod tests {
         assert!(observed.polygons.is_empty());
         assert_eq!(observed.stitching_report.unresolved_input_geometry_count, 0);
         assert_eq!(observed.stitching_report.unresolved_owned_polygon_count, 0);
+        assert_eq!(observed.stitching_report.unresolved_component_tile_count, 4);
+        assert_eq!(observed.stitching_report.unresolved_component_count, 4);
+        for report in &observed.tile_reports {
+            assert_eq!(report.excluded_component_issues.len(), 1);
+            let issue = &report.excluded_component_issues[0];
+            assert_eq!(issue.input_geometry_indices, vec![0, 1, 2, 3]);
+            assert_eq!(issue.component_bbox.min(), Coord { x: -10.0, y: -10.0 });
+            assert_eq!(issue.component_bbox.max(), Coord { x: 30.0, y: 30.0 });
+        }
         assert!(tiled
             .polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateObservedCoverage)
             .unwrap()
@@ -545,7 +554,10 @@ mod tests {
             state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
             tiles.swap(upper, (state as usize) % (upper + 1));
         }
-        let permuted = tiler.polygonize_tiles(tiles, None).unwrap();
+        let endpoint_components = tiler.endpoint_components();
+        let permuted = tiler
+            .polygonize_tiles(tiles, &endpoint_components, None)
+            .unwrap();
 
         assert_eq!(permuted.polygons.len(), forward.polygons.len());
         assert_eq!(permuted.polygons[0].exterior, forward.polygons[0].exterior);

--- a/docs/guide/tiling.md
+++ b/docs/guide/tiling.md
@@ -42,6 +42,15 @@ needed locally. Full output traces record both evidence families as bounded
 `tile_input_boundary` and `tile_owned_face_boundary` events without rescanning
 inputs or reconstructed faces.
 
+`TileReport::excluded_component_issues` covers one additional missing-input
+case. Separate input geometries that share exact endpoints are grouped, and a
+tile reports the component when its combined envelope intersects the buffered
+tile but no member geometry envelope does. This catches an enclosing component
+that is excluded from every halo. It remains conservative: an envelope does not
+prove that the component contains a face, and connections created only by
+mid-segment intersections are not grouped. `StitchingReport` counts affected
+tiles and issue instances.
+
 ## Ownership and deduplication
 
 Tiles use half-open `[min, max)` ownership intervals, except that the final row
@@ -78,11 +87,9 @@ returned to the caller.
   conservative input-boundary evidence is present.
 
 Both validation modes are deliberately narrower than coverage certification.
-They cannot certify missing connected regions whose geometry was excluded from
-every halo.
-The checked-in excluded-component fixture demonstrates this boundary explicitly:
-untiled polygonization reconstructs an enclosing face while every tiled halo
-observes no member geometry, no face, and no coverage issue.
+Excluded exact-endpoint component evidence is reported but is not yet rejected
+by either mode. Connections created at mid-segment intersections also remain
+outside the detector.
 There is currently no halo retry, unresolved-region retry, untiled fallback, or
 retry budget. No retry or fallback trace event is emitted because those execution
 paths do not exist.


### PR DESCRIPTION
## Stack

Parent:
- `main`

This PR:
- Reports exact-endpoint-connected input components excluded from buffered tile input.

Children:
- #1144

## Delivered

- Groups separate input geometries through exact shared endpoints with normalized signed zero.
- Reports component member indexes and combined envelopes when every member is excluded from a relevant halo.
- Adds stitching counts and upgrades the pinned excluded-component regression.
- Documents the conservative evidence boundary and the remaining mid-segment/intersection gap.

## Contract impact

- Additive experimental Rust-only report fields and type.
- BestEffort and validation behavior are unchanged in this parent slice.
- This evidence does not certify that a component contains a face.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings` — passed
- `cargo test -p geo-polygonize-core` — passed, 216 unit tests plus integration suites
- `cargo test -p geo-polygonize-core --no-default-features` — passed, 216 unit tests plus integration suites
- `RUSTDOCFLAGS=-D warnings cargo doc -p geo-polygonize-core --no-deps` — passed

## Agent handoff

Remaining:
- Reject excluded endpoint-component evidence under strict observed coverage.
- Trace the physical evidence with bounded capture.
- Classify components connected only through mid-segment intersections.

Next dependency-ready slice:
- #1144 extends `ValidateObservedCoverage` and its typed error counts.