### PR TITLE
fix(core): bound partial component cancellation

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -793,6 +793,8 @@ When coverage cannot be proven:
     the final canonical merge after tile and region recovery.
   - [x] Observe cancellation during tile input/evidence/ownership filtering,
     including the empty-tile early-return path.
+  - [x] Observe cancellation while scanning connected-component member
+    envelopes for partial component evidence.
   - [x] Record retained tile polygon counts in component-fallback trace events
     and expose retained/recovered aggregate counts in `StitchingReport`;
     expose replaced-retained counts for canonical region replacement.

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -545,12 +545,18 @@ impl<'a> TiledPolygonizer<'a> {
         for (component_index, component) in input_components.iter().enumerate() {
             self.execution_policy
                 .check_cancelled_every("tile_processing", component_index)?;
-            if component.bbox.intersects(&buffered_bbox)
-                && component.input_geometry_indices.iter().any(|&index| {
-                    self.geometries[index]
-                        .1
-                        .is_none_or(|bbox| !bbox.intersects(&buffered_bbox))
-                })
+            if !component.bbox.intersects(&buffered_bbox) {
+                continue;
+            }
+            let mut has_unobserved_member = false;
+            for (member_index, &index) in component.input_geometry_indices.iter().enumerate() {
+                self.execution_policy
+                    .check_cancelled_every("tile_processing", member_index)?;
+                has_unobserved_member |= self.geometries[index]
+                    .1
+                    .is_none_or(|bbox| !bbox.intersects(&buffered_bbox));
+            }
+            if has_unobserved_member
                 && component
                     .input_geometry_indices
                     .iter()

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -1228,6 +1228,33 @@ mod tests {
     }
 
     #[test]
+    fn tile_processing_observes_partial_component_member_cancellation() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 20.0 });
+        let geometry = Geometry::LineString(LineString::new(vec![
+            Coord { x: 1.0, y: 1.0 },
+            Coord { x: 2.0, y: 1.0 },
+        ]));
+        let token = CancellationToken::new();
+        let policy = ExecutionPolicy {
+            cancellation_token: Some(token.clone()),
+            cancel_at_work_item: Some((token, 256)),
+            ..Default::default()
+        };
+        let mut tiled = TiledPolygonizer::new(bbox, 10.0).with_execution_policy(policy);
+        tiled.add_geometry(&geometry);
+        let component = InputComponent {
+            input_geometry_indices: vec![0; 257],
+            bbox,
+            connection: TileComponentConnection::ExactEndpoint,
+        };
+
+        assert!(matches!(
+            tiled.process_tile(bbox, &[component], 0.0, None),
+            Err(PolygonizeError::Cancelled { stage }) if stage == "tile_processing"
+        ));
+    }
+
+    #[test]
     fn component_fallback_keeps_recovered_output_deterministic() {
         let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 20.0 });
         let geometries = [


### PR DESCRIPTION
## Stack

Parent: #1203 (`agent/p3-partial-fixed-grid-evidence`).
Children: none.

## Delivered

- Adds cooperative cancellation checks while scanning every connected-component member envelope used by partial-component evidence.
- Preserves the existing fast envelope intersection guard and duplicate suppression for input-boundary evidence.
- Pins cancellation at the 256-item work boundary with the existing `tile_processing` cancellation contract.
- Updates the P3.2 cancellation evidence without expanding fallback semantics.

## Contract impact

No topology or public API change. Large component evidence scans now terminate with the typed `PolygonizeError::Cancelled { stage: "tile_processing" }` contract instead of remaining uninterruptible.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p geo-polygonize-core tile_processing_observes_partial_component_member_cancellation`
- `cargo test -p geo-polygonize-core tiling` (41 passed)
- Full stack-tip checkpoint: `cargo test --workspace --quiet` (241 core tests plus workspace suites), `cargo test -p geo-polygonize-core --no-default-features --quiet` (241 core tests plus workspace suites), `cargo clippy --workspace --all-targets -- -D warnings`, core rustdoc with warnings denied, `npm test` (54), and `npm run docs:build` all passed. Generated bindings and playground lockfile were restored.

## Agent handoff

Parent: #1203. Children: none. Next work remains the explicitly open topology boundary without conservative envelope closure; do not append independently polygonized regions or start P3.3 graph stitching.