### PR TITLE
test(core): pin certified fixed-grid coverage gap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -698,7 +698,11 @@ covered while the broader coverage-detection rows remain open. Minimized
 pre-snap and fixed-grid fixtures also pin the remaining transformation boundary:
 separate inputs that connect only after caller-selected precision transformations
 are now grouped as conservative component evidence; region coverage remains
-observational rather than certified.
+observational rather than certified. A minimized certified fixed-grid fixture
+also pins a hot-pixel boundary: the noder can connect a segment through an
+endpoint hot pixel even when the tiled preflight's transformed straight
+segments have no exact intersection, so this region can remain absent without
+observed evidence.
 
 - [ ] Detect owned faces or connected regions that touch an unresolved halo or
   partition boundary.
@@ -720,6 +724,8 @@ observational rather than certified.
     reports and bounded traces; broader region coverage detection remains open.
   - [x] Pin and report the corresponding fixed-grid-connected component case
     with bounded trace evidence; broader region coverage detection remains open.
+  - [x] Pin the certified fixed-grid hot-pixel connected-region gap; detection
+    remains open.
 - [x] Report source IDs and boundary evidence that were required but not fully
   observed.
   - [x] Distinguish representative edge IDs from complete aggregate boundary

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -3,9 +3,9 @@
 mod tests {
     use crate::{
         trace::TraceLevelV1, CancellationToken, Coord3D, DedupPolicy, ExecutionPolicy,
-        PolygonizeError, Polygonizer, PolygonizerOptions, PrecisionModel, ProvenanceOptions,
-        TileBoundarySide, TileComponentConnection, TileCoverageGuarantee, TileRetryPolicy,
-        TiledPolygonizeError, TiledPolygonizer,
+        NodingGuarantee, NodingOptions, PolygonizeError, Polygonizer, PolygonizerOptions,
+        PrecisionModel, ProvenanceOptions, TileBoundarySide, TileComponentConnection,
+        TileCoverageGuarantee, TileRetryPolicy, TiledPolygonizeError, TiledPolygonizer,
     };
     use geo::{Contains, Coord, Geometry, LineString, Rect};
 
@@ -1334,6 +1334,63 @@ mod tests {
                 ..
             })
         ));
+    }
+
+    #[test]
+    fn documents_certified_fixed_grid_hot_pixel_region_excluded_from_every_halo() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 20.0 });
+        let options = PolygonizerOptions {
+            node_input: true,
+            precision_model: PrecisionModel::FixedGrid { grid_size: 1.0 },
+            noding: NodingOptions {
+                guarantee: NodingGuarantee::CertifiedFixedPrecision,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let boundaries = [
+            Geometry::LineString(LineString::new(vec![
+                Coord {
+                    x: -200.0,
+                    y: -11.0,
+                },
+                Coord { x: 100.0, y: -10.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 30.0, y: -10.0 },
+                Coord { x: 30.0, y: 30.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 100.0, y: 30.0 },
+                Coord { x: -200.0, y: 31.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: -10.0, y: 30.0 },
+                Coord { x: -10.0, y: -10.0 },
+            ])),
+        ];
+        let mut untiled = Polygonizer::with_options(options.clone());
+        let mut tiled = TiledPolygonizer::new(bbox, 10.0)
+            .with_buffer(2.0)
+            .with_options(options);
+        for boundary in &boundaries {
+            untiled.add_borrowed_geometry(boundary);
+            tiled.add_geometry(boundary);
+        }
+
+        assert_eq!(untiled.polygonize().unwrap().polygons.len(), 1);
+        assert!(tiled.input_components().unwrap().is_empty());
+        let observed = tiled.polygonize().unwrap();
+        assert!(observed.polygons.is_empty());
+        assert!(observed
+            .tile_reports
+            .iter()
+            .all(|report| report.input_geometry_count == 0));
+        assert_eq!(observed.stitching_report.unresolved_input_geometry_count, 0);
+        assert_eq!(observed.stitching_report.unresolved_component_count, 0);
+        assert!(tiled
+            .polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateObservedCoverage)
+            .is_ok());
     }
 
     #[test]


### PR DESCRIPTION
Stack
- Parent: none; base `origin/main` at `221cf33`
- Children: `agent/p3-certified-fixed-grid-component-evidence`

Delivered
- Adds a minimized certified fixed-grid hot-pixel fixture where untiled polygonization produces an owned face but tiled preflight reports no input or component evidence.
- Records the current detection boundary in `ROADMAP.md` without claiming coverage certification.

Contract impact
- Test and roadmap documentation only.
- `ValidateObservedCoverage` is intentionally shown to succeed for this missed region, preserving the explicit observational limitation.

Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p geo-polygonize-core --lib tiling::tests::tests::documents_certified_fixed_grid_hot_pixel_region_excluded_from_every_halo`

Agent handoff
- Parent: none.
- Children: `agent/p3-certified-fixed-grid-component-evidence` starts from this commit and should add conservative certified fixed-grid component evidence by reusing the existing noding path; do not merge this parent into the child. No PR status polling is requested.