### PR TITLE
test(core): bound component fallback traces

### DIFF
--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -601,6 +601,12 @@ mod tests {
             serde_json::json!([0, 1, 2, 3])
         );
         assert_eq!(events[0].payload["output_polygon_count"], 1);
+
+        let bounded = tiled.polygonize_with_trace(TraceLevelV1::Full, 0).unwrap();
+        assert!(bounded.trace.events.is_empty());
+        assert!(bounded.trace.truncated);
+        assert!(bounded.result.stitching_report.component_fallback_used);
+        assert_eq!(bounded.result.polygons.len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Stack

Parent: #1174 (agent/p3-component-fallback-containment-handoff)
Children: none
Branch: agent/p3-component-fallback-trace-budget

## Delivered

- Added a bounded-trace regression for component fallback.
- A zero-byte full trace emits no events and reports truncation while preserving recovered output and component_fallback_used.

## Contract impact

- Test-only child; no production behavior changes.
- Confirms trace capture limits cannot change component recovery results or recovery reporting.
- Existing nested-containment handoff and whole-input fallback contracts remain covered by the parent.

## Validation

- cargo fmt --all -- --check — passed
- git diff --check — passed
- cargo test -p geo-polygonize-core --lib tiling::tests::tests::component_fallback — 3 passed
- cargo test -p geo-polygonize-core --no-default-features --lib tiling::tests::tests::component_fallback — 3 passed
- Generated bindings were restored; no generated artifacts are included.

## Agent handoff

- Parent: #1174 (agent/p3-component-fallback-containment-handoff)
- Children: none
- Next exact branch: agent/p3-broad-region-evidence
- Broader connected-region detection, canonical partial merging, and P3.3 true stitching remain open.