### PR TITLE
feat(core): add safe component fallback

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -751,6 +751,8 @@ When coverage cannot be proven:
 - [ ] fall back to untiled processing for the unresolved connected region;
   - [x] Pin the global-containment boundary where an excluded outer component
     spatially nests an already retained tile-local face.
+  - [x] Add opt-in envelope-disjoint component fallback that declines nested,
+    overlapping, or previously included linework and records the recovery.
   - [x] Provide a caller-enabled whole-input untiled fallback that preserves
     global containment when retries leave observed coverage unresolved.
   - [x] Verify whole-input fallback equality with untiled output across tile
@@ -764,7 +766,8 @@ When coverage cannot be proven:
   - [x] Record deterministic retry attempts and exhausted tiles in tile and
     stitching reports and bounded `tile_halo_retry` trace events.
   - [x] Record whole-input fallback use in the stitching report and a bounded
-    `tile_untiled_fallback` trace event; component-local fallback remains open.
+    `tile_untiled_fallback` trace event; broader partial-merge coverage remains
+    open.
 
 ### P3.3 True graph stitching
 

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -154,6 +154,8 @@ pub struct StitchingReport {
     pub retried_tile_count: usize,
     pub retry_attempt_count: usize,
     pub retry_exhausted_tile_count: usize,
+    /// Whether envelope-disjoint excluded components were recovered separately.
+    pub component_fallback_used: bool,
     /// Whether unresolved tiled output was replaced by one untiled pass over all input.
     pub untiled_fallback_used: bool,
 }
@@ -223,6 +225,11 @@ struct InputComponent {
     input_geometry_indices: Vec<usize>,
     bbox: Rect<f64>,
     connection: TileComponentConnection,
+}
+
+struct ComponentFallbackResult {
+    polygons: Vec<Polygon3D>,
+    events: Vec<(Vec<usize>, usize)>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -349,6 +356,7 @@ pub struct TiledPolygonizer<'a> {
     options: PolygonizerOptions,
     execution_policy: ExecutionPolicy,
     retry_policy: Option<TileRetryPolicy>,
+    component_fallback: bool,
     untiled_fallback: bool,
 }
 
@@ -368,6 +376,7 @@ impl<'a> TiledPolygonizer<'a> {
             options,
             execution_policy: ExecutionPolicy::default(),
             retry_policy: None,
+            component_fallback: false,
             untiled_fallback: false,
         }
     }
@@ -400,6 +409,13 @@ impl<'a> TiledPolygonizer<'a> {
 
     pub fn with_retry_policy(mut self, retry_policy: TileRetryPolicy) -> Self {
         self.retry_policy = Some(retry_policy);
+        self
+    }
+
+    /// Enables conservative recovery for excluded components with disjoint
+    /// input and output envelopes.
+    pub fn with_component_fallback(mut self) -> Self {
+        self.component_fallback = true;
         self
     }
 
@@ -555,6 +571,131 @@ impl<'a> TiledPolygonizer<'a> {
         !report.coverage_issues.is_empty()
             || !report.input_boundary_issues.is_empty()
             || !report.excluded_component_issues.is_empty()
+    }
+
+    fn try_component_fallback(
+        &self,
+        tile_polygons: &[Vec<Polygon3D>],
+        tile_reports: &[TileReport],
+        input_components: &[InputComponent],
+    ) -> Result<Option<ComponentFallbackResult>> {
+        if tile_reports.iter().any(|report| {
+            !report.coverage_issues.is_empty() || !report.input_boundary_issues.is_empty()
+        }) {
+            return Ok(None);
+        }
+
+        let component_keys = tile_reports
+            .iter()
+            .flat_map(|report| &report.excluded_component_issues)
+            .map(|issue| issue.input_geometry_indices.clone())
+            .collect::<HashSet<_>>();
+        if component_keys.is_empty() {
+            return Ok(None);
+        }
+        let components = input_components
+            .iter()
+            .filter(|component| component_keys.contains(&component.input_geometry_indices))
+            .collect::<Vec<_>>();
+        if components.len() != component_keys.len() {
+            return Ok(None);
+        }
+
+        let tiles = self.generate_tiles();
+        let buffered_bbox = |tile: &Rect<f64>| {
+            Rect::new(
+                Coord {
+                    x: tile.min().x - self.buffer,
+                    y: tile.min().y - self.buffer,
+                },
+                Coord {
+                    x: tile.max().x + self.buffer,
+                    y: tile.max().y + self.buffer,
+                },
+            )
+        };
+        let retained_polygon_bboxes = tile_polygons
+            .iter()
+            .flat_map(|polygons| polygons.iter())
+            .filter_map(Self::polygon_bbox)
+            .collect::<Vec<_>>();
+
+        for (component_index, component) in components.iter().enumerate() {
+            if components[..component_index]
+                .iter()
+                .any(|other| other.bbox.intersects(&component.bbox))
+                || retained_polygon_bboxes
+                    .iter()
+                    .any(|polygon_bbox| polygon_bbox.intersects(&component.bbox))
+            {
+                return Ok(None);
+            }
+
+            let member_indices = component
+                .input_geometry_indices
+                .iter()
+                .copied()
+                .collect::<HashSet<_>>();
+            for (geometry_index, (_, geometry_bbox)) in self.geometries.iter().enumerate() {
+                if member_indices.contains(&geometry_index) {
+                    continue;
+                }
+                if geometry_bbox.is_some_and(|bbox| bbox.intersects(&component.bbox)) {
+                    return Ok(None);
+                }
+            }
+
+            if component
+                .input_geometry_indices
+                .iter()
+                .any(|&geometry_index| {
+                    self.geometries[geometry_index]
+                        .1
+                        .is_some_and(|geometry_bbox| {
+                            tiles
+                                .iter()
+                                .any(|tile| geometry_bbox.intersects(&buffered_bbox(tile)))
+                        })
+                })
+            {
+                return Ok(None);
+            }
+        }
+
+        let mut recovered = Vec::new();
+        let mut events = Vec::with_capacity(components.len());
+        for component in components {
+            let mut polygonizer = Polygonizer::with_options(self.options.clone())
+                .with_execution_policy(self.execution_policy.clone());
+            for &geometry_index in &component.input_geometry_indices {
+                polygonizer.add_borrowed_geometry(self.geometries[geometry_index].0);
+            }
+            let polygons = polygonizer.polygonize()?.polygons;
+            if polygons.is_empty() {
+                return Ok(None);
+            }
+            events.push((component.input_geometry_indices.clone(), polygons.len()));
+            recovered.extend(polygons);
+        }
+        Ok(Some(ComponentFallbackResult {
+            polygons: recovered,
+            events,
+        }))
+    }
+
+    fn polygon_bbox(poly: &Polygon3D) -> Option<Rect<f64>> {
+        let first = poly.exterior.first()?;
+        let (mut min_x, mut min_y, mut max_x, mut max_y) = (first.x, first.y, first.x, first.y);
+        for coordinate in &poly.exterior[1..] {
+            min_x = min_x.min(coordinate.x);
+            min_y = min_y.min(coordinate.y);
+            max_x = max_x.max(coordinate.x);
+            max_y = max_y.max(coordinate.y);
+        }
+        Some(Rect::new(
+            Coord { x: min_x, y: min_y },
+            Coord { x: max_x, y: max_y },
+        ))
     }
 
     fn process_tile_with_retries(
@@ -912,6 +1053,7 @@ impl<'a> TiledPolygonizer<'a> {
             }
             TileCoverageGuarantee::ValidateObservedCoverage => {
                 !result.stitching_report.untiled_fallback_used
+                    && !result.stitching_report.component_fallback_used
                     && (result.stitching_report.unresolved_owned_polygon_count != 0
                         || result.stitching_report.unresolved_input_geometry_count != 0
                         || result.stitching_report.unresolved_component_count != 0)
@@ -1060,7 +1202,16 @@ impl<'a> TiledPolygonizer<'a> {
             }
         }
         let unresolved = tile_reports.iter().any(Self::report_is_unresolved);
-        let untiled_fallback_used = self.untiled_fallback && unresolved;
+        let component_fallback = if self.component_fallback && unresolved {
+            self.try_component_fallback(&tile_polygons, &tile_reports, input_components)?
+        } else {
+            None
+        };
+        let component_fallback_used = component_fallback.is_some();
+        let (component_fallback_polygons, component_fallback_events) = component_fallback
+            .map(|fallback| (fallback.polygons, fallback.events))
+            .unwrap_or_default();
+        let untiled_fallback_used = self.untiled_fallback && unresolved && !component_fallback_used;
         let result_polygons: Vec<Polygon3D> = if untiled_fallback_used {
             let mut polygonizer = Polygonizer::with_options(self.options.clone())
                 .with_execution_policy(self.execution_policy.clone());
@@ -1069,7 +1220,11 @@ impl<'a> TiledPolygonizer<'a> {
             }
             polygonizer.polygonize()?.polygons
         } else {
-            tile_polygons.into_iter().flatten().collect()
+            tile_polygons
+                .into_iter()
+                .flatten()
+                .chain(component_fallback_polygons)
+                .collect()
         };
         let merged_polygon_count = result_polygons.len();
 
@@ -1166,9 +1321,20 @@ impl<'a> TiledPolygonizer<'a> {
                 retried_tile_count,
                 retry_attempt_count,
                 retry_exhausted_tile_count,
+                component_fallback_used,
                 untiled_fallback_used,
             },
         };
+        if component_fallback_used {
+            if let Some(trace) = trace.as_deref_mut() {
+                for (input_geometry_indices, output_polygon_count) in component_fallback_events {
+                    trace.record_tile_component_fallback(
+                        &input_geometry_indices,
+                        output_polygon_count,
+                    );
+                }
+            }
+        }
         if untiled_fallback_used {
             if let Some(trace) = trace {
                 trace.record_tile_untiled_fallback(

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -544,6 +544,114 @@ mod tests {
     }
 
     #[test]
+    fn component_fallback_recovers_an_envelope_disjoint_component() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 20.0 });
+        let boundaries = [
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: -10.0, y: -10.0 },
+                Coord { x: 30.0, y: -10.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 30.0, y: -10.0 },
+                Coord { x: 30.0, y: 30.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 30.0, y: 30.0 },
+                Coord { x: -10.0, y: 30.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: -10.0, y: 30.0 },
+                Coord { x: -10.0, y: -10.0 },
+            ])),
+        ];
+        let mut untiled = Polygonizer::new();
+        let mut tiled = TiledPolygonizer::new(bbox, 10.0)
+            .with_buffer(2.0)
+            .with_component_fallback();
+        for boundary in &boundaries {
+            untiled.add_borrowed_geometry(boundary);
+            tiled.add_geometry(boundary);
+        }
+
+        let untiled = untiled.polygonize().unwrap();
+        let result = tiled
+            .polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateObservedCoverage)
+            .unwrap();
+        assert_eq!(result.polygons.len(), 1);
+        assert_eq!(
+            crate::tiling::canonical_polygon_key(&result.polygons[0]),
+            crate::tiling::canonical_polygon_key(&untiled.polygons[0])
+        );
+        assert!(result.stitching_report.component_fallback_used);
+        assert!(!result.stitching_report.untiled_fallback_used);
+        assert_eq!(result.stitching_report.unresolved_component_count, 4);
+
+        let traced = tiled
+            .polygonize_with_trace(TraceLevelV1::Full, usize::MAX)
+            .unwrap();
+        let events = traced
+            .trace
+            .events
+            .iter()
+            .filter(|event| event.kind == "tile_component_fallback")
+            .collect::<Vec<_>>();
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0].payload["input_geometry_indices"],
+            serde_json::json!([0, 1, 2, 3])
+        );
+        assert_eq!(events[0].payload["output_polygon_count"], 1);
+    }
+
+    #[test]
+    fn component_fallback_declines_nested_retained_output() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 20.0 });
+        let geometries = [
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: -10.0, y: -10.0 },
+                Coord { x: 30.0, y: -10.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 30.0, y: -10.0 },
+                Coord { x: 30.0, y: 30.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 30.0, y: 30.0 },
+                Coord { x: -10.0, y: 30.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: -10.0, y: 30.0 },
+                Coord { x: -10.0, y: -10.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 2.0, y: 2.0 },
+                Coord { x: 4.0, y: 2.0 },
+                Coord { x: 4.0, y: 4.0 },
+                Coord { x: 2.0, y: 4.0 },
+                Coord { x: 2.0, y: 2.0 },
+            ])),
+        ];
+        let mut tiled = TiledPolygonizer::new(bbox, 10.0)
+            .with_buffer(2.0)
+            .with_component_fallback();
+        for geometry in &geometries {
+            tiled.add_geometry(geometry);
+        }
+
+        let result = tiled.polygonize().unwrap();
+        assert_eq!(result.polygons.len(), 1);
+        assert!(!result.stitching_report.component_fallback_used);
+        assert!(!result.stitching_report.untiled_fallback_used);
+        assert_eq!(result.stitching_report.unresolved_component_count, 4);
+        assert!(matches!(
+            tiled.polygonize_with_coverage_guarantee(
+                TileCoverageGuarantee::ValidateObservedCoverage
+            ),
+            Err(TiledPolygonizeError::CoverageIncomplete { .. })
+        ));
+    }
+
+    #[test]
     fn documents_intersection_connected_component_excluded_from_every_halo() {
         let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 20.0 });
         let boundaries = [

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -341,6 +341,12 @@ pub struct TileUntiledFallbackTraceV1 {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct TileComponentFallbackTraceV1 {
+    pub input_geometry_indices: Vec<usize>,
+    pub output_polygon_count: usize,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct TileOwnedFaceBoundaryTraceV1 {
     pub tile_index: usize,
     pub polygon_index: usize,
@@ -1271,6 +1277,22 @@ impl TraceRecorderV1 {
                 unresolved_component_count,
             })
             .expect("tile untiled-fallback trace event serializes"),
+        )
+    }
+
+    pub(crate) fn record_tile_component_fallback(
+        &mut self,
+        input_geometry_indices: &[usize],
+        output_polygon_count: usize,
+    ) -> bool {
+        self.record(
+            TraceStageV1::Output,
+            "tile_component_fallback",
+            serde_json::to_value(TileComponentFallbackTraceV1 {
+                input_geometry_indices: input_geometry_indices.to_vec(),
+                output_polygon_count,
+            })
+            .expect("tile component-fallback trace event serializes"),
         )
     }
 

--- a/docs/guide/tiling.md
+++ b/docs/guide/tiling.md
@@ -111,8 +111,14 @@ attempt in `TileReport` and `StitchingReport`. Strict validation returns the
 typed coverage error with retry counts when the bounded schedule is exhausted.
 Retries reuse the same execution policy independently per attempt. Full output
 traces record bounded `tile_halo_retry` events directly from the physical retry
-history. Unresolved-component untiled fallback and cross-region result merging
-remain unavailable.
+history. `with_component_fallback` enables a narrower recovery path for excluded
+components whose member input envelopes miss every tile halo and whose component
+envelope is disjoint from every other input envelope, retained tile polygon, and
+other recovered component. It polygonizes that component with the same options,
+merges the result deterministically, records `component_fallback_used` and a
+bounded `tile_component_fallback` event, and declines recovery when any envelope
+overlaps or nests. `with_untiled_fallback` remains the containment-safe escape
+hatch for those declined cases. Cross-region result merging remains unavailable.
 Applications that require correctness must run an untiled equivalence check for
 their input class or choose untiled polygonization directly when sufficiency is
 unknown.


### PR DESCRIPTION
## Stack

Parent: main
Children: #1171 (agent/p3-component-fallback-determinism)
Branch: agent/p3-component-safe-fallback

## Delivered

- Added opt-in with_component_fallback() for excluded connected components.
- Added a strict envelope-disjoint safety gate: component members must miss every tile halo, and the component must be disjoint from other input envelopes, retained tile polygons, and other recovered components.
- Recovered components use the same polygonizer and execution options, then enter the existing deterministic merge and dedup path.
- Added StitchingReport.component_fallback_used and bounded tile_component_fallback trace evidence.
- Added recovery and nested-containment decline regressions, guide documentation, and precise P3.2 roadmap evidence.

## Contract impact

- Additive experimental API; default tiled behavior is unchanged.
- ValidateObservedCoverage accepts unresolved raw component evidence only when this opt-in recovery completed; raw tile reports remain intact.
- Nested, overlapping, boundary-interacting, or previously included linework declines component recovery. with_untiled_fallback() remains the containment-safe escape hatch.
- Cross-region graph stitching and general partial merging remain out of scope.

## Validation

- cargo fmt --all -- --check
- git diff --check
- cargo test -p geo-polygonize-core --lib tiling::tests — 24 passed
- cargo test -p geo-polygonize-core --no-default-features --lib tiling::tests — 24 passed
- cargo test -p geo-polygonize-core --test tiling_equivalence — 4 passed
- cargo clippy --workspace --all-targets -- -D warnings — passed
- cargo test --workspace — 224 core tests plus all workspace integration/doc tests passed
- cargo test --workspace --no-default-features — 224 core tests plus all workspace integration/doc tests passed
- RUSTDOCFLAGS=-D warnings cargo doc -p geo-polygonize-core --no-deps — passed
- Generated bindings were restored; no generated artifacts are included.

## Agent handoff

- Parent: main
- Children: #1171 (agent/p3-component-fallback-determinism)
- Next exact branch: agent/p3-component-fallback-coverage
- Broader P3.1 undetected-region evidence, general canonical partial merging, and P3.3 true stitching remain open.
- The pinned nested-containment case disproves independently polygonizing and appending overlapping/nested components; this slice intentionally declines it.