### PR TITLE
feat(core): recover interacting tiled regions

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -758,13 +758,15 @@ When coverage cannot be proven:
 - [ ] fall back to untiled processing for the unresolved connected region;
   - [x] Pin the global-containment boundary where an excluded outer component
     spatially nests an already retained tile-local face.
-  - [x] Add opt-in envelope-disjoint component fallback that declines nested,
-    overlapping, or retained-face-interacting linework and records the
+  - [x] Add opt-in envelope-closed component fallback that groups interacting
+    input, retained-face, and connected-component envelopes and records the
     recovery.
-  - [x] Verify declined nested component recovery hands off to the
-    containment-safe whole-input fallback when both are enabled.
+  - [x] Recover a nested retained face by polygonizing the closed region once;
+    whole-input fallback remains the escape hatch for evidence outside that
+    region.
   - [x] Merge one envelope-disjoint recovered component with retained tile
-    output; general region-local partial merging remains open.
+    output; envelope-closed region replacement now covers interacting retained
+    output.
   - [x] Merge multiple pairwise envelope-disjoint recovered components with
     retained tile output; cross-component overlap and graph stitching remain
     open.
@@ -773,7 +775,7 @@ When coverage cannot be proven:
     broader fallback cancellation coverage remains open.
   - [x] Record retained tile polygon counts in component-fallback trace events
     and expose retained/recovered aggregate counts in `StitchingReport`;
-    canonical partial merging remains open.
+    expose replaced-retained counts for canonical region replacement.
   - [x] Provide a caller-enabled whole-input untiled fallback that preserves
     global containment when retries leave observed coverage unresolved.
   - [x] Verify whole-input fallback equality with untiled output across tile
@@ -781,14 +783,21 @@ When coverage cannot be proven:
   - [x] Apply the configured execution policy to whole-input fallback and pin
     exact resource-limit evidence.
 - [ ] merge the fallback result canonically with already validated regions;
+  - [x] Replace retained polygons intersecting an envelope-closed recovery
+    region before canonical deduplication and deterministic ordering.
+  - [ ] Reconcile fallback regions whose topology crosses a partition boundary
+    without a conservative envelope closure.
 - [x] stop with a typed coverage error when the configured retry budget is
   exhausted;
 - [ ] record every retry and fallback in the stitching report and topology trace.
   - [x] Record deterministic retry attempts and exhausted tiles in tile and
     stitching reports and bounded `tile_halo_retry` trace events.
   - [x] Record whole-input fallback use in the stitching report and a bounded
-    `tile_untiled_fallback` trace event; broader partial-merge coverage remains
-    open.
+    `tile_untiled_fallback` trace event; broader declined-fallback coverage
+    remains open.
+  - [x] Record envelope-closed component/region recovery and retained-polygon
+    replacement counts in the stitching report and bounded component-fallback
+    trace events.
 
 ### P3.3 True graph stitching
 

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -146,10 +146,12 @@ pub struct StitchingReport {
     pub output_polygon_count: usize,
     /// Polygon count retained from tile-local ownership before fallback merge.
     pub retained_tile_polygon_count: usize,
-    /// Number of excluded components recovered by component fallback.
+    /// Number of excluded components recovered by component or region fallback.
     pub component_fallback_count: usize,
     /// Polygon count produced by component fallback before final deduplication.
     pub component_fallback_polygon_count: usize,
+    /// Number of retained tile polygons replaced by region fallback.
+    pub component_fallback_replaced_polygon_count: usize,
     pub unresolved_tile_count: usize,
     pub unresolved_owned_polygon_count: usize,
     pub unresolved_input_tile_count: usize,
@@ -161,7 +163,7 @@ pub struct StitchingReport {
     pub retried_tile_count: usize,
     pub retry_attempt_count: usize,
     pub retry_exhausted_tile_count: usize,
-    /// Whether envelope-disjoint excluded components were recovered separately.
+    /// Whether excluded components were recovered by component or region fallback.
     pub component_fallback_used: bool,
     /// Whether unresolved tiled output was replaced by one untiled pass over all input.
     pub untiled_fallback_used: bool,
@@ -236,7 +238,15 @@ struct InputComponent {
 
 struct ComponentFallbackResult {
     polygons: Vec<Polygon3D>,
-    events: Vec<(Vec<usize>, usize)>,
+    events: Vec<ComponentFallbackEvent>,
+    region_bboxes: Vec<Rect<f64>>,
+}
+
+struct ComponentFallbackEvent {
+    input_geometry_indices: Vec<usize>,
+    output_polygon_count: usize,
+    recovered_component_count: usize,
+    replaced_retained_polygon_count: usize,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -350,6 +360,19 @@ fn join_components(parents: &mut [usize], left: usize, right: usize) {
     }
 }
 
+fn expand_rect(rect: &mut Rect<f64>, other: Rect<f64>) {
+    *rect = Rect::new(
+        Coord {
+            x: rect.min().x.min(other.min().x),
+            y: rect.min().y.min(other.min().y),
+        },
+        Coord {
+            x: rect.max().x.max(other.max().x),
+            y: rect.max().y.max(other.max().y),
+        },
+    );
+}
+
 /// Experimental tiled polygonization.
 ///
 /// Equivalence with untiled output is not guaranteed.
@@ -419,8 +442,8 @@ impl<'a> TiledPolygonizer<'a> {
         self
     }
 
-    /// Enables conservative recovery for excluded components with disjoint
-    /// non-member input and retained-output envelopes.
+    /// Enables conservative recovery for excluded components and interacting
+    /// retained regions.
     pub fn with_component_fallback(mut self) -> Self {
         self.component_fallback = true;
         self
@@ -596,24 +619,10 @@ impl<'a> TiledPolygonizer<'a> {
         if component_keys.is_empty() {
             return Ok(None);
         }
-        let components = input_components
+        if tile_reports
             .iter()
-            .filter(|component| component_keys.contains(&component.input_geometry_indices))
-            .collect::<Vec<_>>();
-        if components.len() != component_keys.len() {
-            return Ok(None);
-        }
-        let component_member_indices = components
-            .iter()
-            .flat_map(|component| component.input_geometry_indices.iter().copied())
-            .collect::<HashSet<_>>();
-        if tile_reports.iter().any(|report| {
-            !report.coverage_issues.is_empty()
-                || report
-                    .input_boundary_issues
-                    .iter()
-                    .any(|issue| !component_member_indices.contains(&issue.input_geometry_index))
-        }) {
+            .any(|report| !report.coverage_issues.is_empty())
+        {
             return Ok(None);
         }
 
@@ -623,47 +632,130 @@ impl<'a> TiledPolygonizer<'a> {
             .filter_map(Self::polygon_bbox)
             .collect::<Vec<_>>();
 
-        for (component_index, component) in components.iter().enumerate() {
-            if components[..component_index]
-                .iter()
-                .any(|other| other.bbox.intersects(&component.bbox))
-                || retained_polygon_bboxes
-                    .iter()
-                    .any(|polygon_bbox| polygon_bbox.intersects(&component.bbox))
+        let mut assigned_components = HashSet::new();
+        let mut regions = Vec::new();
+        let seed_component_count = input_components
+            .iter()
+            .filter(|component| component_keys.contains(&component.input_geometry_indices))
+            .count();
+        if seed_component_count != component_keys.len() {
+            return Ok(None);
+        }
+        for (component_index, seed) in input_components.iter().enumerate() {
+            if !component_keys.contains(&seed.input_geometry_indices)
+                || !assigned_components.insert(component_index)
             {
-                return Ok(None);
+                continue;
+            }
+            let mut region_bbox = seed.bbox;
+            let mut region_geometry_indices = seed.input_geometry_indices.clone();
+            let mut region_component_count = 1;
+            let mut selected_geometry_indices = region_geometry_indices
+                .iter()
+                .copied()
+                .collect::<HashSet<_>>();
+
+            loop {
+                self.execution_policy
+                    .check_cancelled("tile_component_fallback")?;
+                let mut expanded = false;
+
+                for polygon_bbox in &retained_polygon_bboxes {
+                    if polygon_bbox.intersects(&region_bbox) {
+                        let previous = region_bbox;
+                        expand_rect(&mut region_bbox, *polygon_bbox);
+                        expanded |= region_bbox != previous;
+                    }
+                }
+
+                for (geometry_index, (_, geometry_bbox)) in self.geometries.iter().enumerate() {
+                    self.execution_policy
+                        .check_cancelled_every("tile_component_fallback", geometry_index)?;
+                    if selected_geometry_indices.contains(&geometry_index) {
+                        continue;
+                    }
+                    if geometry_bbox.is_some_and(|bbox| bbox.intersects(&region_bbox)) {
+                        selected_geometry_indices.insert(geometry_index);
+                        region_geometry_indices.push(geometry_index);
+                        if let Some(geometry_bbox) = geometry_bbox {
+                            expand_rect(&mut region_bbox, *geometry_bbox);
+                        }
+                        expanded = true;
+                    }
+                }
+
+                for (candidate_index, candidate) in input_components.iter().enumerate() {
+                    self.execution_policy
+                        .check_cancelled_every("tile_component_fallback", candidate_index)?;
+                    if assigned_components.contains(&candidate_index)
+                        || !candidate.bbox.intersects(&region_bbox)
+                    {
+                        continue;
+                    }
+                    assigned_components.insert(candidate_index);
+                    region_component_count += 1;
+                    for &geometry_index in &candidate.input_geometry_indices {
+                        if selected_geometry_indices.insert(geometry_index) {
+                            region_geometry_indices.push(geometry_index);
+                        }
+                    }
+                    expand_rect(&mut region_bbox, candidate.bbox);
+                    expanded = true;
+                }
+
+                if !expanded {
+                    break;
+                }
             }
 
-            for (geometry_index, (_, geometry_bbox)) in self.geometries.iter().enumerate() {
-                if component.input_geometry_indices.contains(&geometry_index) {
-                    continue;
-                }
-                if geometry_bbox.is_some_and(|bbox| bbox.intersects(&component.bbox)) {
-                    return Ok(None);
-                }
-            }
+            region_geometry_indices.sort_unstable();
+            regions.push((region_geometry_indices, region_bbox, region_component_count));
+        }
+        let recoverable_geometry_indices = regions
+            .iter()
+            .flat_map(|(indices, _, _)| indices.iter().copied())
+            .collect::<HashSet<_>>();
+        if tile_reports.iter().any(|report| {
+            report
+                .input_boundary_issues
+                .iter()
+                .any(|issue| !recoverable_geometry_indices.contains(&issue.input_geometry_index))
+        }) {
+            return Ok(None);
         }
 
         let mut recovered = Vec::new();
-        let mut events = Vec::with_capacity(components.len());
-        for component in components {
+        let mut events = Vec::with_capacity(regions.len());
+        let mut region_bboxes = Vec::with_capacity(regions.len());
+        for (input_geometry_indices, region_bbox, recovered_component_count) in regions {
             self.execution_policy
                 .check_cancelled("tile_component_fallback")?;
             let mut polygonizer = Polygonizer::with_options(self.options.clone())
                 .with_execution_policy(self.execution_policy.clone());
-            for &geometry_index in &component.input_geometry_indices {
+            for &geometry_index in &input_geometry_indices {
                 polygonizer.add_borrowed_geometry(self.geometries[geometry_index].0);
             }
             let polygons = polygonizer.polygonize()?.polygons;
             if polygons.is_empty() {
                 return Ok(None);
             }
-            events.push((component.input_geometry_indices.clone(), polygons.len()));
+            let replaced_retained_polygon_count = retained_polygon_bboxes
+                .iter()
+                .filter(|polygon_bbox| polygon_bbox.intersects(&region_bbox))
+                .count();
+            events.push(ComponentFallbackEvent {
+                input_geometry_indices,
+                output_polygon_count: polygons.len(),
+                recovered_component_count,
+                replaced_retained_polygon_count,
+            });
+            region_bboxes.push(region_bbox);
             recovered.extend(polygons);
         }
         Ok(Some(ComponentFallbackResult {
             polygons: recovered,
             events,
+            region_bboxes,
         }))
     }
 
@@ -1238,12 +1330,20 @@ impl<'a> TiledPolygonizer<'a> {
             None
         };
         let component_fallback_used = component_fallback.is_some();
-        let (component_fallback_polygons, component_fallback_events) = component_fallback
-            .map(|fallback| (fallback.polygons, fallback.events))
-            .unwrap_or_default();
+        let (component_fallback_polygons, component_fallback_events, region_bboxes) =
+            component_fallback
+                .map(|fallback| (fallback.polygons, fallback.events, fallback.region_bboxes))
+                .unwrap_or_default();
         let retained_tile_polygon_count = tile_polygons.iter().map(Vec::len).sum();
-        let component_fallback_count = component_fallback_events.len();
+        let component_fallback_count = component_fallback_events
+            .iter()
+            .map(|event| event.recovered_component_count)
+            .sum();
         let component_fallback_polygon_count = component_fallback_polygons.len();
+        let component_fallback_replaced_polygon_count = component_fallback_events
+            .iter()
+            .map(|event| event.replaced_retained_polygon_count)
+            .sum();
         let untiled_fallback_used = self.untiled_fallback && unresolved && !component_fallback_used;
         let result_polygons: Vec<Polygon3D> = if untiled_fallback_used {
             let mut polygonizer = Polygonizer::with_options(self.options.clone())
@@ -1256,6 +1356,12 @@ impl<'a> TiledPolygonizer<'a> {
             tile_polygons
                 .into_iter()
                 .flatten()
+                .filter(|polygon| {
+                    !region_bboxes.iter().any(|region_bbox| {
+                        Self::polygon_bbox(polygon)
+                            .is_some_and(|polygon_bbox| polygon_bbox.intersects(region_bbox))
+                    })
+                })
                 .chain(component_fallback_polygons)
                 .collect()
         };
@@ -1348,6 +1454,7 @@ impl<'a> TiledPolygonizer<'a> {
                 retained_tile_polygon_count,
                 component_fallback_count,
                 component_fallback_polygon_count,
+                component_fallback_replaced_polygon_count,
                 unresolved_tile_count,
                 unresolved_owned_polygon_count,
                 unresolved_input_tile_count,
@@ -1363,11 +1470,13 @@ impl<'a> TiledPolygonizer<'a> {
         };
         if component_fallback_used {
             if let Some(trace) = trace.as_deref_mut() {
-                for (input_geometry_indices, output_polygon_count) in component_fallback_events {
+                for event in component_fallback_events {
                     trace.record_tile_component_fallback(
-                        &input_geometry_indices,
-                        output_polygon_count,
+                        &event.input_geometry_indices,
+                        event.output_polygon_count,
                         retained_tile_polygon_count,
+                        event.replaced_retained_polygon_count,
+                        event.recovered_component_count,
                     );
                 }
             }

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -887,81 +887,6 @@ mod tests {
     }
 
     #[test]
-    fn component_fallback_declines_nested_retained_output() {
-        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 20.0 });
-        let geometries = [
-            Geometry::LineString(LineString::new(vec![
-                Coord { x: -10.0, y: -10.0 },
-                Coord { x: 30.0, y: -10.0 },
-            ])),
-            Geometry::LineString(LineString::new(vec![
-                Coord { x: 30.0, y: -10.0 },
-                Coord { x: 30.0, y: 30.0 },
-            ])),
-            Geometry::LineString(LineString::new(vec![
-                Coord { x: 30.0, y: 30.0 },
-                Coord { x: -10.0, y: 30.0 },
-            ])),
-            Geometry::LineString(LineString::new(vec![
-                Coord { x: -10.0, y: 30.0 },
-                Coord { x: -10.0, y: -10.0 },
-            ])),
-            Geometry::LineString(LineString::new(vec![
-                Coord { x: 2.0, y: 2.0 },
-                Coord { x: 4.0, y: 2.0 },
-                Coord { x: 4.0, y: 4.0 },
-                Coord { x: 2.0, y: 4.0 },
-                Coord { x: 2.0, y: 2.0 },
-            ])),
-        ];
-        let mut tiled = TiledPolygonizer::new(bbox, 10.0)
-            .with_buffer(2.0)
-            .with_component_fallback();
-        for geometry in &geometries {
-            tiled.add_geometry(geometry);
-        }
-
-        let result = tiled.polygonize().unwrap();
-        assert_eq!(result.polygons.len(), 1);
-        assert!(!result.stitching_report.component_fallback_used);
-        assert!(!result.stitching_report.untiled_fallback_used);
-        assert_eq!(result.stitching_report.unresolved_component_count, 4);
-        assert!(matches!(
-            tiled.polygonize_with_coverage_guarantee(
-                TileCoverageGuarantee::ValidateObservedCoverage
-            ),
-            Err(TiledPolygonizeError::CoverageIncomplete { .. })
-        ));
-
-        let mut untiled = Polygonizer::new();
-        let mut fallback = TiledPolygonizer::new(bbox, 10.0)
-            .with_buffer(2.0)
-            .with_component_fallback()
-            .with_untiled_fallback();
-        for geometry in &geometries {
-            untiled.add_borrowed_geometry(geometry);
-            fallback.add_geometry(geometry);
-        }
-        let expected = untiled.polygonize().unwrap();
-        let recovered = fallback
-            .polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateObservedCoverage)
-            .unwrap();
-        let expected_keys = expected
-            .polygons
-            .iter()
-            .map(crate::tiling::canonical_polygon_key)
-            .collect::<Vec<_>>();
-        let recovered_keys = recovered
-            .polygons
-            .iter()
-            .map(crate::tiling::canonical_polygon_key)
-            .collect::<Vec<_>>();
-        assert_eq!(recovered_keys, expected_keys);
-        assert!(!recovered.stitching_report.component_fallback_used);
-        assert!(recovered.stitching_report.untiled_fallback_used);
-    }
-
-    #[test]
     fn component_fallback_observes_pre_cancelled_execution_policy() {
         let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 20.0 });
         let token = CancellationToken::new();
@@ -1600,6 +1525,177 @@ mod tests {
                 ..
             }) if tile_reports.iter().all(|report| report.retry_exhausted)
         ));
+    }
+
+    #[test]
+    fn component_fallback_replaces_nested_retained_region() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 20.0 });
+        let geometries = [
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: -10.0, y: -10.0 },
+                Coord { x: 30.0, y: -10.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 30.0, y: -10.0 },
+                Coord { x: 30.0, y: 30.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 30.0, y: 30.0 },
+                Coord { x: -10.0, y: 30.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: -10.0, y: 30.0 },
+                Coord { x: -10.0, y: -10.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 2.0, y: 2.0 },
+                Coord { x: 4.0, y: 2.0 },
+                Coord { x: 4.0, y: 4.0 },
+                Coord { x: 2.0, y: 4.0 },
+                Coord { x: 2.0, y: 2.0 },
+            ])),
+        ];
+        let mut untiled = Polygonizer::new();
+        let mut tiled = TiledPolygonizer::new(bbox, 10.0)
+            .with_buffer(2.0)
+            .with_dedup_policy(DedupPolicy::CanonicalRingHash)
+            .with_component_fallback();
+        for geometry in &geometries {
+            untiled.add_borrowed_geometry(geometry);
+            tiled.add_geometry(geometry);
+        }
+
+        let expected = untiled
+            .polygonize()
+            .unwrap()
+            .polygons
+            .into_iter()
+            .map(|polygon| crate::tiling::canonical_polygon_key(&polygon))
+            .collect::<Vec<_>>();
+        let result = tiled
+            .polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateObservedCoverage)
+            .unwrap();
+        assert_eq!(
+            result
+                .polygons
+                .iter()
+                .map(crate::tiling::canonical_polygon_key)
+                .collect::<Vec<_>>(),
+            expected
+        );
+        assert_eq!(result.polygons.len(), 2);
+        assert!(result
+            .polygons
+            .iter()
+            .any(|polygon| !polygon.interiors.is_empty()));
+        assert!(result.stitching_report.component_fallback_used);
+        assert!(!result.stitching_report.untiled_fallback_used);
+        assert_eq!(result.stitching_report.component_fallback_count, 1);
+        assert_eq!(result.stitching_report.component_fallback_polygon_count, 2);
+        assert_eq!(
+            result
+                .stitching_report
+                .component_fallback_replaced_polygon_count,
+            1
+        );
+
+        let traced = tiled
+            .polygonize_with_trace(TraceLevelV1::Full, usize::MAX)
+            .unwrap();
+        let events = traced
+            .trace
+            .events
+            .iter()
+            .filter(|event| event.kind == "tile_component_fallback")
+            .collect::<Vec<_>>();
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0].payload["input_geometry_indices"],
+            serde_json::json!([0, 1, 2, 3, 4])
+        );
+        assert_eq!(events[0].payload["output_polygon_count"], 2);
+        assert_eq!(events[0].payload["retained_tile_polygon_count"], 1);
+        assert_eq!(events[0].payload["replaced_retained_polygon_count"], 1);
+        assert_eq!(events[0].payload["recovered_component_count"], 1);
+    }
+
+    #[test]
+    fn component_fallback_groups_overlapping_excluded_components() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 20.0 });
+        let mut geometries = Vec::new();
+        for (min, max) in [(-10.0, 30.0), (-20.0, 40.0)] {
+            geometries.extend([
+                Geometry::LineString(LineString::new(vec![
+                    Coord { x: min, y: min },
+                    Coord { x: max, y: min },
+                ])),
+                Geometry::LineString(LineString::new(vec![
+                    Coord { x: max, y: min },
+                    Coord { x: max, y: max },
+                ])),
+                Geometry::LineString(LineString::new(vec![
+                    Coord { x: max, y: max },
+                    Coord { x: min, y: max },
+                ])),
+                Geometry::LineString(LineString::new(vec![
+                    Coord { x: min, y: max },
+                    Coord { x: min, y: min },
+                ])),
+            ]);
+        }
+        let mut untiled = Polygonizer::new();
+        let mut tiled = TiledPolygonizer::new(bbox, 10.0)
+            .with_buffer(2.0)
+            .with_dedup_policy(DedupPolicy::CanonicalRingHash)
+            .with_component_fallback();
+        for geometry in &geometries {
+            untiled.add_borrowed_geometry(geometry);
+            tiled.add_geometry(geometry);
+        }
+
+        let expected = untiled
+            .polygonize()
+            .unwrap()
+            .polygons
+            .into_iter()
+            .map(|polygon| crate::tiling::canonical_polygon_key(&polygon))
+            .collect::<Vec<_>>();
+        let result = tiled
+            .polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateObservedCoverage)
+            .unwrap();
+        assert_eq!(
+            result
+                .polygons
+                .iter()
+                .map(crate::tiling::canonical_polygon_key)
+                .collect::<Vec<_>>(),
+            expected
+        );
+        assert_eq!(result.polygons.len(), 2);
+        assert_eq!(result.stitching_report.component_fallback_count, 2);
+        assert_eq!(result.stitching_report.component_fallback_polygon_count, 2);
+        assert_eq!(
+            result
+                .stitching_report
+                .component_fallback_replaced_polygon_count,
+            0
+        );
+
+        let traced = tiled
+            .polygonize_with_trace(TraceLevelV1::Full, usize::MAX)
+            .unwrap();
+        let events = traced
+            .trace
+            .events
+            .iter()
+            .filter(|event| event.kind == "tile_component_fallback")
+            .collect::<Vec<_>>();
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0].payload["input_geometry_indices"],
+            serde_json::json!([0, 1, 2, 3, 4, 5, 6, 7])
+        );
+        assert_eq!(events[0].payload["recovered_component_count"], 2);
     }
 
     #[test]

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -345,6 +345,8 @@ pub struct TileComponentFallbackTraceV1 {
     pub input_geometry_indices: Vec<usize>,
     pub output_polygon_count: usize,
     pub retained_tile_polygon_count: usize,
+    pub replaced_retained_polygon_count: usize,
+    pub recovered_component_count: usize,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
@@ -1286,6 +1288,8 @@ impl TraceRecorderV1 {
         input_geometry_indices: &[usize],
         output_polygon_count: usize,
         retained_tile_polygon_count: usize,
+        replaced_retained_polygon_count: usize,
+        recovered_component_count: usize,
     ) -> bool {
         self.record(
             TraceStageV1::Output,
@@ -1294,6 +1298,8 @@ impl TraceRecorderV1 {
                 input_geometry_indices: input_geometry_indices.to_vec(),
                 output_polygon_count,
                 retained_tile_polygon_count,
+                replaced_retained_polygon_count,
+                recovered_component_count,
             })
             .expect("tile component-fallback trace event serializes"),
         )

--- a/docs/guide/tiling.md
+++ b/docs/guide/tiling.md
@@ -102,9 +102,10 @@ Both validation modes are deliberately narrower than coverage certification.
 `with_execution_policy` applies segment, candidate, exact-predicate, and
 cancellation bounds to the indexed component preflight, including the optional
 pre-snap and fixed-grid endpoint passes, and passes the same policy to each tile
-polygonization. Numeric work limits apply independently to the preflight and to
-each tile, not as one aggregate budget across the tiled call. The component
-envelope remains conservative evidence rather than proof of a face.
+polygonization and recovery region. Numeric work limits apply independently to
+the preflight, each tile, and each recovery region, not as one aggregate budget
+across the tiled call. The component envelope remains conservative evidence
+rather than proof of a face.
 `with_retry_policy` enables deterministic tile-local halo growth for tiles whose
 final report still contains owned-face, input-boundary, or excluded-component
 evidence. Each attempt adds `buffer_increment` up to `max_attempts` and
@@ -113,23 +114,22 @@ attempt in `TileReport` and `StitchingReport`. Strict validation returns the
 typed coverage error with retry counts when the bounded schedule is exhausted.
 Retries reuse the same execution policy independently per attempt. Full output
 traces record bounded `tile_halo_retry` events directly from the physical retry
-history. `with_component_fallback` enables a narrower recovery path for excluded
-components whose envelope is disjoint from every non-member input envelope,
-retained tile polygon, and other recovered component. Member linework may have
-appeared in a tile halo; if that produced a retained face intersecting the
-component envelope, recovery declines. Otherwise it polygonizes the complete
-component with the same options, merges the result deterministically, records
-`component_fallback_used` and a bounded `tile_component_fallback` event. The
-event includes the recovered polygon count and the number of retained tile
-polygons present at the merge boundary. `StitchingReport` also exposes the
-retained tile polygon count, recovered component count, and recovered polygon
-count before final deduplication. Recovery declines when any envelope
-overlaps or nests. `with_untiled_fallback`
-remains the containment-safe escape hatch for those declined cases. General
-cross-region graph merging remains unavailable. Component fallback also checks
-the execution policy before selecting recovery and before each recovered
-component, so cancellation does not get lost between tile processing and the
-bounded component polygonizer.
+history. `with_component_fallback` enables conservative recovery for excluded
+components. It starts with each excluded component, closes the region over
+intersecting input envelopes, interacting retained polygon envelopes, and other
+connected component envelopes, then polygonizes that complete region once.
+Retained polygons intersecting the recovered region are replaced before the
+existing canonical deduplication and ordering pass, preserving containment for
+the envelope-closed class without independently appending nested output. The
+recovery records `component_fallback_used`, retained/recovered/replaced counts
+in `StitchingReport`, and a bounded `tile_component_fallback` event containing
+the region input indexes, recovered component count, and replacement count.
+Coverage issues or unresolved input evidence outside the closed regions still
+decline component recovery. `with_untiled_fallback` remains the containment-safe
+escape hatch for those cases. General boundary-graph stitching remains
+unavailable. Component fallback checks the execution policy before region
+selection and before each recovery region, so cancellation does not get lost
+between tile processing and the bounded region polygonizer.
 Applications that require correctness must run an untiled equivalence check for
 their input class or choose untiled polygonization directly when sufficiency is
 unknown.


### PR DESCRIPTION
## Stack

- Parent: `main`
- Children: #1190 (`agent/p3-region-fallback-evidence`)

## Delivered

- Replaced append-only component fallback with deterministic envelope-closed recovery regions.
- Includes interacting input envelopes, retained polygon envelopes, and connected component envelopes.
- Re-polygonizes each closed region once, removes intersecting retained polygons, then uses the existing canonical deduplication and ordering pass.
- Added StitchingReport replacement counts and trace payload accounting.
- Added nested-containment and overlapping-excluded-component regressions.
- Updated the tiling guide and P3.2 roadmap evidence.

## Contract impact

- `with_component_fallback` remains opt-in; default tiled behavior is unchanged.
- Nested and overlapping recovery now replaces affected retained output instead of independently appending it.
- Coverage issues or unresolved input evidence outside a closed region still decline component recovery, leaving whole-input fallback as the containment-safe escape hatch.
- The public report gains `component_fallback_replaced_polygon_count`; component fallback trace events gain replacement and recovered-component counts.
- General boundary-graph stitching and arbitrary partial-region proof remain open.

## Validation

- `cargo test --workspace`
- `cargo test -p geo-polygonize-core --lib tiling::tests::tests --no-default-features`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p geo-polygonize-core --no-deps`
- `cargo fmt --all -- --check`
- `git diff --check`
- `npm test`
- `npm run docs:build` (passes with existing npm audit, Vite chunk-size, MUI "use client", and WASM URL warnings; generated bindings/package-lock restored)

## Agent handoff

- Parent: `main`
- Children: #1190 (`agent/p3-region-fallback-evidence`)
- Do not claim P3.2 umbrella completion: envelope-closed canonical partial merging is covered, while arbitrary boundary-crossing region reconciliation remains open.