### PR TITLE
feat(core): report certified fixed-grid components

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -699,10 +699,11 @@ pre-snap and fixed-grid fixtures also pin the remaining transformation boundary:
 separate inputs that connect only after caller-selected precision transformations
 are now grouped as conservative component evidence; region coverage remains
 observational rather than certified. A minimized certified fixed-grid fixture
-also pins a hot-pixel boundary: the noder can connect a segment through an
+also pinned a hot-pixel boundary: the noder could connect a segment through an
 endpoint hot pixel even when the tiled preflight's transformed straight
-segments have no exact intersection, so this region can remain absent without
-observed evidence.
+segments had no exact intersection, so that region could remain absent without
+observed evidence. The preflight now reuses the bounded certified noder for
+that same connectivity case.
 
 - [ ] Detect owned faces or connected regions that touch an unresolved halo or
   partition boundary.
@@ -725,7 +726,7 @@ observed evidence.
   - [x] Pin and report the corresponding fixed-grid-connected component case
     with bounded trace evidence; broader region coverage detection remains open.
   - [x] Pin the certified fixed-grid hot-pixel connected-region gap; detection
-    remains open.
+    and bounded evidence now reuse the certified noder.
 - [x] Report source IDs and boundary evidence that were required but not fully
   observed.
   - [x] Distinguish representative edge IDs from complete aggregate boundary

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -1,7 +1,8 @@
 use crate::diagnostics::ExecutionWorkTracker;
 use crate::index::{IndexedEnvelope, RStarBackend};
+use crate::noding::hot_pixel::HotPixelNoder;
 use crate::noding::snap::SnapNoder;
-use crate::options::{DedupPolicy, ExecutionPolicy, TileOwnershipPolicy};
+use crate::options::{DedupPolicy, ExecutionPolicy, NodingGuarantee, TileOwnershipPolicy};
 use crate::polygonizer::{apply_determinism, canonicalize_ring};
 use crate::trace::{
     TopologyTraceV1, TraceByteLimitsV1, TraceCaptureBudget, TraceLevelV1, TraceRecorderV1,
@@ -885,6 +886,52 @@ impl<'a> TiledPolygonizer<'a> {
                 );
             }
         }
+        let certified_fixed_precision = matches!(
+            self.options.noding.guarantee,
+            NodingGuarantee::CertifiedFixedPrecision
+        );
+        if certified_fixed_precision {
+            // Certified fixed precision can add shared hot-pixel vertices to
+            // lines whose transformed straight segments do not intersect.
+            // Reuse the bounded production noder so component evidence follows
+            // the same connectivity contract as untiled polygonization.
+            let source_segments = segments;
+            let lines = source_segments
+                .iter()
+                .enumerate()
+                .map(|(segment_index, segment)| {
+                    let line_id = u32::try_from(segment_index).map_err(|_| {
+                        PolygonizeError::InvalidGeometry {
+                            reason: "more than u32::MAX tiled certified fixed-grid segments"
+                                .to_string(),
+                        }
+                    })?;
+                    Ok(Line3D::new(
+                        segment.line.start.into(),
+                        segment.line.end.into(),
+                        line_id,
+                    ))
+                })
+                .collect::<Result<Vec<_>>>()?;
+            let noded = HotPixelNoder::new(grid_size)?
+                .with_z_policy(self.options.z.policy)
+                .node_with_execution_policy(lines, &self.execution_policy)?;
+            segments = noded
+                .into_iter()
+                .map(|line| {
+                    let source = source_segments.get(line.line_id as usize).ok_or_else(|| {
+                        PolygonizeError::InternalInvariantViolation {
+                            reason: "tiled certified fixed-grid source segment is missing"
+                                .to_string(),
+                        }
+                    })?;
+                    Ok(InputSegment {
+                        line: line.to_line_2d(),
+                        geometry_index: source.geometry_index,
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?;
+        }
         for segment in &segments {
             for endpoint in [segment.line.start, segment.line.end] {
                 let key = (endpoint_bits(endpoint.x), endpoint_bits(endpoint.y));
@@ -898,7 +945,7 @@ impl<'a> TiledPolygonizer<'a> {
             .map(|index| component_root(&mut parents, index))
             .collect::<Vec<_>>();
         let mut intersection_connected = vec![false; self.geometries.len()];
-        if self.options.node_input {
+        if self.options.node_input && !certified_fixed_precision {
             let envelopes = segments
                 .iter()
                 .enumerate()

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -1372,14 +1372,16 @@ mod tests {
         let mut untiled = Polygonizer::with_options(options.clone());
         let mut tiled = TiledPolygonizer::new(bbox, 10.0)
             .with_buffer(2.0)
-            .with_options(options);
+            .with_options(options.clone());
         for boundary in &boundaries {
             untiled.add_borrowed_geometry(boundary);
             tiled.add_geometry(boundary);
         }
 
         assert_eq!(untiled.polygonize().unwrap().polygons.len(), 1);
-        assert!(tiled.input_components().unwrap().is_empty());
+        let components = tiled.input_components().unwrap();
+        assert_eq!(components.len(), 1);
+        assert_eq!(components[0].input_geometry_indices, vec![0, 1, 2, 3]);
         let observed = tiled.polygonize().unwrap();
         assert!(observed.polygons.is_empty());
         assert!(observed
@@ -1387,10 +1389,56 @@ mod tests {
             .iter()
             .all(|report| report.input_geometry_count == 0));
         assert_eq!(observed.stitching_report.unresolved_input_geometry_count, 0);
-        assert_eq!(observed.stitching_report.unresolved_component_count, 0);
-        assert!(tiled
-            .polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateObservedCoverage)
-            .is_ok());
+        assert_eq!(observed.stitching_report.unresolved_component_tile_count, 4);
+        assert_eq!(observed.stitching_report.unresolved_component_count, 4);
+        assert!(observed.tile_reports.iter().all(|report| {
+            report.excluded_component_issues.len() == 1
+                && report.excluded_component_issues[0].connection
+                    == TileComponentConnection::FixedGrid
+        }));
+        let traced = tiled
+            .polygonize_with_trace(TraceLevelV1::Full, usize::MAX)
+            .unwrap();
+        let events = traced
+            .trace
+            .events
+            .iter()
+            .filter(|event| event.kind == "tile_excluded_fixed_grid_component")
+            .collect::<Vec<_>>();
+        assert_eq!(events.len(), 4);
+        assert_eq!(
+            events[0].payload["input_geometry_indices"],
+            serde_json::json!([0, 1, 2, 3])
+        );
+        assert!(matches!(
+            tiled.polygonize_with_coverage_guarantee(
+                TileCoverageGuarantee::ValidateObservedCoverage
+            ),
+            Err(TiledPolygonizeError::CoverageIncomplete {
+                unresolved_component_tile_count: 4,
+                unresolved_component_count: 4,
+                ..
+            })
+        ));
+
+        let mut limited = TiledPolygonizer::new(bbox, 10.0)
+            .with_buffer(2.0)
+            .with_options(options)
+            .with_execution_policy(ExecutionPolicy {
+                max_candidate_pairs: Some(0),
+                ..Default::default()
+            });
+        for boundary in &boundaries {
+            limited.add_geometry(boundary);
+        }
+        assert!(matches!(
+            limited.polygonize(),
+            Err(PolygonizeError::ResourceLimitExceeded {
+                stage,
+                limit: 0,
+                observed: 1,
+            }) if stage == "candidate_pairs"
+        ));
     }
 
     #[test]

--- a/docs/guide/tiling.md
+++ b/docs/guide/tiling.md
@@ -50,7 +50,9 @@ same bounded preflight applies that caller-selected transformation before
 grouping, and reports those components as `PreSnap`. When a fixed-grid precision
 model is enabled, it applies the selected snap strategy to the same preflight
 endpoints and reports those components as `FixedGrid` unless pre-snap evidence
-takes precedence. A tile reports the
+takes precedence. With `NodingGuarantee::CertifiedFixedPrecision`, the
+preflight reuses the bounded hot-pixel noder so snap-created shared vertices
+are included in the same `FixedGrid` component evidence. A tile reports the
 component when its combined envelope intersects the buffered tile but no member
 geometry envelope does. This catches an enclosing component that is excluded
 from every halo. It remains conservative: an envelope does not prove that the


### PR DESCRIPTION
Stack
- Parent: #1183 `agent/p3-tile-coverage-detection-gap`
- Children: `agent/p3-certified-fixed-grid-preflight-bounds`

Delivered
- Reuses the bounded production `HotPixelNoder` during certified fixed-grid component preflight.
- Maps noded split segments back to their source geometry indexes and reports previously undetected excluded components through the existing `FixedGrid` evidence and trace contract.
- Extends the minimized fixture with report, trace, guarantee-rejection, and candidate-pair limit assertions.
- Updates the tiling guide and roadmap precisely.

Contract impact
- Certified fixed-grid tiled calls now reject the pinned missing-region case under `ValidateObservedCoverage` instead of silently accepting it.
- Existing endpoint, segment-intersection, pre-snap, and non-certified fixed-grid paths retain their current behavior.
- The component envelope remains conservative evidence; this does not certify arbitrary tiled equivalence.

Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p geo-polygonize-core --lib tiling::tests::tests::documents_certified_fixed_grid_hot_pixel_region_excluded_from_every_halo`
- `cargo test -p geo-polygonize-core --no-default-features --lib tiling::tests::tests::documents_certified_fixed_grid_hot_pixel_region_excluded_from_every_halo`
- Full tiling-module validation passed in default and no-default-features configurations before the final trace/limit assertions; the focused commands above include those final assertions.

Agent handoff
- Parent: #1183; child starts from its branch ancestry and must not merge the parent manually.
- Children: `agent/p3-certified-fixed-grid-preflight-bounds` should add any remaining certified-preflight cancellation/limit regression without duplicating the hot-pixel fixture; rebase descendants bottom-up only after a parent merge, using force-with-lease.