### PR TITLE
test(core): cover component fallback noding modes

### DIFF
--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -719,6 +719,56 @@ mod tests {
         assert_eq!(reversed_keys, forward_keys);
         assert!(reversed.stitching_report.component_fallback_used);
         assert_eq!(reversed.stitching_report.output_polygon_count, 1);
+
+        for (options, connection) in [
+            (
+                PolygonizerOptions {
+                    node_input: true,
+                    pre_snap_tolerance: 0.5,
+                    ..Default::default()
+                },
+                TileComponentConnection::PreSnap,
+            ),
+            (
+                PolygonizerOptions {
+                    node_input: true,
+                    precision_model: PrecisionModel::FixedGrid { grid_size: 1.0 },
+                    ..Default::default()
+                },
+                TileComponentConnection::FixedGrid,
+            ),
+        ] {
+            let mut configured_untiled = Polygonizer::with_options(options.clone());
+            let mut configured_tiled = TiledPolygonizer::new(bbox, 10.0)
+                .with_buffer(2.0)
+                .with_options(options)
+                .with_component_fallback();
+            for geometry in &geometries {
+                configured_untiled.add_borrowed_geometry(geometry);
+                configured_tiled.add_geometry(geometry);
+            }
+            let expected = configured_untiled
+                .polygonize()
+                .unwrap()
+                .polygons
+                .into_iter()
+                .map(|polygon| crate::tiling::canonical_polygon_key(&polygon))
+                .collect::<Vec<_>>();
+            let result = configured_tiled
+                .polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateObservedCoverage)
+                .unwrap();
+            let actual = result
+                .polygons
+                .iter()
+                .map(crate::tiling::canonical_polygon_key)
+                .collect::<Vec<_>>();
+            assert_eq!(actual, expected);
+            assert!(result.stitching_report.component_fallback_used);
+            assert!(result.tile_reports.iter().all(|report| {
+                report.excluded_component_issues.len() == 1
+                    && report.excluded_component_issues[0].connection == connection
+            }));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Stack

Parent: #1171 (agent/p3-component-fallback-determinism)
Children: none
Branch: agent/p3-component-fallback-coverage

## Delivered

- Added contract coverage for component fallback with pre-snap-connected input components.
- Added contract coverage for fixed-grid-connected input components.
- Both modes compare recovered canonical output with an untiled polygonizer and verify the reported connection classification.

## Contract impact

- Test-only child; no production API or behavior changes.
- Confirms the opt-in recovery uses the configured noding mode and preserves the same output contract across default and no-default-features builds.
- The strict envelope-disjoint gate and nested-containment decline remain unchanged.

## Validation

- cargo fmt --all -- --check — passed
- git diff --check — passed
- cargo test -p geo-polygonize-core --lib tiling::tests::tests::component_fallback — 3 passed
- cargo test -p geo-polygonize-core --no-default-features --lib tiling::tests::tests::component_fallback — 3 passed
- Generated bindings were restored; no generated artifacts are included.

## Agent handoff

- Parent: #1171 (agent/p3-component-fallback-determinism)
- Children: none
- Next exact branch: agent/p3-broad-region-evidence
- Broader P3.1 undetected-region evidence, general canonical partial merging, and P3.3 true stitching remain open.