### PR TITLE
feat(core): expose tiled fallback merge counts

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -763,6 +763,8 @@ When coverage cannot be proven:
     open.
   - [x] Apply the configured output limit to component recovery; broader
     fallback cancellation coverage remains open.
+  - [x] Record retained tile polygon counts in component-fallback trace events;
+    aggregate partial-merge accounting remains open.
   - [x] Provide a caller-enabled whole-input untiled fallback that preserves
     global containment when retries leave observed coverage unresolved.
   - [x] Verify whole-input fallback equality with untiled output across tile

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -1184,6 +1184,7 @@ impl<'a> TiledPolygonizer<'a> {
         let (component_fallback_polygons, component_fallback_events) = component_fallback
             .map(|fallback| (fallback.polygons, fallback.events))
             .unwrap_or_default();
+        let retained_tile_polygon_count = tile_polygons.iter().map(Vec::len).sum();
         let untiled_fallback_used = self.untiled_fallback && unresolved && !component_fallback_used;
         let result_polygons: Vec<Polygon3D> = if untiled_fallback_used {
             let mut polygonizer = Polygonizer::with_options(self.options.clone())
@@ -1304,6 +1305,7 @@ impl<'a> TiledPolygonizer<'a> {
                     trace.record_tile_component_fallback(
                         &input_geometry_indices,
                         output_polygon_count,
+                        retained_tile_polygon_count,
                     );
                 }
             }

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -601,6 +601,7 @@ mod tests {
             serde_json::json!([0, 1, 2, 3])
         );
         assert_eq!(events[0].payload["output_polygon_count"], 1);
+        assert_eq!(events[0].payload["retained_tile_polygon_count"], 0);
 
         let bounded = tiled.polygonize_with_trace(TraceLevelV1::Full, 0).unwrap();
         assert!(bounded.trace.events.is_empty());
@@ -849,6 +850,9 @@ mod tests {
         assert!(fallback_events
             .iter()
             .all(|event| event.payload["output_polygon_count"] == 1));
+        assert!(fallback_events
+            .iter()
+            .all(|event| event.payload["retained_tile_polygon_count"] == 2));
 
         let mut reversed = TiledPolygonizer::new(bbox, 10.0)
             .with_dedup_policy(DedupPolicy::CanonicalRingHash)

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -344,6 +344,7 @@ pub struct TileUntiledFallbackTraceV1 {
 pub struct TileComponentFallbackTraceV1 {
     pub input_geometry_indices: Vec<usize>,
     pub output_polygon_count: usize,
+    pub retained_tile_polygon_count: usize,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
@@ -1284,6 +1285,7 @@ impl TraceRecorderV1 {
         &mut self,
         input_geometry_indices: &[usize],
         output_polygon_count: usize,
+        retained_tile_polygon_count: usize,
     ) -> bool {
         self.record(
             TraceStageV1::Output,
@@ -1291,6 +1293,7 @@ impl TraceRecorderV1 {
             serde_json::to_value(TileComponentFallbackTraceV1 {
                 input_geometry_indices: input_geometry_indices.to_vec(),
                 output_polygon_count,
+                retained_tile_polygon_count,
             })
             .expect("tile component-fallback trace event serializes"),
         )

--- a/docs/guide/tiling.md
+++ b/docs/guide/tiling.md
@@ -117,8 +117,10 @@ retained tile polygon, and other recovered component. Member linework may have
 appeared in a tile halo; if that produced a retained face intersecting the
 component envelope, recovery declines. Otherwise it polygonizes the complete
 component with the same options, merges the result deterministically, records
-`component_fallback_used` and a bounded `tile_component_fallback` event, and
-declines recovery when any envelope overlaps or nests. `with_untiled_fallback`
+`component_fallback_used` and a bounded `tile_component_fallback` event. The
+event includes the recovered polygon count and the number of retained tile
+polygons present at the merge boundary. Recovery declines when any envelope
+overlaps or nests. `with_untiled_fallback`
 remains the containment-safe escape hatch for those declined cases. General
 cross-region graph merging remains unavailable.
 Applications that require correctness must run an untiled equivalence check for


### PR DESCRIPTION
## Stack

Parent: #1181 (agent/p3-component-fallback-limits)
Children: none
Branch: agent/p3-component-fallback-trace-merge

## Delivered

- Add `retained_tile_polygon_count` to `TileComponentFallbackTraceV1`.
- Record the number of tile polygons present at the fallback merge boundary for every recovered component.
- Add zero-retained and partial-merge trace regressions.
- Document the additive trace evidence and update the P3.2 checklist.

## Contract impact

- Additive output-trace field; existing event fields and fallback behavior are unchanged.
- The count is pre-dedup tile output entering the merge, not a certification of globally validated coverage.
- General aggregate stitching accounting, nested/overlapping recovery, and true graph stitching remain open.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p geo-polygonize-core --lib tiling::tests::tests::component_fallback` (default and no-default-features: 5 passed each)
- `cargo test -p geo-polygonize-core --lib tiling::tests` (default and no-default-features: 27 passed each)
- `cargo test -p geo-polygonize-core --test tiling_equivalence` (4 passed)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p geo-polygonize-core --no-deps`
- `cargo test --workspace` and `cargo test --workspace --no-default-features` (both exit 0)
- Generated bindings were restored; no generated artifacts are included.

## Agent handoff

Parent: #1181 (agent/p3-component-fallback-limits)
Children: none
Next branch: agent/p3-tile-coverage-detection-gap
Next slice: minimize and classify the remaining broad P3.1 undetected-region boundary; do not claim certification or start graph stitching.