### PR TITLE
fix(core): bound tiled component preflight work

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -708,6 +708,8 @@ covered while the broader coverage-detection rows remain open.
   - [x] Classify exact segment-intersection components with one indexed global
     candidate pass when input noding is enabled.
   - [x] Trace excluded segment-intersection components without rescanning input.
+  - [x] Apply execution-policy segment, candidate, exact-predicate, and
+    cancellation bounds during the indexed component preflight.
 - [ ] Report source IDs and boundary evidence that were required but not fully
   observed.
 - [ ] Add explicit guarantee levels such as `BestEffort` and

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -1,3 +1,4 @@
+use crate::diagnostics::ExecutionWorkTracker;
 use crate::index::{IndexedEnvelope, RStarBackend};
 use crate::options::{DedupPolicy, ExecutionPolicy, TileOwnershipPolicy};
 use crate::polygonizer::{apply_determinism, canonicalize_ring};
@@ -207,46 +208,75 @@ fn line_string_segments(
     line: &LineString<f64>,
     geometry_index: usize,
     segments: &mut Vec<InputSegment>,
-) {
-    segments.extend(line.lines().map(|line| InputSegment {
-        line,
-        geometry_index,
-    }));
+    execution_policy: &ExecutionPolicy,
+) -> Result<()> {
+    for line in line.lines() {
+        let observed = segments.len().checked_add(1).ok_or_else(|| {
+            PolygonizeError::InternalInvariantViolation {
+                reason: "tiled component segment counter overflow".to_string(),
+            }
+        })?;
+        execution_policy.check(
+            "input_segments",
+            execution_policy.max_input_segments,
+            observed,
+        )?;
+        execution_policy.check_cancelled_every("tile_component_preflight", observed)?;
+        segments.push(InputSegment {
+            line,
+            geometry_index,
+        });
+    }
+    Ok(())
 }
 
 fn geometry_segments(
     geometry: &Geometry<f64>,
     geometry_index: usize,
     segments: &mut Vec<InputSegment>,
-) {
+    execution_policy: &ExecutionPolicy,
+) -> Result<()> {
     match geometry {
-        Geometry::LineString(line) => line_string_segments(line, geometry_index, segments),
+        Geometry::LineString(line) => {
+            line_string_segments(line, geometry_index, segments, execution_policy)?
+        }
         Geometry::MultiLineString(lines) => {
             for line in lines {
-                line_string_segments(line, geometry_index, segments);
+                line_string_segments(line, geometry_index, segments, execution_policy)?;
             }
         }
         Geometry::Polygon(polygon) => {
-            line_string_segments(polygon.exterior(), geometry_index, segments);
+            line_string_segments(
+                polygon.exterior(),
+                geometry_index,
+                segments,
+                execution_policy,
+            )?;
             for ring in polygon.interiors() {
-                line_string_segments(ring, geometry_index, segments);
+                line_string_segments(ring, geometry_index, segments, execution_policy)?;
             }
         }
         Geometry::MultiPolygon(polygons) => {
             for polygon in polygons {
-                line_string_segments(polygon.exterior(), geometry_index, segments);
+                line_string_segments(
+                    polygon.exterior(),
+                    geometry_index,
+                    segments,
+                    execution_policy,
+                )?;
                 for ring in polygon.interiors() {
-                    line_string_segments(ring, geometry_index, segments);
+                    line_string_segments(ring, geometry_index, segments, execution_policy)?;
                 }
             }
         }
         Geometry::GeometryCollection(collection) => {
             for member in collection {
-                geometry_segments(member, geometry_index, segments);
+                geometry_segments(member, geometry_index, segments, execution_policy)?;
             }
         }
         _ => {}
     }
+    Ok(())
 }
 
 fn component_root(parents: &mut [usize], index: usize) -> usize {
@@ -282,6 +312,7 @@ pub struct TiledPolygonizer<'a> {
     ownership_policy: TileOwnershipPolicy,
     dedup_policy: DedupPolicy,
     options: PolygonizerOptions,
+    execution_policy: ExecutionPolicy,
 }
 
 impl<'a> TiledPolygonizer<'a> {
@@ -298,6 +329,7 @@ impl<'a> TiledPolygonizer<'a> {
             ownership_policy: TileOwnershipPolicy::Centroid,
             dedup_policy: DedupPolicy::KeepAll,
             options,
+            execution_policy: ExecutionPolicy::default(),
         }
     }
 
@@ -321,6 +353,12 @@ impl<'a> TiledPolygonizer<'a> {
         self
     }
 
+    /// Sets non-semantic limits for the component preflight and each tile polygonization.
+    pub fn with_execution_policy(mut self, execution_policy: ExecutionPolicy) -> Self {
+        self.execution_policy = execution_policy;
+        self
+    }
+
     pub fn add_geometry(&mut self, geom: &'a Geometry<f64>) {
         let bbox = geom.bounding_rect();
         self.geometries.push((geom, bbox));
@@ -333,7 +371,8 @@ impl<'a> TiledPolygonizer<'a> {
         capture_byte_limit: Option<usize>,
     ) -> Result<TileProcessResult> {
         let mut capture_budget = capture_byte_limit.map(TraceCaptureBudget::new);
-        let mut local_poly = Polygonizer::with_options(self.options.clone());
+        let mut local_poly = Polygonizer::with_options(self.options.clone())
+            .with_execution_policy(self.execution_policy.clone());
 
         // Define buffered bbox
         let buffered_bbox = Rect::new(
@@ -561,12 +600,19 @@ impl<'a> TiledPolygonizer<'a> {
         tiles
     }
 
-    fn input_components(&self) -> Vec<InputComponent> {
+    fn input_components(&self) -> Result<Vec<InputComponent>> {
+        self.execution_policy
+            .check_cancelled("tile_component_preflight")?;
         let mut parents = (0..self.geometries.len()).collect::<Vec<_>>();
         let mut endpoint_owners = HashMap::new();
         let mut segments = Vec::new();
         for (geometry_index, (geometry, _)) in self.geometries.iter().enumerate() {
-            geometry_segments(geometry, geometry_index, &mut segments);
+            geometry_segments(
+                geometry,
+                geometry_index,
+                &mut segments,
+                &self.execution_policy,
+            )?;
         }
         for segment in &segments {
             for endpoint in [segment.line.start, segment.line.end] {
@@ -600,8 +646,7 @@ impl<'a> TiledPolygonizer<'a> {
                 })
                 .collect();
             let index = RStarBackend::new(envelopes);
-            // ponytail: this exact preflight can have quadratic dense candidates; thread an
-            // execution policy through the experimental tiled API before certification.
+            let mut work = ExecutionWorkTracker::new(Some(&self.execution_policy), None);
             for (segment_index, segment) in segments.iter().enumerate() {
                 let envelope = AABB::from_corners(
                     [
@@ -618,9 +663,12 @@ impl<'a> TiledPolygonizer<'a> {
                         continue;
                     }
                     let candidate = segments[candidate_index];
-                    if candidate.geometry_index == segment.geometry_index
-                        || line_intersection(segment.line, candidate.line).is_none()
-                    {
+                    if candidate.geometry_index == segment.geometry_index {
+                        work.candidate(false)?;
+                        continue;
+                    }
+                    work.candidate(true)?;
+                    if line_intersection(segment.line, candidate.line).is_none() {
                         continue;
                     }
                     if endpoint_roots[segment.geometry_index]
@@ -683,7 +731,7 @@ impl<'a> TiledPolygonizer<'a> {
             })
             .collect::<Vec<_>>();
         components.sort_unstable_by_key(|component| component.input_geometry_indices[0]);
-        components
+        Ok(components)
     }
 
     pub fn polygonize(&self) -> Result<TiledPolygonizeResult> {
@@ -754,7 +802,7 @@ impl<'a> TiledPolygonizer<'a> {
     ) -> Result<TiledPolygonizeResult> {
         self.validate()?;
         let tiles = self.generate_tiles();
-        let input_components = self.input_components();
+        let input_components = self.input_components()?;
         self.polygonize_tiles(tiles, &input_components, trace)
     }
 

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -2,9 +2,9 @@
 #[allow(clippy::module_inception)]
 mod tests {
     use crate::{
-        trace::TraceLevelV1, Coord3D, DedupPolicy, PolygonizeError, Polygonizer,
-        PolygonizerOptions, ProvenanceOptions, TileBoundarySide, TileComponentConnection,
-        TileCoverageGuarantee, TiledPolygonizeError, TiledPolygonizer,
+        trace::TraceLevelV1, CancellationToken, Coord3D, DedupPolicy, ExecutionPolicy,
+        PolygonizeError, Polygonizer, PolygonizerOptions, ProvenanceOptions, TileBoundarySide,
+        TileComponentConnection, TileCoverageGuarantee, TiledPolygonizeError, TiledPolygonizer,
     };
     use geo::{Contains, Coord, Geometry, LineString, Rect};
 
@@ -615,6 +615,56 @@ mod tests {
                 .unresolved_component_count,
             0
         );
+
+        let mut limited = TiledPolygonizer::new(bbox, 10.0)
+            .with_buffer(2.0)
+            .with_execution_policy(ExecutionPolicy {
+                max_candidate_pairs: Some(0),
+                ..Default::default()
+            });
+        for boundary in &boundaries {
+            limited.add_geometry(boundary);
+        }
+        assert!(matches!(
+            limited.polygonize(),
+            Err(PolygonizeError::ResourceLimitExceeded {
+                stage,
+                limit: 0,
+                observed: 1,
+            }) if stage == "candidate_pairs"
+        ));
+    }
+
+    #[test]
+    fn tiled_component_preflight_observes_midflight_cancellation() {
+        let bbox = Rect::new(Coord { x: -2.0, y: -2.0 }, Coord { x: 2.0, y: 2.0 });
+        let token = CancellationToken::new();
+        let policy = ExecutionPolicy {
+            cancellation_token: Some(token.clone()),
+            cancel_at_work_item: Some((token, 256)),
+            ..Default::default()
+        };
+        let lines = (0..24)
+            .map(|index| {
+                let angle = index as f64 * std::f64::consts::TAU / 24.0;
+                Geometry::LineString(LineString::new(vec![
+                    Coord { x: 0.0, y: 0.0 },
+                    Coord {
+                        x: angle.cos(),
+                        y: angle.sin(),
+                    },
+                ]))
+            })
+            .collect::<Vec<_>>();
+        let mut tiled = TiledPolygonizer::new(bbox, 2.0).with_execution_policy(policy);
+        for line in &lines {
+            tiled.add_geometry(line);
+        }
+
+        assert!(matches!(
+            tiled.polygonize(),
+            Err(PolygonizeError::Cancelled { stage }) if stage == "candidate_enumeration"
+        ));
     }
 
     #[test]
@@ -675,7 +725,7 @@ mod tests {
             state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
             tiles.swap(upper, (state as usize) % (upper + 1));
         }
-        let input_components = tiler.input_components();
+        let input_components = tiler.input_components().unwrap();
         let permuted = tiler
             .polygonize_tiles(tiles, &input_components, None)
             .unwrap();

--- a/docs/guide/tiling.md
+++ b/docs/guide/tiling.md
@@ -91,8 +91,12 @@ returned to the caller.
   present.
 
 Both validation modes are deliberately narrower than coverage certification.
-The indexed component preflight is not yet execution-policy bounded, and the
-component envelope remains conservative evidence rather than proof of a face.
+`with_execution_policy` applies segment, candidate, exact-predicate, and
+cancellation bounds to the indexed component preflight and passes the same
+policy to each tile polygonization. Numeric work limits apply independently to
+the preflight and to each tile, not as one aggregate budget across the tiled
+call. The component envelope remains conservative evidence rather than proof of
+a face.
 There is currently no halo retry, unresolved-region retry, untiled fallback, or
 retry budget. No retry or fallback trace event is emitted because those execution
 paths do not exist.


### PR DESCRIPTION
## Stack

Parent:
- #1149

This PR:
- Applies execution-policy limits and cancellation to tiled component preflight work.

Children:
- not opened yet

## Delivered

- Adds `TiledPolygonizer::with_execution_policy`.
- Checks `max_input_segments` before component-segment growth.
- Reuses `ExecutionWorkTracker` for deterministic candidate and exact-predicate limits.
- Polls cancellation inside dense indexed candidate enumeration.
- Passes the same policy to each physical tile polygonization.
- Adds limit-plus-one and mid-flight cancellation regressions.

## Contract impact

- Additive experimental execution-policy builder.
- Numeric work budgets apply independently to preflight and each tile; they are not one aggregate tiled-call budget.
- Default behavior remains unlimited.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo test -p geo-polygonize-core tiled_component_preflight_observes_midflight_cancellation` — passed
- `cargo test -p geo-polygonize-core documents_intersection_connected_component_excluded_from_every_halo` — passed
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings` — passed

## Agent handoff

Remaining:
- Decide whether deterministic recovery uses per-region or aggregate tiled-call budgets.
- Add retry/fallback reporting only after that budget ownership is explicit.

Next dependency-ready slice:
- Define a bounded deterministic halo-retry contract for classified unresolved tiles without adding graph stitching.