### PR TITLE
fix(core): validate excluded tiled endpoint components

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -711,6 +711,8 @@ that physical-pass evidence as `tile_input_boundary` and
     subset; missing-region coverage certification remains open.
   - [x] Add `ValidateObservedCoverage` to reject either owned-face or
     conservative input-boundary evidence without claiming certification.
+  - [x] Extend `ValidateObservedCoverage` to reject conservative excluded
+    exact-endpoint component evidence without claiming certification.
 - [x] Randomize tile origins, sizes, input orders, and tile traversal order in
   deterministic metamorphic tests with sufficient halos.
 - [ ] Expand exact tiled/untiled fixtures for nested disconnected rings, long

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -134,7 +134,8 @@ pub enum TileCoverageGuarantee {
     /// This validates reconstructed owned faces only. It cannot detect a region
     /// that is absent because its closing linework fell outside every tile halo.
     ValidateOwnedFaces,
-    /// Reject output when either owned-face or input-boundary evidence is present.
+    /// Reject output when owned-face, input-boundary, or excluded endpoint-component evidence is
+    /// present.
     ///
     /// This validates the observed evidence only. It does not certify connected
     /// regions whose geometry never intersected a tile halo.
@@ -147,13 +148,15 @@ pub enum TiledPolygonizeError {
     #[error(transparent)]
     Polygonize(#[from] PolygonizeError),
     #[error(
-        "tiled coverage validation failed for {unresolved_owned_polygon_count} owned polygons and {unresolved_input_geometry_count} input boundary instances"
+        "tiled coverage validation failed for {unresolved_owned_polygon_count} owned polygons, {unresolved_input_geometry_count} input boundary instances, and {unresolved_component_count} excluded endpoint-component instances"
     )]
     CoverageIncomplete {
         unresolved_tile_count: usize,
         unresolved_owned_polygon_count: usize,
         unresolved_input_tile_count: usize,
         unresolved_input_geometry_count: usize,
+        unresolved_component_tile_count: usize,
+        unresolved_component_count: usize,
         tile_reports: Vec<TileReport>,
     },
 }
@@ -600,6 +603,7 @@ impl<'a> TiledPolygonizer<'a> {
             TileCoverageGuarantee::ValidateObservedCoverage => {
                 result.stitching_report.unresolved_owned_polygon_count != 0
                     || result.stitching_report.unresolved_input_geometry_count != 0
+                    || result.stitching_report.unresolved_component_count != 0
             }
         };
         if reject {
@@ -612,6 +616,10 @@ impl<'a> TiledPolygonizer<'a> {
                 unresolved_input_geometry_count: result
                     .stitching_report
                     .unresolved_input_geometry_count,
+                unresolved_component_tile_count: result
+                    .stitching_report
+                    .unresolved_component_tile_count,
+                unresolved_component_count: result.stitching_report.unresolved_component_count,
                 tile_reports: result.tile_reports,
             });
         }

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -490,10 +490,19 @@ mod tests {
             assert_eq!(issue.component_bbox.max(), Coord { x: 30.0, y: 30.0 });
         }
         assert!(tiled
+            .polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateOwnedFaces)
+            .is_ok());
+        let error = tiled
             .polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateObservedCoverage)
-            .unwrap()
-            .polygons
-            .is_empty());
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            TiledPolygonizeError::CoverageIncomplete {
+                unresolved_component_tile_count: 4,
+                unresolved_component_count: 4,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/docs/guide/tiling.md
+++ b/docs/guide/tiling.md
@@ -83,13 +83,12 @@ returned to the caller.
 - `BestEffort` preserves the existing output behavior and reports detected issues.
 - `ValidateOwnedFaces` returns `TiledPolygonizeError::CoverageIncomplete` instead
   of polygons when a reconstructed owned face reaches an internal halo boundary.
-- `ValidateObservedCoverage` returns that typed error when either owned-face or
-  conservative input-boundary evidence is present.
+- `ValidateObservedCoverage` returns that typed error when owned-face,
+  conservative input-boundary, or excluded exact-endpoint component evidence is
+  present.
 
 Both validation modes are deliberately narrower than coverage certification.
-Excluded exact-endpoint component evidence is reported but is not yet rejected
-by either mode. Connections created at mid-segment intersections also remain
-outside the detector.
+Connections created at mid-segment intersections remain outside the detector.
 There is currently no halo retry, unresolved-region retry, untiled fallback, or
 retry budget. No retry or fallback trace event is emitted because those execution
 paths do not exist.


### PR DESCRIPTION
## Stack

Parent:
- #1143

This PR:
- Makes strict observed-coverage validation reject excluded exact-endpoint component evidence.

Children:
- #1146

## Delivered

- Includes excluded component evidence in `ValidateObservedCoverage`.
- Carries affected-tile and issue-instance counts through the typed coverage error.
- Preserves `BestEffort` and `ValidateOwnedFaces` behavior.
- Converts the pinned excluded-component characterization into a strict-validation regression.

## Contract impact

- `ValidateObservedCoverage` now rejects one additional conservative evidence family.
- This does not claim certified coverage; mid-segment/intersection-connected components remain outside detection.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo test -p geo-polygonize-core documents_component_excluded_from_every_halo` — passed
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings` — passed

## Agent handoff

Remaining:
- Add bounded topology-trace evidence for excluded endpoint components.
- Classify components connected only through mid-segment intersections.

Next dependency-ready slice:
- #1146 records excluded endpoint-component reports as bounded physical-pass output trace events.