### PR TITLE
feat(core): report pre-snap tiled components

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -696,8 +696,9 @@ no member geometry does. Bounded full traces distinguish endpoint-only and
 segment-intersection component evidence, so this specific missing-region gap is
 covered while the broader coverage-detection rows remain open. A minimized
 pre-snap fixture also pins the remaining boundary: separate inputs that connect
-only after caller-enabled `pre_snap_tolerance` are not exact-linework components
-in the tiled preflight and can remain absent without observed evidence.
+only after caller-enabled `pre_snap_tolerance` are now grouped as conservative
+pre-snap component evidence; region coverage remains observational rather than
+certified.
 
 - [ ] Detect owned faces or connected regions that touch an unresolved halo or
   partition boundary.
@@ -714,7 +715,9 @@ in the tiled preflight and can remain absent without observed evidence.
   - [x] Apply execution-policy segment, candidate, exact-predicate, and
     cancellation bounds during the indexed component preflight.
   - [x] Pin the undetected connected-region case where separate inputs connect
-    only after caller-enabled pre-snap; detection remains open.
+    only after caller-enabled pre-snap.
+  - [x] Report caller-enabled pre-snap-connected components distinctly in tile
+    reports and bounded traces; broader region coverage detection remains open.
 - [x] Report source IDs and boundary evidence that were required but not fully
   observed.
   - [x] Distinguish representative edge IDs from complete aggregate boundary

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -1,12 +1,13 @@
 use crate::diagnostics::ExecutionWorkTracker;
 use crate::index::{IndexedEnvelope, RStarBackend};
+use crate::noding::snap::SnapNoder;
 use crate::options::{DedupPolicy, ExecutionPolicy, TileOwnershipPolicy};
 use crate::polygonizer::{apply_determinism, canonicalize_ring};
 use crate::trace::{
     TopologyTraceV1, TraceByteLimitsV1, TraceCaptureBudget, TraceLevelV1, TraceRecorderV1,
     TraceStageV1,
 };
-use crate::types::{Coord3D, Polygon3D};
+use crate::types::{Coord3D, Line3D, Polygon3D};
 use crate::{PolygonizeError, Polygonizer, PolygonizerOptions, Result};
 use geo::algorithm::line_intersection::line_intersection;
 use geo::bounding_rect::BoundingRect;
@@ -77,6 +78,7 @@ pub struct TileInputBoundaryIssue {
 pub enum TileComponentConnection {
     ExactEndpoint,
     SegmentIntersection,
+    PreSnap,
 }
 
 /// An exact-linework-connected input component excluded from a tile halo.
@@ -712,6 +714,46 @@ impl<'a> TiledPolygonizer<'a> {
                 &self.execution_policy,
             )?;
         }
+        if self.options.pre_snap_tolerance > 0.0 {
+            let source_segments = segments;
+            let lines = source_segments
+                .iter()
+                .enumerate()
+                .map(|(segment_index, segment)| {
+                    let line_id = u32::try_from(segment_index).map_err(|_| {
+                        PolygonizeError::InvalidGeometry {
+                            reason: "more than u32::MAX tiled component pre-snap segments"
+                                .to_string(),
+                        }
+                    })?;
+                    Ok(Line3D::new(
+                        segment.line.start.into(),
+                        segment.line.end.into(),
+                        line_id,
+                    ))
+                })
+                .collect::<Result<Vec<_>>>()?;
+            let (snapped, _) = SnapNoder::pre_snap_to_reference_vertices_with_stats(
+                &lines,
+                self.options.pre_snap_tolerance,
+                self.options.z.policy,
+                &self.execution_policy,
+            )?;
+            segments = snapped
+                .into_iter()
+                .map(|line| {
+                    let source = source_segments.get(line.line_id as usize).ok_or_else(|| {
+                        PolygonizeError::InternalInvariantViolation {
+                            reason: "tiled pre-snap source segment is missing".to_string(),
+                        }
+                    })?;
+                    Ok(InputSegment {
+                        line: line.to_line_2d(),
+                        geometry_index: source.geometry_index,
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?;
+        }
         for segment in &segments {
             for endpoint in [segment.line.start, segment.line.end] {
                 let key = (endpoint_bits(endpoint.x), endpoint_bits(endpoint.y));
@@ -820,7 +862,9 @@ impl<'a> TiledPolygonizer<'a> {
                 Some(InputComponent {
                     input_geometry_indices,
                     bbox,
-                    connection: if intersection_roots.contains(&root) {
+                    connection: if self.options.pre_snap_tolerance > 0.0 {
+                        TileComponentConnection::PreSnap
+                    } else if intersection_roots.contains(&root) {
                         TileComponentConnection::SegmentIntersection
                     } else {
                         TileComponentConnection::ExactEndpoint
@@ -942,6 +986,9 @@ impl<'a> TiledPolygonizer<'a> {
                         }
                         TileComponentConnection::SegmentIntersection => {
                             trace.record_tile_excluded_segment_component(tile_index, issue)?
+                        }
+                        TileComponentConnection::PreSnap => {
+                            trace.record_tile_excluded_pre_snap_component(tile_index, issue)?
                         }
                     };
                     if !recorded {

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -686,7 +686,7 @@ mod tests {
         }
 
         assert_eq!(untiled.polygonize().unwrap().polygons.len(), 1);
-        assert!(tiled.input_components().unwrap().is_empty());
+        assert_eq!(tiled.input_components().unwrap().len(), 1);
         let observed = tiled.polygonize().unwrap();
         assert!(observed.polygons.is_empty());
         assert!(observed
@@ -694,10 +694,38 @@ mod tests {
             .iter()
             .all(|report| report.input_geometry_count == 0));
         assert_eq!(observed.stitching_report.unresolved_input_geometry_count, 0);
-        assert_eq!(observed.stitching_report.unresolved_component_count, 0);
-        assert!(tiled
-            .polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateObservedCoverage)
-            .is_ok());
+        assert_eq!(observed.stitching_report.unresolved_component_tile_count, 4);
+        assert_eq!(observed.stitching_report.unresolved_component_count, 4);
+        assert!(observed.tile_reports.iter().all(|report| {
+            report.excluded_component_issues.len() == 1
+                && report.excluded_component_issues[0].connection
+                    == TileComponentConnection::PreSnap
+        }));
+        let traced = tiled
+            .polygonize_with_trace(TraceLevelV1::Full, usize::MAX)
+            .unwrap();
+        let events = traced
+            .trace
+            .events
+            .iter()
+            .filter(|event| event.kind == "tile_excluded_pre_snap_component")
+            .collect::<Vec<_>>();
+        assert_eq!(events.len(), 4);
+        assert_eq!(events[0].payload["tile_index"], 0);
+        assert_eq!(
+            events[0].payload["input_geometry_indices"],
+            serde_json::json!([0, 1, 2, 3])
+        );
+        assert!(matches!(
+            tiled.polygonize_with_coverage_guarantee(
+                TileCoverageGuarantee::ValidateObservedCoverage
+            ),
+            Err(TiledPolygonizeError::CoverageIncomplete {
+                unresolved_component_tile_count: 4,
+                unresolved_component_count: 4,
+                ..
+            })
+        ));
     }
 
     #[test]

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -304,6 +304,14 @@ pub struct TileExcludedSegmentComponentTraceV1 {
     pub component_max: CoordinateFingerprintV1,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct TileExcludedPreSnapComponentTraceV1 {
+    pub tile_index: usize,
+    pub input_geometry_indices: Vec<usize>,
+    pub component_min: CoordinateFingerprintV1,
+    pub component_max: CoordinateFingerprintV1,
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct TileHaloRetryTraceV1 {
     pub tile_index: usize,
@@ -1172,6 +1180,26 @@ impl TraceRecorderV1 {
                 component_max: coordinate_fingerprint(crate::Coord3D::new(max.x, max.y, 0.0))?,
             })
             .expect("tile excluded segment-component trace event serializes"),
+        ))
+    }
+
+    pub(crate) fn record_tile_excluded_pre_snap_component(
+        &mut self,
+        tile_index: usize,
+        issue: &crate::tiling::TileExcludedComponentIssue,
+    ) -> crate::Result<bool> {
+        let min = issue.component_bbox.min();
+        let max = issue.component_bbox.max();
+        Ok(self.record(
+            TraceStageV1::Output,
+            "tile_excluded_pre_snap_component",
+            serde_json::to_value(TileExcludedPreSnapComponentTraceV1 {
+                tile_index,
+                input_geometry_indices: issue.input_geometry_indices.clone(),
+                component_min: coordinate_fingerprint(crate::Coord3D::new(min.x, min.y, 0.0))?,
+                component_max: coordinate_fingerprint(crate::Coord3D::new(max.x, max.y, 0.0))?,
+            })
+            .expect("tile excluded pre-snap component trace event serializes"),
         ))
     }
 

--- a/docs/guide/tiling.md
+++ b/docs/guide/tiling.md
@@ -45,14 +45,17 @@ inputs or reconstructed faces.
 `TileReport::excluded_component_issues` covers one additional missing-input
 case. Separate input geometries that share exact endpoints are grouped. When
 input noding is enabled, an indexed exact-intersection pass also groups geometry
-connected through segment interiors. A tile reports the component when its
-combined envelope intersects the buffered tile but no member geometry envelope
-does. This catches an enclosing component that is excluded from every halo. It
-remains conservative: an envelope does not prove that the component contains a
-face. `TileComponentConnection` distinguishes endpoint-only and
-segment-intersection evidence, and `StitchingReport` counts affected tiles and
-issue instances. Full output traces distinguish bounded
-`tile_excluded_endpoint_component` and `tile_excluded_segment_component` events.
+connected through segment interiors. When `pre_snap_tolerance` is enabled, the
+same bounded preflight applies that caller-selected transformation before
+grouping, and reports those components as `PreSnap`. A tile reports the
+component when its combined envelope intersects the buffered tile but no member
+geometry envelope does. This catches an enclosing component that is excluded
+from every halo. It remains conservative: an envelope does not prove that the
+component contains a face. `TileComponentConnection` distinguishes endpoint,
+segment-intersection, and pre-snap evidence, and `StitchingReport` counts
+affected tiles and issue instances. Full output traces distinguish bounded
+`tile_excluded_endpoint_component`, `tile_excluded_segment_component`, and
+`tile_excluded_pre_snap_component` events.
 
 ## Ownership and deduplication
 
@@ -92,11 +95,11 @@ returned to the caller.
 
 Both validation modes are deliberately narrower than coverage certification.
 `with_execution_policy` applies segment, candidate, exact-predicate, and
-cancellation bounds to the indexed component preflight and passes the same
-policy to each tile polygonization. Numeric work limits apply independently to
-the preflight and to each tile, not as one aggregate budget across the tiled
-call. The component envelope remains conservative evidence rather than proof of
-a face.
+cancellation bounds to the indexed component preflight, including the optional
+pre-snap pass, and passes the same policy to each tile polygonization. Numeric
+work limits apply independently to the preflight and to each tile, not as one
+aggregate budget across the tiled call. The component envelope remains
+conservative evidence rather than proof of a face.
 `with_retry_policy` enables deterministic tile-local halo growth for tiles whose
 final report still contains owned-face, input-boundary, or excluded-component
 evidence. Each attempt adds `buffer_increment` up to `max_attempts` and


### PR DESCRIPTION
## Stack

Parent:
- #1166 (`agent/p3-tile-undetected-region-fixture`)

This PR:
- Reports excluded connected components after caller-enabled pre-snap.

Children:
- #1169 (`agent/p3-tile-fixed-grid-component-evidence`)

## Delivered

- Reuses `SnapNoder::pre_snap_to_reference_vertices_with_stats` in the bounded tiled component preflight when `pre_snap_tolerance` is enabled.
- Preserves source geometry indexes across pre-snap-created segments and applies the existing execution-policy bounds.
- Adds `TileComponentConnection::PreSnap` plus a bounded `tile_excluded_pre_snap_component` trace event.
- Upgrades the minimized enclosing-ring fixture to prove per-tile report evidence and strict observed-coverage rejection.
- Documents the evidence boundary without implementing region-local fallback, canonical partial merging, or graph stitching.

## Contract impact

- Additive experimental report/trace evidence and one connection classification.
- Best-effort tiled output remains unchanged; `ValidateObservedCoverage` now rejects detected pre-snap-connected excluded components.
- The evidence remains conservative and does not certify that a component contains a face.

## Validation

- `cargo fmt --all -- --check` — passed
- `cargo test -p geo-polygonize-core --lib tiling::tests` — passed (21 tests)
- `cargo test -p geo-polygonize-core --no-default-features --lib tiling::tests` — passed (21 tests)
- `cargo test -p geo-polygonize-core --test tiling_equivalence` — passed (4 tests)
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `cargo test --workspace` — passed (221 core unit tests and workspace integration suites)
- `RUSTDOCFLAGS='-D warnings' cargo doc -p geo-polygonize-core --no-deps` — passed; generated bindings were restored
- `git diff --check` — passed after restoring generated bindings
- Stack-root checkpoint from #1166: `npm test` passed (54 tests); `npm run docs:build` passed with existing MUI directive and chunk-size warnings

## Agent handoff

Remaining:
- Broader coverage detection remains open for connectivity introduced by other caller-selected precision transformations and for regions that still evade all conservative evidence.
- Containment-safe region-local fallback and canonical partial merging remain open; do not append independently polygonized components.
- P3.3 true boundary-graph stitching remains later work.

Next dependency-ready slice:
- #1169 characterizes and reports connected regions created by fixed-grid endpoint snapping without widening the coverage guarantee.
