### PR TITLE
feat(core): recover mixed tiled component evidence

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -792,6 +792,9 @@ When coverage cannot be proven:
     the indexed connected component is only partially visible in a halo.
   - [x] Recover an indexed component with mixed observed and unobserved
     members while replacing nested retained output before canonical merge.
+  - [x] Recover mixed owned-face and indexed component/input-boundary evidence
+    only when every owned-face witness lies inside an envelope-closed recovery
+    region; decline conservatively when any witness is outside that region.
   - [x] Merge one envelope-disjoint recovered component with retained tile
     output; envelope-closed region replacement now covers interacting retained
     output.

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -867,12 +867,6 @@ impl<'a> TiledPolygonizer<'a> {
                 ComponentFallbackDeclineReason::NoIndexedComponentEvidence,
             ));
         }
-        if has_coverage_evidence {
-            return Ok(ComponentFallbackDecision::Declined(
-                ComponentFallbackDeclineReason::OwnedFaceCoverageEvidence,
-            ));
-        }
-
         let retained_polygon_bboxes = tile_polygons
             .iter()
             .flat_map(|polygons| polygons.iter())
@@ -973,6 +967,27 @@ impl<'a> TiledPolygonizer<'a> {
             return Ok(ComponentFallbackDecision::Declined(
                 ComponentFallbackDeclineReason::InputBoundaryOutsideRecoveryRegion,
             ));
+        }
+        if has_coverage_evidence {
+            let mut coverage_region_closed = true;
+            'coverage: for report in tile_reports {
+                for issue in &report.coverage_issues {
+                    self.execution_policy
+                        .check_cancelled("tile_component_fallback")?;
+                    if !regions
+                        .iter()
+                        .any(|(_, region_bbox, _)| issue.polygon_bbox.intersects(region_bbox))
+                    {
+                        coverage_region_closed = false;
+                        break 'coverage;
+                    }
+                }
+            }
+            if !coverage_region_closed {
+                return Ok(ComponentFallbackDecision::Declined(
+                    ComponentFallbackDeclineReason::OwnedFaceCoverageEvidence,
+                ));
+            }
         }
 
         let mut recovered = Vec::new();

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -1,13 +1,16 @@
 #[cfg(test)]
 #[allow(clippy::module_inception)]
 mod tests {
-    use crate::tiling::InputComponent;
+    use crate::tiling::{
+        ComponentFallbackDecision, ComponentFallbackDeclineReason, InputComponent,
+    };
     use crate::{
         trace::TraceLevelV1, CancellationToken, Coord3D, DedupPolicy, ExecutionPolicy,
         NodingGuarantee, NodingOptions, Polygon3D, PolygonizeError, Polygonizer,
         PolygonizerOptions, PrecisionModel, ProvenanceOptions, TileBoundarySide,
-        TileComponentConnection, TileCoverageGuarantee, TileExcludedComponentIssue, TileReport,
-        TileRetryPolicy, TiledPolygonizeError, TiledPolygonizer,
+        TileComponentConnection, TileCoverageGuarantee, TileCoverageIssue,
+        TileExcludedComponentIssue, TileReport, TileRetryPolicy, TiledPolygonizeError,
+        TiledPolygonizer,
     };
     use geo::{Contains, Coord, Geometry, LineString, MultiLineString, Rect};
 
@@ -1192,6 +1195,74 @@ mod tests {
                 .collect::<Vec<_>>()
         );
         assert!(reversed.stitching_report.component_fallback_used);
+    }
+
+    #[test]
+    fn component_fallback_declines_coverage_evidence_outside_recovery_region() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 20.0 });
+        let geometries = [
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 0.0, y: 0.0 },
+                Coord { x: 1.0, y: 0.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 1.0, y: 0.0 },
+                Coord { x: 1.0, y: 1.0 },
+            ])),
+        ];
+        let retained_polygon = Polygon3D::new(
+            vec![
+                Coord3D::new(10.0, 10.0, 0.0),
+                Coord3D::new(11.0, 10.0, 0.0),
+                Coord3D::new(11.0, 11.0, 0.0),
+                Coord3D::new(10.0, 11.0, 0.0),
+                Coord3D::new(10.0, 10.0, 0.0),
+            ],
+            vec![],
+            vec![],
+            vec![],
+        );
+        let report = TileReport {
+            tile_bbox: bbox,
+            input_geometry_count: 0,
+            polygon_count: 1,
+            owned_polygon_count: 1,
+            dangle_count: 0,
+            cut_edge_count: 0,
+            invalid_ring_count: 0,
+            coverage_issues: vec![TileCoverageIssue {
+                polygon_index: 0,
+                polygon_bbox: Rect::new(Coord { x: 10.0, y: 10.0 }, Coord { x: 11.0, y: 11.0 }),
+                unresolved_sides: vec![TileBoundarySide::MaxX],
+                representative_source_line_ids: vec![],
+                aggregate_source_line_ids: vec![],
+                aggregate_source_line_ids_complete: false,
+            }],
+            input_boundary_issues: vec![],
+            excluded_component_issues: vec![TileExcludedComponentIssue {
+                input_geometry_indices: vec![0, 1],
+                component_bbox: Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 1.0, y: 1.0 }),
+                connection: TileComponentConnection::ExactEndpoint,
+            }],
+            retry_attempts: vec![],
+            retry_exhausted: false,
+        };
+        let mut tiled = TiledPolygonizer::new(bbox, 10.0);
+        for geometry in &geometries {
+            tiled.add_geometry(geometry);
+        }
+        let component = InputComponent {
+            input_geometry_indices: vec![0, 1],
+            bbox: Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 1.0, y: 1.0 }),
+            connection: TileComponentConnection::ExactEndpoint,
+        };
+
+        assert!(matches!(
+            tiled.try_component_fallback(&[vec![retained_polygon]], &[report], &[component]),
+            Ok(ComponentFallbackDecision::Declined(
+                ComponentFallbackDeclineReason::OwnedFaceCoverageEvidence,
+            ))
+        ));
     }
 
     #[test]
@@ -2874,4 +2945,144 @@ fn documents_single_geometry_region_excluded_from_every_halo() {
     assert!(tiled
         .polygonize_with_coverage_guarantee(crate::TileCoverageGuarantee::ValidateObservedCoverage)
         .is_ok());
+}
+
+#[test]
+fn component_fallback_recovers_mixed_owned_face_and_component_evidence() {
+    use crate::{DedupPolicy, Polygonizer, TileCoverageGuarantee, TiledPolygonizer};
+    use geo::{Coord, Geometry, LineString, Rect};
+
+    let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 20.0 });
+    let geometries = [
+        Geometry::LineString(LineString::new(vec![
+            Coord { x: 4.0, y: 4.0 },
+            Coord { x: 8.0, y: 4.0 },
+        ])),
+        Geometry::LineString(LineString::new(vec![
+            Coord { x: 8.0, y: 4.0 },
+            Coord { x: 8.0, y: 12.0 },
+        ])),
+        Geometry::LineString(LineString::new(vec![
+            Coord { x: 8.0, y: 12.0 },
+            Coord { x: 4.0, y: 12.0 },
+        ])),
+        Geometry::LineString(LineString::new(vec![
+            Coord { x: 4.0, y: 12.0 },
+            Coord { x: 4.0, y: 4.0 },
+        ])),
+    ];
+    let mut untiled = Polygonizer::new();
+    let mut tiled = TiledPolygonizer::new(bbox, 10.0)
+        .with_buffer(2.0)
+        .with_dedup_policy(DedupPolicy::CanonicalRingHash)
+        .with_component_fallback();
+    for geometry in &geometries {
+        untiled.add_borrowed_geometry(geometry);
+        tiled.add_geometry(geometry);
+    }
+
+    let expected = untiled
+        .polygonize()
+        .unwrap()
+        .polygons
+        .into_iter()
+        .map(|polygon| crate::tiling::canonical_polygon_key(&polygon))
+        .collect::<Vec<_>>();
+    let result = tiled
+        .polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateObservedCoverage)
+        .unwrap();
+    assert_eq!(
+        result
+            .polygons
+            .iter()
+            .map(crate::tiling::canonical_polygon_key)
+            .collect::<Vec<_>>(),
+        expected
+    );
+    assert!(result.stitching_report.component_fallback_used);
+    assert!(!result.stitching_report.untiled_fallback_used);
+    assert_eq!(result.stitching_report.component_fallback_count, 1);
+    assert_eq!(result.stitching_report.component_fallback_polygon_count, 1);
+    assert_eq!(
+        result
+            .stitching_report
+            .component_fallback_replaced_polygon_count,
+        1
+    );
+    assert!(result.stitching_report.unresolved_owned_polygon_count > 0);
+    assert!(result.stitching_report.unresolved_input_geometry_count > 0);
+    let traced = tiled
+        .polygonize_with_trace(crate::trace::TraceLevelV1::Full, usize::MAX)
+        .unwrap();
+    let fallback_events = traced
+        .trace
+        .events
+        .iter()
+        .filter(|event| event.kind == "tile_component_fallback")
+        .collect::<Vec<_>>();
+    assert_eq!(fallback_events.len(), 1);
+    assert_eq!(
+        fallback_events[0].payload["input_geometry_indices"],
+        serde_json::json!([0, 1, 2, 3])
+    );
+    assert_eq!(fallback_events[0].payload["output_polygon_count"], 1);
+    assert_eq!(
+        fallback_events[0].payload["replaced_retained_polygon_count"],
+        1
+    );
+    assert!(!traced
+        .trace
+        .events
+        .iter()
+        .any(|event| event.kind == "tile_component_fallback_declined"));
+}
+
+#[test]
+fn component_fallback_declines_unclosed_coverage_region_outside_component() {
+    use crate::{DedupPolicy, TileCoverageGuarantee, TiledPolygonizeError, TiledPolygonizer};
+    use geo::{Coord, Geometry, LineString, Rect};
+
+    let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 60.0, y: 60.0 });
+    let geometries = [
+        Geometry::LineString(LineString::new(vec![
+            Coord { x: -10.0, y: -10.0 },
+            Coord { x: 30.0, y: -10.0 },
+        ])),
+        Geometry::LineString(LineString::new(vec![
+            Coord { x: 30.0, y: -10.0 },
+            Coord { x: 30.0, y: 30.0 },
+        ])),
+        Geometry::LineString(LineString::new(vec![
+            Coord { x: 30.0, y: 30.0 },
+            Coord { x: -10.0, y: 30.0 },
+        ])),
+        Geometry::LineString(LineString::new(vec![
+            Coord { x: -10.0, y: 30.0 },
+            Coord { x: -10.0, y: -10.0 },
+        ])),
+        Geometry::LineString(LineString::new(vec![
+            Coord { x: 44.0, y: 44.0 },
+            Coord { x: 48.0, y: 44.0 },
+            Coord { x: 48.0, y: 52.0 },
+            Coord { x: 44.0, y: 52.0 },
+            Coord { x: 44.0, y: 44.0 },
+        ])),
+    ];
+    let mut tiled = TiledPolygonizer::new(bbox, 10.0)
+        .with_buffer(2.0)
+        .with_dedup_policy(DedupPolicy::CanonicalRingHash)
+        .with_component_fallback();
+    for geometry in &geometries {
+        tiled.add_geometry(geometry);
+    }
+
+    let result =
+        tiled.polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateObservedCoverage);
+    assert!(matches!(
+        result,
+        Err(TiledPolygonizeError::CoverageIncomplete {
+            component_fallback_decline_reason: Some("input_boundary_outside_recovery_region"),
+            ..
+        })
+    ));
 }


### PR DESCRIPTION
## Stack

Parent: none; this is a root PR from main at 119f996.
Children: none at creation.
Release PR #1002 is excluded.

## Delivered

- Reuse envelope-closed indexed component recovery when owned-face coverage evidence and indexed component/input-boundary evidence describe the same recovered region.
- Decline conservatively with the existing owned-face evidence reason when any coverage witness lies outside every recovery region.
- Add mixed-evidence, outside-region, canonical-output, trace, replacement-count, and typed-decline regressions.
- Update ROADMAP.md without marking the broader P3.1/P3.2 umbrellas complete.

## Contract impact

- Opt-in component fallback only; default tiled behavior is unchanged.
- Recovery still replaces intersecting retained polygons before canonical merge; it does not append partial polygons or introduce graph stitching.
- ValidateObservedCoverage succeeds only for observed evidence covered by an envelope-closed recovery region; unobserved connected regions remain observationally limited.
- Deterministic output, provenance/Z handling, execution limits, and cancellation paths are preserved.

## Validation

- cargo fmt --all -- --check
- cargo test -p geo-polygonize-core component_fallback --quiet (15 passed)
- cargo test -p geo-polygonize-core tiling --quiet (47 passed)
- cargo test --workspace --quiet (247 core tests plus all workspace suites passed)
- cargo test -p geo-polygonize-core --no-default-features --quiet (247 passed)
- cargo clippy --workspace --all-targets -- -D warnings
- RUSTDOCFLAGS='-D warnings' cargo doc -p geo-polygonize-core --no-deps
- npm test (11 files, 54 tests)
- npm run docs:build (passed; existing MUI/Vite, runtime-WASM, chunk-size, and npm audit warnings)
- Generated bindings, docs churn, and playground/package-lock changes restored.

## Agent handoff

Parent: none.
Children: none.
Next branch: agent/p3-non-envelope-closed-reconciliation, only after this root is published.
Do not treat this PR as evidence for broad missing-region detection or true graph stitching.