### PR TITLE
feat(core): trace bounded tiled halo retries

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -742,7 +742,8 @@ When coverage cannot be proven:
   exhausted;
 - [ ] record every retry and fallback in the stitching report and topology trace.
   - [x] Record deterministic retry attempts and exhausted tiles in tile and
-    stitching reports; bounded retry trace events remain open.
+    stitching reports and bounded `tile_halo_retry` trace events; fallback
+    remains open.
 
 ### P3.3 True graph stitching
 

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -909,6 +909,11 @@ impl<'a> TiledPolygonizer<'a> {
                 let (polygons, report, ownership_decisions, capture_truncated) =
                     self.process_tile_with_retries(tile, input_components, capture_byte_limit)?;
                 let trace = trace.as_deref_mut().expect("tile trace exists");
+                for attempt in &report.retry_attempts {
+                    if !trace.record_tile_halo_retry(tile_index, attempt) {
+                        break;
+                    }
+                }
                 for issue in &report.excluded_component_issues {
                     let recorded = match issue.connection {
                         TileComponentConnection::ExactEndpoint => {

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -691,6 +691,24 @@ mod tests {
                 && report.retry_attempts[0].buffer == 42.0
                 && report.retry_attempts[0].resolved
         }));
+        let traced = tiled
+            .polygonize_with_trace(TraceLevelV1::Full, usize::MAX)
+            .unwrap();
+        let retry_events = traced
+            .trace
+            .events
+            .iter()
+            .filter(|event| event.kind == "tile_halo_retry")
+            .collect::<Vec<_>>();
+        assert_eq!(retry_events.len(), 4);
+        assert_eq!(retry_events[0].payload["tile_index"], 0);
+        assert_eq!(retry_events[0].payload["attempt"], 1);
+        assert_eq!(retry_events[0].payload["buffer"], 42.0);
+        assert_eq!(retry_events[0].payload["resolved"], true);
+        let bounded = tiled.polygonize_with_trace(TraceLevelV1::Full, 0).unwrap();
+        assert!(bounded.trace.events.is_empty());
+        assert!(bounded.trace.truncated);
+        assert_eq!(bounded.result.stitching_report.retry_attempt_count, 4);
 
         let mut exhausted = TiledPolygonizer::new(bbox, 10.0)
             .with_buffer(2.0)

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -304,6 +304,17 @@ pub struct TileExcludedSegmentComponentTraceV1 {
     pub component_max: CoordinateFingerprintV1,
 }
 
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct TileHaloRetryTraceV1 {
+    pub tile_index: usize,
+    pub attempt: usize,
+    pub buffer: f64,
+    pub unresolved_owned_polygon_count: usize,
+    pub unresolved_input_geometry_count: usize,
+    pub unresolved_component_count: usize,
+    pub resolved: bool,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct TileOwnedFaceBoundaryTraceV1 {
     pub tile_index: usize,
@@ -1151,6 +1162,27 @@ impl TraceRecorderV1 {
             })
             .expect("tile excluded segment-component trace event serializes"),
         ))
+    }
+
+    pub(crate) fn record_tile_halo_retry(
+        &mut self,
+        tile_index: usize,
+        attempt: &crate::tiling::TileRetryAttempt,
+    ) -> bool {
+        self.record(
+            TraceStageV1::Output,
+            "tile_halo_retry",
+            serde_json::to_value(TileHaloRetryTraceV1 {
+                tile_index,
+                attempt: attempt.attempt,
+                buffer: attempt.buffer,
+                unresolved_owned_polygon_count: attempt.unresolved_owned_polygon_count,
+                unresolved_input_geometry_count: attempt.unresolved_input_geometry_count,
+                unresolved_component_count: attempt.unresolved_component_count,
+                resolved: attempt.resolved,
+            })
+            .expect("tile halo-retry trace event serializes"),
+        )
     }
 
     pub(crate) fn record_tile_dedup(&mut self, polygon_index: usize, retained: bool) {

--- a/docs/guide/tiling.md
+++ b/docs/guide/tiling.md
@@ -103,8 +103,9 @@ evidence. Each attempt adds `buffer_increment` up to `max_attempts` and
 `max_buffer`, replaces that tile's earlier polygons and report, and records the
 attempt in `TileReport` and `StitchingReport`. Strict validation returns the
 typed coverage error with retry counts when the bounded schedule is exhausted.
-Retries reuse the same execution policy independently per attempt. Retry trace
-events, unresolved-component untiled fallback, and cross-region result merging
+Retries reuse the same execution policy independently per attempt. Full output
+traces record bounded `tile_halo_retry` events directly from the physical retry
+history. Unresolved-component untiled fallback and cross-region result merging
 remain unavailable.
 Applications that require correctness must run an untiled equivalence check for
 their input class or choose untiled polygonization directly when sufficiency is


### PR DESCRIPTION
## Stack

Parent:
- #1152

This PR:
- Records bounded halo retry attempts from the physical tile retry history.

Children:
- #1155

## Delivered

- Adds `tile_halo_retry` events with tile, attempt, buffer, unresolved counts, and resolution status.
- Reuses `TileRetryAttempt` records without replaying polygonization.
- Preserves retry/stitching evidence when a zero-byte trace suppresses events.

## Contract impact

- Additive topology trace event under the existing V1 envelope.
- Retry execution and final results are unchanged relative to the parent.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo test -p geo-polygonize-core bounded_halo_retry_resolves_an_excluded_component` — passed
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings` — passed

## Agent handoff

Remaining:
- Define unresolved-component untiled fallback and canonical merge boundaries.
- Record fallback decisions once that physical path exists.

Next dependency-ready slice:
- #1155 pins the exhausted-retry fixture that constrains component-local untiled fallback.