### PR TITLE
feat(core): trace excluded tiled segment components

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -692,9 +692,9 @@ and internal halo sides even when no local face was reconstructed. Missing
 regions formed by separate input geometries that share exact endpoints or, when
 input noding is enabled, exact segment intersections now produce conservative
 excluded-component evidence when their combined envelope intersects a halo but
-no member geometry does. Endpoint-only components retain bounded full trace
-evidence; segment-intersection trace evidence remains open, so the
-coverage-detection rows remain open.
+no member geometry does. Bounded full traces distinguish endpoint-only and
+segment-intersection component evidence, so this specific missing-region gap is
+covered while the broader coverage-detection rows remain open.
 
 - [ ] Detect owned faces or connected regions that touch an unresolved halo or
   partition boundary.
@@ -707,6 +707,7 @@ coverage-detection rows remain open.
     only through segment-interior intersections.
   - [x] Classify exact segment-intersection components with one indexed global
     candidate pass when input noding is enabled.
+  - [x] Trace excluded segment-intersection components without rescanning input.
 - [ ] Report source IDs and boundary evidence that were required but not fully
   observed.
 - [ ] Add explicit guarantee levels such as `BestEffort` and

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -780,12 +780,16 @@ impl<'a> TiledPolygonizer<'a> {
                 let (polygons, report, ownership_decisions, capture_truncated) =
                     self.process_tile(tile, input_components, capture_byte_limit)?;
                 let trace = trace.as_deref_mut().expect("tile trace exists");
-                for issue in report
-                    .excluded_component_issues
-                    .iter()
-                    .filter(|issue| issue.connection == TileComponentConnection::ExactEndpoint)
-                {
-                    if !trace.record_tile_excluded_endpoint_component(tile_index, issue)? {
+                for issue in &report.excluded_component_issues {
+                    let recorded = match issue.connection {
+                        TileComponentConnection::ExactEndpoint => {
+                            trace.record_tile_excluded_endpoint_component(tile_index, issue)?
+                        }
+                        TileComponentConnection::SegmentIntersection => {
+                            trace.record_tile_excluded_segment_component(tile_index, issue)?
+                        }
+                    };
+                    if !recorded {
                         break;
                     }
                 }

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -568,6 +568,28 @@ mod tests {
                 && report.excluded_component_issues[0].connection
                     == TileComponentConnection::SegmentIntersection
         }));
+        let traced = tiled
+            .polygonize_with_trace(TraceLevelV1::Full, usize::MAX)
+            .unwrap();
+        let events = traced
+            .trace
+            .events
+            .iter()
+            .filter(|event| event.kind == "tile_excluded_segment_component")
+            .collect::<Vec<_>>();
+        assert_eq!(events.len(), 4);
+        assert_eq!(events[0].payload["tile_index"], 0);
+        assert_eq!(
+            events[0].payload["input_geometry_indices"],
+            serde_json::json!([0, 1, 2, 3])
+        );
+        let bounded = tiled.polygonize_with_trace(TraceLevelV1::Full, 0).unwrap();
+        assert!(bounded.trace.events.is_empty());
+        assert!(bounded.trace.truncated);
+        assert_eq!(
+            bounded.result.stitching_report.unresolved_component_count,
+            4
+        );
         let error = tiled
             .polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateObservedCoverage)
             .unwrap_err();

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -297,6 +297,14 @@ pub struct TileExcludedEndpointComponentTraceV1 {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct TileExcludedSegmentComponentTraceV1 {
+    pub tile_index: usize,
+    pub input_geometry_indices: Vec<usize>,
+    pub component_min: CoordinateFingerprintV1,
+    pub component_max: CoordinateFingerprintV1,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct TileOwnedFaceBoundaryTraceV1 {
     pub tile_index: usize,
     pub polygon_index: usize,
@@ -1122,6 +1130,26 @@ impl TraceRecorderV1 {
                 component_max: coordinate_fingerprint(crate::Coord3D::new(max.x, max.y, 0.0))?,
             })
             .expect("tile excluded endpoint-component trace event serializes"),
+        ))
+    }
+
+    pub(crate) fn record_tile_excluded_segment_component(
+        &mut self,
+        tile_index: usize,
+        issue: &crate::tiling::TileExcludedComponentIssue,
+    ) -> crate::Result<bool> {
+        let min = issue.component_bbox.min();
+        let max = issue.component_bbox.max();
+        Ok(self.record(
+            TraceStageV1::Output,
+            "tile_excluded_segment_component",
+            serde_json::to_value(TileExcludedSegmentComponentTraceV1 {
+                tile_index,
+                input_geometry_indices: issue.input_geometry_indices.clone(),
+                component_min: coordinate_fingerprint(crate::Coord3D::new(min.x, min.y, 0.0))?,
+                component_max: coordinate_fingerprint(crate::Coord3D::new(max.x, max.y, 0.0))?,
+            })
+            .expect("tile excluded segment-component trace event serializes"),
         ))
     }
 

--- a/docs/guide/tiling.md
+++ b/docs/guide/tiling.md
@@ -51,9 +51,8 @@ does. This catches an enclosing component that is excluded from every halo. It
 remains conservative: an envelope does not prove that the component contains a
 face. `TileComponentConnection` distinguishes endpoint-only and
 segment-intersection evidence, and `StitchingReport` counts affected tiles and
-issue instances. Full output traces currently record endpoint-only evidence as
-bounded `tile_excluded_endpoint_component` events; intersection events are a
-separate pending trace slice.
+issue instances. Full output traces distinguish bounded
+`tile_excluded_endpoint_component` and `tile_excluded_segment_component` events.
 
 ## Ownership and deduplication
 


### PR DESCRIPTION
## Stack

Parent:
- #1148

This PR:
- Records excluded exact-segment component evidence in bounded output traces.

Children:
- #1151

## Delivered

- Adds `tile_excluded_segment_component` events with tile index, member geometry indexes, and component envelope.
- Keeps the existing endpoint event schema unchanged.
- Reuses physical tile reports without rescanning input.
- Proves a zero-byte trace retains stitching evidence while suppressing events.

## Contract impact

- Additive topology trace event under the existing V1 envelope.
- Polygonization and strict validation behavior are unchanged relative to the parent.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo test -p geo-polygonize-core documents_intersection_connected_component_excluded_from_every_halo` — passed
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings` — passed

## Agent handoff

Remaining:
- Thread execution-policy bounds through tiled component preflight.
- Define deterministic retry/fallback from classified evidence.

Next dependency-ready slice:
- #1151 adds an execution-policy-aware tiled entrypoint and live candidate accounting for the global component preflight.