### PR TITLE
test(core): bound region fallback cancellation

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -772,7 +772,8 @@ When coverage cannot be proven:
     open.
   - [x] Apply the configured output limit to component recovery and observe
     cancellation before fallback selection and each recovered component;
-    broader fallback cancellation coverage remains open.
+    envelope-closure region-selection cancellation is now pinned; cancellation
+    coverage for later fallback stages remains open.
   - [x] Record retained tile polygon counts in component-fallback trace events
     and expose retained/recovered aggregate counts in `StitchingReport`;
     expose replaced-retained counts for canonical region replacement.

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -927,6 +927,58 @@ mod tests {
     }
 
     #[test]
+    fn component_fallback_observes_region_selection_cancellation() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 20.0 });
+        let geometries = (0..=256)
+            .map(|_| {
+                Geometry::LineString(LineString::new(vec![
+                    Coord { x: 0.0, y: 0.0 },
+                    Coord { x: 1.0, y: 0.0 },
+                ]))
+            })
+            .collect::<Vec<_>>();
+        let token = CancellationToken::new();
+        let policy = ExecutionPolicy {
+            cancellation_token: Some(token.clone()),
+            cancel_at_work_item: Some((token, 256)),
+            ..Default::default()
+        };
+        let mut tiled = TiledPolygonizer::new(bbox, 10.0).with_execution_policy(policy);
+        for geometry in &geometries {
+            tiled.add_geometry(geometry);
+        }
+        let component_indices = vec![0, 1];
+        let report = TileReport {
+            tile_bbox: bbox,
+            input_geometry_count: 0,
+            polygon_count: 0,
+            owned_polygon_count: 0,
+            dangle_count: 0,
+            cut_edge_count: 0,
+            invalid_ring_count: 0,
+            coverage_issues: Vec::new(),
+            input_boundary_issues: Vec::new(),
+            excluded_component_issues: vec![TileExcludedComponentIssue {
+                input_geometry_indices: component_indices.clone(),
+                component_bbox: Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 1.0, y: 1.0 }),
+                connection: TileComponentConnection::ExactEndpoint,
+            }],
+            retry_attempts: Vec::new(),
+            retry_exhausted: false,
+        };
+        let component = InputComponent {
+            input_geometry_indices: component_indices,
+            bbox: Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 1.0, y: 1.0 }),
+            connection: TileComponentConnection::ExactEndpoint,
+        };
+
+        assert!(matches!(
+            tiled.try_component_fallback(&[Vec::new()], &[report], &[component]),
+            Err(PolygonizeError::Cancelled { stage }) if stage == "tile_component_fallback"
+        ));
+    }
+
+    #[test]
     fn component_fallback_keeps_recovered_output_deterministic() {
         let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 20.0 });
         let geometries = [


### PR DESCRIPTION
## Stack

- Parent: #1189 (`agent/p3-region-local-fallback`)
- Children: none

## Delivered

- Adds a midflight cancellation regression that reaches the 256-item envelope-closure selection poll.
- Pins the `tile_component_fallback` cancellation stage before region polygonization begins.
- Updates the P3.2 cancellation evidence without claiming all later fallback-stage cancellation coverage complete.

## Contract impact

- Test-only; no runtime or public API change.
- Confirms the parent region-selection scan remains cooperatively cancellable under the existing ExecutionPolicy polling interval.

## Validation

- `cargo test -p geo-polygonize-core --lib tiling::tests::tests`
- `cargo test -p geo-polygonize-core --lib tiling::tests::tests --no-default-features`
- `cargo fmt --all -- --check`
- `git diff --check`

## Agent handoff

- Parent: #1189 (`agent/p3-region-local-fallback`)
- Children: none.
- Keep the P3.2 umbrella open: later fallback-stage cancellation and non-envelope-closed boundary reconciliation remain unverified.