### PR TITLE
test(core): verify global tiled fallback escalation

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -823,6 +823,9 @@ When coverage cannot be proven:
 - [ ] merge the fallback result canonically with already validated regions;
   - [x] Replace retained polygons intersecting an envelope-closed recovery
     region before canonical deduplication and deterministic ordering.
+  - [x] Route non-envelope-closed recovery evidence through the caller-enabled
+    whole-input fallback, preserving global containment and tracing the decline;
+    region-local reconciliation remains open.
   - [ ] Reconcile fallback regions whose topology crosses a partition boundary
     without a conservative envelope closure.
 - [x] stop with a typed coverage error when the configured retry budget is

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -3039,7 +3039,9 @@ fn component_fallback_recovers_mixed_owned_face_and_component_evidence() {
 
 #[test]
 fn component_fallback_declines_unclosed_coverage_region_outside_component() {
-    use crate::{DedupPolicy, TileCoverageGuarantee, TiledPolygonizeError, TiledPolygonizer};
+    use crate::{
+        DedupPolicy, Polygonizer, TileCoverageGuarantee, TiledPolygonizeError, TiledPolygonizer,
+    };
     use geo::{Coord, Geometry, LineString, Rect};
 
     let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 60.0, y: 60.0 });
@@ -3085,4 +3087,60 @@ fn component_fallback_declines_unclosed_coverage_region_outside_component() {
             ..
         })
     ));
+
+    let mut expected = Polygonizer::new();
+    for geometry in &geometries {
+        expected.add_borrowed_geometry(geometry);
+    }
+    let expected = expected
+        .polygonize()
+        .unwrap()
+        .polygons
+        .into_iter()
+        .map(|polygon| crate::tiling::canonical_polygon_key(&polygon))
+        .collect::<Vec<_>>();
+    let mut globally_fallback = TiledPolygonizer::new(bbox, 10.0)
+        .with_buffer(2.0)
+        .with_dedup_policy(DedupPolicy::CanonicalRingHash)
+        .with_component_fallback()
+        .with_untiled_fallback();
+    for geometry in &geometries {
+        globally_fallback.add_geometry(geometry);
+    }
+    let result = globally_fallback
+        .polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateObservedCoverage)
+        .unwrap();
+    assert_eq!(
+        result
+            .polygons
+            .iter()
+            .map(crate::tiling::canonical_polygon_key)
+            .collect::<Vec<_>>(),
+        expected
+    );
+    assert!(result.stitching_report.component_fallback_attempted);
+    assert!(!result.stitching_report.component_fallback_used);
+    assert_eq!(
+        result.stitching_report.component_fallback_decline_reason,
+        Some("input_boundary_outside_recovery_region")
+    );
+    assert!(result.stitching_report.untiled_fallback_used);
+    let traced = globally_fallback
+        .polygonize_with_trace(crate::trace::TraceLevelV1::Full, usize::MAX)
+        .unwrap();
+    let recovery_events = traced
+        .trace
+        .events
+        .iter()
+        .filter_map(|event| match event.kind.as_str() {
+            "tile_component_fallback_declined" | "tile_untiled_fallback" => {
+                Some(event.kind.as_str())
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        recovery_events,
+        vec!["tile_component_fallback_declined", "tile_untiled_fallback"]
+    );
 }


### PR DESCRIPTION
## Stack

Parent: #1211 feat(core): recover mixed tiled component evidence.
Children: none.
This PR must land after #1211; it is not a merge of the parent into the child.

## Delivered

- Prove that mixed/non-envelope-closed recovery evidence declines region-local component fallback rather than appending an unsafe partial result.
- Prove that caller-enabled whole-input fallback then produces canonical output equal to untiled polygonization.
- Pin the retained decline reason and deterministic trace order: component fallback declined, then untiled fallback.
- Update ROADMAP.md with the safe global-escalation evidence while leaving region-local reconciliation unchecked.

## Contract impact

- Opt-in component and whole-input fallback only; defaults remain unchanged.
- Global fallback preserves containment across partition boundaries without introducing graph stitching or implicit clipping.
- Region-local reconciliation for topology crossing a partition boundary without envelope closure remains intentionally unsupported and conservatively declined.
- Trace/report observability and canonical output contracts are preserved.

## Validation

- cargo fmt --all -- --check
- cargo test -p geo-polygonize-core component_fallback_declines_unclosed_coverage_region_outside_component --quiet (1 passed)
- cargo test -p geo-polygonize-core tiling --quiet (47 passed)
- cargo test --workspace --quiet (247 core tests plus all workspace suites passed)
- cargo clippy --workspace --all-targets -- -D warnings
- Generated bindings were restored after validation.

## Agent handoff

Parent: #1211.
Children: none.
Next branch: agent/p3-undetected-region-coverage-contract, after this child is published.
Do not mark P3.2 region-local reconciliation or broad P3.1 missing-region detection complete.