### PR TITLE
feat(core): trace excluded tiled endpoint components

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -693,8 +693,9 @@ regions formed by separate input geometries that share exact endpoints now
 produce conservative excluded-component evidence when their combined envelope
 intersects a halo but no member geometry does. Connections created at
 mid-segment intersections are not yet classified. Bounded full traces reuse
-that physical-pass evidence as `tile_input_boundary` and
-`tile_owned_face_boundary` events, so the coverage-detection rows remain open.
+that physical-pass evidence as `tile_input_boundary`,
+`tile_owned_face_boundary`, and `tile_excluded_endpoint_component` events, so
+the coverage-detection rows remain open.
 
 - [ ] Detect owned faces or connected regions that touch an unresolved halo or
   partition boundary.

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -680,6 +680,11 @@ impl<'a> TiledPolygonizer<'a> {
                 let (polygons, report, ownership_decisions, capture_truncated) =
                     self.process_tile(tile, endpoint_components, capture_byte_limit)?;
                 let trace = trace.as_deref_mut().expect("tile trace exists");
+                for issue in &report.excluded_component_issues {
+                    if !trace.record_tile_excluded_endpoint_component(tile_index, issue)? {
+                        break;
+                    }
+                }
                 for issue in &report.input_boundary_issues {
                     if !trace.record_tile_input_boundary(tile_index, issue)? {
                         break;

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -489,6 +489,28 @@ mod tests {
             assert_eq!(issue.component_bbox.min(), Coord { x: -10.0, y: -10.0 });
             assert_eq!(issue.component_bbox.max(), Coord { x: 30.0, y: 30.0 });
         }
+        let traced = tiled
+            .polygonize_with_trace(TraceLevelV1::Full, usize::MAX)
+            .unwrap();
+        let component_events = traced
+            .trace
+            .events
+            .iter()
+            .filter(|event| event.kind == "tile_excluded_endpoint_component")
+            .collect::<Vec<_>>();
+        assert_eq!(component_events.len(), 4);
+        assert_eq!(component_events[0].payload["tile_index"], 0);
+        assert_eq!(
+            component_events[0].payload["input_geometry_indices"],
+            serde_json::json!([0, 1, 2, 3])
+        );
+        let bounded = tiled.polygonize_with_trace(TraceLevelV1::Full, 0).unwrap();
+        assert!(bounded.trace.events.is_empty());
+        assert!(bounded.trace.truncated);
+        assert_eq!(
+            bounded.result.stitching_report.unresolved_component_count,
+            4
+        );
         assert!(tiled
             .polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateOwnedFaces)
             .is_ok());

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -289,6 +289,14 @@ pub struct TileInputBoundaryTraceV1 {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct TileExcludedEndpointComponentTraceV1 {
+    pub tile_index: usize,
+    pub input_geometry_indices: Vec<usize>,
+    pub component_min: CoordinateFingerprintV1,
+    pub component_max: CoordinateFingerprintV1,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct TileOwnedFaceBoundaryTraceV1 {
     pub tile_index: usize,
     pub polygon_index: usize,
@@ -1094,6 +1102,26 @@ impl TraceRecorderV1 {
                 aggregate_source_line_ids: source_ids(&issue.aggregate_source_line_ids),
             })
             .expect("tile owned-face boundary trace event serializes"),
+        ))
+    }
+
+    pub(crate) fn record_tile_excluded_endpoint_component(
+        &mut self,
+        tile_index: usize,
+        issue: &crate::tiling::TileExcludedComponentIssue,
+    ) -> crate::Result<bool> {
+        let min = issue.component_bbox.min();
+        let max = issue.component_bbox.max();
+        Ok(self.record(
+            TraceStageV1::Output,
+            "tile_excluded_endpoint_component",
+            serde_json::to_value(TileExcludedEndpointComponentTraceV1 {
+                tile_index,
+                input_geometry_indices: issue.input_geometry_indices.clone(),
+                component_min: coordinate_fingerprint(crate::Coord3D::new(min.x, min.y, 0.0))?,
+                component_max: coordinate_fingerprint(crate::Coord3D::new(max.x, max.y, 0.0))?,
+            })
+            .expect("tile excluded endpoint-component trace event serializes"),
         ))
     }
 

--- a/docs/guide/tiling.md
+++ b/docs/guide/tiling.md
@@ -49,7 +49,8 @@ tile but no member geometry envelope does. This catches an enclosing component
 that is excluded from every halo. It remains conservative: an envelope does not
 prove that the component contains a face, and connections created only by
 mid-segment intersections are not grouped. `StitchingReport` counts affected
-tiles and issue instances.
+tiles and issue instances. Full output traces reuse the report as bounded
+`tile_excluded_endpoint_component` events without rescanning input.
 
 ## Ownership and deduplication
 


### PR DESCRIPTION
## Stack

Parent:
- #1144

This PR:
- Records excluded exact-endpoint component evidence in bounded output traces.

Children:
- #1147

## Delivered

- Adds `tile_excluded_endpoint_component` output events with tile index, member geometry indexes, and component envelope.
- Reuses the physical tile report without rescanning input.
- Preserves report evidence when a zero-byte trace budget suppresses all events.

## Contract impact

- Additive topology trace event under the existing V1 envelope.
- Polygonization results and coverage validation behavior are unchanged relative to the parent.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo test -p geo-polygonize-core documents_component_excluded_from_every_halo` — passed
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings` — passed

## Agent handoff

Remaining:
- Classify components connected only through mid-segment intersections.
- Define the smallest deterministic recovery slice after coverage evidence is complete enough.

Next dependency-ready slice:
- #1147 pins the mid-segment-connected excluded-component gap without adding retry or graph stitching.