### PR TITLE
feat(core): expose component fallback counts

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -771,8 +771,9 @@ When coverage cannot be proven:
   - [x] Apply the configured output limit to component recovery and observe
     cancellation before fallback selection and each recovered component;
     broader fallback cancellation coverage remains open.
-  - [x] Record retained tile polygon counts in component-fallback trace events;
-    aggregate partial-merge accounting remains open.
+  - [x] Record retained tile polygon counts in component-fallback trace events
+    and expose retained/recovered aggregate counts in `StitchingReport`;
+    canonical partial merging remains open.
   - [x] Provide a caller-enabled whole-input untiled fallback that preserves
     global containment when retries leave observed coverage unresolved.
   - [x] Verify whole-input fallback equality with untiled output across tile

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -144,6 +144,12 @@ pub struct StitchingReport {
     pub merged_polygon_count: usize,
     pub duplicate_polygon_count: usize,
     pub output_polygon_count: usize,
+    /// Polygon count retained from tile-local ownership before fallback merge.
+    pub retained_tile_polygon_count: usize,
+    /// Number of excluded components recovered by component fallback.
+    pub component_fallback_count: usize,
+    /// Polygon count produced by component fallback before final deduplication.
+    pub component_fallback_polygon_count: usize,
     pub unresolved_tile_count: usize,
     pub unresolved_owned_polygon_count: usize,
     pub unresolved_input_tile_count: usize,
@@ -1236,6 +1242,8 @@ impl<'a> TiledPolygonizer<'a> {
             .map(|fallback| (fallback.polygons, fallback.events))
             .unwrap_or_default();
         let retained_tile_polygon_count = tile_polygons.iter().map(Vec::len).sum();
+        let component_fallback_count = component_fallback_events.len();
+        let component_fallback_polygon_count = component_fallback_polygons.len();
         let untiled_fallback_used = self.untiled_fallback && unresolved && !component_fallback_used;
         let result_polygons: Vec<Polygon3D> = if untiled_fallback_used {
             let mut polygonizer = Polygonizer::with_options(self.options.clone())
@@ -1337,6 +1345,9 @@ impl<'a> TiledPolygonizer<'a> {
                 merged_polygon_count,
                 duplicate_polygon_count: merged_polygon_count - output_polygon_count,
                 output_polygon_count,
+                retained_tile_polygon_count,
+                component_fallback_count,
+                component_fallback_polygon_count,
                 unresolved_tile_count,
                 unresolved_owned_polygon_count,
                 unresolved_input_tile_count,

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -586,6 +586,9 @@ mod tests {
         );
         assert!(result.stitching_report.component_fallback_used);
         assert!(!result.stitching_report.untiled_fallback_used);
+        assert_eq!(result.stitching_report.retained_tile_polygon_count, 0);
+        assert_eq!(result.stitching_report.component_fallback_count, 1);
+        assert_eq!(result.stitching_report.component_fallback_polygon_count, 1);
         assert_eq!(result.stitching_report.unresolved_component_count, 4);
 
         let traced = tiled
@@ -838,6 +841,9 @@ mod tests {
         );
         assert!(result.stitching_report.component_fallback_used);
         assert!(!result.stitching_report.untiled_fallback_used);
+        assert_eq!(result.stitching_report.retained_tile_polygon_count, 2);
+        assert_eq!(result.stitching_report.component_fallback_count, 2);
+        assert_eq!(result.stitching_report.component_fallback_polygon_count, 2);
 
         let traced = tiled
             .polygonize_with_trace(TraceLevelV1::Full, usize::MAX)

--- a/docs/guide/tiling.md
+++ b/docs/guide/tiling.md
@@ -121,7 +121,9 @@ component envelope, recovery declines. Otherwise it polygonizes the complete
 component with the same options, merges the result deterministically, records
 `component_fallback_used` and a bounded `tile_component_fallback` event. The
 event includes the recovered polygon count and the number of retained tile
-polygons present at the merge boundary. Recovery declines when any envelope
+polygons present at the merge boundary. `StitchingReport` also exposes the
+retained tile polygon count, recovered component count, and recovered polygon
+count before final deduplication. Recovery declines when any envelope
 overlaps or nests. `with_untiled_fallback`
 remains the containment-safe escape hatch for those declined cases. General
 cross-region graph merging remains unavailable. Component fallback also checks


### PR DESCRIPTION
Stack
- Parent: #1187 `agent/p3-component-fallback-cancellation`
- Children: none; stack cap reached at five PRs

Delivered
- Adds retained tile polygon, recovered component, and recovered polygon counts to `StitchingReport`.
- Populates the counts from the physical partial-merge inputs before final deduplication.
- Extends single- and multi-component fallback regressions and updates the guide/roadmap.

Contract impact
- Experimental report shape gains deterministic aggregate accounting; polygon topology, provenance, Z, ownership, and deduplication behavior are unchanged.
- Counts describe partial-merge inputs only and do not certify canonical region-local merging; nested/overlapping recovery remains declined.

Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p geo-polygonize-core --lib tiling::tests::tests::component_fallback` (6 passed, default features)
- `cargo test -p geo-polygonize-core --no-default-features --lib tiling::tests::tests::component_fallback` (6 passed)

Agent handoff
- Parent: #1187; this branch starts from the immediate parent and must not merge it manually.
- Children: none; the five-PR stack cap is reached. The next branch should start only after a parent merges and stack ancestry is refreshed bottom-up.