### PR TITLE
test(core): verify tiled fallback provenance

### DIFF
--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -637,9 +637,19 @@ mod tests {
                 Coord { x: 52.0, y: 52.0 },
             ])),
         ];
-        let mut untiled = Polygonizer::new();
+        let options = PolygonizerOptions {
+            node_input: true,
+            provenance: ProvenanceOptions {
+                enabled: true,
+                include_boundary_line_ids: true,
+            },
+            input_profile_id: Some("tiled-partial-merge-v1".to_string()),
+            ..Default::default()
+        };
+        let mut untiled = Polygonizer::with_options(options.clone());
         let mut tiled = TiledPolygonizer::new(bbox, 10.0)
             .with_buffer(0.0)
+            .with_options(options.clone())
             .with_dedup_policy(DedupPolicy::CanonicalRingHash)
             .with_component_fallback();
         for geometry in &geometries {
@@ -673,7 +683,36 @@ mod tests {
             .flat_map(|report| &report.input_boundary_issues)
             .all(|issue| issue.input_geometry_index < 4));
 
+        let mut expected_provenance = expected
+            .polygons
+            .iter()
+            .map(|polygon| {
+                let provenance = polygon.provenance.as_ref().unwrap();
+                (
+                    crate::tiling::canonical_polygon_key(polygon),
+                    provenance.boundary_line_ids.clone(),
+                    provenance.input_profile_id.clone(),
+                )
+            })
+            .collect::<Vec<_>>();
+        let mut actual_provenance = result
+            .polygons
+            .iter()
+            .map(|polygon| {
+                let provenance = polygon.provenance.as_ref().unwrap();
+                (
+                    crate::tiling::canonical_polygon_key(polygon),
+                    provenance.boundary_line_ids.clone(),
+                    provenance.input_profile_id.clone(),
+                )
+            })
+            .collect::<Vec<_>>();
+        expected_provenance.sort_unstable_by(|left, right| left.0.cmp(&right.0));
+        actual_provenance.sort_unstable_by(|left, right| left.0.cmp(&right.0));
+        assert_eq!(actual_provenance, expected_provenance);
+
         let mut reversed = TiledPolygonizer::new(bbox, 10.0)
+            .with_options(options)
             .with_dedup_policy(DedupPolicy::CanonicalRingHash)
             .with_component_fallback();
         for geometry in geometries.iter().rev() {


### PR DESCRIPTION
## Stack

Parent: #1178 (agent/p3-component-fallback-multi-merge)
Children: #1181 (agent/p3-component-fallback-limits)
Branch: agent/p3-component-fallback-provenance

## Delivered

- Enable provenance and a stable input profile on the retained-plus-recovered partial-merge fixture.
- Compare canonical geometry, boundary-line metadata, and input-profile metadata against untiled output.
- Keep reversed input-order canonical equality under the provenance-enabled contract.

## Contract impact

- Test-only; no runtime behavior or public API changes.
- Pins that opt-in component recovery preserves cloned polygonizer options for both retained and recovered output.
- The tiled borrowed-geometry API retains its existing source-ID behavior; this test does not claim a new global source-ID namespace.
- General provenance reconciliation for future graph stitching remains open.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p geo-polygonize-core --lib tiling::tests::tests::component_fallback_merges_disjoint_retained_output` (1 passed)
- `cargo test -p geo-polygonize-core --lib tiling::tests::tests::component_fallback` (5 passed)
- `cargo test -p geo-polygonize-core --no-default-features --lib tiling::tests::tests::component_fallback` (5 passed)
- Parent stack validation includes full tiling, equivalence, workspace default/no-default tests, clippy, rustdoc, and generated-artifact restoration.

## Agent handoff

Parent: #1178 (agent/p3-component-fallback-multi-merge)
Children: #1181 (agent/p3-component-fallback-limits)
Next branch: agent/p3-component-fallback-cancellation
Next slice: only add cancellation evidence if a deterministic post-preflight cancellation witness can be isolated; otherwise stop this fallback stack and leave the explicit boundary documented.