### PR TITLE
feat(core): report fixed-grid tiled components

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -694,11 +694,11 @@ input noding is enabled, exact segment intersections now produce conservative
 excluded-component evidence when their combined envelope intersects a halo but
 no member geometry does. Bounded full traces distinguish endpoint-only and
 segment-intersection component evidence, so this specific missing-region gap is
-covered while the broader coverage-detection rows remain open. A minimized
-pre-snap fixture also pins the remaining boundary: separate inputs that connect
-only after caller-enabled `pre_snap_tolerance` are now grouped as conservative
-pre-snap component evidence; region coverage remains observational rather than
-certified.
+covered while the broader coverage-detection rows remain open. Minimized
+pre-snap and fixed-grid fixtures also pin the remaining transformation boundary:
+separate inputs that connect only after caller-selected precision transformations
+are now grouped as conservative component evidence; region coverage remains
+observational rather than certified.
 
 - [ ] Detect owned faces or connected regions that touch an unresolved halo or
   partition boundary.
@@ -718,6 +718,8 @@ certified.
     only after caller-enabled pre-snap.
   - [x] Report caller-enabled pre-snap-connected components distinctly in tile
     reports and bounded traces; broader region coverage detection remains open.
+  - [x] Pin and report the corresponding fixed-grid-connected component case
+    with bounded trace evidence; broader region coverage detection remains open.
 - [x] Report source IDs and boundary evidence that were required but not fully
   observed.
   - [x] Distinguish representative edge IDs from complete aggregate boundary

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -79,9 +79,10 @@ pub enum TileComponentConnection {
     ExactEndpoint,
     SegmentIntersection,
     PreSnap,
+    FixedGrid,
 }
 
-/// An exact-linework-connected input component excluded from a tile halo.
+/// A transformed-connected input component excluded from a tile halo.
 ///
 /// The component envelope intersects the buffered tile, but none of its member
 /// geometry envelopes do. This is conservative evidence, not proof that the
@@ -754,6 +755,22 @@ impl<'a> TiledPolygonizer<'a> {
                 })
                 .collect::<Result<Vec<_>>>()?;
         }
+        let grid_size = self.options.precision_model.grid_size();
+        if grid_size > 0.0 {
+            let snapper = SnapNoder::new(grid_size)
+                .with_snap_strategy(self.options.snap_strategy.clone())
+                .with_z_policy(self.options.z.policy);
+            for (segment_index, segment) in segments.iter_mut().enumerate() {
+                self.execution_policy
+                    .check_cancelled_every("tile_component_preflight", segment_index)?;
+                let start: Coord3D = segment.line.start.into();
+                let end: Coord3D = segment.line.end.into();
+                segment.line = Line::new(
+                    snapper.snap(start).to_coord_2d(),
+                    snapper.snap(end).to_coord_2d(),
+                );
+            }
+        }
         for segment in &segments {
             for endpoint in [segment.line.start, segment.line.end] {
                 let key = (endpoint_bits(endpoint.x), endpoint_bits(endpoint.y));
@@ -864,6 +881,8 @@ impl<'a> TiledPolygonizer<'a> {
                     bbox,
                     connection: if self.options.pre_snap_tolerance > 0.0 {
                         TileComponentConnection::PreSnap
+                    } else if grid_size > 0.0 {
+                        TileComponentConnection::FixedGrid
                     } else if intersection_roots.contains(&root) {
                         TileComponentConnection::SegmentIntersection
                     } else {
@@ -989,6 +1008,9 @@ impl<'a> TiledPolygonizer<'a> {
                         }
                         TileComponentConnection::PreSnap => {
                             trace.record_tile_excluded_pre_snap_component(tile_index, issue)?
+                        }
+                        TileComponentConnection::FixedGrid => {
+                            trace.record_tile_excluded_fixed_grid_component(tile_index, issue)?
                         }
                     };
                     if !recorded {

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -129,7 +129,7 @@ pub struct TileReport {
     pub coverage_issues: Vec<TileCoverageIssue>,
     /// Inputs that may connect to linework beyond this tile's halo.
     pub input_boundary_issues: Vec<TileInputBoundaryIssue>,
-    /// Exact-linework-connected components excluded from this tile's halo.
+    /// Transformed-connected components excluded from this tile's halo.
     pub excluded_component_issues: Vec<TileExcludedComponentIssue>,
     pub retry_attempts: Vec<TileRetryAttempt>,
     pub retry_exhausted: bool,
@@ -178,7 +178,7 @@ pub enum TileCoverageGuarantee {
     /// that is absent because its closing linework fell outside every tile halo.
     ValidateOwnedFaces,
     /// Reject tiled output when owned-face, input-boundary, or excluded
-    /// linework-component evidence is present.
+    /// component evidence is present.
     ///
     /// A successful caller-enabled untiled fallback replaces unresolved tiled
     /// output and satisfies this guarantee. Otherwise this validates observed

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -3,9 +3,9 @@
 mod tests {
     use crate::{
         trace::TraceLevelV1, CancellationToken, Coord3D, DedupPolicy, ExecutionPolicy,
-        PolygonizeError, Polygonizer, PolygonizerOptions, ProvenanceOptions, TileBoundarySide,
-        TileComponentConnection, TileCoverageGuarantee, TileRetryPolicy, TiledPolygonizeError,
-        TiledPolygonizer,
+        PolygonizeError, Polygonizer, PolygonizerOptions, PrecisionModel, ProvenanceOptions,
+        TileBoundarySide, TileComponentConnection, TileCoverageGuarantee, TileRetryPolicy,
+        TiledPolygonizeError, TiledPolygonizer,
     };
     use geo::{Contains, Coord, Geometry, LineString, Rect};
 
@@ -709,6 +709,84 @@ mod tests {
             .events
             .iter()
             .filter(|event| event.kind == "tile_excluded_pre_snap_component")
+            .collect::<Vec<_>>();
+        assert_eq!(events.len(), 4);
+        assert_eq!(events[0].payload["tile_index"], 0);
+        assert_eq!(
+            events[0].payload["input_geometry_indices"],
+            serde_json::json!([0, 1, 2, 3])
+        );
+        assert!(matches!(
+            tiled.polygonize_with_coverage_guarantee(
+                TileCoverageGuarantee::ValidateObservedCoverage
+            ),
+            Err(TiledPolygonizeError::CoverageIncomplete {
+                unresolved_component_tile_count: 4,
+                unresolved_component_count: 4,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn documents_fixed_grid_connected_region_excluded_from_every_halo() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 20.0 });
+        let boundaries = [
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: -10.0, y: -10.0 },
+                Coord { x: 30.0, y: -10.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 30.4, y: -10.4 },
+                Coord { x: 30.4, y: 30.4 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 30.3, y: 30.3 },
+                Coord { x: -10.3, y: 30.3 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: -10.4, y: 30.4 },
+                Coord { x: -10.4, y: -10.4 },
+            ])),
+        ];
+        let options = PolygonizerOptions {
+            node_input: true,
+            precision_model: PrecisionModel::FixedGrid { grid_size: 1.0 },
+            ..Default::default()
+        };
+        let mut untiled = Polygonizer::with_options(options.clone());
+        let mut tiled = TiledPolygonizer::new(bbox, 10.0)
+            .with_buffer(2.0)
+            .with_options(options);
+        for boundary in &boundaries {
+            untiled.add_borrowed_geometry(boundary);
+            tiled.add_geometry(boundary);
+        }
+
+        assert_eq!(untiled.polygonize().unwrap().polygons.len(), 1);
+        assert_eq!(tiled.input_components().unwrap().len(), 1);
+        let observed = tiled.polygonize().unwrap();
+        assert!(observed.polygons.is_empty());
+        assert!(observed
+            .tile_reports
+            .iter()
+            .all(|report| report.input_geometry_count == 0));
+        assert_eq!(observed.stitching_report.unresolved_input_geometry_count, 0);
+        assert_eq!(observed.stitching_report.unresolved_component_tile_count, 4);
+        assert_eq!(observed.stitching_report.unresolved_component_count, 4);
+        assert!(observed.tile_reports.iter().all(|report| {
+            report.excluded_component_issues.len() == 1
+                && report.excluded_component_issues[0].connection
+                    == TileComponentConnection::FixedGrid
+        }));
+        let traced = tiled
+            .polygonize_with_trace(TraceLevelV1::Full, usize::MAX)
+            .unwrap();
+        let events = traced
+            .trace
+            .events
+            .iter()
+            .filter(|event| event.kind == "tile_excluded_fixed_grid_component")
             .collect::<Vec<_>>();
         assert_eq!(events.len(), 4);
         assert_eq!(events[0].payload["tile_index"], 0);

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -312,6 +312,14 @@ pub struct TileExcludedPreSnapComponentTraceV1 {
     pub component_max: CoordinateFingerprintV1,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct TileExcludedFixedGridComponentTraceV1 {
+    pub tile_index: usize,
+    pub input_geometry_indices: Vec<usize>,
+    pub component_min: CoordinateFingerprintV1,
+    pub component_max: CoordinateFingerprintV1,
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct TileHaloRetryTraceV1 {
     pub tile_index: usize,
@@ -1200,6 +1208,26 @@ impl TraceRecorderV1 {
                 component_max: coordinate_fingerprint(crate::Coord3D::new(max.x, max.y, 0.0))?,
             })
             .expect("tile excluded pre-snap component trace event serializes"),
+        ))
+    }
+
+    pub(crate) fn record_tile_excluded_fixed_grid_component(
+        &mut self,
+        tile_index: usize,
+        issue: &crate::tiling::TileExcludedComponentIssue,
+    ) -> crate::Result<bool> {
+        let min = issue.component_bbox.min();
+        let max = issue.component_bbox.max();
+        Ok(self.record(
+            TraceStageV1::Output,
+            "tile_excluded_fixed_grid_component",
+            serde_json::to_value(TileExcludedFixedGridComponentTraceV1 {
+                tile_index,
+                input_geometry_indices: issue.input_geometry_indices.clone(),
+                component_min: coordinate_fingerprint(crate::Coord3D::new(min.x, min.y, 0.0))?,
+                component_max: coordinate_fingerprint(crate::Coord3D::new(max.x, max.y, 0.0))?,
+            })
+            .expect("tile excluded fixed-grid component trace event serializes"),
         ))
     }
 

--- a/docs/guide/tiling.md
+++ b/docs/guide/tiling.md
@@ -47,15 +47,19 @@ case. Separate input geometries that share exact endpoints are grouped. When
 input noding is enabled, an indexed exact-intersection pass also groups geometry
 connected through segment interiors. When `pre_snap_tolerance` is enabled, the
 same bounded preflight applies that caller-selected transformation before
-grouping, and reports those components as `PreSnap`. A tile reports the
+grouping, and reports those components as `PreSnap`. When a fixed-grid precision
+model is enabled, it applies the selected snap strategy to the same preflight
+endpoints and reports those components as `FixedGrid` unless pre-snap evidence
+takes precedence. A tile reports the
 component when its combined envelope intersects the buffered tile but no member
 geometry envelope does. This catches an enclosing component that is excluded
 from every halo. It remains conservative: an envelope does not prove that the
 component contains a face. `TileComponentConnection` distinguishes endpoint,
-segment-intersection, and pre-snap evidence, and `StitchingReport` counts
-affected tiles and issue instances. Full output traces distinguish bounded
-`tile_excluded_endpoint_component`, `tile_excluded_segment_component`, and
-`tile_excluded_pre_snap_component` events.
+segment-intersection, pre-snap, and fixed-grid evidence, and `StitchingReport`
+counts affected tiles and issue instances. Full output traces distinguish
+bounded `tile_excluded_endpoint_component`,
+`tile_excluded_segment_component`, `tile_excluded_pre_snap_component`, and
+`tile_excluded_fixed_grid_component` events.
 
 ## Ownership and deduplication
 
@@ -90,16 +94,15 @@ returned to the caller.
 - `ValidateOwnedFaces` returns `TiledPolygonizeError::CoverageIncomplete` instead
   of polygons when a reconstructed owned face reaches an internal halo boundary.
 - `ValidateObservedCoverage` returns that typed error when owned-face,
-  conservative input-boundary, or excluded exact-linework component evidence is
-  present.
+  conservative input-boundary, or excluded component evidence is present.
 
 Both validation modes are deliberately narrower than coverage certification.
 `with_execution_policy` applies segment, candidate, exact-predicate, and
 cancellation bounds to the indexed component preflight, including the optional
-pre-snap pass, and passes the same policy to each tile polygonization. Numeric
-work limits apply independently to the preflight and to each tile, not as one
-aggregate budget across the tiled call. The component envelope remains
-conservative evidence rather than proof of a face.
+pre-snap and fixed-grid endpoint passes, and passes the same policy to each tile
+polygonization. Numeric work limits apply independently to the preflight and to
+each tile, not as one aggregate budget across the tiled call. The component
+envelope remains conservative evidence rather than proof of a face.
 `with_retry_policy` enables deterministic tile-local halo growth for tiles whose
 final report still contains owned-face, input-boundary, or excluded-component
 evidence. Each attempt adds `buffer_increment` up to `max_attempts` and


### PR DESCRIPTION
## Stack

- Parent: #1167 (`agent/p3-tile-pre-snap-component-evidence`)
- Children: none yet
- Branch: `agent/p3-tile-fixed-grid-component-evidence`

## Delivered

- Added a minimized regression fixture where four separate boundary inputs form
  one untiled polygon only after the caller-selected fixed-grid precision
  transformation, while every member geometry is excluded from every tile halo.
- Applied the existing `SnapNoder` snap strategy during bounded component
  preflight, grouped the transformed component, and reported it as
  `TileComponentConnection::FixedGrid`.
- Added bounded `tile_excluded_fixed_grid_component` trace evidence and updated
  the tiling guide and P3.1 roadmap evidence.
- Preserved whole-input fallback and containment behavior; no component-local
  fallback or partial merge was added.

## Contract impact

- Fixed-grid-connected excluded components now appear in tile reports and are
  rejected by `ValidateObservedCoverage` as conservative observed evidence.
- The public `TileComponentConnection` enum gains `FixedGrid`; trace output adds
  the corresponding event kind.
- This remains evidence, not a coverage certificate: component envelopes do not
  prove a missing face, and region-local recovery/stitching remain unavailable.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- Focused fixed-grid regression test, tiled test module, and
  `cargo test -p geo-polygonize-core --test tiling_equivalence`
- Focused tiled tests pass with and without default features.
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo test --workspace --no-default-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p geo-polygonize-core --no-deps`

## Agent handoff

- Next exact branch: `agent/p3-tile-broad-region-evidence`
- Parent is #1167; this PR has no child yet.
- The next slice should target a separately minimized undetected connected
  region after the existing exact-endpoint, exact-intersection, pre-snap, and
  fixed-grid evidence families; do not implement component-local append/merge.
