### PR TITLE
test(core): cover multiple tiled fallback merges

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -758,6 +758,9 @@ When coverage cannot be proven:
     containment-safe whole-input fallback when both are enabled.
   - [x] Merge one envelope-disjoint recovered component with retained tile
     output; general region-local partial merging remains open.
+  - [x] Merge multiple pairwise envelope-disjoint recovered components with
+    retained tile output; cross-component overlap and graph stitching remain
+    open.
   - [x] Provide a caller-enabled whole-input untiled fallback that preserves
     global containment when retries leave observed coverage unresolved.
   - [x] Verify whole-input fallback equality with untiled output across tile

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -698,6 +698,125 @@ mod tests {
     }
 
     #[test]
+    fn component_fallback_merges_multiple_disjoint_components() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 100.0, y: 100.0 });
+        let geometries = [
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: -10.0, y: -10.0 },
+                Coord { x: 30.0, y: -10.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 30.0, y: -10.0 },
+                Coord { x: 30.0, y: 30.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 30.0, y: 30.0 },
+                Coord { x: -10.0, y: 30.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: -10.0, y: 30.0 },
+                Coord { x: -10.0, y: -10.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 70.0, y: -10.0 },
+                Coord { x: 110.0, y: -10.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 110.0, y: -10.0 },
+                Coord { x: 110.0, y: 30.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 110.0, y: 30.0 },
+                Coord { x: 70.0, y: 30.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 70.0, y: 30.0 },
+                Coord { x: 70.0, y: -10.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 42.0, y: 42.0 },
+                Coord { x: 48.0, y: 42.0 },
+                Coord { x: 48.0, y: 48.0 },
+                Coord { x: 42.0, y: 48.0 },
+                Coord { x: 42.0, y: 42.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 52.0, y: 52.0 },
+                Coord { x: 58.0, y: 52.0 },
+                Coord { x: 58.0, y: 58.0 },
+                Coord { x: 52.0, y: 58.0 },
+                Coord { x: 52.0, y: 52.0 },
+            ])),
+        ];
+        let mut untiled = Polygonizer::new();
+        let mut tiled = TiledPolygonizer::new(bbox, 10.0)
+            .with_dedup_policy(DedupPolicy::CanonicalRingHash)
+            .with_component_fallback();
+        for geometry in &geometries {
+            untiled.add_borrowed_geometry(geometry);
+            tiled.add_geometry(geometry);
+        }
+
+        let expected = untiled.polygonize().unwrap();
+        assert_eq!(expected.polygons.len(), 4);
+        let result = tiled
+            .polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateObservedCoverage)
+            .unwrap();
+        assert_eq!(result.polygons.len(), 4);
+        assert_eq!(
+            result
+                .polygons
+                .iter()
+                .map(crate::tiling::canonical_polygon_key)
+                .collect::<Vec<_>>(),
+            expected
+                .polygons
+                .iter()
+                .map(crate::tiling::canonical_polygon_key)
+                .collect::<Vec<_>>()
+        );
+        assert!(result.stitching_report.component_fallback_used);
+        assert!(!result.stitching_report.untiled_fallback_used);
+
+        let traced = tiled
+            .polygonize_with_trace(TraceLevelV1::Full, usize::MAX)
+            .unwrap();
+        let fallback_events = traced
+            .trace
+            .events
+            .iter()
+            .filter(|event| event.kind == "tile_component_fallback")
+            .collect::<Vec<_>>();
+        assert_eq!(fallback_events.len(), 2);
+        assert!(fallback_events
+            .iter()
+            .all(|event| event.payload["output_polygon_count"] == 1));
+
+        let mut reversed = TiledPolygonizer::new(bbox, 10.0)
+            .with_dedup_policy(DedupPolicy::CanonicalRingHash)
+            .with_component_fallback();
+        for geometry in geometries.iter().rev() {
+            reversed.add_geometry(geometry);
+        }
+        let reversed = reversed
+            .polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateObservedCoverage)
+            .unwrap();
+        assert_eq!(
+            reversed
+                .polygons
+                .iter()
+                .map(crate::tiling::canonical_polygon_key)
+                .collect::<Vec<_>>(),
+            result
+                .polygons
+                .iter()
+                .map(crate::tiling::canonical_polygon_key)
+                .collect::<Vec<_>>()
+        );
+        assert!(reversed.stitching_report.component_fallback_used);
+    }
+
+    #[test]
     fn component_fallback_declines_nested_retained_output() {
         let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 20.0 });
         let geometries = [


### PR DESCRIPTION
## Stack

Parent: #1177 (agent/p3-component-fallback-partial-merge)
Children: #1180 (agent/p3-component-fallback-provenance)
Branch: agent/p3-component-fallback-multi-merge

## Delivered

- Add a four-face fixture with two pairwise envelope-disjoint excluded components and two retained tile-local faces.
- Verify canonical output equality with untiled output, two bounded component-fallback trace events, and reversed input-order equality.
- Record the narrow P3.2 multi-component merge evidence without closing general region-local merging or graph stitching.

## Contract impact

- Test-only; no runtime behavior or public API changes.
- Confirms the parent opt-in fallback can append multiple spatially safe recovered components to retained output.
- Overlapping, nested, or graph-connected regions remain outside this contract and continue to decline component fallback.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p geo-polygonize-core --lib tiling::tests::tests::component_fallback` (default: 5 passed)
- `cargo test -p geo-polygonize-core --no-default-features --lib tiling::tests::tests::component_fallback` (5 passed)
- `cargo test -p geo-polygonize-core --lib tiling::tests` (default and no-default-features: 27 passed each)
- `cargo test -p geo-polygonize-core --test tiling_equivalence` (4 passed)
- Parent PR validation includes workspace default/no-default tests, clippy, rustdoc, and generated-artifact restoration.

## Agent handoff

Parent: #1177 (agent/p3-component-fallback-partial-merge)
Children: #1180 (agent/p3-component-fallback-provenance)
Next branch: agent/p3-component-fallback-z
Next slice: add a Z-policy regression or stop this line if tiled borrowed geometry cannot carry meaningful source Z under the current API.