### PR TITLE
test(core): pin tiled fallback containment boundary

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -737,6 +737,8 @@ When coverage cannot be proven:
 
 - [x] retry only the unresolved tile region with a caller-bounded larger halo;
 - [ ] fall back to untiled processing for the unresolved connected region;
+  - [x] Pin the global-containment boundary where an excluded outer component
+    spatially nests an already retained tile-local face.
 - [ ] merge the fallback result canonically with already validated regions;
 - [x] stop with a typed coverage error when the configured retry budget is
   exhausted;

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -734,6 +734,63 @@ mod tests {
     }
 
     #[test]
+    fn documents_fallback_component_global_containment_boundary() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 20.0 });
+        let geometries = [
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: -10.0, y: -10.0 },
+                Coord { x: 30.0, y: -10.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 30.0, y: -10.0 },
+                Coord { x: 30.0, y: 30.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 30.0, y: 30.0 },
+                Coord { x: -10.0, y: 30.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: -10.0, y: 30.0 },
+                Coord { x: -10.0, y: -10.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 2.0, y: 2.0 },
+                Coord { x: 4.0, y: 2.0 },
+                Coord { x: 4.0, y: 4.0 },
+                Coord { x: 2.0, y: 4.0 },
+                Coord { x: 2.0, y: 2.0 },
+            ])),
+        ];
+        let mut untiled = Polygonizer::new();
+        let mut tiled = TiledPolygonizer::new(bbox, 10.0)
+            .with_buffer(2.0)
+            .with_retry_policy(TileRetryPolicy {
+                max_attempts: 1,
+                buffer_increment: 1.0,
+                max_buffer: 3.0,
+            });
+        for geometry in &geometries {
+            untiled.add_borrowed_geometry(geometry);
+            tiled.add_geometry(geometry);
+        }
+
+        let untiled = untiled.polygonize().unwrap();
+        assert_eq!(untiled.polygons.len(), 2);
+        assert!(untiled
+            .polygons
+            .iter()
+            .any(|polygon| !polygon.interiors.is_empty()));
+        let tiled = tiled.polygonize().unwrap();
+        assert_eq!(tiled.polygons.len(), 1);
+        assert!(tiled.polygons[0].interiors.is_empty());
+        assert_eq!(tiled.stitching_report.retry_exhausted_tile_count, 4);
+        assert!(tiled
+            .tile_reports
+            .iter()
+            .any(|report| !report.excluded_component_issues.is_empty()));
+    }
+
+    #[test]
     fn tiled_component_preflight_observes_midflight_cancellation() {
         let bbox = Rect::new(Coord { x: -2.0, y: -2.0 }, Coord { x: 2.0, y: 2.0 });
         let token = CancellationToken::new();


### PR DESCRIPTION
## Stack

Parent:
- #1153

This PR:
- Pins the global containment boundary for future component-local untiled fallback.

Children:
- not opened yet

## Delivered

- Adds an exhausted-retry fixture with an excluded outer component nesting a retained tile-local face.
- Proves untiled output requires a global shell/hole relationship.
- Shows that independently appending an untiled outer component would overlap the retained inner face.

## Contract impact

- Test and roadmap evidence only; runtime behavior is unchanged.
- Future fallback must recompute or reconcile global containment rather than append component polygons independently.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo test -p geo-polygonize-core documents_fallback_component_global_containment_boundary` — passed
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings` — passed

## Agent handoff

Remaining:
- Define a fallback merge that preserves global containment and canonical order.
- Keep component-local noding while applying global shell/hole assignment.

Next dependency-ready slice:
- Separate fallback linework reconstruction from global containment materialization before adding the physical fallback path.