### PR TITLE
fix(core): report partially observed components

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -705,7 +705,7 @@ segments had no exact intersection, so that region could remain absent without
 observed evidence. The preflight now reuses the bounded certified noder for
 that same connectivity case. A partially observed transformed-connected
 component, where one member geometry intersects a halo and other members do
-not, also remains undetected without a conservative component-boundary check.
+not, is now reported as conservative excluded-component evidence.
 
 - [ ] Detect owned faces or connected regions that touch an unresolved halo or
   partition boundary.
@@ -732,9 +732,9 @@ not, also remains undetected without a conservative component-boundary check.
   - [x] Use indexed connected-component evidence to identify a component that
     is only partially observed in a tile halo; broad undetected-region coverage
     remains open.
-  - [x] Pin the partially observed transformed-connected component case where
-    one member intersects a halo and other members remain outside; detection
-    remains open.
+  - [x] Report conservative excluded-component evidence when one
+    transformed-connected member intersects a halo and other members remain
+    outside it.
 - [x] Report source IDs and boundary evidence that were required but not fully
   observed.
   - [x] Distinguish representative edge IDs from complete aggregate boundary

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -774,6 +774,8 @@ When coverage cannot be proven:
     region.
   - [x] Seed the same region-local recovery from input-boundary evidence when
     the indexed connected component is only partially visible in a halo.
+  - [x] Recover an indexed component with mixed observed and unobserved
+    members while replacing nested retained output before canonical merge.
   - [x] Merge one envelope-disjoint recovered component with retained tile
     output; envelope-closed region replacement now covers interacting retained
     output.

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -537,16 +537,24 @@ impl<'a> TiledPolygonizer<'a> {
                 }
             }
         }
+        let input_boundary_geometry_indices = input_boundary_issues
+            .iter()
+            .map(|issue| issue.input_geometry_index)
+            .collect::<HashSet<_>>();
         let mut excluded_component_issues = Vec::new();
         for (component_index, component) in input_components.iter().enumerate() {
             self.execution_policy
                 .check_cancelled_every("tile_processing", component_index)?;
             if component.bbox.intersects(&buffered_bbox)
-                && component.input_geometry_indices.iter().all(|&index| {
+                && component.input_geometry_indices.iter().any(|&index| {
                     self.geometries[index]
                         .1
                         .is_none_or(|bbox| !bbox.intersects(&buffered_bbox))
                 })
+                && component
+                    .input_geometry_indices
+                    .iter()
+                    .all(|index| !input_boundary_geometry_indices.contains(index))
             {
                 excluded_component_issues.push(TileExcludedComponentIssue {
                     input_geometry_indices: component.input_geometry_indices.clone(),

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -1814,6 +1814,88 @@ mod tests {
     }
 
     #[test]
+    fn component_fallback_recovers_partially_observed_pre_snap_component() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 20.0 });
+        let x_ranges = [
+            (-10.0, -2.25),
+            (-1.75, 7.75),
+            (8.25, 11.75),
+            (12.25, 17.75),
+            (18.25, 21.75),
+            (22.25, 30.0),
+        ];
+        let mut boundaries = Vec::new();
+        for y in [5.0, 15.0] {
+            for &(min_x, max_x) in &x_ranges {
+                boundaries.push(Geometry::LineString(LineString::new(vec![
+                    Coord { x: min_x, y },
+                    Coord { x: max_x, y },
+                ])));
+            }
+        }
+        boundaries.extend([
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: -10.0, y: 5.0 },
+                Coord { x: -10.0, y: 15.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 30.0, y: 15.0 },
+                Coord { x: 30.0, y: 5.0 },
+            ])),
+        ]);
+        let inner = Geometry::LineString(LineString::new(vec![
+            Coord { x: 2.0, y: 2.0 },
+            Coord { x: 4.0, y: 2.0 },
+            Coord { x: 4.0, y: 4.0 },
+            Coord { x: 2.0, y: 4.0 },
+            Coord { x: 2.0, y: 2.0 },
+        ]));
+        let options = PolygonizerOptions {
+            node_input: true,
+            pre_snap_tolerance: 1.0,
+            ..Default::default()
+        };
+        let mut untiled = Polygonizer::with_options(options.clone());
+        for boundary in &boundaries {
+            untiled.add_borrowed_geometry(boundary);
+        }
+        untiled.add_borrowed_geometry(&inner);
+        let expected = untiled
+            .polygonize()
+            .unwrap()
+            .polygons
+            .into_iter()
+            .map(|polygon| crate::tiling::canonical_polygon_key(&polygon))
+            .collect::<Vec<_>>();
+
+        let mut tiled = TiledPolygonizer::new(bbox, 10.0)
+            .with_buffer(2.0)
+            .with_options(options)
+            .with_component_fallback();
+        for boundary in &boundaries {
+            tiled.add_geometry(boundary);
+        }
+        tiled.add_geometry(&inner);
+        let result = tiled
+            .polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateObservedCoverage)
+            .unwrap();
+        let actual = result
+            .polygons
+            .iter()
+            .map(crate::tiling::canonical_polygon_key)
+            .collect::<Vec<_>>();
+        assert_eq!(actual, expected);
+        assert!(result.stitching_report.component_fallback_used);
+        assert_eq!(result.stitching_report.retained_tile_polygon_count, 1);
+        assert_eq!(
+            result
+                .stitching_report
+                .component_fallback_replaced_polygon_count,
+            1
+        );
+    }
+
+    #[test]
     fn bounded_halo_retry_resolves_an_excluded_component() {
         let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 20.0 });
         let boundaries = [

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -1794,15 +1794,23 @@ mod tests {
             .tile_reports
             .iter()
             .all(|report| report.input_boundary_issues.is_empty()));
-        assert!(observed
-            .tile_reports
-            .iter()
-            .all(|report| report.excluded_component_issues.is_empty()));
+        assert!(observed.tile_reports.iter().all(|report| {
+            report.excluded_component_issues.len() == 1
+                && report.excluded_component_issues[0].connection
+                    == TileComponentConnection::PreSnap
+        }));
         assert_eq!(observed.stitching_report.unresolved_input_geometry_count, 0);
-        assert_eq!(observed.stitching_report.unresolved_component_count, 0);
-        assert!(tiled
-            .polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateObservedCoverage)
-            .is_ok());
+        assert_eq!(observed.stitching_report.unresolved_component_count, 4);
+        assert!(matches!(
+            tiled.polygonize_with_coverage_guarantee(
+                TileCoverageGuarantee::ValidateObservedCoverage
+            ),
+            Err(TiledPolygonizeError::CoverageIncomplete {
+                unresolved_component_tile_count: 4,
+                unresolved_component_count: 4,
+                ..
+            })
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Stack

Parent: #1200 (`agent/p3-partial-component-evidence`).
Children: #1203 (`agent/p3-partial-fixed-grid-evidence`).

## Delivered

- Reports an excluded component when its envelope intersects a tile halo but at least one connected member remains outside the halo.
- Reuses existing indexed component evidence and preserves the existing input-boundary report without duplicate component instances.
- Verifies component fallback recovers the mixed observed/unobserved region and replaces a nested retained polygon before canonical merge.
- Updates the P3.1/P3.2 contract evidence without claiming broad coverage certification.

## Contract impact

Tiled `TileReport` and `StitchingReport` now conservatively report partially observed connected components. `ValidateObservedCoverage` rejects this evidence unless an existing fallback resolves it; best-effort output remains unchanged.

## Validation

- `cargo fmt --all`
- `cargo test -p geo-polygonize-core documents_partially_observed_pre_snap_component_without_boundary_evidence`
- `cargo test -p geo-polygonize-core component_fallback_recovers_partially_observed_pre_snap_component`
- `cargo test -p geo-polygonize-core tiling` (39 passed)

## Agent handoff

Parent: #1200. Children: #1203. The child exercises the same conservative partial-component contract under fixed-grid connectivity.