### PR TITLE
test(core): close tiled recovery trace contract

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -447,7 +447,7 @@ Candidate events and snapshots:
 - [x] shell/hole classification and containment candidates;
 - [x] canonical ordering decisions;
 - [x] tile ownership and deduplication decisions;
-- [ ] tile retry and fallback decisions after those execution paths exist.
+- [x] tile retry and fallback decisions.
 
 Trace output must include byte limits, truncation metadata, schema version,
 library version, and canonical options.

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -814,6 +814,23 @@ mod tests {
         assert_eq!(fallback_events.len(), 1);
         assert_eq!(fallback_events[0].payload["input_geometry_count"], 5);
         assert_eq!(fallback_events[0].payload["output_polygon_count"], 2);
+        let recovery_events = traced
+            .trace
+            .events
+            .iter()
+            .filter(|event| {
+                matches!(
+                    event.kind.as_str(),
+                    "tile_halo_retry" | "tile_untiled_fallback"
+                )
+            })
+            .map(|event| event.kind.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(recovery_events.len(), 5);
+        assert!(recovery_events[..4]
+            .iter()
+            .all(|kind| *kind == "tile_halo_retry"));
+        assert_eq!(recovery_events[4], "tile_untiled_fallback");
         let bounded = tiled.polygonize_with_trace(TraceLevelV1::Full, 0).unwrap();
         assert!(bounded.trace.events.is_empty());
         assert!(bounded.trace.truncated);


### PR DESCRIPTION
## Stack

Parent:
- `main`

This PR:
- Close the remaining P1.5 tiled recovery trace contract.

Children:
- #1162

## Delivered

- Proves retry events precede the final untiled fallback decision deterministically.
- Reuses the existing nested-containment recovery fixture and bounded trace path.
- Marks only the completed P1.5 retry/fallback trace row complete.

## Contract impact

- Test and roadmap evidence only; no runtime or schema change.
- Zero-byte traces remain empty and explicitly truncated.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo test -p geo-polygonize-core untiled_fallback_preserves_global_containment` — passed
- `cargo clippy -p geo-polygonize-core --lib -- -D warnings` — passed
- `git diff --check` — passed

## Agent handoff

Remaining:
- Add exact retained-family tiled/untiled evidence for dangles and cut edges.

Next dependency-ready slice:
- #1162 adds the P3.1 retained-family equivalence fixture.
