### PR TITLE
test(core): expand tiled differential fixtures

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -770,6 +770,10 @@ boundary without adding an implicit clipping contract.
   - [x] Exercise bounded in-domain tiled-vs-untiled ownership and deduplication
     inputs in the scheduled fuzz target; a mismatch without observed coverage
     evidence fails the target rather than being silently accepted.
+  - [x] Exercise deterministic adversarial closed-face, hole, concavity, and
+    dirty-overlap families across shifted ownership origins, tile sizes, input
+    rotations, and reversals; an in-domain mismatch without observed evidence
+    fails the contract.
 - [x] Expand exact tiled/untiled fixtures for nested disconnected rings, long
   faces, narrow concavities, holes crossing boundaries, dangles, cut edges,
   overlaps, and dirty boundary intersections.

--- a/crates/geo-polygonize-core/tests/tiling_equivalence.rs
+++ b/crates/geo-polygonize-core/tests/tiling_equivalence.rs
@@ -179,6 +179,112 @@ fn in_domain_tiled_mismatches_have_observed_coverage_evidence() {
 }
 
 #[test]
+fn adversarial_in_domain_mismatches_keep_coverage_evidence_under_permutations() {
+    let mut concave = ring(&[
+        (3.0, 3.0),
+        (21.0, 3.0),
+        (21.0, 21.0),
+        (19.0, 21.0),
+        (19.0, 6.0),
+        (5.0, 6.0),
+        (5.0, 21.0),
+        (3.0, 21.0),
+    ]);
+    concave.push(line((1.0, 12.0), (23.0, 12.0)));
+
+    let mut boundary_crossing_hole = ring(&[(1.0, 1.0), (23.0, 1.0), (23.0, 23.0), (1.0, 23.0)]);
+    boundary_crossing_hole.extend(ring(&[(6.0, 6.0), (18.0, 6.0), (18.0, 18.0), (6.0, 18.0)]));
+
+    let mut dirty_overlap = ring(&[(3.0, 3.0), (21.0, 3.0), (21.0, 21.0), (3.0, 21.0)]);
+    dirty_overlap.extend([
+        line((1.0, 12.0), (23.0, 12.0)),
+        line((12.0, 1.0), (12.0, 23.0)),
+    ]);
+    dirty_overlap.extend(ring(&[
+        (12.0, 8.0),
+        (23.0, 8.0),
+        (23.0, 20.0),
+        (12.0, 20.0),
+    ]));
+
+    let cases = [
+        (
+            "shifted concavity",
+            concave,
+            Rect::new(Coord { x: -2.0, y: -1.0 }, Coord { x: 25.0, y: 24.0 }),
+        ),
+        (
+            "boundary-crossing hole",
+            boundary_crossing_hole,
+            Rect::new(Coord { x: -1.0, y: -2.0 }, Coord { x: 25.0, y: 26.0 }),
+        ),
+        ("dirty overlap", dirty_overlap, world(24.0)),
+    ];
+    let options = PolygonizerOptions {
+        node_input: true,
+        ..Default::default()
+    };
+
+    for (case_index, (name, lines, bbox)) in cases.into_iter().enumerate() {
+        let expected = polygonize(lines.iter().copied(), &options)
+            .unwrap_or_else(|error| panic!("{name} untiled: {error}"));
+        let base_geometries = lines
+            .iter()
+            .map(|line| {
+                Geometry::LineString(LineString::new(vec![
+                    line.start.to_coord_2d(),
+                    line.end.to_coord_2d(),
+                ]))
+            })
+            .collect::<Vec<_>>();
+
+        for (tile_index, tile_size) in [5.0, 7.0, 10.0].into_iter().enumerate() {
+            for buffer in [0.0, 1.0, 3.0] {
+                for permutation in 0..2 {
+                    let mut geometries = base_geometries.clone();
+                    let rotation = (case_index + tile_index + permutation) % geometries.len();
+                    geometries.rotate_left(rotation);
+                    if permutation == 1 {
+                        geometries.reverse();
+                    }
+
+                    let mut tiled = TiledPolygonizer::new(bbox, tile_size)
+                        .with_buffer(buffer)
+                        .with_options(options.clone())
+                        .with_ownership_policy(
+                            TileOwnershipPolicy::RepresentativePointInsidePolygon,
+                        )
+                        .with_dedup_policy(DedupPolicy::CanonicalRingHash);
+                    for geometry in &geometries {
+                        tiled.add_geometry(geometry);
+                    }
+                    let actual = tiled.polygonize().unwrap_or_else(|error| {
+                        panic!("{name}, tile size {tile_size}, buffer {buffer}: {error}")
+                    });
+                    let equivalent = actual.polygons.len() == expected.polygons.len()
+                        && actual.polygons.iter().zip(&expected.polygons).all(
+                            |(actual, expected)| {
+                                actual.exterior == expected.exterior
+                                    && actual.interiors == expected.interiors
+                            },
+                        );
+                    if !equivalent {
+                        assert!(
+                            actual.tile_reports.iter().any(|report| {
+                                !report.coverage_issues.is_empty()
+                                    || !report.input_boundary_issues.is_empty()
+                                    || !report.excluded_component_issues.is_empty()
+                            }),
+                            "undetected {name} mismatch for tile size {tile_size}, buffer {buffer}, permutation {permutation}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[test]
 fn tiled_report_matches_untiled_dangle_and_cut_edge_families() {
     let mut lines = ring(&[(0.0, 0.0), (10.0, 0.0), (10.0, 10.0), (0.0, 10.0)]);
     lines.push(line((10.0, 10.0), (15.0, 15.0)));


### PR DESCRIPTION
## Stack

- Parent: none (origin/main)
- Children: #1219 (agent/p3-tiled-multipart-differential)

## Delivered

- Added deterministic in-domain differential coverage for shifted ownership origins.
- Exercised concavity, boundary-crossing holes, and dirty overlap families across tile sizes, bounded buffers, input rotations, and reversals.
- Required every in-domain tiled/untiled mismatch to retain existing owned-face, input-boundary, or excluded-component evidence.
- Updated ROADMAP.md with the completed P3.1 evidence slice.

## Contract impact

No production behavior or public API changed. This strengthens the observational P3.1 contract; it does not certify arbitrary halo sufficiency, repair ownership-domain omissions, or provide graph stitching.

## Validation

- cargo fmt --all -- --check
- cargo test -p geo-polygonize-core --test tiling_equivalence --quiet
- cargo test -p geo-polygonize-core tiling --quiet

## Agent handoff

- Parent: none
- Children: #1219 (agent/p3-tiled-multipart-differential)
- Next branch: agent/p3-fallback-contract-matrix
- Keep the P3.1 broad missing-region umbrella open; continue only with evidence-backed slices.