### PR TITLE
feat(core): preserve tiled fallback error reasons

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -825,6 +825,7 @@ When coverage cannot be proven:
     deterministic reason.
   - [x] Expose the deterministic component-fallback decline reason directly in
     `StitchingReport` as well as the bounded trace event.
+  - [x] Preserve that decline reason in typed `CoverageIncomplete` errors.
 
 ### P3.3 True graph stitching
 

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -219,6 +219,7 @@ pub enum TiledPolygonizeError {
         unresolved_component_count: usize,
         retry_attempt_count: usize,
         retry_exhausted_tile_count: usize,
+        component_fallback_decline_reason: Option<&'static str>,
         tile_reports: Vec<TileReport>,
     },
 }
@@ -1317,6 +1318,9 @@ impl<'a> TiledPolygonizer<'a> {
                 unresolved_component_count: result.stitching_report.unresolved_component_count,
                 retry_attempt_count: result.stitching_report.retry_attempt_count,
                 retry_exhausted_tile_count: result.stitching_report.retry_exhausted_tile_count,
+                component_fallback_decline_reason: result
+                    .stitching_report
+                    .component_fallback_decline_reason,
                 tile_reports: result.tile_reports,
             });
         }

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -459,6 +459,17 @@ mod tests {
             result.stitching_report.unresolved_input_geometry_count
         );
         assert_eq!(declined.payload["unresolved_component_count"], 0);
+
+        let error = tiled
+            .polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateObservedCoverage)
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            TiledPolygonizeError::CoverageIncomplete {
+                component_fallback_decline_reason: Some("no_indexed_component_evidence"),
+                ..
+            }
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Stack

- Parent: #1205 `feat(core): report tiled fallback decline reasons`
- Children: none

## Delivered

- Carry `component_fallback_decline_reason` into typed `CoverageIncomplete` errors.
- Pin the same deterministic reason in the existing conservative-decline fixture.
- Update the roadmap’s fallback observability contract.

## Contract impact

- No topology, precision, provenance, Z, serial/parallel, resource-limit, or cancellation behavior changes.
- `ValidateObservedCoverage` callers now retain the reason a component recovery was declined when the typed coverage error is returned.
- The existing report and bounded trace fields remain unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace --quiet` — passed
- `cargo test -p geo-polygonize-core --no-default-features --quiet` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `RUSTDOCFLAGS='-D warnings' cargo doc -p geo-polygonize-core --no-deps` — passed
- `cargo test -p geo-polygonize-core tiling --quiet` — 41 passed
- `cargo test -p geo-polygonize-core records_declined_component_fallback_for_owned_face_evidence -- --nocapture` — passed
- `npm test` — 11 files, 54 tests passed
- `npm run docs:build` — passed; existing MUI/`wasm`/chunk-size/audit warnings only
- Restored generated TypeScript bindings, `FingerprintDiffV1.ts`, and `playground/package-lock.json`

## Agent handoff

- Parent: #1205.
- Children: none.
- Do not claim broad undetected-region certification, cross-partition topology reconciliation, or true graph stitching from this observability-only slice.