### PR TITLE
test(core): close tiled guarantee-level contract

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -714,7 +714,7 @@ covered while the broader coverage-detection rows remain open.
   observed.
   - [x] Distinguish representative edge IDs from complete aggregate boundary
     source IDs explicitly in tile reports and bounded traces.
-- [ ] Add explicit guarantee levels such as `BestEffort` and
+- [x] Add explicit guarantee levels such as `BestEffort` and
   `ValidateCoverage`; do not rename best effort as certified.
   - [x] Add `BestEffort` and `ValidateOwnedFaces` for the reconstructed-face
     subset; missing-region coverage certification remains open.

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -897,6 +897,10 @@ mod tests {
 
     #[test]
     fn validated_owned_face_coverage_rejects_reported_halo_escape() {
+        assert_eq!(
+            TileCoverageGuarantee::default(),
+            TileCoverageGuarantee::BestEffort
+        );
         let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 10.0 });
         let face = Geometry::LineString(LineString::new(vec![
             Coord { x: 1.0, y: 2.0 },


### PR DESCRIPTION
## Stack

Parent:
- #1164

This PR:
- Close the explicit tiled guarantee-level contract row.

Children:
- not opened yet

## Delivered

- Pins `BestEffort` as the default guarantee in the existing halo-escape contract test.
- Retains the existing proof that validation levels reject observed evidence while sufficient coverage succeeds.
- Corrects the stale P3.1 umbrella checkbox.

## Contract impact

- Test and roadmap evidence only; no runtime or public API change.
- `ValidateObservedCoverage` remains explicitly observational, not certified.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo test -p geo-polygonize-core validated_owned_face_coverage_rejects_reported_halo_escape` — passed
- `cargo clippy -p geo-polygonize-core --lib -- -D warnings` — passed
- `git diff --check` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed at stack checkpoint
- `cargo test --workspace` — passed at stack checkpoint
- `cargo test -p geo-polygonize-core --no-default-features` — passed at stack checkpoint
- `RUSTDOCFLAGS='-D warnings' cargo doc -p geo-polygonize-core --no-deps` — passed at stack checkpoint
- `npm test` — passed (54 tests); emitted the existing wasm-bindgen initialization deprecation warning
- `npm run docs:build` — passed; emitted existing MUI directive, bundle-size, npm-audit, and runtime WASM URL warnings

## Agent handoff

Remaining:
- The broad P3.1 coverage-detection umbrella remains open.
- Region-local fallback and true graph stitching remain separate future work.

Next dependency-ready slice:
- Pin the remaining undetected connected-region boundary with a minimized fixture before extending detection.
