### PR TITLE
feat(core): recover partially observed components

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -727,6 +727,9 @@ that same connectivity case.
     with bounded trace evidence; broader region coverage detection remains open.
   - [x] Pin the certified fixed-grid hot-pixel connected-region gap; detection
     and bounded evidence now reuse the certified noder.
+  - [x] Use indexed connected-component evidence to identify a component that
+    is only partially observed in a tile halo; broad undetected-region coverage
+    remains open.
 - [x] Report source IDs and boundary evidence that were required but not fully
   observed.
   - [x] Distinguish representative edge IDs from complete aggregate boundary
@@ -760,10 +763,12 @@ When coverage cannot be proven:
     spatially nests an already retained tile-local face.
   - [x] Add opt-in envelope-closed component fallback that groups interacting
     input, retained-face, and connected-component envelopes and records the
-    recovery.
+    recovery, including input-boundary-seeded components.
   - [x] Recover a nested retained face by polygonizing the closed region once;
     whole-input fallback remains the escape hatch for evidence outside that
     region.
+  - [x] Seed the same region-local recovery from input-boundary evidence when
+    the indexed connected component is only partially visible in a halo.
   - [x] Merge one envelope-disjoint recovered component with retained tile
     output; envelope-closed region replacement now covers interacting retained
     output.

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -83,11 +83,11 @@ pub enum TileComponentConnection {
     FixedGrid,
 }
 
-/// A transformed-connected input component excluded from a tile halo.
+/// A transformed-connected input component not fully observed in a tile halo.
 ///
-/// The component envelope intersects the buffered tile, but none of its member
-/// geometry envelopes do. This is conservative evidence, not proof that the
-/// component contains a face.
+/// The component envelope intersects the buffered tile, but its member geometry
+/// envelopes are not fully observed there. This is conservative evidence, not
+/// proof that the component contains a face.
 #[derive(Clone, Debug)]
 pub struct TileExcludedComponentIssue {
     pub input_geometry_indices: Vec<usize>,
@@ -130,7 +130,7 @@ pub struct TileReport {
     pub coverage_issues: Vec<TileCoverageIssue>,
     /// Inputs that may connect to linework beyond this tile's halo.
     pub input_boundary_issues: Vec<TileInputBoundaryIssue>,
-    /// Transformed-connected components excluded from this tile's halo.
+    /// Transformed-connected components not fully observed in this tile's halo.
     pub excluded_component_issues: Vec<TileExcludedComponentIssue>,
     pub retry_attempts: Vec<TileRetryAttempt>,
     pub retry_exhausted: bool,
@@ -146,7 +146,7 @@ pub struct StitchingReport {
     pub output_polygon_count: usize,
     /// Polygon count retained from tile-local ownership before fallback merge.
     pub retained_tile_polygon_count: usize,
-    /// Number of excluded components recovered by component or region fallback.
+    /// Number of indexed components recovered by component or region fallback.
     pub component_fallback_count: usize,
     /// Polygon count produced by component fallback before final deduplication.
     pub component_fallback_polygon_count: usize,
@@ -163,7 +163,7 @@ pub struct StitchingReport {
     pub retried_tile_count: usize,
     pub retry_attempt_count: usize,
     pub retry_exhausted_tile_count: usize,
-    /// Whether excluded components were recovered by component or region fallback.
+    /// Whether indexed components were recovered by component or region fallback.
     pub component_fallback_used: bool,
     /// Whether unresolved tiled output was replaced by one untiled pass over all input.
     pub untiled_fallback_used: bool,
@@ -611,11 +611,27 @@ impl<'a> TiledPolygonizer<'a> {
     ) -> Result<Option<ComponentFallbackResult>> {
         self.execution_policy
             .check_cancelled("tile_component_fallback")?;
-        let component_keys = tile_reports
+        let mut component_keys = tile_reports
             .iter()
             .flat_map(|report| &report.excluded_component_issues)
             .map(|issue| issue.input_geometry_indices.clone())
             .collect::<HashSet<_>>();
+        let input_boundary_geometry_indices = tile_reports
+            .iter()
+            .flat_map(|report| &report.input_boundary_issues)
+            .map(|issue| issue.input_geometry_index)
+            .collect::<HashSet<_>>();
+        for (component_index, component) in input_components.iter().enumerate() {
+            self.execution_policy
+                .check_cancelled_every("tile_component_fallback", component_index)?;
+            if component
+                .input_geometry_indices
+                .iter()
+                .any(|index| input_boundary_geometry_indices.contains(index))
+            {
+                component_keys.insert(component.input_geometry_indices.clone());
+            }
+        }
         if component_keys.is_empty() {
             return Ok(None);
         }

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -635,6 +635,99 @@ mod tests {
     }
 
     #[test]
+    fn component_fallback_recovers_input_boundary_connected_region() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 20.0 });
+        let geometries = [
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 4.0, y: 4.0 },
+                Coord { x: 6.0, y: 4.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 6.0, y: 4.0 },
+                Coord { x: 16.0, y: 4.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 16.0, y: 4.0 },
+                Coord { x: 16.0, y: 16.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 16.0, y: 16.0 },
+                Coord { x: 4.0, y: 16.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 4.0, y: 16.0 },
+                Coord { x: 4.0, y: 4.0 },
+            ])),
+        ];
+        let mut untiled = Polygonizer::new();
+        let mut tiled = TiledPolygonizer::new(bbox, 10.0)
+            .with_buffer(1.0)
+            .with_dedup_policy(DedupPolicy::CanonicalRingHash)
+            .with_component_fallback();
+        for geometry in &geometries {
+            untiled.add_borrowed_geometry(geometry);
+            tiled.add_geometry(geometry);
+        }
+
+        let expected = untiled.polygonize().unwrap();
+        assert_eq!(expected.polygons.len(), 1);
+        let result = tiled
+            .polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateObservedCoverage)
+            .unwrap();
+        assert_eq!(result.polygons.len(), 1);
+        assert_eq!(
+            crate::tiling::canonical_polygon_key(&result.polygons[0]),
+            crate::tiling::canonical_polygon_key(&expected.polygons[0])
+        );
+        assert!(result.stitching_report.component_fallback_used);
+        assert!(!result.stitching_report.untiled_fallback_used);
+        assert_eq!(result.stitching_report.component_fallback_count, 1);
+        assert!(result.stitching_report.unresolved_input_geometry_count > 0);
+        assert!(result
+            .tile_reports
+            .iter()
+            .all(|report| report.excluded_component_issues.is_empty()));
+
+        let traced = tiled
+            .polygonize_with_trace(TraceLevelV1::Full, usize::MAX)
+            .unwrap();
+        let events = traced
+            .trace
+            .events
+            .iter()
+            .filter(|event| event.kind == "tile_component_fallback")
+            .collect::<Vec<_>>();
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0].payload["input_geometry_indices"],
+            serde_json::json!([0, 1, 2, 3, 4])
+        );
+
+        let mut reversed = TiledPolygonizer::new(bbox, 10.0)
+            .with_buffer(1.0)
+            .with_dedup_policy(DedupPolicy::CanonicalRingHash)
+            .with_component_fallback();
+        for geometry in geometries.iter().rev() {
+            reversed.add_geometry(geometry);
+        }
+        let reversed = reversed
+            .polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateObservedCoverage)
+            .unwrap();
+        assert_eq!(
+            reversed
+                .polygons
+                .iter()
+                .map(crate::tiling::canonical_polygon_key)
+                .collect::<Vec<_>>(),
+            result
+                .polygons
+                .iter()
+                .map(crate::tiling::canonical_polygon_key)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
     fn component_fallback_merges_disjoint_retained_output() {
         let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 60.0, y: 60.0 });
         let geometries = [

--- a/docs/guide/tiling.md
+++ b/docs/guide/tiling.md
@@ -115,9 +115,10 @@ typed coverage error with retry counts when the bounded schedule is exhausted.
 Retries reuse the same execution policy independently per attempt. Full output
 traces record bounded `tile_halo_retry` events directly from the physical retry
 history. `with_component_fallback` enables conservative recovery for excluded
-components. It starts with each excluded component, closes the region over
-intersecting input envelopes, interacting retained polygon envelopes, and other
-connected component envelopes, then polygonizes that complete region once.
+or partially observed indexed components. It starts with each component
+identified by excluded-component or input-boundary evidence, closes the region
+over intersecting input envelopes, interacting retained polygon envelopes, and
+other connected component envelopes, then polygonizes that complete region once.
 Retained polygons intersecting the recovered region are replaced before the
 existing canonical deduplication and ordering pass, preserving containment for
 the envelope-closed class without independently appending nested output. The


### PR DESCRIPTION
## Stack

- Parent: `main`
- Children: none

## Delivered

- Seeds existing envelope-closed component recovery from input-boundary evidence when the indexed multi-geometry component is only partially observed in a tile halo.
- Keeps standalone input-boundary evidence on the existing whole-input fallback path.
- Adds canonical output, input-order permutation, coverage-guarantee, and bounded trace regression evidence.
- Updates the public tiling guide and P3.1/P3.2 roadmap evidence.

## Contract impact

- No new public option or output mutation.
- `TileExcludedComponentIssue` and report documentation now describe components that are not fully observed, including partial observation.
- Region recovery remains conservative: coverage evidence outside the recovered component still declines component fallback.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- Focused tiling tests: default 30 passed; `--no-default-features` 30 passed
- `cargo test --workspace`: passed
- `cargo clippy --workspace --all-targets -- -D warnings`: passed
- `RUSTDOCFLAGS='-D warnings' cargo doc -p geo-polygonize-core --no-deps`: passed
- `npm test`: 54 passed
- `npm run docs:build`: passed with existing MUI `use client`, large-chunk, and deprecation warnings; generated bindings and `playground/package-lock.json` restored

## Agent handoff

- Parent: `main`
- Children: none
- Next branch: `agent/p3-fallback-decline-trace`
- Do not claim broad undetected connected-region coverage or true graph stitching from this slice.