### PR TITLE
test(core): cover empty tiled fallback output

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -855,6 +855,9 @@ When coverage cannot be proven:
   - [x] Record enabled-but-declined component recovery in the stitching report
     and bounded `tile_component_fallback_declined` trace events with a
     deterministic reason.
+  - [x] Pin an envelope-closed recovery decline for empty polygonization output,
+    including report, trace, typed error, and global-fallback ordering; broader
+    declined-fallback coverage remains open.
   - [x] Expose the deterministic component-fallback decline reason directly in
     `StitchingReport` as well as the bounded trace event.
   - [x] Preserve that decline reason in typed `CoverageIncomplete` errors.

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -598,6 +598,85 @@ mod tests {
     }
 
     #[test]
+    fn declines_closed_boundary_fallback_for_empty_recovery_output() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 10.0 });
+        let degenerate_closed = Geometry::LineString(LineString::new(vec![
+            Coord { x: 1.0, y: 2.0 },
+            Coord { x: 19.0, y: 2.0 },
+            Coord { x: 1.0, y: 2.0 },
+            Coord { x: 1.0, y: 2.0 },
+        ]));
+        let mut tiled = TiledPolygonizer::new(bbox, 10.0)
+            .with_buffer(0.0)
+            .with_component_fallback();
+        tiled.add_geometry(&degenerate_closed);
+
+        let result = tiled.polygonize().unwrap();
+        assert!(result.polygons.is_empty());
+        assert!(result.stitching_report.component_fallback_attempted);
+        assert!(!result.stitching_report.component_fallback_used);
+        assert_eq!(
+            result.stitching_report.component_fallback_decline_reason,
+            Some("empty_recovery_output")
+        );
+
+        let traced = tiled
+            .polygonize_with_trace(TraceLevelV1::Full, usize::MAX)
+            .unwrap();
+        let declined = traced
+            .trace
+            .events
+            .iter()
+            .find(|event| event.kind == "tile_component_fallback_declined")
+            .unwrap();
+        assert_eq!(declined.payload["reason"], "empty_recovery_output");
+        assert_eq!(
+            declined.payload["unresolved_input_geometry_count"],
+            result.stitching_report.unresolved_input_geometry_count
+        );
+        assert!(matches!(
+            tiled.polygonize_with_coverage_guarantee(
+                TileCoverageGuarantee::ValidateObservedCoverage
+            ),
+            Err(TiledPolygonizeError::CoverageIncomplete {
+                component_fallback_decline_reason: Some("empty_recovery_output"),
+                ..
+            })
+        ));
+
+        let mut globally_fallback = TiledPolygonizer::new(bbox, 10.0)
+            .with_buffer(0.0)
+            .with_component_fallback()
+            .with_untiled_fallback();
+        globally_fallback.add_geometry(&degenerate_closed);
+        let result = globally_fallback.polygonize().unwrap();
+        assert!(result.polygons.is_empty());
+        assert!(result.stitching_report.untiled_fallback_used);
+        assert_eq!(
+            result.stitching_report.component_fallback_decline_reason,
+            Some("empty_recovery_output")
+        );
+        let traced = globally_fallback
+            .polygonize_with_trace(TraceLevelV1::Full, usize::MAX)
+            .unwrap();
+        let recovery_events = traced
+            .trace
+            .events
+            .iter()
+            .filter_map(|event| match event.kind.as_str() {
+                "tile_component_fallback_declined" | "tile_untiled_fallback" => {
+                    Some(event.kind.as_str())
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            recovery_events,
+            vec!["tile_component_fallback_declined", "tile_untiled_fallback"]
+        );
+    }
+
+    #[test]
     fn reports_boundary_inputs_when_no_local_face_is_reconstructed() {
         let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 10.0 });
         let boundaries = [


### PR DESCRIPTION
## Stack

- Parent: #1219 (agent/p3-tiled-multipart-differential)
- Children: none

## Delivered

- Added a reachable degenerate closed-boundary recovery fixture whose region polygonizes to no output.
- Verifies `empty_recovery_output` is preserved in `StitchingReport`, the bounded topology trace, and typed `CoverageIncomplete`.
- Verifies the containment-safe global fallback follows the decline event in deterministic order.
- Updated ROADMAP.md with this P3.2 declined-fallback evidence slice.

## Contract impact

No production behavior or public API changed. This closes one previously unpinned decline path; it does not make an empty recovery safe to append, and broader region-local reconciliation and true graph stitching remain open.

## Validation

- cargo fmt --all -- --check
- cargo test -p geo-polygonize-core declines_closed_boundary_fallback_for_empty_recovery_output --quiet
- cargo test -p geo-polygonize-core tiling --quiet (48 passed)
- cargo test -p geo-polygonize-core --test tiling_equivalence --quiet (6 passed)

## Agent handoff

- Parent: #1219 (agent/p3-tiled-multipart-differential)
- Children: none
- Next branch: agent/p3-coverage-cancellation-checkpoint
- Preserve decline-before-global-fallback ordering and keep the P3.2 umbrella open for non-envelope-closed topology.