### PR TITLE
test(core): pin intersection-connected tiled coverage gap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -704,6 +704,8 @@ the coverage-detection rows remain open.
   - [x] Report conservative excluded-component evidence for separate input
     geometries connected by exact shared endpoints; intersection-connected
     components remain open.
+  - [x] Pin the excluded-component gap for separate input geometries connected
+    only through segment-interior intersections.
 - [ ] Report source IDs and boundary evidence that were required but not fully
   observed.
 - [ ] Add explicit guarantee levels such as `BestEffort` and

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -528,6 +528,48 @@ mod tests {
     }
 
     #[test]
+    fn documents_intersection_connected_component_excluded_from_every_halo() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 20.0 });
+        let boundaries = [
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: -20.0, y: -10.0 },
+                Coord { x: 40.0, y: -10.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 30.0, y: -20.0 },
+                Coord { x: 30.0, y: 40.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 40.0, y: 30.0 },
+                Coord { x: -20.0, y: 30.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: -10.0, y: 40.0 },
+                Coord { x: -10.0, y: -20.0 },
+            ])),
+        ];
+        let mut untiled = Polygonizer::with_options(PolygonizerOptions {
+            node_input: true,
+            ..Default::default()
+        });
+        let mut tiled = TiledPolygonizer::new(bbox, 10.0).with_buffer(2.0);
+        for boundary in &boundaries {
+            untiled.add_borrowed_geometry(boundary);
+            tiled.add_geometry(boundary);
+        }
+
+        assert_eq!(untiled.polygonize().unwrap().polygons.len(), 1);
+        let observed = tiled.polygonize().unwrap();
+        assert!(observed.polygons.is_empty());
+        assert_eq!(observed.stitching_report.unresolved_component_count, 0);
+        assert!(tiled
+            .polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateObservedCoverage)
+            .unwrap()
+            .polygons
+            .is_empty());
+    }
+
+    #[test]
     fn validated_owned_face_coverage_rejects_reported_halo_escape() {
         let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 10.0 });
         let face = Geometry::LineString(LineString::new(vec![


### PR DESCRIPTION
## Stack

Parent:
- #1146

This PR:
- Pins the remaining excluded-component gap when separate inputs connect only through segment-interior intersections.

Children:
- not opened yet

## Delivered

- Adds a four-segment enclosing fixture whose intersections occur only in segment interiors.
- Proves untiled noding reconstructs the face while every tiled halo excludes every member.
- Records that endpoint-component diagnostics remain empty and strict observed coverage currently accepts the incomplete result.

## Contract impact

- Test and roadmap evidence only; runtime behavior is unchanged.
- The regression prevents the remaining coverage boundary from being mistaken for certification.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo test -p geo-polygonize-core documents_intersection_connected_component_excluded_from_every_halo` — passed
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings` — passed

## Agent handoff

Remaining:
- Choose a live-accounted global connectivity scan or a less expensive conservative detector for intersection-connected excluded components.
- Add deterministic recovery only after that coverage boundary is explicit.

Next dependency-ready slice:
- Design the smallest intersection-component detector that reuses existing candidate infrastructure and does not duplicate full noding work.