### PR TITLE
feat(core): report tiled source evidence completeness

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -710,8 +710,10 @@ covered while the broader coverage-detection rows remain open.
   - [x] Trace excluded segment-intersection components without rescanning input.
   - [x] Apply execution-policy segment, candidate, exact-predicate, and
     cancellation bounds during the indexed component preflight.
-- [ ] Report source IDs and boundary evidence that were required but not fully
+- [x] Report source IDs and boundary evidence that were required but not fully
   observed.
+  - [x] Distinguish representative edge IDs from complete aggregate boundary
+    source IDs explicitly in tile reports and bounded traces.
 - [ ] Add explicit guarantee levels such as `BestEffort` and
   `ValidateCoverage`; do not rename best effort as certified.
   - [x] Add `BestEffort` and `ValidateOwnedFaces` for the reconstructed-face

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -57,6 +57,8 @@ pub struct TileCoverageIssue {
     pub representative_source_line_ids: Vec<u32>,
     /// Complete source IDs when aggregate provenance was requested.
     pub aggregate_source_line_ids: Vec<u32>,
+    /// Whether `aggregate_source_line_ids` contains the complete boundary source set.
+    pub aggregate_source_line_ids_complete: bool,
 }
 
 /// Input geometry that reaches an internal buffered-tile boundary.
@@ -639,6 +641,8 @@ impl<'a> TiledPolygonizer<'a> {
             unresolved_sides,
             representative_source_line_ids,
             aggregate_source_line_ids: poly.boundary_source_line_ids.clone(),
+            aggregate_source_line_ids_complete: self.options.provenance.enabled
+                && self.options.provenance.include_boundary_line_ids,
         })
     }
 

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -336,6 +336,7 @@ mod tests {
         assert_eq!(issues[0].polygon_bbox.max().x, 19.0);
         assert!(!issues[0].representative_source_line_ids.is_empty());
         assert!(issues[0].aggregate_source_line_ids.is_empty());
+        assert!(!issues[0].aggregate_source_line_ids_complete);
         assert_eq!(result.stitching_report.unresolved_tile_count, 1);
         assert_eq!(result.stitching_report.unresolved_owned_polygon_count, 1);
         let traced = tiler
@@ -353,6 +354,7 @@ mod tests {
             .as_array()
             .unwrap()
             .is_empty());
+        assert_eq!(event.payload["aggregate_source_line_ids_complete"], false);
 
         let mut tiler = TiledPolygonizer::new(bbox, 10.0)
             .with_buffer(2.0)
@@ -372,6 +374,7 @@ mod tests {
             .next()
             .unwrap();
         assert!(!issue.aggregate_source_line_ids.is_empty());
+        assert!(issue.aggregate_source_line_ids_complete);
     }
 
     #[test]

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -333,6 +333,7 @@ pub struct TileOwnedFaceBoundaryTraceV1 {
     pub unresolved_sides: Vec<String>,
     pub representative_source_line_ids: Vec<String>,
     pub aggregate_source_line_ids: Vec<String>,
+    pub aggregate_source_line_ids_complete: bool,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
@@ -1128,6 +1129,7 @@ impl TraceRecorderV1 {
                     .collect(),
                 representative_source_line_ids: source_ids(&issue.representative_source_line_ids),
                 aggregate_source_line_ids: source_ids(&issue.aggregate_source_line_ids),
+                aggregate_source_line_ids_complete: issue.aggregate_source_line_ids_complete,
             })
             .expect("tile owned-face boundary trace event serializes"),
         ))


### PR DESCRIPTION
## Stack

Parent:
- #1162

This PR:
- Make tile boundary-source evidence completeness explicit.

Children:
- #1165

## Delivered

- Adds `aggregate_source_line_ids_complete` to owned-face coverage issues.
- Sets it only when aggregate boundary provenance was actually requested and retained.
- Carries the completeness bit into bounded `tile_owned_face_boundary` trace events.
- Closes the corresponding P3.1 evidence-reporting row.

## Contract impact

- Additive experimental report and trace fields.
- Representative edge IDs remain available in every issue; an empty aggregate list is no longer ambiguous.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo test -p geo-polygonize-core reports_owned_faces_that_escape_an_internal_halo` — passed
- `cargo clippy -p geo-polygonize-core --lib -- -D warnings` — passed
- `git diff --check` — passed

## Agent handoff

Remaining:
- The broad P3.1 detection umbrella and region-local recovery remain open.

Next dependency-ready slice:
- #1165 closes the named observed-coverage guarantee contract without claiming full certification.
