### PR TITLE
fix(core): observe tiled fallback merge cancellation

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -777,8 +777,8 @@ When coverage cannot be proven:
     open.
   - [x] Apply the configured output limit to component recovery and observe
     cancellation before fallback selection and each recovered component;
-    envelope-closure region-selection cancellation is now pinned; cancellation
-    coverage for later fallback stages remains open.
+    envelope-closure region-selection and retained-region replacement,
+    recovered-output merge, and deduplication cancellation are now pinned.
   - [x] Enforce the configured aggregate output limit and cancellation during
     the final canonical merge after tile and region recovery.
   - [x] Record retained tile polygon counts in component-fallback trace events

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -830,6 +830,47 @@ impl<'a> TiledPolygonizer<'a> {
         ))
     }
 
+    fn merge_fallback_polygons(
+        &self,
+        tile_polygons: Vec<Vec<Polygon3D>>,
+        region_bboxes: &[Rect<f64>],
+        component_fallback_polygons: Vec<Polygon3D>,
+    ) -> Result<Vec<Polygon3D>> {
+        self.execution_policy
+            .check_cancelled("tile_fallback_merge")?;
+        let mut result = Vec::new();
+        let mut work_items = 0;
+        for polygons in tile_polygons {
+            for polygon in polygons {
+                self.execution_policy
+                    .check_cancelled_every("tile_fallback_merge", work_items)?;
+                work_items = work_items.saturating_add(1);
+                let polygon_bbox = Self::polygon_bbox(&polygon);
+                let mut replaced = false;
+                for region_bbox in region_bboxes {
+                    self.execution_policy
+                        .check_cancelled_every("tile_fallback_merge", work_items)?;
+                    work_items = work_items.saturating_add(1);
+                    if polygon_bbox.is_some_and(|polygon_bbox| polygon_bbox.intersects(region_bbox))
+                    {
+                        replaced = true;
+                        break;
+                    }
+                }
+                if !replaced {
+                    result.push(polygon);
+                }
+            }
+        }
+        for polygon in component_fallback_polygons {
+            self.execution_policy
+                .check_cancelled_every("tile_fallback_merge", work_items)?;
+            work_items = work_items.saturating_add(1);
+            result.push(polygon);
+        }
+        Ok(result)
+    }
+
     fn process_tile_with_retries(
         &self,
         tile_bbox: Rect<f64>,
@@ -1418,27 +1459,25 @@ impl<'a> TiledPolygonizer<'a> {
             }
             polygonizer.polygonize()?.polygons
         } else {
-            tile_polygons
-                .into_iter()
-                .flatten()
-                .filter(|polygon| {
-                    !region_bboxes.iter().any(|region_bbox| {
-                        Self::polygon_bbox(polygon)
-                            .is_some_and(|polygon_bbox| polygon_bbox.intersects(region_bbox))
-                    })
-                })
-                .chain(component_fallback_polygons)
-                .collect()
+            self.merge_fallback_polygons(
+                tile_polygons,
+                &region_bboxes,
+                component_fallback_polygons,
+            )?
         };
         let merged_polygon_count = result_polygons.len();
 
         let polygons = if untiled_fallback_used {
             result_polygons
         } else {
+            self.execution_policy
+                .check_cancelled("tile_deduplication")?;
             match self.dedup_policy {
                 DedupPolicy::KeepAll => {
                     if let Some(trace) = trace.as_deref_mut() {
                         for polygon_index in 0..result_polygons.len() {
+                            self.execution_policy
+                                .check_cancelled_every("tile_deduplication", polygon_index)?;
                             trace.record_tile_dedup(polygon_index, true);
                         }
                     }
@@ -1449,6 +1488,8 @@ impl<'a> TiledPolygonizer<'a> {
                     let mut seen = HashSet::new();
 
                     for (polygon_index, poly) in result_polygons.into_iter().enumerate() {
+                        self.execution_policy
+                            .check_cancelled_every("tile_deduplication", polygon_index)?;
                         let retained = seen.insert(canonical_polygon_key(&poly));
                         if let Some(trace) = trace.as_deref_mut() {
                             trace.record_tile_dedup(polygon_index, retained);

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -4,10 +4,10 @@ mod tests {
     use crate::tiling::InputComponent;
     use crate::{
         trace::TraceLevelV1, CancellationToken, Coord3D, DedupPolicy, ExecutionPolicy,
-        NodingGuarantee, NodingOptions, PolygonizeError, Polygonizer, PolygonizerOptions,
-        PrecisionModel, ProvenanceOptions, TileBoundarySide, TileComponentConnection,
-        TileCoverageGuarantee, TileExcludedComponentIssue, TileReport, TileRetryPolicy,
-        TiledPolygonizeError, TiledPolygonizer,
+        NodingGuarantee, NodingOptions, Polygon3D, PolygonizeError, Polygonizer,
+        PolygonizerOptions, PrecisionModel, ProvenanceOptions, TileBoundarySide,
+        TileComponentConnection, TileCoverageGuarantee, TileExcludedComponentIssue, TileReport,
+        TileRetryPolicy, TiledPolygonizeError, TiledPolygonizer,
     };
     use geo::{Contains, Coord, Geometry, LineString, Rect};
 
@@ -1146,6 +1146,40 @@ mod tests {
         assert!(matches!(
             tiled.try_component_fallback(&[Vec::new()], &[report], &[component]),
             Err(PolygonizeError::Cancelled { stage }) if stage == "tile_component_fallback"
+        ));
+    }
+
+    #[test]
+    fn fallback_merge_observes_cancellation_during_recovery_output() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 20.0 });
+        let token = CancellationToken::new();
+        let policy = ExecutionPolicy {
+            cancellation_token: Some(token.clone()),
+            cancel_at_work_item: Some((token, 256)),
+            ..Default::default()
+        };
+        let tiled = TiledPolygonizer::new(bbox, 10.0).with_execution_policy(policy);
+        let fallback_polygons = (0..=256)
+            .map(|index| {
+                let x = index as f64;
+                Polygon3D::new(
+                    vec![
+                        Coord3D::new(x, 0.0, 0.0),
+                        Coord3D::new(x + 1.0, 0.0, 0.0),
+                        Coord3D::new(x + 1.0, 1.0, 0.0),
+                        Coord3D::new(x, 1.0, 0.0),
+                        Coord3D::new(x, 0.0, 0.0),
+                    ],
+                    vec![],
+                    vec![],
+                    vec![],
+                )
+            })
+            .collect();
+
+        assert!(matches!(
+            tiled.merge_fallback_polygons(Vec::new(), &[], fallback_polygons),
+            Err(PolygonizeError::Cancelled { stage }) if stage == "tile_fallback_merge"
         ));
     }
 

--- a/docs/guide/tiling.md
+++ b/docs/guide/tiling.md
@@ -135,7 +135,9 @@ is marked in `StitchingReport` and recorded as a bounded
 counts and a deterministic decline reason. Component fallback checks the
 execution policy before region selection and before each recovery region, so
 cancellation does not get lost between tile processing and the bounded region
-polygonizer.
+polygonizer. The same policy is checked while replacing retained polygons,
+appending recovered output, and deduplicating the fallback merge, so a
+cancellation request is not lost after recovery finishes.
 Applications that require correctness must run an untiled equivalence check for
 their input class or choose untiled polygonization directly when sufficiency is
 unknown.


### PR DESCRIPTION
## Stack

Parent: none; this PR targets `main` after the merged tiled evidence stack through #1196.
Children: #1198 (`agent/p3-tile-filter-cancellation`).

## Delivered

- Extracted the retained-region replacement and recovered-output append into a cancellable fallback merge phase.
- Added cooperative checks while replacing retained polygons and appending recovered polygons.
- Added cancellation checks to tiled deduplication, plus a regression that cancels during recovery output.
- Updated the tiling guide and P3.2 roadmap evidence.

## Contract impact

- Core-only, no public API or binding changes.
- Preserves retained-before-recovered ordering, envelope-closed replacement semantics, canonical deduplication, Z/provenance payloads, and serial/parallel behavior.
- Does not claim coverage certification or boundary-crossing recovery; conservative envelope closure and whole-input fallback remain the safety boundary.

## Validation

- `cargo test -p geo-polygonize-core fallback_merge_observes_cancellation_during_recovery_output` — 1 passed.
- `cargo test -p geo-polygonize-core tiling` — 35 passed.
- `cargo test -p geo-polygonize-core --no-default-features tiling` — 35 passed.
- `cargo test --workspace --quiet` — all workspace tests passed, including 235 core tests.
- `cargo clippy --workspace --all-targets -- -D warnings` — passed.
- `RUSTDOCFLAGS='-D warnings' cargo doc -p geo-polygonize-core --no-deps` — passed.
- `npm test` — 54 passed.
- `npm run docs:build` — passed with existing MUI `use client`, large-chunk, missing-runtime-asset, and npm audit warnings; generated bindings and playground lockfile restored.
- Aggregate `cargo doc --workspace --no-deps` remains blocked by the repository's pre-existing duplicate `geo_polygonize_core` output-name collision between core and Python.

## Agent handoff

Parent: none; base is `main`.
Children: #1198 (`agent/p3-tile-filter-cancellation`).
Next branch: `agent/p3-undetected-region-evidence` remains the next executable roadmap candidate only after finding a reproducible broad undetected-region fixture; do not claim component-local correctness by independently appending polygonized output.