### PR TITLE
feat(core): report tiled fallback decline reasons

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -823,6 +823,8 @@ When coverage cannot be proven:
   - [x] Record enabled-but-declined component recovery in the stitching report
     and bounded `tile_component_fallback_declined` trace events with a
     deterministic reason.
+  - [x] Expose the deterministic component-fallback decline reason directly in
+    `StitchingReport` as well as the bounded trace event.
 
 ### P3.3 True graph stitching
 

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -154,6 +154,8 @@ pub struct StitchingReport {
     pub component_fallback_replaced_polygon_count: usize,
     /// Whether component fallback was enabled and attempted for unresolved output.
     pub component_fallback_attempted: bool,
+    /// Why an attempted component fallback was declined, when it was not safe.
+    pub component_fallback_decline_reason: Option<&'static str>,
     pub unresolved_tile_count: usize,
     pub unresolved_owned_polygon_count: usize,
     pub unresolved_input_tile_count: usize,
@@ -1587,6 +1589,7 @@ impl<'a> TiledPolygonizer<'a> {
                 component_fallback_polygon_count,
                 component_fallback_replaced_polygon_count,
                 component_fallback_attempted,
+                component_fallback_decline_reason,
                 unresolved_tile_count,
                 unresolved_owned_polygon_count,
                 unresolved_input_tile_count,

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -434,6 +434,10 @@ mod tests {
         let result = tiled.polygonize().unwrap();
         assert!(result.stitching_report.component_fallback_attempted);
         assert!(!result.stitching_report.component_fallback_used);
+        assert_eq!(
+            result.stitching_report.component_fallback_decline_reason,
+            Some("no_indexed_component_evidence")
+        );
         assert!(result.stitching_report.unresolved_owned_polygon_count > 0);
 
         let traced = tiled


### PR DESCRIPTION
## Stack

- Parent: none
- Children: #1206 `feat(core): preserve tiled fallback error reasons`

## Delivered

- Expose the deterministic component-fallback decline reason on `StitchingReport`.
- Preserve the existing bounded `tile_component_fallback_declined` trace event and reason values.
- Pin the no-indexed-component decline contract.

## Contract impact

- No topology, precision, provenance, Z, serial/parallel, resource-limit, or cancellation behavior changes.
- Successful best-effort/validated tiled results now expose `component_fallback_decline_reason` when an attempted recovery was conservatively declined.
- The field is `None` when component fallback was not attempted or recovered successfully.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace --quiet` — passed
- `cargo test -p geo-polygonize-core --no-default-features --quiet` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `RUSTDOCFLAGS='-D warnings' cargo doc -p geo-polygonize-core --no-deps` — passed
- `cargo test -p geo-polygonize-core tiling --quiet` — 41 passed
- `cargo test -p geo-polygonize-core records_declined_component_fallback_for_owned_face_evidence -- --nocapture` — passed
- `npm test` — 11 files, 54 tests passed
- `npm run docs:build` — passed; existing MUI/`wasm`/chunk-size/audit warnings only
- Restored generated TypeScript bindings, `FingerprintDiffV1.ts`, and `playground/package-lock.json`

## Agent handoff

- Parent: none.
- Children: #1206.
- Child #1206 carries the same reason through typed `CoverageIncomplete` errors.
- Do not claim broad undetected-region certification or true graph stitching from this slice.