### PR TITLE
docs(core): clarify undetected tiled coverage

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -792,6 +792,9 @@ When coverage cannot be proven:
     the indexed connected component is only partially visible in a halo.
   - [x] Recover an indexed component with mixed observed and unobserved
     members while replacing nested retained output before canonical merge.
+  - [x] Recover mixed owned-face and indexed component/input-boundary evidence
+    only when every owned-face witness lies inside an envelope-closed recovery
+    region; decline conservatively when any witness is outside that region.
   - [x] Merge one envelope-disjoint recovered component with retained tile
     output; envelope-closed region replacement now covers interacting retained
     output.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -823,6 +823,9 @@ When coverage cannot be proven:
 - [ ] merge the fallback result canonically with already validated regions;
   - [x] Replace retained polygons intersecting an envelope-closed recovery
     region before canonical deduplication and deterministic ordering.
+  - [x] Route non-envelope-closed recovery evidence through the caller-enabled
+    whole-input fallback, preserving global containment and tracing the decline;
+    region-local reconciliation remains open.
   - [ ] Reconcile fallback regions whose topology crosses a partition boundary
     without a conservative envelope closure.
 - [x] stop with a typed coverage error when the configured retry budget is

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -748,6 +748,9 @@ boundary without adding an implicit clipping contract.
   - [x] Pin the single-geometry envelope-only gap where an untiled face's
     ownership point falls outside the configured ownership domain; broad
     missing-region detection remains open.
+  - [x] Pin that caller-enabled whole-input fallback cannot repair the same
+    single-geometry ownership-domain gap without observed evidence; no implicit
+    clipping is introduced.
 - [x] Report source IDs and boundary evidence that were required but not fully
   observed.
   - [x] Distinguish representative edge IDs from complete aggregate boundary

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -867,12 +867,6 @@ impl<'a> TiledPolygonizer<'a> {
                 ComponentFallbackDeclineReason::NoIndexedComponentEvidence,
             ));
         }
-        if has_coverage_evidence {
-            return Ok(ComponentFallbackDecision::Declined(
-                ComponentFallbackDeclineReason::OwnedFaceCoverageEvidence,
-            ));
-        }
-
         let retained_polygon_bboxes = tile_polygons
             .iter()
             .flat_map(|polygons| polygons.iter())
@@ -973,6 +967,27 @@ impl<'a> TiledPolygonizer<'a> {
             return Ok(ComponentFallbackDecision::Declined(
                 ComponentFallbackDeclineReason::InputBoundaryOutsideRecoveryRegion,
             ));
+        }
+        if has_coverage_evidence {
+            let mut coverage_region_closed = true;
+            'coverage: for report in tile_reports {
+                for issue in &report.coverage_issues {
+                    self.execution_policy
+                        .check_cancelled("tile_component_fallback")?;
+                    if !regions
+                        .iter()
+                        .any(|(_, region_bbox, _)| issue.polygon_bbox.intersects(region_bbox))
+                    {
+                        coverage_region_closed = false;
+                        break 'coverage;
+                    }
+                }
+            }
+            if !coverage_region_closed {
+                return Ok(ComponentFallbackDecision::Declined(
+                    ComponentFallbackDeclineReason::OwnedFaceCoverageEvidence,
+                ));
+            }
         }
 
         let mut recovered = Vec::new();

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -3039,7 +3039,9 @@ fn component_fallback_recovers_mixed_owned_face_and_component_evidence() {
 
 #[test]
 fn component_fallback_declines_unclosed_coverage_region_outside_component() {
-    use crate::{DedupPolicy, TileCoverageGuarantee, TiledPolygonizeError, TiledPolygonizer};
+    use crate::{
+        DedupPolicy, Polygonizer, TileCoverageGuarantee, TiledPolygonizeError, TiledPolygonizer,
+    };
     use geo::{Coord, Geometry, LineString, Rect};
 
     let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 60.0, y: 60.0 });
@@ -3085,4 +3087,60 @@ fn component_fallback_declines_unclosed_coverage_region_outside_component() {
             ..
         })
     ));
+
+    let mut expected = Polygonizer::new();
+    for geometry in &geometries {
+        expected.add_borrowed_geometry(geometry);
+    }
+    let expected = expected
+        .polygonize()
+        .unwrap()
+        .polygons
+        .into_iter()
+        .map(|polygon| crate::tiling::canonical_polygon_key(&polygon))
+        .collect::<Vec<_>>();
+    let mut globally_fallback = TiledPolygonizer::new(bbox, 10.0)
+        .with_buffer(2.0)
+        .with_dedup_policy(DedupPolicy::CanonicalRingHash)
+        .with_component_fallback()
+        .with_untiled_fallback();
+    for geometry in &geometries {
+        globally_fallback.add_geometry(geometry);
+    }
+    let result = globally_fallback
+        .polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateObservedCoverage)
+        .unwrap();
+    assert_eq!(
+        result
+            .polygons
+            .iter()
+            .map(crate::tiling::canonical_polygon_key)
+            .collect::<Vec<_>>(),
+        expected
+    );
+    assert!(result.stitching_report.component_fallback_attempted);
+    assert!(!result.stitching_report.component_fallback_used);
+    assert_eq!(
+        result.stitching_report.component_fallback_decline_reason,
+        Some("input_boundary_outside_recovery_region")
+    );
+    assert!(result.stitching_report.untiled_fallback_used);
+    let traced = globally_fallback
+        .polygonize_with_trace(crate::trace::TraceLevelV1::Full, usize::MAX)
+        .unwrap();
+    let recovery_events = traced
+        .trace
+        .events
+        .iter()
+        .filter_map(|event| match event.kind.as_str() {
+            "tile_component_fallback_declined" | "tile_untiled_fallback" => {
+                Some(event.kind.as_str())
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        recovery_events,
+        vec!["tile_component_fallback_declined", "tile_untiled_fallback"]
+    );
 }

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -1,13 +1,16 @@
 #[cfg(test)]
 #[allow(clippy::module_inception)]
 mod tests {
-    use crate::tiling::InputComponent;
+    use crate::tiling::{
+        ComponentFallbackDecision, ComponentFallbackDeclineReason, InputComponent,
+    };
     use crate::{
         trace::TraceLevelV1, CancellationToken, Coord3D, DedupPolicy, ExecutionPolicy,
         NodingGuarantee, NodingOptions, Polygon3D, PolygonizeError, Polygonizer,
         PolygonizerOptions, PrecisionModel, ProvenanceOptions, TileBoundarySide,
-        TileComponentConnection, TileCoverageGuarantee, TileExcludedComponentIssue, TileReport,
-        TileRetryPolicy, TiledPolygonizeError, TiledPolygonizer,
+        TileComponentConnection, TileCoverageGuarantee, TileCoverageIssue,
+        TileExcludedComponentIssue, TileReport, TileRetryPolicy, TiledPolygonizeError,
+        TiledPolygonizer,
     };
     use geo::{Contains, Coord, Geometry, LineString, MultiLineString, Rect};
 
@@ -1192,6 +1195,74 @@ mod tests {
                 .collect::<Vec<_>>()
         );
         assert!(reversed.stitching_report.component_fallback_used);
+    }
+
+    #[test]
+    fn component_fallback_declines_coverage_evidence_outside_recovery_region() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 20.0 });
+        let geometries = [
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 0.0, y: 0.0 },
+                Coord { x: 1.0, y: 0.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 1.0, y: 0.0 },
+                Coord { x: 1.0, y: 1.0 },
+            ])),
+        ];
+        let retained_polygon = Polygon3D::new(
+            vec![
+                Coord3D::new(10.0, 10.0, 0.0),
+                Coord3D::new(11.0, 10.0, 0.0),
+                Coord3D::new(11.0, 11.0, 0.0),
+                Coord3D::new(10.0, 11.0, 0.0),
+                Coord3D::new(10.0, 10.0, 0.0),
+            ],
+            vec![],
+            vec![],
+            vec![],
+        );
+        let report = TileReport {
+            tile_bbox: bbox,
+            input_geometry_count: 0,
+            polygon_count: 1,
+            owned_polygon_count: 1,
+            dangle_count: 0,
+            cut_edge_count: 0,
+            invalid_ring_count: 0,
+            coverage_issues: vec![TileCoverageIssue {
+                polygon_index: 0,
+                polygon_bbox: Rect::new(Coord { x: 10.0, y: 10.0 }, Coord { x: 11.0, y: 11.0 }),
+                unresolved_sides: vec![TileBoundarySide::MaxX],
+                representative_source_line_ids: vec![],
+                aggregate_source_line_ids: vec![],
+                aggregate_source_line_ids_complete: false,
+            }],
+            input_boundary_issues: vec![],
+            excluded_component_issues: vec![TileExcludedComponentIssue {
+                input_geometry_indices: vec![0, 1],
+                component_bbox: Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 1.0, y: 1.0 }),
+                connection: TileComponentConnection::ExactEndpoint,
+            }],
+            retry_attempts: vec![],
+            retry_exhausted: false,
+        };
+        let mut tiled = TiledPolygonizer::new(bbox, 10.0);
+        for geometry in &geometries {
+            tiled.add_geometry(geometry);
+        }
+        let component = InputComponent {
+            input_geometry_indices: vec![0, 1],
+            bbox: Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 1.0, y: 1.0 }),
+            connection: TileComponentConnection::ExactEndpoint,
+        };
+
+        assert!(matches!(
+            tiled.try_component_fallback(&[vec![retained_polygon]], &[report], &[component]),
+            Ok(ComponentFallbackDecision::Declined(
+                ComponentFallbackDeclineReason::OwnedFaceCoverageEvidence,
+            ))
+        ));
     }
 
     #[test]
@@ -2874,4 +2945,144 @@ fn documents_single_geometry_region_excluded_from_every_halo() {
     assert!(tiled
         .polygonize_with_coverage_guarantee(crate::TileCoverageGuarantee::ValidateObservedCoverage)
         .is_ok());
+}
+
+#[test]
+fn component_fallback_recovers_mixed_owned_face_and_component_evidence() {
+    use crate::{DedupPolicy, Polygonizer, TileCoverageGuarantee, TiledPolygonizer};
+    use geo::{Coord, Geometry, LineString, Rect};
+
+    let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 20.0 });
+    let geometries = [
+        Geometry::LineString(LineString::new(vec![
+            Coord { x: 4.0, y: 4.0 },
+            Coord { x: 8.0, y: 4.0 },
+        ])),
+        Geometry::LineString(LineString::new(vec![
+            Coord { x: 8.0, y: 4.0 },
+            Coord { x: 8.0, y: 12.0 },
+        ])),
+        Geometry::LineString(LineString::new(vec![
+            Coord { x: 8.0, y: 12.0 },
+            Coord { x: 4.0, y: 12.0 },
+        ])),
+        Geometry::LineString(LineString::new(vec![
+            Coord { x: 4.0, y: 12.0 },
+            Coord { x: 4.0, y: 4.0 },
+        ])),
+    ];
+    let mut untiled = Polygonizer::new();
+    let mut tiled = TiledPolygonizer::new(bbox, 10.0)
+        .with_buffer(2.0)
+        .with_dedup_policy(DedupPolicy::CanonicalRingHash)
+        .with_component_fallback();
+    for geometry in &geometries {
+        untiled.add_borrowed_geometry(geometry);
+        tiled.add_geometry(geometry);
+    }
+
+    let expected = untiled
+        .polygonize()
+        .unwrap()
+        .polygons
+        .into_iter()
+        .map(|polygon| crate::tiling::canonical_polygon_key(&polygon))
+        .collect::<Vec<_>>();
+    let result = tiled
+        .polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateObservedCoverage)
+        .unwrap();
+    assert_eq!(
+        result
+            .polygons
+            .iter()
+            .map(crate::tiling::canonical_polygon_key)
+            .collect::<Vec<_>>(),
+        expected
+    );
+    assert!(result.stitching_report.component_fallback_used);
+    assert!(!result.stitching_report.untiled_fallback_used);
+    assert_eq!(result.stitching_report.component_fallback_count, 1);
+    assert_eq!(result.stitching_report.component_fallback_polygon_count, 1);
+    assert_eq!(
+        result
+            .stitching_report
+            .component_fallback_replaced_polygon_count,
+        1
+    );
+    assert!(result.stitching_report.unresolved_owned_polygon_count > 0);
+    assert!(result.stitching_report.unresolved_input_geometry_count > 0);
+    let traced = tiled
+        .polygonize_with_trace(crate::trace::TraceLevelV1::Full, usize::MAX)
+        .unwrap();
+    let fallback_events = traced
+        .trace
+        .events
+        .iter()
+        .filter(|event| event.kind == "tile_component_fallback")
+        .collect::<Vec<_>>();
+    assert_eq!(fallback_events.len(), 1);
+    assert_eq!(
+        fallback_events[0].payload["input_geometry_indices"],
+        serde_json::json!([0, 1, 2, 3])
+    );
+    assert_eq!(fallback_events[0].payload["output_polygon_count"], 1);
+    assert_eq!(
+        fallback_events[0].payload["replaced_retained_polygon_count"],
+        1
+    );
+    assert!(!traced
+        .trace
+        .events
+        .iter()
+        .any(|event| event.kind == "tile_component_fallback_declined"));
+}
+
+#[test]
+fn component_fallback_declines_unclosed_coverage_region_outside_component() {
+    use crate::{DedupPolicy, TileCoverageGuarantee, TiledPolygonizeError, TiledPolygonizer};
+    use geo::{Coord, Geometry, LineString, Rect};
+
+    let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 60.0, y: 60.0 });
+    let geometries = [
+        Geometry::LineString(LineString::new(vec![
+            Coord { x: -10.0, y: -10.0 },
+            Coord { x: 30.0, y: -10.0 },
+        ])),
+        Geometry::LineString(LineString::new(vec![
+            Coord { x: 30.0, y: -10.0 },
+            Coord { x: 30.0, y: 30.0 },
+        ])),
+        Geometry::LineString(LineString::new(vec![
+            Coord { x: 30.0, y: 30.0 },
+            Coord { x: -10.0, y: 30.0 },
+        ])),
+        Geometry::LineString(LineString::new(vec![
+            Coord { x: -10.0, y: 30.0 },
+            Coord { x: -10.0, y: -10.0 },
+        ])),
+        Geometry::LineString(LineString::new(vec![
+            Coord { x: 44.0, y: 44.0 },
+            Coord { x: 48.0, y: 44.0 },
+            Coord { x: 48.0, y: 52.0 },
+            Coord { x: 44.0, y: 52.0 },
+            Coord { x: 44.0, y: 44.0 },
+        ])),
+    ];
+    let mut tiled = TiledPolygonizer::new(bbox, 10.0)
+        .with_buffer(2.0)
+        .with_dedup_policy(DedupPolicy::CanonicalRingHash)
+        .with_component_fallback();
+    for geometry in &geometries {
+        tiled.add_geometry(geometry);
+    }
+
+    let result =
+        tiled.polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateObservedCoverage);
+    assert!(matches!(
+        result,
+        Err(TiledPolygonizeError::CoverageIncomplete {
+            component_fallback_decline_reason: Some("input_boundary_outside_recovery_region"),
+            ..
+        })
+    ));
 }

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -2945,6 +2945,24 @@ fn documents_single_geometry_region_excluded_from_every_halo() {
     assert!(tiled
         .polygonize_with_coverage_guarantee(crate::TileCoverageGuarantee::ValidateObservedCoverage)
         .is_ok());
+
+    let mut fallback = TiledPolygonizer::new(bbox, 16.0)
+        .with_buffer(0.0)
+        .with_untiled_fallback();
+    fallback.add_geometry(&boundary);
+    let fallback_result = fallback
+        .polygonize_with_coverage_guarantee(crate::TileCoverageGuarantee::ValidateObservedCoverage)
+        .unwrap();
+    assert!(fallback_result.polygons.is_empty());
+    assert!(!fallback_result.stitching_report.untiled_fallback_used);
+    let traced = fallback
+        .polygonize_with_trace(crate::trace::TraceLevelV1::Full, usize::MAX)
+        .unwrap();
+    assert!(!traced
+        .trace
+        .events
+        .iter()
+        .any(|event| event.kind == "tile_untiled_fallback"));
 }
 
 #[test]

--- a/docs/guide/tiling.md
+++ b/docs/guide/tiling.md
@@ -127,18 +127,24 @@ the envelope-closed class without independently appending nested output. The
 recovery records `component_fallback_used`, retained/recovered/replaced counts
 in `StitchingReport`, and a bounded `tile_component_fallback` event containing
 the region input indexes, recovered component count, and replacement count.
-Coverage issues or unresolved input evidence outside the closed regions still
-decline component recovery. `with_untiled_fallback` remains the containment-safe
-escape hatch for those cases. General boundary-graph stitching remains
-unavailable. When enabled for unresolved output, a declined component recovery
-is marked in `StitchingReport` and recorded as a bounded
-`tile_component_fallback_declined` trace event with the remaining evidence
-counts and a deterministic decline reason. Component fallback checks the
-execution policy before region selection and before each recovery region, so
-cancellation does not get lost between tile processing and the bounded region
-polygonizer. The same policy is checked while replacing retained polygons,
-appending recovered output, and deduplicating the fallback merge, so a
-cancellation request is not lost after recovery finishes.
+When owned-face coverage evidence co-occurs with indexed component or
+input-boundary evidence, every owned-face witness must intersect an
+envelope-closed recovery region; a witness outside those regions declines
+component recovery rather than replacing unrelated retained output.
+`with_untiled_fallback` remains the containment-safe escape hatch for observed
+cases that decline region-local recovery. General boundary-graph stitching
+remains unavailable. When enabled for unresolved output, a declined component
+recovery is marked in `StitchingReport` and recorded as a bounded
+`tile_component_fallback_declined` trace event before the
+`tile_untiled_fallback` event. The whole-input fallback only runs when tile
+reports contain observed unresolved evidence. It cannot detect an unowned
+single-geometry face whose representative ownership point falls outside the
+configured ownership domain, and it never clips that input implicitly.
+Component fallback checks the execution policy before region selection and
+before each recovery region, so cancellation does not get lost between tile
+processing and the bounded region polygonizer. The same policy is checked while
+replacing retained polygons, appending recovered output, and deduplicating the
+fallback merge, so a cancellation request is not lost after recovery finishes.
 Applications that require correctness must run an untiled equivalence check for
 their input class or choose untiled polygonization directly when sufficiency is
 unknown.


### PR DESCRIPTION
## Stack

Parent: #1212 test(core): verify global tiled fallback escalation.
Children: none.
This PR must land after #1212; it is not a merge of the parent into the child.

## Delivered

- Pin that a single closed geometry whose representative ownership point lies outside the configured ownership domain produces no owned tiled output and no observed fallback evidence.
- Pin that caller-enabled whole-input fallback does not run without observed unresolved tile evidence.
- Clarify the mixed-evidence envelope-closure rule, decline-before-global-fallback trace order, and no-implicit-clipping boundary in docs/guide/tiling.md.
- Update ROADMAP.md precisely; broad P3.1 missing-region detection remains open.

## Contract impact

- Documentation and regression coverage only; runtime defaults and fallback selection are unchanged.
- with_untiled_fallback is an evidence-driven containment escape hatch, not a general missing-region detector.
- The tiled API does not clip or extend the ownership domain implicitly.
- General boundary-graph stitching and undetected-region certification remain unavailable.

## Validation

- cargo fmt --all -- --check
- cargo test -p geo-polygonize-core documents_single_geometry_region_excluded_from_every_halo --quiet (1 passed)
- cargo test -p geo-polygonize-core tiling --quiet (47 passed)
- npm run docs:build (passed; existing MUI/Vite, runtime-WASM, chunk-size, and npm audit warnings)
- Generated bindings, docs output, and playground/package-lock changes restored.

## Agent handoff

Parent: #1212.
Children: none.
Next branch: agent/p3-coverage-probe-design, only after this documentation/contract slice is published.
Do not claim broad P3.1 detection, single-geometry certification, or P3.3 graph stitching.