### PR TITLE
feat(core): trace untiled tiled-coverage fallback

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -746,8 +746,9 @@ When coverage cannot be proven:
   exhausted;
 - [ ] record every retry and fallback in the stitching report and topology trace.
   - [x] Record deterministic retry attempts and exhausted tiles in tile and
-    stitching reports and bounded `tile_halo_retry` trace events; fallback
-    remains open.
+    stitching reports and bounded `tile_halo_retry` trace events.
+  - [x] Record whole-input fallback use in the stitching report and a bounded
+    `tile_untiled_fallback` trace event; component-local fallback remains open.
 
 ### P3.3 True graph stitching
 

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -1077,7 +1077,7 @@ impl<'a> TiledPolygonizer<'a> {
             .iter()
             .filter(|report| report.retry_exhausted)
             .count();
-        Ok(TiledPolygonizeResult {
+        let result = TiledPolygonizeResult {
             polygons,
             tile_reports,
             stitching_report: StitchingReport {
@@ -1095,7 +1095,19 @@ impl<'a> TiledPolygonizer<'a> {
                 retry_exhausted_tile_count,
                 untiled_fallback_used,
             },
-        })
+        };
+        if untiled_fallback_used {
+            if let Some(trace) = trace {
+                trace.record_tile_untiled_fallback(
+                    self.geometries.len(),
+                    result.stitching_report.output_polygon_count,
+                    result.stitching_report.unresolved_owned_polygon_count,
+                    result.stitching_report.unresolved_input_geometry_count,
+                    result.stitching_report.unresolved_component_count,
+                );
+            }
+        }
+        Ok(result)
     }
 
     fn validate(&self) -> Result<()> {

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -781,11 +781,11 @@ mod tests {
             .polygons
             .iter()
             .any(|polygon| !polygon.interiors.is_empty()));
-        let tiled = tiled
+        let result = tiled
             .polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateObservedCoverage)
             .unwrap();
         assert_eq!(
-            tiled
+            result
                 .polygons
                 .iter()
                 .map(crate::tiling::canonical_polygon_key)
@@ -796,12 +796,28 @@ mod tests {
                 .map(crate::tiling::canonical_polygon_key)
                 .collect::<Vec<_>>()
         );
-        assert!(tiled.stitching_report.untiled_fallback_used);
-        assert_eq!(tiled.stitching_report.retry_exhausted_tile_count, 4);
-        assert!(tiled
+        assert!(result.stitching_report.untiled_fallback_used);
+        assert_eq!(result.stitching_report.retry_exhausted_tile_count, 4);
+        assert!(result
             .tile_reports
             .iter()
             .any(|report| !report.excluded_component_issues.is_empty()));
+        let traced = tiled
+            .polygonize_with_trace(TraceLevelV1::Full, usize::MAX)
+            .unwrap();
+        let fallback_events = traced
+            .trace
+            .events
+            .iter()
+            .filter(|event| event.kind == "tile_untiled_fallback")
+            .collect::<Vec<_>>();
+        assert_eq!(fallback_events.len(), 1);
+        assert_eq!(fallback_events[0].payload["input_geometry_count"], 5);
+        assert_eq!(fallback_events[0].payload["output_polygon_count"], 2);
+        let bounded = tiled.polygonize_with_trace(TraceLevelV1::Full, 0).unwrap();
+        assert!(bounded.trace.events.is_empty());
+        assert!(bounded.trace.truncated);
+        assert!(bounded.result.stitching_report.untiled_fallback_used);
     }
 
     #[test]

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -316,6 +316,15 @@ pub struct TileHaloRetryTraceV1 {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct TileUntiledFallbackTraceV1 {
+    pub input_geometry_count: usize,
+    pub output_polygon_count: usize,
+    pub unresolved_owned_polygon_count: usize,
+    pub unresolved_input_geometry_count: usize,
+    pub unresolved_component_count: usize,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct TileOwnedFaceBoundaryTraceV1 {
     pub tile_index: usize,
     pub polygon_index: usize,
@@ -1182,6 +1191,28 @@ impl TraceRecorderV1 {
                 resolved: attempt.resolved,
             })
             .expect("tile halo-retry trace event serializes"),
+        )
+    }
+
+    pub(crate) fn record_tile_untiled_fallback(
+        &mut self,
+        input_geometry_count: usize,
+        output_polygon_count: usize,
+        unresolved_owned_polygon_count: usize,
+        unresolved_input_geometry_count: usize,
+        unresolved_component_count: usize,
+    ) -> bool {
+        self.record(
+            TraceStageV1::Output,
+            "tile_untiled_fallback",
+            serde_json::to_value(TileUntiledFallbackTraceV1 {
+                input_geometry_count,
+                output_polygon_count,
+                unresolved_owned_polygon_count,
+                unresolved_input_geometry_count,
+                unresolved_component_count,
+            })
+            .expect("tile untiled-fallback trace event serializes"),
         )
     }
 


### PR DESCRIPTION
## Stack

Parent:
- #1156

This PR:
- Record the whole-input untiled fallback decision in bounded topology traces.

Children:
- #1159

## Delivered

- Adds one `tile_untiled_fallback` output-stage event with input, output, and unresolved evidence counts.
- Keeps trace recording under the existing exact byte budget.
- Extends the nested-containment regression across full and zero-byte traces.
- Updates only the delivered fallback-evidence sub-slice in P3.2.

## Contract impact

- Additive trace event only; the V1 trace envelope and existing event schemas are unchanged.
- Disabled and exhausted trace paths do not allocate or retain the fallback event.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings` — passed
- `cargo test -p geo-polygonize-core untiled_fallback_preserves_global_containment` — passed

## Agent handoff

Remaining:
- Keep component-local fallback and canonical partial merging open until global containment can be preserved.

Next dependency-ready slice:
- #1159 verifies exact fallback equivalence across tile and input permutations.
