### PR TITLE
fix(core): observe component fallback cancellation

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -768,8 +768,9 @@ When coverage cannot be proven:
   - [x] Merge multiple pairwise envelope-disjoint recovered components with
     retained tile output; cross-component overlap and graph stitching remain
     open.
-  - [x] Apply the configured output limit to component recovery; broader
-    fallback cancellation coverage remains open.
+  - [x] Apply the configured output limit to component recovery and observe
+    cancellation before fallback selection and each recovered component;
+    broader fallback cancellation coverage remains open.
   - [x] Record retained tile polygon counts in component-fallback trace events;
     aggregate partial-merge accounting remains open.
   - [x] Provide a caller-enabled whole-input untiled fallback that preserves

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -580,6 +580,8 @@ impl<'a> TiledPolygonizer<'a> {
         tile_reports: &[TileReport],
         input_components: &[InputComponent],
     ) -> Result<Option<ComponentFallbackResult>> {
+        self.execution_policy
+            .check_cancelled("tile_component_fallback")?;
         let component_keys = tile_reports
             .iter()
             .flat_map(|report| &report.excluded_component_issues)
@@ -639,6 +641,8 @@ impl<'a> TiledPolygonizer<'a> {
         let mut recovered = Vec::new();
         let mut events = Vec::with_capacity(components.len());
         for component in components {
+            self.execution_policy
+                .check_cancelled("tile_component_fallback")?;
             let mut polygonizer = Polygonizer::with_options(self.options.clone())
                 .with_execution_policy(self.execution_policy.clone());
             for &geometry_index in &component.input_geometry_indices {

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -1,11 +1,13 @@
 #[cfg(test)]
 #[allow(clippy::module_inception)]
 mod tests {
+    use crate::tiling::InputComponent;
     use crate::{
         trace::TraceLevelV1, CancellationToken, Coord3D, DedupPolicy, ExecutionPolicy,
         NodingGuarantee, NodingOptions, PolygonizeError, Polygonizer, PolygonizerOptions,
         PrecisionModel, ProvenanceOptions, TileBoundarySide, TileComponentConnection,
-        TileCoverageGuarantee, TileRetryPolicy, TiledPolygonizeError, TiledPolygonizer,
+        TileCoverageGuarantee, TileExcludedComponentIssue, TileReport, TileRetryPolicy,
+        TiledPolygonizeError, TiledPolygonizer,
     };
     use geo::{Contains, Coord, Geometry, LineString, Rect};
 
@@ -951,6 +953,46 @@ mod tests {
         assert_eq!(recovered_keys, expected_keys);
         assert!(!recovered.stitching_report.component_fallback_used);
         assert!(recovered.stitching_report.untiled_fallback_used);
+    }
+
+    #[test]
+    fn component_fallback_observes_pre_cancelled_execution_policy() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 20.0 });
+        let token = CancellationToken::new();
+        token.cancel();
+        let tiled = TiledPolygonizer::new(bbox, 10.0).with_execution_policy(ExecutionPolicy {
+            cancellation_token: Some(token),
+            ..Default::default()
+        });
+        let component_indices = vec![0, 1];
+        let report = TileReport {
+            tile_bbox: bbox,
+            input_geometry_count: 0,
+            polygon_count: 0,
+            owned_polygon_count: 0,
+            dangle_count: 0,
+            cut_edge_count: 0,
+            invalid_ring_count: 0,
+            coverage_issues: Vec::new(),
+            input_boundary_issues: Vec::new(),
+            excluded_component_issues: vec![TileExcludedComponentIssue {
+                input_geometry_indices: component_indices.clone(),
+                component_bbox: bbox,
+                connection: TileComponentConnection::ExactEndpoint,
+            }],
+            retry_attempts: Vec::new(),
+            retry_exhausted: false,
+        };
+        let component = InputComponent {
+            input_geometry_indices: component_indices,
+            bbox,
+            connection: TileComponentConnection::ExactEndpoint,
+        };
+
+        assert!(matches!(
+            tiled.try_component_fallback(&[Vec::new()], &[report], &[component]),
+            Err(PolygonizeError::Cancelled { stage }) if stage == "tile_component_fallback"
+        ));
     }
 
     #[test]

--- a/docs/guide/tiling.md
+++ b/docs/guide/tiling.md
@@ -124,7 +124,10 @@ event includes the recovered polygon count and the number of retained tile
 polygons present at the merge boundary. Recovery declines when any envelope
 overlaps or nests. `with_untiled_fallback`
 remains the containment-safe escape hatch for those declined cases. General
-cross-region graph merging remains unavailable.
+cross-region graph merging remains unavailable. Component fallback also checks
+the execution policy before selecting recovery and before each recovered
+component, so cancellation does not get lost between tile processing and the
+bounded component polygonizer.
 Applications that require correctness must run an untiled equivalence check for
 their input class or choose untiled polygonization directly when sufficiency is
 unknown.


### PR DESCRIPTION
Stack
- Parent: #1186 `agent/p3-certified-fixed-grid-preflight-bounds`
- Children: none yet

Delivered
- Checks the configured execution policy before component-fallback selection and before each recovered component.
- Adds a direct regression proving a pre-cancelled fallback cannot reach component geometry indexing or return a partial result.
- Documents the cancellation boundary and keeps the broader partial-merge limitation open in `ROADMAP.md`.

Contract impact
- Cancellation now returns `PolygonizeError::Cancelled { stage: "tile_component_fallback" }` at the fallback boundary.
- No topology, provenance, Z, output-limit, or public API behavior changes for non-cancelled calls.

Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p geo-polygonize-core --lib tiling::tests::tests::component_fallback_observes_pre_cancelled_execution_policy`
- `cargo test -p geo-polygonize-core --lib tiling::tests::tests` (27 passed, default features)
- `cargo test -p geo-polygonize-core --no-default-features --lib tiling::tests::tests` (27 passed)

Agent handoff
- Parent: #1186; this branch starts from the immediate parent and must not merge it manually.
- Children: none currently; keep any future child at the top of the linked stack.