### PR TITLE
test(core): fuzz tiled multipart geometries

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -774,6 +774,9 @@ boundary without adding an implicit clipping contract.
     dirty-overlap families across shifted ownership origins, tile sizes, input
     rotations, and reversals; an in-domain mismatch without observed evidence
     fails the contract.
+  - [x] Exercise the scheduled tiled differential probe with `MultiLineString`
+    containers as well as per-segment geometries; a topology mismatch without
+    observed evidence fails the target.
 - [x] Expand exact tiled/untiled fixtures for nested disconnected rings, long
   faces, narrow concavities, holes crossing boundaries, dangles, cut edges,
   overlaps, and dirty boundary intersections.

--- a/crates/geo-polygonize-core/fuzz/fuzz_targets/tile_ownership_dedup.rs
+++ b/crates/geo-polygonize-core/fuzz/fuzz_targets/tile_ownership_dedup.rs
@@ -1,7 +1,7 @@
 #![no_main]
 
 use arbitrary::Arbitrary;
-use geo::{Coord, Geometry, LineString, Rect};
+use geo::{Coord, Geometry, LineString, MultiLineString, Rect};
 use geo_polygonize_core::{
     polygonize, Coord3D, DedupPolicy, Line3D, Polygon3D, PolygonizerOptions,
     TileOwnershipPolicy, TiledPolygonizer,
@@ -14,6 +14,7 @@ struct FuzzInput {
     tile_size: u8,
     buffer: u8,
     reverse_input: bool,
+    group_lines: bool,
 }
 
 fn world() -> Rect<f64> {
@@ -71,15 +72,20 @@ fuzz_target!(|input: FuzzInput| {
         return;
     };
 
-    let geometries = lines
+    let parts = lines
         .iter()
         .map(|line| {
-            Geometry::LineString(LineString::new(vec![
+            LineString::new(vec![
                 line.start.to_coord_2d(),
                 line.end.to_coord_2d(),
-            ]))
+            ])
         })
         .collect::<Vec<_>>();
+    let geometries = if input.group_lines {
+        vec![Geometry::MultiLineString(MultiLineString::new(parts))]
+    } else {
+        parts.into_iter().map(Geometry::LineString).collect()
+    };
     let mut tiled = TiledPolygonizer::new(world(), 1.0 + f64::from(input.tile_size % 16))
         .with_buffer(f64::from(input.buffer % 17))
         .with_options(options)


### PR DESCRIPTION
## Stack

- Parent: #1218 (agent/p3-coverage-probe-expansion)
- Children: #1221 (agent/p3-fallback-contract-matrix)

## Delivered

- Extended the scheduled `tile_ownership_dedup` differential probe with a bounded `group_lines` mode.
- Exercises the same generated segments as one `MultiLineString` container and as individual `LineString` geometries.
- Keeps the existing exact tiled/untiled XY comparison and observed-evidence failure rule.
- Updated ROADMAP.md with the multipart-geometry evidence slice.

## Contract impact

No production behavior or public API changed. This broadens scheduled P3.1 evidence over an existing geometry-container input path; it does not certify arbitrary halo sufficiency or close the ownership-domain and graph-stitching boundaries.

## Validation

- cargo fmt --all -- --check
- cargo check --manifest-path crates/geo-polygonize-core/fuzz/Cargo.toml --bin tile_ownership_dedup --locked
- cargo test -p geo-polygonize-core --test tiling_equivalence --quiet
- cargo +nightly-2026-07-15 fuzz run tile_ownership_dedup -- -runs=1000 (completed with no failures)

## Agent handoff

- Parent: #1218 (agent/p3-coverage-probe-expansion)
- Children: #1221 (agent/p3-fallback-contract-matrix)
- Next branch: agent/p3-fallback-contract-matrix
- Keep the probe bounded and evidence-driven; do not turn multipart packaging into a new topology algorithm.