### PR TITLE
test(core): enforce component fallback output limits

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -761,6 +761,8 @@ When coverage cannot be proven:
   - [x] Merge multiple pairwise envelope-disjoint recovered components with
     retained tile output; cross-component overlap and graph stitching remain
     open.
+  - [x] Apply the configured output limit to component recovery; broader
+    fallback cancellation coverage remains open.
   - [x] Provide a caller-enabled whole-input untiled fallback that preserves
     global containment when retries leave observed coverage unresolved.
   - [x] Verify whole-input fallback equality with untiled output across tile

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -607,6 +607,25 @@ mod tests {
         assert!(bounded.trace.truncated);
         assert!(bounded.result.stitching_report.component_fallback_used);
         assert_eq!(bounded.result.polygons.len(), 1);
+
+        let mut limited = TiledPolygonizer::new(bbox, 10.0)
+            .with_buffer(2.0)
+            .with_execution_policy(ExecutionPolicy {
+                max_output_polygons: Some(0),
+                ..Default::default()
+            })
+            .with_component_fallback();
+        for boundary in &boundaries {
+            limited.add_geometry(boundary);
+        }
+        assert!(matches!(
+            limited.polygonize(),
+            Err(PolygonizeError::ResourceLimitExceeded {
+                ref stage,
+                limit: 0,
+                observed: 1,
+            }) if stage == "output_polygons"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Stack

Parent: #1180 (agent/p3-component-fallback-provenance)
Children: #1182 (agent/p3-component-fallback-trace-merge)
Branch: agent/p3-component-fallback-limits

## Delivered

- Add a bounded component-recovery case with `max_output_polygons = 0`.
- Assert the recovered pass returns the typed `output_polygons` resource-limit error instead of bypassing the caller policy.
- Record the narrow P3.2 execution-policy evidence while leaving cancellation coverage explicitly open.

## Contract impact

- Test-only; no runtime behavior or public API changes.
- Confirms component fallback uses the same execution policy as normal polygonization.
- This slice covers output limits only; cancellation, aggregate budgets, and general region-local merging remain open.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p geo-polygonize-core --lib tiling::tests::tests::component_fallback` (default: 5 passed)
- `cargo test -p geo-polygonize-core --no-default-features --lib tiling::tests::tests::component_fallback` (5 passed)
- Parent stack validation includes full tiling, equivalence, workspace default/no-default tests, clippy, rustdoc, and generated-artifact restoration.

## Agent handoff

Parent: #1180 (agent/p3-component-fallback-provenance)
Children: #1182 (agent/p3-component-fallback-trace-merge)
Next branch: agent/p3-tile-coverage-detection-gap
Next slice: minimize and classify the remaining broad P3.1 undetected-region boundary; do not claim certification or start graph stitching.