### PR TITLE
test(core): pin partially observed tiled component

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -703,7 +703,9 @@ also pinned a hot-pixel boundary: the noder could connect a segment through an
 endpoint hot pixel even when the tiled preflight's transformed straight
 segments had no exact intersection, so that region could remain absent without
 observed evidence. The preflight now reuses the bounded certified noder for
-that same connectivity case.
+that same connectivity case. A partially observed transformed-connected
+component, where one member geometry intersects a halo and other members do
+not, also remains undetected without a conservative component-boundary check.
 
 - [ ] Detect owned faces or connected regions that touch an unresolved halo or
   partition boundary.
@@ -729,6 +731,9 @@ that same connectivity case.
     and bounded evidence now reuse the certified noder.
   - [x] Use indexed connected-component evidence to identify a component that
     is only partially observed in a tile halo; broad undetected-region coverage
+    remains open.
+  - [x] Pin the partially observed transformed-connected component case where
+    one member intersects a halo and other members remain outside; detection
     remains open.
 - [x] Report source IDs and boundary evidence that were required but not fully
   observed.

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -1743,6 +1743,69 @@ mod tests {
     }
 
     #[test]
+    fn documents_partially_observed_pre_snap_component_without_boundary_evidence() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 20.0 });
+        let x_ranges = [
+            (-10.0, -2.25),
+            (-1.75, 7.75),
+            (8.25, 11.75),
+            (12.25, 17.75),
+            (18.25, 21.75),
+            (22.25, 30.0),
+        ];
+        let mut boundaries = Vec::new();
+        for y in [5.0, 15.0] {
+            for &(min_x, max_x) in &x_ranges {
+                boundaries.push(Geometry::LineString(LineString::new(vec![
+                    Coord { x: min_x, y },
+                    Coord { x: max_x, y },
+                ])));
+            }
+        }
+        boundaries.extend([
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: -10.0, y: 5.0 },
+                Coord { x: -10.0, y: 15.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 30.0, y: 15.0 },
+                Coord { x: 30.0, y: 5.0 },
+            ])),
+        ]);
+        let options = PolygonizerOptions {
+            node_input: true,
+            pre_snap_tolerance: 1.0,
+            ..Default::default()
+        };
+        let mut untiled = Polygonizer::with_options(options.clone());
+        let mut tiled = TiledPolygonizer::new(bbox, 10.0)
+            .with_buffer(2.0)
+            .with_options(options);
+        for boundary in &boundaries {
+            untiled.add_borrowed_geometry(boundary);
+            tiled.add_geometry(boundary);
+        }
+
+        assert_eq!(untiled.polygonize().unwrap().polygons.len(), 1);
+        assert_eq!(tiled.input_components().unwrap().len(), 1);
+        let observed = tiled.polygonize().unwrap();
+        assert!(observed.polygons.is_empty());
+        assert!(observed
+            .tile_reports
+            .iter()
+            .all(|report| report.input_boundary_issues.is_empty()));
+        assert!(observed
+            .tile_reports
+            .iter()
+            .all(|report| report.excluded_component_issues.is_empty()));
+        assert_eq!(observed.stitching_report.unresolved_input_geometry_count, 0);
+        assert_eq!(observed.stitching_report.unresolved_component_count, 0);
+        assert!(tiled
+            .polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateObservedCoverage)
+            .is_ok());
+    }
+
+    #[test]
     fn bounded_halo_retry_resolves_an_excluded_component() {
         let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 20.0 });
         let boundaries = [


### PR DESCRIPTION
## Stack

Parent: none (main).
Children: #1201 (`agent/p3-partial-component-detection`).

## Delivered

- Adds a minimized pre-snap ring whose connected component is only partially present in each tile halo.
- Pins the current false-negative: untiled polygonization returns one face while tiled output reports no input-boundary or excluded-component evidence.
- Records the remaining P3.1 detection gap without claiming coverage certification.

## Contract impact

Test and roadmap evidence only. No runtime behavior or public API changes.

## Validation

- `cargo fmt --all`
- `cargo test -p geo-polygonize-core documents_partially_observed_pre_snap_component_without_boundary_evidence`

## Agent handoff

Parent: none. Children: #1201. The child adds conservative excluded-component evidence when a connected component has both observed and unobserved member envelopes, then proves fallback equality.