### PR TITLE
test(core): bound certified fixed-grid preflight

### DIFF
--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -1176,7 +1176,34 @@ mod tests {
                 stage,
                 limit: 0,
                 observed: 1,
-            }) if stage == "candidate_pairs"
+                }) if stage == "candidate_pairs"
+        ));
+
+        let mut split_limited = TiledPolygonizer::new(bbox, 10.0)
+            .with_buffer(2.0)
+            .with_options(PolygonizerOptions {
+                node_input: true,
+                precision_model: PrecisionModel::FixedGrid { grid_size: 1.0 },
+                noding: NodingOptions {
+                    guarantee: NodingGuarantee::CertifiedFixedPrecision,
+                    ..Default::default()
+                },
+                ..Default::default()
+            })
+            .with_execution_policy(ExecutionPolicy {
+                max_split_events: Some(0),
+                ..Default::default()
+            });
+        for boundary in &boundaries {
+            split_limited.add_geometry(boundary);
+        }
+        assert!(matches!(
+            split_limited.polygonize(),
+            Err(PolygonizeError::ResourceLimitExceeded {
+                stage,
+                limit: 0,
+                observed,
+            }) if stage == "split_events" && observed > 0
         ));
     }
 


### PR DESCRIPTION
Stack
- Parent: #1184 `agent/p3-certified-fixed-grid-component-evidence`
- Children: none yet

Delivered
- Adds a certified fixed-grid hot-pixel regression for the configured `max_split_events` execution limit.
- Confirms the newly reused component preflight cannot grow snap-created split output beyond the caller budget.

Contract impact
- Test-only coverage; no runtime API or output change.
- Certified fixed-grid component detection remains conservative and cancellation/limit-aware.

Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p geo-polygonize-core --lib tiling::tests::tests::documents_certified_fixed_grid_hot_pixel_region_excluded_from_every_halo`

Agent handoff
- Parent: #1184; this branch starts from the immediate parent and must not merge it manually.
- Children: none currently; keep the stack bottom-up if another focused slice is added.