### PR TITLE
feat(core): recover closed tiled boundary regions

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -706,6 +706,10 @@ observed evidence. The preflight now reuses the bounded certified noder for
 that same connectivity case. A partially observed transformed-connected
 component, where one member geometry intersects a halo and other members do
 not, is now reported as conservative excluded-component evidence.
+Opt-in component fallback also recovers a closed single-input boundary region
+when retained-face or input-boundary evidence reaches a halo; mixed or open
+single-geometry boundaries decline conservatively, so broad missing-region
+coverage detection remains observational.
 
 - [ ] Detect owned faces or connected regions that touch an unresolved halo or
   partition boundary.
@@ -772,6 +776,9 @@ When coverage cannot be proven:
   - [x] Add opt-in envelope-closed component fallback that groups interacting
     input, retained-face, and connected-component envelopes and records the
     recovery, including input-boundary-seeded components.
+  - [x] Recover a halo-crossing region seeded by a caller-owned closed input
+    geometry; decline mixed or open single-geometry regions with deterministic
+    evidence rather than appending an unsafe partial result.
   - [x] Recover a nested retained face by polygonizing the closed region once;
     whole-input fallback remains the escape hatch for evidence outside that
     region.

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -260,6 +260,7 @@ enum ComponentFallbackDeclineReason {
     OwnedFaceCoverageEvidence,
     IndexedComponentMissing,
     InputBoundaryOutsideRecoveryRegion,
+    NonClosedRecoveryRegion,
     EmptyRecoveryOutput,
 }
 
@@ -270,6 +271,7 @@ impl ComponentFallbackDeclineReason {
             Self::OwnedFaceCoverageEvidence => "owned_face_coverage_evidence",
             Self::IndexedComponentMissing => "indexed_component_missing",
             Self::InputBoundaryOutsideRecoveryRegion => "input_boundary_outside_recovery_region",
+            Self::NonClosedRecoveryRegion => "non_closed_recovery_region",
             Self::EmptyRecoveryOutput => "empty_recovery_output",
         }
     }
@@ -367,6 +369,43 @@ fn geometry_segments(
         _ => {}
     }
     Ok(())
+}
+
+fn line_string_has_closed_boundary(line: &LineString<f64>) -> bool {
+    let Some((first, last)) = line.0.first().zip(line.0.last()) else {
+        return false;
+    };
+    line.0.len() >= 4 && first.x == last.x && first.y == last.y
+}
+
+fn geometry_has_closed_boundary(geometry: &Geometry<f64>) -> bool {
+    match geometry {
+        Geometry::LineString(line) => line_string_has_closed_boundary(line),
+        Geometry::MultiLineString(lines) => {
+            !lines.0.is_empty() && lines.0.iter().all(line_string_has_closed_boundary)
+        }
+        Geometry::Polygon(polygon) => {
+            line_string_has_closed_boundary(polygon.exterior())
+                && polygon
+                    .interiors()
+                    .iter()
+                    .all(line_string_has_closed_boundary)
+        }
+        Geometry::MultiPolygon(polygons) => {
+            !polygons.0.is_empty()
+                && polygons.iter().all(|polygon| {
+                    line_string_has_closed_boundary(polygon.exterior())
+                        && polygon
+                            .interiors()
+                            .iter()
+                            .all(line_string_has_closed_boundary)
+                })
+        }
+        Geometry::GeometryCollection(collection) => {
+            !collection.0.is_empty() && collection.0.iter().all(geometry_has_closed_boundary)
+        }
+        _ => false,
+    }
 }
 
 fn component_root(parents: &mut [usize], index: usize) -> usize {
@@ -655,6 +694,136 @@ impl<'a> TiledPolygonizer<'a> {
             || !report.excluded_component_issues.is_empty()
     }
 
+    fn try_closed_boundary_fallback(
+        &self,
+        tile_polygons: &[Vec<Polygon3D>],
+        tile_reports: &[TileReport],
+    ) -> Result<ComponentFallbackDecision> {
+        self.execution_policy
+            .check_cancelled("tile_component_fallback")?;
+        let Some(mut region_bbox) = tile_reports
+            .iter()
+            .flat_map(|report| {
+                report
+                    .coverage_issues
+                    .iter()
+                    .map(|issue| issue.polygon_bbox)
+                    .chain(
+                        report
+                            .input_boundary_issues
+                            .iter()
+                            .map(|issue| issue.geometry_bbox),
+                    )
+            })
+            .next()
+        else {
+            return Ok(ComponentFallbackDecision::Declined(
+                ComponentFallbackDeclineReason::NoIndexedComponentEvidence,
+            ));
+        };
+        for bbox in tile_reports.iter().flat_map(|report| {
+            report
+                .coverage_issues
+                .iter()
+                .map(|issue| issue.polygon_bbox)
+                .chain(
+                    report
+                        .input_boundary_issues
+                        .iter()
+                        .map(|issue| issue.geometry_bbox),
+                )
+        }) {
+            expand_rect(&mut region_bbox, bbox);
+        }
+
+        let retained_polygon_bboxes = tile_polygons
+            .iter()
+            .flat_map(|polygons| polygons.iter())
+            .filter_map(Self::polygon_bbox)
+            .collect::<Vec<_>>();
+        let mut selected_geometry_indices = HashSet::new();
+        loop {
+            self.execution_policy
+                .check_cancelled("tile_component_fallback")?;
+            let previous_region_bbox = region_bbox;
+            for (geometry_index, (geometry, geometry_bbox)) in self.geometries.iter().enumerate() {
+                self.execution_policy
+                    .check_cancelled_every("tile_component_fallback", geometry_index)?;
+                let Some(geometry_bbox) = *geometry_bbox else {
+                    continue;
+                };
+                if selected_geometry_indices.contains(&geometry_index)
+                    || !geometry_bbox.intersects(&region_bbox)
+                {
+                    continue;
+                }
+                if !geometry_has_closed_boundary(geometry) {
+                    return Ok(ComponentFallbackDecision::Declined(
+                        ComponentFallbackDeclineReason::NonClosedRecoveryRegion,
+                    ));
+                }
+                selected_geometry_indices.insert(geometry_index);
+                expand_rect(&mut region_bbox, geometry_bbox);
+            }
+            for (polygon_index, polygon_bbox) in retained_polygon_bboxes.iter().enumerate() {
+                self.execution_policy
+                    .check_cancelled_every("tile_component_fallback", polygon_index)?;
+                if polygon_bbox.intersects(&region_bbox) {
+                    expand_rect(&mut region_bbox, *polygon_bbox);
+                }
+            }
+            if region_bbox == previous_region_bbox {
+                break;
+            }
+        }
+
+        if selected_geometry_indices.is_empty()
+            || tile_reports.iter().any(|report| {
+                report
+                    .input_boundary_issues
+                    .iter()
+                    .any(|issue| !selected_geometry_indices.contains(&issue.input_geometry_index))
+            })
+        {
+            return Ok(ComponentFallbackDecision::Declined(
+                ComponentFallbackDeclineReason::InputBoundaryOutsideRecoveryRegion,
+            ));
+        }
+
+        let mut input_geometry_indices = selected_geometry_indices.into_iter().collect::<Vec<_>>();
+        input_geometry_indices.sort_unstable();
+        self.execution_policy
+            .check_cancelled("tile_component_fallback")?;
+        let mut polygonizer = Polygonizer::with_options(self.options.clone())
+            .with_execution_policy(self.execution_policy.clone());
+        for &geometry_index in &input_geometry_indices {
+            polygonizer.add_borrowed_geometry(self.geometries[geometry_index].0);
+        }
+        let polygons = polygonizer.polygonize()?.polygons;
+        if polygons.is_empty() {
+            return Ok(ComponentFallbackDecision::Declined(
+                ComponentFallbackDeclineReason::EmptyRecoveryOutput,
+            ));
+        }
+        let output_polygon_count = polygons.len();
+        let replaced_retained_polygon_count = retained_polygon_bboxes
+            .iter()
+            .filter(|polygon_bbox| polygon_bbox.intersects(&region_bbox))
+            .count();
+        Ok(ComponentFallbackDecision::Recovered(
+            ComponentFallbackResult {
+                polygons,
+                events: vec![ComponentFallbackEvent {
+                    input_geometry_indices,
+                    output_polygon_count,
+                    recovered_component_count: 1,
+                    replaced_retained_polygon_count,
+                }],
+                region_bboxes: vec![region_bbox],
+            },
+        ))
+    }
+
     fn try_component_fallback(
         &self,
         tile_polygons: &[Vec<Polygon3D>],
@@ -684,15 +853,21 @@ impl<'a> TiledPolygonizer<'a> {
                 component_keys.insert(component.input_geometry_indices.clone());
             }
         }
+        let has_coverage_evidence = tile_reports
+            .iter()
+            .any(|report| !report.coverage_issues.is_empty());
+        let has_input_boundary_evidence = tile_reports
+            .iter()
+            .any(|report| !report.input_boundary_issues.is_empty());
         if component_keys.is_empty() {
+            if has_coverage_evidence || has_input_boundary_evidence {
+                return self.try_closed_boundary_fallback(tile_polygons, tile_reports);
+            }
             return Ok(ComponentFallbackDecision::Declined(
                 ComponentFallbackDeclineReason::NoIndexedComponentEvidence,
             ));
         }
-        if tile_reports
-            .iter()
-            .any(|report| !report.coverage_issues.is_empty())
-        {
+        if has_coverage_evidence {
             return Ok(ComponentFallbackDecision::Declined(
                 ComponentFallbackDeclineReason::OwnedFaceCoverageEvidence,
             ));

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -9,7 +9,7 @@ mod tests {
         TileComponentConnection, TileCoverageGuarantee, TileExcludedComponentIssue, TileReport,
         TileRetryPolicy, TiledPolygonizeError, TiledPolygonizer,
     };
-    use geo::{Contains, Coord, Geometry, LineString, Rect};
+    use geo::{Contains, Coord, Geometry, LineString, MultiLineString, Rect};
 
     #[test]
     fn test_tiled_polygonization_grid() {
@@ -417,7 +417,7 @@ mod tests {
     }
 
     #[test]
-    fn records_declined_component_fallback_for_owned_face_evidence() {
+    fn component_fallback_recovers_closed_boundary_region() {
         let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 10.0 });
         let face = Geometry::LineString(LineString::new(vec![
             Coord { x: 1.0, y: 2.0 },
@@ -426,19 +426,141 @@ mod tests {
             Coord { x: 1.0, y: 8.0 },
             Coord { x: 1.0, y: 2.0 },
         ]));
+        let mut untiled = Polygonizer::new();
+        untiled.add_borrowed_geometry(&face);
         let mut tiled = TiledPolygonizer::new(bbox, 10.0)
             .with_buffer(2.0)
             .with_component_fallback();
         tiled.add_geometry(&face);
+
+        let expected = untiled
+            .polygonize()
+            .unwrap()
+            .polygons
+            .into_iter()
+            .map(|polygon| crate::tiling::canonical_polygon_key(&polygon))
+            .collect::<Vec<_>>();
+        let result = tiled
+            .polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateObservedCoverage)
+            .unwrap();
+        assert_eq!(
+            result
+                .polygons
+                .iter()
+                .map(crate::tiling::canonical_polygon_key)
+                .collect::<Vec<_>>(),
+            expected
+        );
+        assert_eq!(result.polygons.len(), 1);
+        assert!(result.stitching_report.component_fallback_attempted);
+        assert!(result.stitching_report.component_fallback_used);
+        assert_eq!(result.stitching_report.component_fallback_count, 1);
+        assert_eq!(result.stitching_report.component_fallback_polygon_count, 1);
+        assert_eq!(
+            result
+                .stitching_report
+                .component_fallback_replaced_polygon_count,
+            1
+        );
+
+        let traced = tiled
+            .polygonize_with_trace(TraceLevelV1::Full, usize::MAX)
+            .unwrap();
+        let recovered = traced
+            .trace
+            .events
+            .iter()
+            .find(|event| event.kind == "tile_component_fallback")
+            .unwrap();
+        assert_eq!(
+            recovered.payload["input_geometry_indices"],
+            serde_json::json!([0])
+        );
+        assert_eq!(recovered.payload["output_polygon_count"], 1);
+        assert_eq!(recovered.payload["recovered_component_count"], 1);
+        assert!(!traced
+            .trace
+            .events
+            .iter()
+            .any(|event| event.kind == "tile_component_fallback_declined"));
+    }
+
+    #[test]
+    fn component_fallback_preserves_nested_closed_boundary_containment() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 10.0 });
+        let geometries = [
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 1.0, y: 1.0 },
+                Coord { x: 19.0, y: 1.0 },
+                Coord { x: 19.0, y: 9.0 },
+                Coord { x: 1.0, y: 9.0 },
+                Coord { x: 1.0, y: 1.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 4.0, y: 3.0 },
+                Coord { x: 16.0, y: 3.0 },
+                Coord { x: 16.0, y: 7.0 },
+                Coord { x: 4.0, y: 7.0 },
+                Coord { x: 4.0, y: 3.0 },
+            ])),
+        ];
+        let mut untiled = Polygonizer::new();
+        let mut tiled = TiledPolygonizer::new(bbox, 10.0)
+            .with_buffer(2.0)
+            .with_dedup_policy(DedupPolicy::CanonicalRingHash)
+            .with_component_fallback();
+        for geometry in &geometries {
+            untiled.add_borrowed_geometry(geometry);
+            tiled.add_geometry(geometry);
+        }
+
+        let expected = untiled
+            .polygonize()
+            .unwrap()
+            .polygons
+            .into_iter()
+            .map(|polygon| crate::tiling::canonical_polygon_key(&polygon))
+            .collect::<Vec<_>>();
+        let result = tiled
+            .polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateObservedCoverage)
+            .unwrap();
+        assert_eq!(
+            result
+                .polygons
+                .iter()
+                .map(crate::tiling::canonical_polygon_key)
+                .collect::<Vec<_>>(),
+            expected
+        );
+        assert_eq!(result.polygons.len(), 2);
+        assert!(result
+            .polygons
+            .iter()
+            .any(|polygon| !polygon.interiors.is_empty()));
+        assert_eq!(result.stitching_report.component_fallback_count, 1);
+    }
+
+    #[test]
+    fn declines_closed_boundary_fallback_for_open_single_geometry() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 10.0 });
+        let open_boundary = Geometry::MultiLineString(MultiLineString::new(vec![
+            LineString::new(vec![Coord { x: 1.0, y: 2.0 }, Coord { x: 19.0, y: 2.0 }]),
+            LineString::new(vec![Coord { x: 19.0, y: 2.0 }, Coord { x: 19.0, y: 8.0 }]),
+            LineString::new(vec![Coord { x: 19.0, y: 8.0 }, Coord { x: 1.0, y: 8.0 }]),
+            LineString::new(vec![Coord { x: 1.0, y: 8.0 }, Coord { x: 1.0, y: 2.0 }]),
+        ]));
+        let mut tiled = TiledPolygonizer::new(bbox, 10.0)
+            .with_buffer(2.0)
+            .with_component_fallback();
+        tiled.add_geometry(&open_boundary);
 
         let result = tiled.polygonize().unwrap();
         assert!(result.stitching_report.component_fallback_attempted);
         assert!(!result.stitching_report.component_fallback_used);
         assert_eq!(
             result.stitching_report.component_fallback_decline_reason,
-            Some("no_indexed_component_evidence")
+            Some("non_closed_recovery_region")
         );
-        assert!(result.stitching_report.unresolved_owned_polygon_count > 0);
 
         let traced = tiled
             .polygonize_with_trace(TraceLevelV1::Full, usize::MAX)
@@ -449,7 +571,7 @@ mod tests {
             .iter()
             .find(|event| event.kind == "tile_component_fallback_declined")
             .unwrap();
-        assert_eq!(declined.payload["reason"], "no_indexed_component_evidence");
+        assert_eq!(declined.payload["reason"], "non_closed_recovery_region");
         assert_eq!(
             declined.payload["unresolved_owned_polygon_count"],
             result.stitching_report.unresolved_owned_polygon_count
@@ -466,7 +588,7 @@ mod tests {
         assert!(matches!(
             error,
             TiledPolygonizeError::CoverageIncomplete {
-                component_fallback_decline_reason: Some("no_indexed_component_evidence"),
+                component_fallback_decline_reason: Some("non_closed_recovery_region"),
                 ..
             }
         ));


### PR DESCRIPTION
## Stack

Parent: none; this is a root stack slice from `main` at `d2ac576`.
Children: none.
Release PR #1002 is intentionally excluded.

## Delivered

- Extend opt-in component fallback to recover one halo-crossing region seeded by retained-face or input-boundary evidence when the selected caller-owned geometries have closed boundaries.
- Reuse the existing region replacement and canonical deduplication path, preserving nested containment instead of independently appending polygonized output.
- Add deterministic `non_closed_recovery_region` evidence for open or mixed single-geometry regions.
- Add canonical-equivalence, nested-containment, trace, typed-error, and decline regression coverage.
- Update P3.1/P3.2 roadmap evidence without claiming broad missing-region detection or graph stitching.

## Contract impact

- Default tiled behavior is unchanged; recovery remains opt-in via `with_component_fallback()`.
- Closed-region recovery is accepted by `ValidateObservedCoverage` only through the existing component-fallback contract and is reported through existing counts/traces.
- Open or mixed boundary evidence declines conservatively; no unsafe partial output is appended.
- Broad undetected connected-region coverage, non-envelope-closed reconciliation, and true stitching remain explicitly unresolved.

## Validation

- `cargo test -p geo-polygonize-core tiling --quiet`: 43 passed.
- `cargo test --workspace --quiet`: passed.
- `cargo test -p geo-polygonize-core --no-default-features --quiet`: passed.
- `cargo clippy --workspace --all-targets -- -D warnings`: passed.
- `RUSTDOCFLAGS='-D warnings' cargo doc -p geo-polygonize-core --no-deps`: passed.
- `npm test`: 11 files / 54 tests passed.
- `npm run docs:build`: passed; generated bindings and playground lockfile were restored.
- Known non-blocking warnings: deprecated WASM initialization, MUI `use client` bundle notices, runtime WASM URL, large playground chunks, and npm audit findings.

## Agent handoff

Parent: none. Children: none.
The next executable roadmap slice after this PR is the broad P3.1 undetected connected-region boundary fixture/evidence search, followed by non-envelope-closed reconciliation. Do not claim P3.1/P3.2 complete from this partial evidence.