### PR TITLE
test(core): prove component fallback determinism

### DIFF
--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -652,6 +652,76 @@ mod tests {
     }
 
     #[test]
+    fn component_fallback_keeps_recovered_output_deterministic() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 20.0 });
+        let geometries = [
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: -10.0, y: -10.0 },
+                Coord { x: 30.0, y: -10.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 30.0, y: -10.0 },
+                Coord { x: 30.0, y: 30.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 30.0, y: 30.0 },
+                Coord { x: -10.0, y: 30.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: -10.0, y: 30.0 },
+                Coord { x: -10.0, y: -10.0 },
+            ])),
+        ];
+        let mut untiled = Polygonizer::new();
+        let mut tiled = TiledPolygonizer::new(bbox, 10.0)
+            .with_buffer(2.0)
+            .with_dedup_policy(DedupPolicy::CanonicalRingHash)
+            .with_component_fallback();
+        for geometry in &geometries {
+            untiled.add_borrowed_geometry(geometry);
+            tiled.add_geometry(geometry);
+        }
+
+        let expected = untiled
+            .polygonize()
+            .unwrap()
+            .polygons
+            .into_iter()
+            .map(|polygon| crate::tiling::canonical_polygon_key(&polygon))
+            .collect::<Vec<_>>();
+        let forward = tiled
+            .polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateObservedCoverage)
+            .unwrap();
+        let forward_keys = forward
+            .polygons
+            .iter()
+            .map(crate::tiling::canonical_polygon_key)
+            .collect::<Vec<_>>();
+        assert_eq!(forward_keys, expected);
+        assert!(forward.stitching_report.component_fallback_used);
+        assert!(!forward.stitching_report.untiled_fallback_used);
+
+        let mut reversed = TiledPolygonizer::new(bbox, 10.0)
+            .with_buffer(2.0)
+            .with_dedup_policy(DedupPolicy::CanonicalRingHash)
+            .with_component_fallback();
+        for geometry in geometries.iter().rev() {
+            reversed.add_geometry(geometry);
+        }
+        let reversed = reversed
+            .polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateObservedCoverage)
+            .unwrap();
+        let reversed_keys = reversed
+            .polygons
+            .iter()
+            .map(crate::tiling::canonical_polygon_key)
+            .collect::<Vec<_>>();
+        assert_eq!(reversed_keys, forward_keys);
+        assert!(reversed.stitching_report.component_fallback_used);
+        assert_eq!(reversed.stitching_report.output_polygon_count, 1);
+    }
+
+    #[test]
     fn documents_intersection_connected_component_excluded_from_every_halo() {
         let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 20.0 });
         let boundaries = [


### PR DESCRIPTION
## Stack

Parent: #1170 (agent/p3-component-safe-fallback)
Children: #1173 (agent/p3-component-fallback-coverage)
Branch: agent/p3-component-fallback-determinism

## Delivered

- Added a regression for the opt-in component fallback under canonical-ring deduplication.
- Verifies recovered output equals untiled canonical output.
- Verifies reversed input order produces the same canonical output and still reports component recovery.

## Contract impact

- Test-only child; no production API or behavior changes.
- The same assertion passes in the default parallel-feature build and the no-default-features serial build.
- The test keeps the nested-containment decline contract covered by the parent.

## Validation

- cargo fmt --all -- --check — passed
- git diff --check — passed
- cargo test -p geo-polygonize-core --lib tiling::tests::tests::component_fallback — 3 passed
- cargo test -p geo-polygonize-core --no-default-features --lib tiling::tests::tests::component_fallback — 3 passed
- Generated bindings were restored; no generated artifacts are included.

## Agent handoff

- Parent: #1170 (agent/p3-component-safe-fallback)
- Children: #1173 (agent/p3-component-fallback-coverage)
- Next exact branch: agent/p3-broad-region-evidence
- Broader P3.1 undetected-region evidence, general canonical partial merging, and P3.3 true stitching remain open.