### PR TITLE
test(core): pin single-geometry tiled coverage gap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -709,7 +709,10 @@ not, is now reported as conservative excluded-component evidence.
 Opt-in component fallback also recovers a closed single-input boundary region
 when retained-face or input-boundary evidence reaches a halo; mixed or open
 single-geometry boundaries decline conservatively, so broad missing-region
-coverage detection remains observational.
+coverage detection remains observational. A single closed geometry whose
+envelope only grazes the ownership domain can also remain absent when its
+ownership point falls outside every tile; this pins the remaining envelope-only
+boundary without adding an implicit clipping contract.
 
 - [ ] Detect owned faces or connected regions that touch an unresolved halo or
   partition boundary.
@@ -742,6 +745,9 @@ coverage detection remains observational.
   - [x] Pin the partially observed fixed-grid-connected component contract,
     including certified fixed-grid noding; broader transformed-region coverage
     remains observational.
+  - [x] Pin the single-geometry envelope-only gap where an untiled face's
+    ownership point falls outside the configured ownership domain; broad
+    missing-region detection remains open.
 - [x] Report source IDs and boundary evidence that were required but not fully
   observed.
   - [x] Distinguish representative edge IDs from complete aggregate boundary

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -2837,3 +2837,41 @@ fn canonical_dedup_key_compares_exact_geometry() {
     assert_eq!(key, canonical_polygon_key(&equivalent));
     assert_ne!(key, canonical_polygon_key(&polygon(2.0)));
 }
+
+#[test]
+fn documents_single_geometry_region_excluded_from_every_halo() {
+    use crate::{Polygonizer, TiledPolygonizer};
+    use geo::{Coord, Geometry, LineString, Rect};
+
+    let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 32.0, y: 32.0 });
+    let boundary = Geometry::LineString(LineString::new(vec![
+        Coord { x: 25.0, y: 17.0 },
+        Coord { x: 45.0, y: 17.0 },
+        Coord { x: 45.0, y: 41.0 },
+        Coord { x: 25.0, y: 41.0 },
+        Coord { x: 25.0, y: 17.0 },
+    ]));
+    let mut untiled = Polygonizer::new();
+    untiled.add_borrowed_geometry(&boundary);
+    let mut tiled = TiledPolygonizer::new(bbox, 16.0).with_buffer(0.0);
+    tiled.add_geometry(&boundary);
+
+    assert_eq!(untiled.polygonize().unwrap().polygons.len(), 1);
+    assert!(tiled.input_components().unwrap().is_empty());
+    let observed = tiled.polygonize().unwrap();
+    assert!(observed.polygons.is_empty());
+    assert!(observed
+        .tile_reports
+        .iter()
+        .any(|report| report.input_geometry_count == 1));
+    assert!(observed.tile_reports.iter().all(|report| {
+        report.coverage_issues.is_empty()
+            && report.input_boundary_issues.is_empty()
+            && report.excluded_component_issues.is_empty()
+    }));
+    assert_eq!(observed.stitching_report.unresolved_input_geometry_count, 0);
+    assert_eq!(observed.stitching_report.unresolved_component_count, 0);
+    assert!(tiled
+        .polygonize_with_coverage_guarantee(crate::TileCoverageGuarantee::ValidateObservedCoverage)
+        .is_ok());
+}


### PR DESCRIPTION
## Stack

Parent: #1208, `feat(core): recover closed tiled boundary regions`.
Children: none.
This PR targets `agent/p3-closed-boundary-region-fallback`; it must not be merged independently of its parent. Release PR #1002 remains excluded.

## Delivered

- Pin a single closed input geometry whose envelope intersects a buffered tile but whose ownership point lies outside the configured ownership domain.
- Demonstrate that untiled polygonization returns one face while tiled output returns none.
- Demonstrate that all existing coverage, input-boundary, and excluded-component evidence remains empty and `ValidateObservedCoverage` succeeds.
- Record the boundary precisely in P3.1 without adding implicit clipping or changing runtime behavior.

## Contract impact

- Test and roadmap evidence only; no production behavior changes.
- The fixture proves that observed-evidence validation cannot certify faces outside the configured ownership domain when no tile owns a reconstructed face.
- The broad P3.1 detection item remains open; no umbrella item is marked complete.

## Validation

- `cargo fmt --all -- --check`: passed.
- `cargo test -p geo-polygonize-core tiling --quiet`: 44 passed.
- Parent #1208 supplied the full workspace checkpoint: workspace Rust tests, no-default core tests, clippy, rustdoc, `npm test`, and `npm run docs:build` passed; generated artifacts were restored.

## Agent handoff

Parent: #1208. Children: none.
Next executable work is a production contract decision for singleton geometry envelopes that overlap the ownership domain without an owned face; preserve the current no-clipping boundary unless an explicit domain policy is added.