### PR TITLE
feat(core): merge disjoint tiled fallback regions

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -752,9 +752,12 @@ When coverage cannot be proven:
   - [x] Pin the global-containment boundary where an excluded outer component
     spatially nests an already retained tile-local face.
   - [x] Add opt-in envelope-disjoint component fallback that declines nested,
-    overlapping, or previously included linework and records the recovery.
+    overlapping, or retained-face-interacting linework and records the
+    recovery.
   - [x] Verify declined nested component recovery hands off to the
     containment-safe whole-input fallback when both are enabled.
+  - [x] Merge one envelope-disjoint recovered component with retained tile
+    output; general region-local partial merging remains open.
   - [x] Provide a caller-enabled whole-input untiled fallback that preserves
     global containment when retries leave observed coverage unresolved.
   - [x] Verify whole-input fallback equality with untiled output across tile

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -413,7 +413,7 @@ impl<'a> TiledPolygonizer<'a> {
     }
 
     /// Enables conservative recovery for excluded components with disjoint
-    /// input and output envelopes.
+    /// non-member input and retained-output envelopes.
     pub fn with_component_fallback(mut self) -> Self {
         self.component_fallback = true;
         self
@@ -579,12 +579,6 @@ impl<'a> TiledPolygonizer<'a> {
         tile_reports: &[TileReport],
         input_components: &[InputComponent],
     ) -> Result<Option<ComponentFallbackResult>> {
-        if tile_reports.iter().any(|report| {
-            !report.coverage_issues.is_empty() || !report.input_boundary_issues.is_empty()
-        }) {
-            return Ok(None);
-        }
-
         let component_keys = tile_reports
             .iter()
             .flat_map(|report| &report.excluded_component_issues)
@@ -600,20 +594,20 @@ impl<'a> TiledPolygonizer<'a> {
         if components.len() != component_keys.len() {
             return Ok(None);
         }
+        let component_member_indices = components
+            .iter()
+            .flat_map(|component| component.input_geometry_indices.iter().copied())
+            .collect::<HashSet<_>>();
+        if tile_reports.iter().any(|report| {
+            !report.coverage_issues.is_empty()
+                || report
+                    .input_boundary_issues
+                    .iter()
+                    .any(|issue| !component_member_indices.contains(&issue.input_geometry_index))
+        }) {
+            return Ok(None);
+        }
 
-        let tiles = self.generate_tiles();
-        let buffered_bbox = |tile: &Rect<f64>| {
-            Rect::new(
-                Coord {
-                    x: tile.min().x - self.buffer,
-                    y: tile.min().y - self.buffer,
-                },
-                Coord {
-                    x: tile.max().x + self.buffer,
-                    y: tile.max().y + self.buffer,
-                },
-            )
-        };
         let retained_polygon_bboxes = tile_polygons
             .iter()
             .flat_map(|polygons| polygons.iter())
@@ -631,34 +625,13 @@ impl<'a> TiledPolygonizer<'a> {
                 return Ok(None);
             }
 
-            let member_indices = component
-                .input_geometry_indices
-                .iter()
-                .copied()
-                .collect::<HashSet<_>>();
             for (geometry_index, (_, geometry_bbox)) in self.geometries.iter().enumerate() {
-                if member_indices.contains(&geometry_index) {
+                if component.input_geometry_indices.contains(&geometry_index) {
                     continue;
                 }
                 if geometry_bbox.is_some_and(|bbox| bbox.intersects(&component.bbox)) {
                     return Ok(None);
                 }
-            }
-
-            if component
-                .input_geometry_indices
-                .iter()
-                .any(|&geometry_index| {
-                    self.geometries[geometry_index]
-                        .1
-                        .is_some_and(|geometry_bbox| {
-                            tiles
-                                .iter()
-                                .any(|tile| geometry_bbox.intersects(&buffered_bbox(tile)))
-                        })
-                })
-            {
-                return Ok(None);
             }
         }
 

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -610,6 +610,94 @@ mod tests {
     }
 
     #[test]
+    fn component_fallback_merges_disjoint_retained_output() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 60.0, y: 60.0 });
+        let geometries = [
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: -10.0, y: -10.0 },
+                Coord { x: 30.0, y: -10.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 30.0, y: -10.0 },
+                Coord { x: 30.0, y: 30.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 30.0, y: 30.0 },
+                Coord { x: -10.0, y: 30.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: -10.0, y: 30.0 },
+                Coord { x: -10.0, y: -10.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 52.0, y: 52.0 },
+                Coord { x: 58.0, y: 52.0 },
+                Coord { x: 58.0, y: 58.0 },
+                Coord { x: 52.0, y: 58.0 },
+                Coord { x: 52.0, y: 52.0 },
+            ])),
+        ];
+        let mut untiled = Polygonizer::new();
+        let mut tiled = TiledPolygonizer::new(bbox, 10.0)
+            .with_buffer(0.0)
+            .with_dedup_policy(DedupPolicy::CanonicalRingHash)
+            .with_component_fallback();
+        for geometry in &geometries {
+            untiled.add_borrowed_geometry(geometry);
+            tiled.add_geometry(geometry);
+        }
+
+        let expected = untiled.polygonize().unwrap();
+        assert_eq!(expected.polygons.len(), 2);
+        let result = tiled
+            .polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateObservedCoverage)
+            .unwrap();
+        assert_eq!(
+            result
+                .polygons
+                .iter()
+                .map(crate::tiling::canonical_polygon_key)
+                .collect::<Vec<_>>(),
+            expected
+                .polygons
+                .iter()
+                .map(crate::tiling::canonical_polygon_key)
+                .collect::<Vec<_>>()
+        );
+        assert!(result.stitching_report.component_fallback_used);
+        assert!(!result.stitching_report.untiled_fallback_used);
+        assert!(result.stitching_report.unresolved_input_geometry_count > 0);
+        assert!(result
+            .tile_reports
+            .iter()
+            .flat_map(|report| &report.input_boundary_issues)
+            .all(|issue| issue.input_geometry_index < 4));
+
+        let mut reversed = TiledPolygonizer::new(bbox, 10.0)
+            .with_dedup_policy(DedupPolicy::CanonicalRingHash)
+            .with_component_fallback();
+        for geometry in geometries.iter().rev() {
+            reversed.add_geometry(geometry);
+        }
+        let reversed = reversed
+            .polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateObservedCoverage)
+            .unwrap();
+        assert_eq!(
+            reversed
+                .polygons
+                .iter()
+                .map(crate::tiling::canonical_polygon_key)
+                .collect::<Vec<_>>(),
+            result
+                .polygons
+                .iter()
+                .map(crate::tiling::canonical_polygon_key)
+                .collect::<Vec<_>>()
+        );
+        assert!(reversed.stitching_report.component_fallback_used);
+    }
+
+    #[test]
     fn component_fallback_declines_nested_retained_output() {
         let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 20.0 });
         let geometries = [

--- a/docs/guide/tiling.md
+++ b/docs/guide/tiling.md
@@ -112,13 +112,15 @@ typed coverage error with retry counts when the bounded schedule is exhausted.
 Retries reuse the same execution policy independently per attempt. Full output
 traces record bounded `tile_halo_retry` events directly from the physical retry
 history. `with_component_fallback` enables a narrower recovery path for excluded
-components whose member input envelopes miss every tile halo and whose component
-envelope is disjoint from every other input envelope, retained tile polygon, and
-other recovered component. It polygonizes that component with the same options,
-merges the result deterministically, records `component_fallback_used` and a
-bounded `tile_component_fallback` event, and declines recovery when any envelope
-overlaps or nests. `with_untiled_fallback` remains the containment-safe escape
-hatch for those declined cases. Cross-region result merging remains unavailable.
+components whose envelope is disjoint from every non-member input envelope,
+retained tile polygon, and other recovered component. Member linework may have
+appeared in a tile halo; if that produced a retained face intersecting the
+component envelope, recovery declines. Otherwise it polygonizes the complete
+component with the same options, merges the result deterministically, records
+`component_fallback_used` and a bounded `tile_component_fallback` event, and
+declines recovery when any envelope overlaps or nests. `with_untiled_fallback`
+remains the containment-safe escape hatch for those declined cases. General
+cross-region graph merging remains unavailable.
 Applications that require correctness must run an untiled equivalence check for
 their input class or choose untiled polygonization directly when sufficiency is
 unknown.


### PR DESCRIPTION
## Stack

Parent: main
Children: #1178 (agent/p3-component-fallback-multi-merge)
Branch: agent/p3-component-fallback-partial-merge

## Delivered

- Allow component fallback when unresolved input-boundary evidence belongs only to the recovered component members.
- Preserve conservative rejection for owned-face coverage, non-member input-envelope overlap, retained tile-face overlap, and overlapping recovered components.
- Add a regression proving deterministic canonical merging of one recovered component with an unrelated retained tile face, including reversed input order.
- Update the tiling guide and P3.2 roadmap evidence.

## Contract impact

- Additive opt-in behavior behind `with_component_fallback()`; default tiled behavior is unchanged.
- `ValidateObservedCoverage` accepts member-boundary evidence only when the complete component is recovered; unrelated evidence still rejects.
- Nested, overlapping, or retained-face-interacting components still decline recovery and can use whole-input fallback.
- General region-local merging and P3.3 graph stitching remain open.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p geo-polygonize-core --lib tiling::tests::tests::component_fallback` (default and no-default-features: 4 passed each)
- `cargo test -p geo-polygonize-core --lib tiling::tests` (default and no-default-features: 26 passed each)
- `cargo test -p geo-polygonize-core --test tiling_equivalence` (4 passed)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p geo-polygonize-core --no-deps`
- `cargo test --workspace` and `cargo test --workspace --no-default-features` (both exit 0)
- Generated bindings were restored; no generated artifacts are included.

## Agent handoff

Parent: main
Children: #1178 (agent/p3-component-fallback-multi-merge)
Next branch: agent/p3-component-fallback-provenance
Next slice: add a provenance-preservation regression for retained and recovered outputs before considering any broader merge proof.