### PR TITLE
fix(core): bound tiled merge output

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -779,6 +779,8 @@ When coverage cannot be proven:
     cancellation before fallback selection and each recovered component;
     envelope-closure region-selection cancellation is now pinned; cancellation
     coverage for later fallback stages remains open.
+  - [x] Enforce the configured aggregate output limit and cancellation during
+    the final canonical merge after tile and region recovery.
   - [x] Record retained tile polygon counts in component-fallback trace events
     and expose retained/recovered aggregate counts in `StitchingReport`;
     expose replaced-retained counts for canonical region replacement.

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -1471,10 +1471,14 @@ impl<'a> TiledPolygonizer<'a> {
             &mut cut_edges,
             &mut invalid_rings,
             &self.options,
-            &ExecutionPolicy::default(),
+            &self.execution_policy,
             None,
-        )
-        .expect("default execution policy cannot cancel");
+        )?;
+        self.execution_policy.check(
+            "output_polygons",
+            self.execution_policy.max_output_polygons,
+            polygons.len(),
+        )?;
         let output_polygon_count = polygons.len();
         let unresolved_tile_count = tile_reports
             .iter()

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -313,6 +313,43 @@ mod tests {
     }
 
     #[test]
+    fn tiled_merge_applies_aggregate_output_limit() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 10.0 });
+        let squares = [
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 1.0, y: 1.0 },
+                Coord { x: 3.0, y: 1.0 },
+                Coord { x: 3.0, y: 3.0 },
+                Coord { x: 1.0, y: 3.0 },
+                Coord { x: 1.0, y: 1.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 11.0, y: 1.0 },
+                Coord { x: 13.0, y: 1.0 },
+                Coord { x: 13.0, y: 3.0 },
+                Coord { x: 11.0, y: 3.0 },
+                Coord { x: 11.0, y: 1.0 },
+            ])),
+        ];
+        let mut tiled = TiledPolygonizer::new(bbox, 10.0).with_execution_policy(ExecutionPolicy {
+            max_output_polygons: Some(1),
+            ..Default::default()
+        });
+        for square in &squares {
+            tiled.add_geometry(square);
+        }
+
+        assert!(matches!(
+            tiled.polygonize(),
+            Err(PolygonizeError::ResourceLimitExceeded {
+                ref stage,
+                limit: 1,
+                observed: 2,
+            }) if stage == "output_polygons"
+        ));
+    }
+
+    #[test]
     fn reports_owned_faces_that_escape_an_internal_halo() {
         let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 10.0 });
         let face = Geometry::LineString(LineString::new(vec![

--- a/docs/guide/tiling.md
+++ b/docs/guide/tiling.md
@@ -104,8 +104,9 @@ cancellation bounds to the indexed component preflight, including the optional
 pre-snap and fixed-grid endpoint passes, and passes the same policy to each tile
 polygonization and recovery region. Numeric work limits apply independently to
 the preflight, each tile, and each recovery region, not as one aggregate budget
-across the tiled call. The component envelope remains conservative evidence
-rather than proof of a face.
+across the tiled call; the final canonical merge also enforces the configured
+aggregate output-polygon limit and observes cancellation. The component
+envelope remains conservative evidence rather than proof of a face.
 `with_retry_policy` enables deterministic tile-local halo growth for tiles whose
 final report still contains owned-face, input-boundary, or excluded-component
 evidence. Each attempt adds `buffer_increment` up to `max_attempts` and


### PR DESCRIPTION
## Stack

- Parent: #1195 `agent/p3-fallback-decline-reason`
- Children: none

## Delivered

- Runs final tiled canonicalization under the caller's execution policy instead of an uncancellable default policy.
- Enforces the configured aggregate `output_polygons` limit after tile and region results are merged.
- Pins the multi-tile over-limit case in default and no-default builds.
- Updates the tiling guide and P3.2 resource/cancellation evidence.

## Contract impact

- Valid tiled output is unchanged.
- Tiled calls now reject aggregate output exceeding `ExecutionPolicy.max_output_polygons`, including multiple individually valid tile results.
- Final canonical merge now observes caller cancellation and existing canonical-sort bounds.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- Focused tiling tests: default 32 passed; `--no-default-features` 32 passed
- `cargo test --workspace --quiet`: exit 0; 234 core tests and all workspace/integration/doc tests passed
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings`: passed
- Generated bindings were restored after validation.

## Agent handoff

- Parent: #1195 `agent/p3-fallback-decline-reason`
- Children: none
- Next branch: `agent/p3-fallback-cancellation-regression`
- Remaining risk: final-merge cancellation is now bounded, but broad undetected connected-region coverage and P3.3 graph stitching remain open.