### PR TITLE
fix(core): honor tiled filtering cancellation

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -781,6 +781,8 @@ When coverage cannot be proven:
     recovered-output merge, and deduplication cancellation are now pinned.
   - [x] Enforce the configured aggregate output limit and cancellation during
     the final canonical merge after tile and region recovery.
+  - [x] Observe cancellation during tile input/evidence/ownership filtering,
+    including the empty-tile early-return path.
   - [x] Record retained tile polygon counts in component-fallback trace events
     and expose retained/recovered aggregate counts in `StitchingReport`;
     expose replaced-retained counts for canonical region replacement.

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -498,6 +498,7 @@ impl<'a> TiledPolygonizer<'a> {
         buffer: f64,
         capture_byte_limit: Option<usize>,
     ) -> Result<TileProcessResult> {
+        self.execution_policy.check_cancelled("tile_processing")?;
         let mut capture_budget = capture_byte_limit.map(TraceCaptureBudget::new);
         let mut local_poly = Polygonizer::with_options(self.options.clone())
             .with_execution_policy(self.execution_policy.clone());
@@ -518,6 +519,8 @@ impl<'a> TiledPolygonizer<'a> {
         let mut relevant_lines = 0;
         let mut input_boundary_issues = Vec::new();
         for (input_geometry_index, (geom, bbox)) in self.geometries.iter().enumerate() {
+            self.execution_policy
+                .check_cancelled_every("tile_processing", input_geometry_index)?;
             if let Some(geometry_bbox) = bbox
                 .as_ref()
                 .filter(|geometry_bbox| geometry_bbox.intersects(&buffered_bbox))
@@ -534,22 +537,24 @@ impl<'a> TiledPolygonizer<'a> {
                 }
             }
         }
-        let excluded_component_issues = input_components
-            .iter()
-            .filter(|component| {
-                component.bbox.intersects(&buffered_bbox)
-                    && component.input_geometry_indices.iter().all(|&index| {
-                        self.geometries[index]
-                            .1
-                            .is_none_or(|bbox| !bbox.intersects(&buffered_bbox))
-                    })
-            })
-            .map(|component| TileExcludedComponentIssue {
-                input_geometry_indices: component.input_geometry_indices.clone(),
-                component_bbox: component.bbox,
-                connection: component.connection,
-            })
-            .collect();
+        let mut excluded_component_issues = Vec::new();
+        for (component_index, component) in input_components.iter().enumerate() {
+            self.execution_policy
+                .check_cancelled_every("tile_processing", component_index)?;
+            if component.bbox.intersects(&buffered_bbox)
+                && component.input_geometry_indices.iter().all(|&index| {
+                    self.geometries[index]
+                        .1
+                        .is_none_or(|bbox| !bbox.intersects(&buffered_bbox))
+                })
+            {
+                excluded_component_issues.push(TileExcludedComponentIssue {
+                    input_geometry_indices: component.input_geometry_indices.clone(),
+                    component_bbox: component.bbox,
+                    connection: component.connection,
+                });
+            }
+        }
 
         let mut report = TileReport {
             tile_bbox,
@@ -579,6 +584,8 @@ impl<'a> TiledPolygonizer<'a> {
         let mut valid_polys = Vec::new();
         let mut ownership_decisions = Vec::new();
         for (polygon_index, poly) in result.polygons.into_iter().enumerate() {
+            self.execution_policy
+                .check_cancelled_every("tile_processing", polygon_index)?;
             let ownership_point = self.ownership_point(&poly);
             let owned = ownership_point.is_some_and(|c| {
                 // Check inclusion [min, max)

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -1184,6 +1184,50 @@ mod tests {
     }
 
     #[test]
+    fn tile_processing_observes_cancellation_before_empty_tile_return() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 20.0 });
+        let token = CancellationToken::new();
+        token.cancel();
+        let tiled = TiledPolygonizer::new(bbox, 10.0).with_execution_policy(ExecutionPolicy {
+            cancellation_token: Some(token),
+            ..Default::default()
+        });
+
+        assert!(matches!(
+            tiled.process_tile(bbox, &[], 0.0, None),
+            Err(PolygonizeError::Cancelled { stage }) if stage == "tile_processing"
+        ));
+    }
+
+    #[test]
+    fn tile_processing_observes_midflight_filter_cancellation() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 20.0 });
+        let token = CancellationToken::new();
+        let policy = ExecutionPolicy {
+            cancellation_token: Some(token.clone()),
+            cancel_at_work_item: Some((token, 256)),
+            ..Default::default()
+        };
+        let mut tiled = TiledPolygonizer::new(bbox, 10.0).with_execution_policy(policy);
+        let geometries = (0..=256)
+            .map(|_| {
+                Geometry::LineString(LineString::new(vec![
+                    Coord { x: 0.0, y: 0.0 },
+                    Coord { x: 1.0, y: 0.0 },
+                ]))
+            })
+            .collect::<Vec<_>>();
+        for geometry in &geometries {
+            tiled.add_geometry(geometry);
+        }
+
+        assert!(matches!(
+            tiled.process_tile(bbox, &[], 0.0, None),
+            Err(PolygonizeError::Cancelled { stage }) if stage == "tile_processing"
+        ));
+    }
+
+    #[test]
     fn component_fallback_keeps_recovered_output_deterministic() {
         let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 20.0 });
         let geometries = [

--- a/docs/guide/tiling.md
+++ b/docs/guide/tiling.md
@@ -102,8 +102,9 @@ Both validation modes are deliberately narrower than coverage certification.
 `with_execution_policy` applies segment, candidate, exact-predicate, and
 cancellation bounds to the indexed component preflight, including the optional
 pre-snap and fixed-grid endpoint passes, and passes the same policy to each tile
-polygonization and recovery region. Numeric work limits apply independently to
-the preflight, each tile, and each recovery region, not as one aggregate budget
+polygonization, tile input/evidence filtering, ownership pass, and recovery
+region. Numeric work limits apply independently to the preflight, each tile,
+and each recovery region, not as one aggregate budget
 across the tiled call; the final canonical merge also enforces the configured
 aggregate output-polygon limit and observes cancellation. The component
 envelope remains conservative evidence rather than proof of a face.


### PR DESCRIPTION
## Stack

Parent: #1197 (`agent/p3-fallback-stage-cancellation`).
Children: none.

## Delivered

- Check cancellation before tile work begins, including the no-intersecting-input early return.
- Bound input-geometry filtering, excluded-component evidence collection, and ownership filtering with the existing cooperative policy.
- Add regressions for pre-cancelled empty tiles and midflight filtering cancellation.
- Update the tiling guide and P3.2 roadmap evidence.

## Contract impact

- Core-only, no public API or binding changes.
- Preserves tile evidence, ownership, output ordering, Z/provenance payloads, and serial/parallel behavior.
- Cancellation now returns a typed `PolygonizeError::Cancelled` before an empty tile can be reported as successful.
- Coverage certification, boundary-crossing recovery, and true graph stitching remain unchanged and open where documented.

## Validation

- `cargo test -p geo-polygonize-core tile_processing_observes` — 2 passed.
- `cargo test -p geo-polygonize-core tiling` — 37 passed.
- `cargo test -p geo-polygonize-core --no-default-features tiling` — 37 passed.
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings` — passed.
- `cargo test --workspace --quiet` — all workspace tests passed, including 237 core tests.
- `cargo clippy --workspace --all-targets -- -D warnings` — passed.
- `RUSTDOCFLAGS='-D warnings' cargo doc -p geo-polygonize-core --no-deps` — passed.
- `npm test` — 54 passed.
- `npm run docs:build` — passed with existing MUI `use client`, large-chunk, missing-runtime-asset, and npm audit warnings; generated bindings and playground lockfile restored.
- Aggregate `cargo doc --workspace --no-deps` remains blocked by the repository's pre-existing duplicate `geo_polygonize_core` output-name collision between core and Python.

## Agent handoff

Parent: #1197 (`agent/p3-fallback-stage-cancellation`).
Children: none.
Next branch: `agent/p3-undetected-region-evidence` remains the next executable roadmap candidate only after finding a reproducible broad undetected-region fixture; do not claim component-local correctness by independently appending polygonized output.