### PR TITLE
test(core): bound untiled tiled-coverage fallback

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -743,6 +743,8 @@ When coverage cannot be proven:
     global containment when retries leave observed coverage unresolved.
   - [x] Verify whole-input fallback equality with untiled output across tile
     sizes and input-order permutations.
+  - [x] Apply the configured execution policy to whole-input fallback and pin
+    exact resource-limit evidence.
 - [ ] merge the fallback result canonically with already validated regions;
 - [x] stop with a typed coverage error when the configured retry budget is
   exhausted;

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -818,6 +818,29 @@ mod tests {
         assert!(bounded.trace.events.is_empty());
         assert!(bounded.trace.truncated);
         assert!(bounded.result.stitching_report.untiled_fallback_used);
+
+        let mut limited = TiledPolygonizer::new(bbox, 10.0)
+            .with_buffer(2.0)
+            .with_execution_policy(ExecutionPolicy {
+                max_input_segments: Some(4),
+                ..Default::default()
+            })
+            .with_untiled_fallback();
+        for geometry in &geometries {
+            limited.add_geometry(geometry);
+        }
+        let limited_error = limited.polygonize().unwrap_err();
+        assert!(
+            matches!(
+                limited_error,
+                PolygonizeError::ResourceLimitExceeded {
+                    ref stage,
+                    limit: 4,
+                    observed: 5,
+                } if stage == "input_segments"
+            ),
+            "{limited_error:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Stack

Parent:
- #1159

This PR:
- Pin whole-input fallback execution-limit behavior.

Children:
- not opened yet

## Delivered

- Reuses the nested-containment fallback regression with an input-segment budget.
- Proves tile attempts remain within the budget while the global fallback stops at deterministic `limit + 1` evidence.
- Records the delivered execution-policy guarantee precisely in P3.2.

## Contract impact

- Test and roadmap evidence only; no runtime or public API change relative to the parent.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings` — passed
- `cargo test -p geo-polygonize-core untiled_fallback_preserves_global_containment` — passed
- `cargo clippy -p geo-polygonize-core --lib -- -D warnings` — passed

## Agent handoff

Remaining:
- Keep component-local fallback and canonical partial merging open until global containment can be preserved.

Next dependency-ready slice:
- Advance the next independent P3 evidence slice; containment-safe region-local merging remains blocked on a global topology strategy.
