### PR TITLE
feat(core): trace declined component fallback

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -804,6 +804,8 @@ When coverage cannot be proven:
   - [x] Record envelope-closed component/region recovery and retained-polygon
     replacement counts in the stitching report and bounded component-fallback
     trace events.
+  - [x] Record enabled-but-declined component recovery in the stitching report
+    and bounded `tile_component_fallback_declined` trace events.
 
 ### P3.3 True graph stitching
 

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -152,6 +152,8 @@ pub struct StitchingReport {
     pub component_fallback_polygon_count: usize,
     /// Number of retained tile polygons replaced by region fallback.
     pub component_fallback_replaced_polygon_count: usize,
+    /// Whether component fallback was enabled and attempted for unresolved output.
+    pub component_fallback_attempted: bool,
     pub unresolved_tile_count: usize,
     pub unresolved_owned_polygon_count: usize,
     pub unresolved_input_tile_count: usize,
@@ -1340,7 +1342,8 @@ impl<'a> TiledPolygonizer<'a> {
             }
         }
         let unresolved = tile_reports.iter().any(Self::report_is_unresolved);
-        let component_fallback = if self.component_fallback && unresolved {
+        let component_fallback_attempted = self.component_fallback && unresolved;
+        let component_fallback = if component_fallback_attempted {
             self.try_component_fallback(&tile_polygons, &tile_reports, input_components)?
         } else {
             None
@@ -1471,6 +1474,7 @@ impl<'a> TiledPolygonizer<'a> {
                 component_fallback_count,
                 component_fallback_polygon_count,
                 component_fallback_replaced_polygon_count,
+                component_fallback_attempted,
                 unresolved_tile_count,
                 unresolved_owned_polygon_count,
                 unresolved_input_tile_count,
@@ -1484,6 +1488,15 @@ impl<'a> TiledPolygonizer<'a> {
                 untiled_fallback_used,
             },
         };
+        if component_fallback_attempted && !component_fallback_used {
+            if let Some(trace) = trace.as_deref_mut() {
+                trace.record_tile_component_fallback_declined(
+                    result.stitching_report.unresolved_owned_polygon_count,
+                    result.stitching_report.unresolved_input_geometry_count,
+                    result.stitching_report.unresolved_component_count,
+                );
+            }
+        }
         if component_fallback_used {
             if let Some(trace) = trace.as_deref_mut() {
                 for event in component_fallback_events {

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -380,6 +380,46 @@ mod tests {
     }
 
     #[test]
+    fn records_declined_component_fallback_for_owned_face_evidence() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 10.0 });
+        let face = Geometry::LineString(LineString::new(vec![
+            Coord { x: 1.0, y: 2.0 },
+            Coord { x: 19.0, y: 2.0 },
+            Coord { x: 19.0, y: 8.0 },
+            Coord { x: 1.0, y: 8.0 },
+            Coord { x: 1.0, y: 2.0 },
+        ]));
+        let mut tiled = TiledPolygonizer::new(bbox, 10.0)
+            .with_buffer(2.0)
+            .with_component_fallback();
+        tiled.add_geometry(&face);
+
+        let result = tiled.polygonize().unwrap();
+        assert!(result.stitching_report.component_fallback_attempted);
+        assert!(!result.stitching_report.component_fallback_used);
+        assert!(result.stitching_report.unresolved_owned_polygon_count > 0);
+
+        let traced = tiled
+            .polygonize_with_trace(TraceLevelV1::Full, usize::MAX)
+            .unwrap();
+        let declined = traced
+            .trace
+            .events
+            .iter()
+            .find(|event| event.kind == "tile_component_fallback_declined")
+            .unwrap();
+        assert_eq!(
+            declined.payload["unresolved_owned_polygon_count"],
+            result.stitching_report.unresolved_owned_polygon_count
+        );
+        assert_eq!(
+            declined.payload["unresolved_input_geometry_count"],
+            result.stitching_report.unresolved_input_geometry_count
+        );
+        assert_eq!(declined.payload["unresolved_component_count"], 0);
+    }
+
+    #[test]
     fn reports_boundary_inputs_when_no_local_face_is_reconstructed() {
         let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 10.0 });
         let boundaries = [

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -350,6 +350,13 @@ pub struct TileComponentFallbackTraceV1 {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct TileComponentFallbackDeclinedTraceV1 {
+    pub unresolved_owned_polygon_count: usize,
+    pub unresolved_input_geometry_count: usize,
+    pub unresolved_component_count: usize,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct TileOwnedFaceBoundaryTraceV1 {
     pub tile_index: usize,
     pub polygon_index: usize,
@@ -1302,6 +1309,24 @@ impl TraceRecorderV1 {
                 recovered_component_count,
             })
             .expect("tile component-fallback trace event serializes"),
+        )
+    }
+
+    pub(crate) fn record_tile_component_fallback_declined(
+        &mut self,
+        unresolved_owned_polygon_count: usize,
+        unresolved_input_geometry_count: usize,
+        unresolved_component_count: usize,
+    ) -> bool {
+        self.record(
+            TraceStageV1::Output,
+            "tile_component_fallback_declined",
+            serde_json::to_value(TileComponentFallbackDeclinedTraceV1 {
+                unresolved_owned_polygon_count,
+                unresolved_input_geometry_count,
+                unresolved_component_count,
+            })
+            .expect("tile component-fallback-declined trace event serializes"),
         )
     }
 

--- a/docs/guide/tiling.md
+++ b/docs/guide/tiling.md
@@ -128,9 +128,12 @@ the region input indexes, recovered component count, and replacement count.
 Coverage issues or unresolved input evidence outside the closed regions still
 decline component recovery. `with_untiled_fallback` remains the containment-safe
 escape hatch for those cases. General boundary-graph stitching remains
-unavailable. Component fallback checks the execution policy before region
-selection and before each recovery region, so cancellation does not get lost
-between tile processing and the bounded region polygonizer.
+unavailable. When enabled for unresolved output, a declined component recovery
+is marked in `StitchingReport` and recorded as a bounded
+`tile_component_fallback_declined` trace event with the remaining evidence
+counts. Component fallback checks the execution policy before region selection
+and before each recovery region, so cancellation does not get lost between tile
+processing and the bounded region polygonizer.
 Applications that require correctness must run an untiled equivalence check for
 their input class or choose untiled polygonization directly when sufficiency is
 unknown.


### PR DESCRIPTION
## Stack

- Parent: #1192 `agent/p3-region-fallback-input-boundary`
- Children: none

## Delivered

- Adds `StitchingReport.component_fallback_attempted` so enabled-but-declined recovery is distinguishable from an unused option.
- Emits bounded `tile_component_fallback_declined` trace events with the remaining owned-face, input-boundary, and excluded-component evidence counts.
- Pins declined recovery behavior with default/no-default regression coverage and updates the tiling guide and roadmap.

## Contract impact

- Adds one diagnostic field to `StitchingReport`; polygon output and coverage guarantees are unchanged.
- Declined recovery remains conservative and still leaves the existing typed coverage error or caller-enabled whole-input fallback responsible for unresolved output.
- Trace capture remains bounded by the existing output trace limits.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- Focused tiling tests: default 31 passed; `--no-default-features` 31 passed
- `cargo test --workspace`: 233 core tests and all workspace/integration/doc tests passed

## Agent handoff

- Parent: #1192 `agent/p3-region-fallback-input-boundary`
- Children: none
- Next branch: `agent/p3-fallback-decline-reason`
- Do not claim a topology guarantee from the new event; it records conservative evidence and the declined decision only.