### PR TITLE
test(core): pin pre-snap tiled coverage gap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -694,7 +694,10 @@ input noding is enabled, exact segment intersections now produce conservative
 excluded-component evidence when their combined envelope intersects a halo but
 no member geometry does. Bounded full traces distinguish endpoint-only and
 segment-intersection component evidence, so this specific missing-region gap is
-covered while the broader coverage-detection rows remain open.
+covered while the broader coverage-detection rows remain open. A minimized
+pre-snap fixture also pins the remaining boundary: separate inputs that connect
+only after caller-enabled `pre_snap_tolerance` are not exact-linework components
+in the tiled preflight and can remain absent without observed evidence.
 
 - [ ] Detect owned faces or connected regions that touch an unresolved halo or
   partition boundary.
@@ -710,6 +713,8 @@ covered while the broader coverage-detection rows remain open.
   - [x] Trace excluded segment-intersection components without rescanning input.
   - [x] Apply execution-policy segment, candidate, exact-predicate, and
     cancellation bounds during the indexed component preflight.
+  - [x] Pin the undetected connected-region case where separate inputs connect
+    only after caller-enabled pre-snap; detection remains open.
 - [x] Report source IDs and boundary evidence that were required but not fully
   observed.
   - [x] Distinguish representative edge IDs from complete aggregate boundary

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -651,6 +651,56 @@ mod tests {
     }
 
     #[test]
+    fn documents_pre_snap_connected_region_excluded_from_every_halo() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 20.0 });
+        let boundaries = [
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: -10.0, y: -10.0 },
+                Coord { x: 30.0, y: -10.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 30.1, y: -10.1 },
+                Coord { x: 30.1, y: 30.1 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 30.2, y: 30.2 },
+                Coord { x: -10.2, y: 30.2 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: -10.3, y: 30.3 },
+                Coord { x: -10.3, y: -10.3 },
+            ])),
+        ];
+        let options = PolygonizerOptions {
+            node_input: true,
+            pre_snap_tolerance: 0.5,
+            ..Default::default()
+        };
+        let mut untiled = Polygonizer::with_options(options.clone());
+        let mut tiled = TiledPolygonizer::new(bbox, 10.0)
+            .with_buffer(2.0)
+            .with_options(options);
+        for boundary in &boundaries {
+            untiled.add_borrowed_geometry(boundary);
+            tiled.add_geometry(boundary);
+        }
+
+        assert_eq!(untiled.polygonize().unwrap().polygons.len(), 1);
+        assert!(tiled.input_components().unwrap().is_empty());
+        let observed = tiled.polygonize().unwrap();
+        assert!(observed.polygons.is_empty());
+        assert!(observed
+            .tile_reports
+            .iter()
+            .all(|report| report.input_geometry_count == 0));
+        assert_eq!(observed.stitching_report.unresolved_input_geometry_count, 0);
+        assert_eq!(observed.stitching_report.unresolved_component_count, 0);
+        assert!(tiled
+            .polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateObservedCoverage)
+            .is_ok());
+    }
+
+    #[test]
     fn bounded_halo_retry_resolves_an_excluded_component() {
         let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 20.0 });
         let boundaries = [


### PR DESCRIPTION
## Stack

Parent:
- `main`

This PR:
- Pins the remaining P3.1 undetected connected-region boundary.

Children:
- #1167 (`agent/p3-tile-pre-snap-component-evidence`)

## Delivered

- Adds a minimized four-input enclosing ring whose corner gaps close only after caller-enabled `pre_snap_tolerance`.
- Proves untiled polygonization returns one face while every tiled halo excludes every input geometry.
- Proves exact-linework component preflight and all current observed coverage evidence remain empty, so strict observed validation accepts the incomplete tiled result.
- Records the limitation precisely in P3.1 without claiming coverage certification or implementing recovery.

## Contract impact

- Test and roadmap evidence only; no runtime or public API change.
- `ValidateObservedCoverage` remains observational and does not detect connectivity introduced by pre-snap on this parent commit.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo test --workspace` — passed (221 core unit tests and workspace integration suites)
- `cargo test -p geo-polygonize-core --no-default-features` — passed (221 core unit tests and integration suites)
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `RUSTDOCFLAGS='-D warnings' cargo doc -p geo-polygonize-core --no-deps` — passed
- `cargo test -p geo-polygonize-core --lib tiling::tests::tests::documents_pre_snap_connected_region_excluded_from_every_halo -- --exact` — passed with and without default features
- `npm test` — passed (54 tests); emitted the existing wasm-bindgen initialization deprecation warning
- `npm run docs:build` — passed; emitted existing MUI directive and chunk-size warnings
- `git diff --check` — passed

## Agent handoff

Remaining:
- Broader coverage detection remains open for regions that evade all conservative evidence families.
- Containment-safe region-local fallback and canonical partial merging remain open; do not append independently polygonized components.
- P3.3 true boundary-graph stitching remains later work.

Next dependency-ready slice:
- #1167 adds the bounded evidence path for pre-snap-connected excluded regions, reusing the existing component preflight and preserving the caller's precision contract.
