### PR TITLE
test(core): probe tiled coverage differentials

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -767,6 +767,9 @@ boundary without adding an implicit clipping contract.
     without claiming certification.
 - [x] Randomize tile origins, sizes, input orders, and tile traversal order in
   deterministic metamorphic tests with sufficient halos.
+  - [x] Exercise bounded in-domain tiled-vs-untiled ownership and deduplication
+    inputs in the scheduled fuzz target; a mismatch without observed coverage
+    evidence fails the target rather than being silently accepted.
 - [x] Expand exact tiled/untiled fixtures for nested disconnected rings, long
   faces, narrow concavities, holes crossing boundaries, dangles, cut edges,
   overlaps, and dirty boundary intersections.

--- a/crates/geo-polygonize-core/fuzz/fuzz_targets/tile_ownership_dedup.rs
+++ b/crates/geo-polygonize-core/fuzz/fuzz_targets/tile_ownership_dedup.rs
@@ -1,42 +1,107 @@
 #![no_main]
 
 use arbitrary::Arbitrary;
-use geo_polygonize_core::PolygonizerOptions;
-use geo_polygonize_core::polygonize;
-use geo_polygonize_core::{Coord3D, Line3D};
+use geo::{Coord, Geometry, LineString, Rect};
+use geo_polygonize_core::{
+    polygonize, Coord3D, DedupPolicy, Line3D, Polygon3D, PolygonizerOptions,
+    TileOwnershipPolicy, TiledPolygonizer,
+};
 use libfuzzer_sys::fuzz_target;
 
 #[derive(Arbitrary, Debug)]
 struct FuzzInput {
-    lines: Vec<(f64, f64, f64, f64, f64, f64)>,
+    lines: Vec<(i8, i8, i8, i8)>,
+    tile_size: u8,
+    buffer: u8,
+    reverse_input: bool,
+}
+
+fn world() -> Rect<f64> {
+    Rect::new(
+        Coord { x: -32.0, y: -32.0 },
+        Coord { x: 32.0, y: 32.0 },
+    )
+}
+
+fn bounded_coordinate(value: i8) -> f64 {
+    f64::from(value.clamp(-24, 24))
+}
+
+fn same_polygons(left: &[Polygon3D], right: &[Polygon3D]) -> bool {
+    left.len() == right.len()
+        && left.iter().zip(right).all(|(left, right)| {
+            left.exterior == right.exterior && left.interiors == right.interiors
+        })
+}
+
+fn has_coverage_evidence(result: &geo_polygonize_core::TiledPolygonizeResult) -> bool {
+    result.tile_reports.iter().any(|report| {
+        !report.coverage_issues.is_empty()
+            || !report.input_boundary_issues.is_empty()
+            || !report.excluded_component_issues.is_empty()
+    })
 }
 
 fuzz_target!(|input: FuzzInput| {
-    if input.lines.len() > 100 {
+    if input.lines.len() > 32 {
         return;
     }
 
-    let mut lines = Vec::new();
-    for (sx, sy, sz, ex, ey, ez) in input.lines {
-        if sx.is_nan() || sy.is_nan() || sz.is_nan() || ex.is_nan() || ey.is_nan() || ez.is_nan() {
-            return;
-        }
-        lines.push(Line3D {
-            start: Coord3D {
-                x: sx,
-                y: sy,
-                z: sz,
-            },
-            end: Coord3D {
-                x: ex,
-                y: ey,
-                z: ez,
-            },
-            line_id: 0,
-        });
+    let mut lines = input
+        .lines
+        .into_iter()
+        .enumerate()
+        .map(|(line_id, (sx, sy, ex, ey))| {
+            Line3D::new(
+                Coord3D::new(bounded_coordinate(sx), bounded_coordinate(sy), 0.0),
+                Coord3D::new(bounded_coordinate(ex), bounded_coordinate(ey), 0.0),
+                u32::try_from(line_id).unwrap(),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    if input.reverse_input {
+        lines.reverse();
+    }
+    let options = PolygonizerOptions {
+        node_input: true,
+        ..Default::default()
+    };
+    let Ok(expected) = polygonize(lines.iter().copied(), &options) else {
+        return;
+    };
+
+    let geometries = lines
+        .iter()
+        .map(|line| {
+            Geometry::LineString(LineString::new(vec![
+                line.start.to_coord_2d(),
+                line.end.to_coord_2d(),
+            ]))
+        })
+        .collect::<Vec<_>>();
+    let mut tiled = TiledPolygonizer::new(world(), 1.0 + f64::from(input.tile_size % 16))
+        .with_buffer(f64::from(input.buffer % 17))
+        .with_options(options)
+        .with_ownership_policy(TileOwnershipPolicy::RepresentativePointInsidePolygon)
+        .with_dedup_policy(DedupPolicy::CanonicalRingHash);
+    for geometry in &geometries {
+        tiled.add_geometry(geometry);
     }
 
-    let options = PolygonizerOptions::default();
+    let Ok(actual) = tiled.polygonize() else {
+        return;
+    };
+    if same_polygons(&expected.polygons, &actual.polygons) || has_coverage_evidence(&actual) {
+        return;
+    }
 
-    let _ = polygonize(lines.iter().copied(), &options);
+    panic!(
+        "undetected tiled mismatch: lines={}, tile_size={}, buffer={}, untiled_polygons={}, tiled_polygons={}",
+        lines.len(),
+        1 + (input.tile_size % 16),
+        input.buffer % 17,
+        expected.polygons.len(),
+        actual.polygons.len(),
+    );
 });

--- a/crates/geo-polygonize-core/tests/tiling_equivalence.rs
+++ b/crates/geo-polygonize-core/tests/tiling_equivalence.rs
@@ -124,6 +124,61 @@ fn untiled_fallback_matches_global_output_across_tile_and_input_permutations() {
 }
 
 #[test]
+fn in_domain_tiled_mismatches_have_observed_coverage_evidence() {
+    let mut lines = ring(&[(2.0, 2.0), (18.0, 2.0), (18.0, 18.0), (2.0, 18.0)]);
+    lines.extend(ring(&[(6.0, 6.0), (14.0, 6.0), (14.0, 14.0), (6.0, 14.0)]));
+    let options = PolygonizerOptions {
+        node_input: true,
+        ..Default::default()
+    };
+    let expected = polygonize(lines.iter().copied(), &options).unwrap();
+    let geometries = lines
+        .iter()
+        .map(|line| {
+            Geometry::LineString(LineString::new(vec![
+                line.start.to_coord_2d(),
+                line.end.to_coord_2d(),
+            ]))
+        })
+        .collect::<Vec<_>>();
+
+    for tile_size in [4.0, 7.0, 10.0] {
+        for buffer in [0.0, 1.0, 4.0] {
+            let mut tiled = TiledPolygonizer::new(world(20.0), tile_size)
+                .with_buffer(buffer)
+                .with_options(options.clone())
+                .with_ownership_policy(TileOwnershipPolicy::RepresentativePointInsidePolygon)
+                .with_dedup_policy(DedupPolicy::CanonicalRingHash);
+            for geometry in &geometries {
+                tiled.add_geometry(geometry);
+            }
+            let actual = tiled
+                .polygonize()
+                .unwrap_or_else(|error| panic!("tile size {tile_size}, buffer {buffer}: {error}"));
+            let equivalent = actual.polygons.len() == expected.polygons.len()
+                && actual
+                    .polygons
+                    .iter()
+                    .zip(&expected.polygons)
+                    .all(|(actual, expected)| {
+                        actual.exterior == expected.exterior
+                            && actual.interiors == expected.interiors
+                    });
+            if !equivalent {
+                assert!(
+                    actual.tile_reports.iter().any(|report| {
+                        !report.coverage_issues.is_empty()
+                            || !report.input_boundary_issues.is_empty()
+                            || !report.excluded_component_issues.is_empty()
+                    }),
+                    "undetected in-domain mismatch for tile size {tile_size}, buffer {buffer}"
+                );
+            }
+        }
+    }
+}
+
+#[test]
 fn tiled_report_matches_untiled_dangle_and_cut_edge_families() {
     let mut lines = ring(&[(0.0, 0.0), (10.0, 0.0), (10.0, 10.0), (0.0, 10.0)]);
     lines.push(line((10.0, 10.0), (15.0, 15.0)));


### PR DESCRIPTION
## Stack

- Parent: #1215 `fix(core): remove duplicated tiled regression tests`.
- Children: none; this is currently the top of the stack.

## Delivered

- Replaced the dormant tile ownership fuzz smoke test with a bounded in-domain tiled-vs-untiled differential probe.
- Varies integer linework, tile size, halo buffer, and input order while preserving finite in-domain coordinates.
- Fails only when tiled output differs without one of the existing observed coverage evidence classes.
- Added a deterministic integration contract covering nested rings across tile sizes and buffers.
- Updated P3.1 with the evidence boundary; the broad missing-region certification item remains open.

## Contract impact

- No production code or public API changes.
- The fuzz target now exercises ownership/deduplication and rejects silent in-domain mismatches; observed unresolved coverage remains an allowed diagnostic boundary.
- No implicit clipping, fallback, provenance, Z, cancellation, or serial/parallel contract changes.

## Validation

- `cargo test -p geo-polygonize-core --test tiling_equivalence --quiet` — 5 passed.
- `cargo test -p geo-polygonize-core tiling --quiet` — 47 passed.
- `cargo check --manifest-path crates/geo-polygonize-core/fuzz/Cargo.toml --bin tile_ownership_dedup --locked` — passed.
- `cargo +nightly-2026-07-15 fuzz run tile_ownership_dedup -- -runs=1000` — completed with no failures.
- Full checkpoint passed: `cargo test --workspace --quiet`, `cargo test -p geo-polygonize-core --no-default-features --quiet`, `cargo clippy --workspace --all-targets -- -D warnings`, `RUSTDOCFLAGS='-D warnings' cargo doc -p geo-polygonize-core --no-deps`, `npm test`, and `npm run docs:build`.
- Docs-build generated bindings and `playground/package-lock.json` were restored.

## Agent handoff

- Exact parent: #1215.
- Exact children: none.
- Next branch: `agent/p3-coverage-probe-expansion`, unless a later probe produces a reproducible silent mismatch requiring a minimizer first.
- Keep this PR draft/readiness state unchanged; the user controls readiness.