### PR TITLE
feat(core): report unowned tiled faces

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -712,7 +712,11 @@ single-geometry boundaries decline conservatively, so broad missing-region
 coverage detection remains observational. A single closed geometry whose
 envelope only grazes the ownership domain can also remain absent when its
 ownership point falls outside every tile; this pins the remaining envelope-only
-boundary without adding an implicit clipping contract.
+boundary without adding an implicit clipping contract. Reconstructed faces
+whose ownership points fall outside the configured domain are now reported as
+definite ownership-domain evidence when their envelopes overlap that domain;
+BestEffort remains domain-scoped, while strict observed validation and the
+opt-in whole-input fallback handle the evidence explicitly.
 
 - [ ] Detect owned faces or connected regions that touch an unresolved halo or
   partition boundary.
@@ -748,6 +752,9 @@ boundary without adding an implicit clipping contract.
   - [x] Pin the single-geometry envelope-only gap where an untiled face's
     ownership point falls outside the configured ownership domain; broad
     missing-region detection remains open.
+  - [x] Report reconstructed faces that overlap the ownership domain but have
+    no tile-owned ownership point; this remains evidence rather than implicit
+    clipping.
   - [x] Pin that caller-enabled whole-input fallback cannot repair the same
     single-geometry ownership-domain gap without observed evidence; no implicit
     clipping is introduced.

--- a/crates/geo-polygonize-core/src/lib.rs
+++ b/crates/geo-polygonize-core/src/lib.rs
@@ -66,8 +66,8 @@ pub use polygonizer::{
 #[doc(hidden)]
 pub use tiling::{
     StitchingReport, TileBoundarySide, TileComponentConnection, TileCoverageGuarantee,
-    TileCoverageIssue, TileExcludedComponentIssue, TileInputBoundaryIssue, TileReport,
-    TileRetryAttempt, TileRetryPolicy, TiledPolygonizeError, TiledPolygonizeResult,
-    TiledPolygonizer, TracedTiledPolygonizeResultV1,
+    TileCoverageIssue, TileExcludedComponentIssue, TileInputBoundaryIssue,
+    TileOwnershipDomainIssue, TileReport, TileRetryAttempt, TileRetryPolicy, TiledPolygonizeError,
+    TiledPolygonizeResult, TiledPolygonizer, TracedTiledPolygonizeResultV1,
 };
 pub use types::{Coord3D, Line3D, Polygon3D, PolygonProvenance};

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -63,6 +63,19 @@ pub struct TileCoverageIssue {
     pub aggregate_source_line_ids_complete: bool,
 }
 
+/// A reconstructed face whose selected ownership point falls outside the
+/// configured ownership domain while its envelope overlaps that domain.
+///
+/// This is definite evidence that the face cannot be owned by any generated
+/// tile. It does not clip the face or infer how an application wants to handle
+/// input outside the ownership domain.
+#[derive(Clone, Debug)]
+pub struct TileOwnershipDomainIssue {
+    pub polygon_index: usize,
+    pub polygon_bbox: Rect<f64>,
+    pub ownership_point: Coord3D,
+}
+
 /// Input geometry that reaches an internal buffered-tile boundary.
 ///
 /// This is conservative evidence that topology may continue through linework
@@ -111,6 +124,7 @@ pub struct TileRetryAttempt {
     pub unresolved_owned_polygon_count: usize,
     pub unresolved_input_geometry_count: usize,
     pub unresolved_component_count: usize,
+    pub unresolved_ownership_domain_count: usize,
     pub resolved: bool,
 }
 
@@ -128,6 +142,8 @@ pub struct TileReport {
     pub invalid_ring_count: usize,
     /// Definite halo insufficiency observed for owned faces in this tile.
     pub coverage_issues: Vec<TileCoverageIssue>,
+    /// Reconstructed faces that cannot be owned by any tile in the domain.
+    pub ownership_domain_issues: Vec<TileOwnershipDomainIssue>,
     /// Inputs that may connect to linework beyond this tile's halo.
     pub input_boundary_issues: Vec<TileInputBoundaryIssue>,
     /// Transformed-connected components not fully observed in this tile's halo.
@@ -158,6 +174,8 @@ pub struct StitchingReport {
     pub component_fallback_decline_reason: Option<&'static str>,
     pub unresolved_tile_count: usize,
     pub unresolved_owned_polygon_count: usize,
+    pub unresolved_ownership_domain_tile_count: usize,
+    pub unresolved_ownership_domain_count: usize,
     pub unresolved_input_tile_count: usize,
     /// Input-boundary issue instances across tiles; a geometry may occur more than once.
     pub unresolved_input_geometry_count: usize,
@@ -208,11 +226,13 @@ pub enum TiledPolygonizeError {
     #[error(transparent)]
     Polygonize(#[from] PolygonizeError),
     #[error(
-        "tiled coverage validation failed for {unresolved_owned_polygon_count} owned polygons, {unresolved_input_geometry_count} input boundary instances, and {unresolved_component_count} excluded linework-component instances"
+        "tiled coverage validation failed for {unresolved_owned_polygon_count} owned polygons, {unresolved_ownership_domain_count} ownership-domain faces, {unresolved_input_geometry_count} input boundary instances, and {unresolved_component_count} excluded linework-component instances"
     )]
     CoverageIncomplete {
         unresolved_tile_count: usize,
         unresolved_owned_polygon_count: usize,
+        unresolved_ownership_domain_tile_count: usize,
+        unresolved_ownership_domain_count: usize,
         unresolved_input_tile_count: usize,
         unresolved_input_geometry_count: usize,
         unresolved_component_tile_count: usize,
@@ -621,6 +641,7 @@ impl<'a> TiledPolygonizer<'a> {
             cut_edge_count: 0,
             invalid_ring_count: 0,
             coverage_issues: Vec::new(),
+            ownership_domain_issues: Vec::new(),
             input_boundary_issues,
             excluded_component_issues,
             retry_attempts: Vec::new(),
@@ -662,6 +683,29 @@ impl<'a> TiledPolygonizer<'a> {
                 };
                 in_x && in_y
             });
+            if !owned {
+                if let Some(ownership_point) = ownership_point {
+                    if let Some(polygon_bbox) = Self::polygon_bbox(&poly) {
+                        let point_in_domain = ownership_point.x() >= self.bbox.min().x
+                            && ownership_point.x() <= self.bbox.max().x
+                            && ownership_point.y() >= self.bbox.min().y
+                            && ownership_point.y() <= self.bbox.max().y;
+                        if !point_in_domain && polygon_bbox.intersects(&self.bbox) {
+                            report
+                                .ownership_domain_issues
+                                .push(TileOwnershipDomainIssue {
+                                    polygon_index,
+                                    polygon_bbox,
+                                    ownership_point: Coord3D::new(
+                                        ownership_point.x(),
+                                        ownership_point.y(),
+                                        0.0,
+                                    ),
+                                });
+                        }
+                    }
+                }
+            }
             if let Some(budget) = capture_budget.as_mut() {
                 budget.capture(
                     &mut ownership_decisions,
@@ -689,6 +733,13 @@ impl<'a> TiledPolygonizer<'a> {
     }
 
     fn report_is_unresolved(report: &TileReport) -> bool {
+        !report.coverage_issues.is_empty()
+            || !report.ownership_domain_issues.is_empty()
+            || !report.input_boundary_issues.is_empty()
+            || !report.excluded_component_issues.is_empty()
+    }
+
+    fn report_has_retry_evidence(report: &TileReport) -> bool {
         !report.coverage_issues.is_empty()
             || !report.input_boundary_issues.is_empty()
             || !report.excluded_component_issues.is_empty()
@@ -1100,7 +1151,7 @@ impl<'a> TiledPolygonizer<'a> {
         let mut retry_attempts = Vec::new();
         let mut capture_truncated = result.3;
         for attempt in 1..=policy.max_attempts {
-            if !Self::report_is_unresolved(&result.1) || buffer >= policy.max_buffer {
+            if !Self::report_has_retry_evidence(&result.1) || buffer >= policy.max_buffer {
                 break;
             }
             buffer = (buffer + policy.buffer_increment).min(policy.max_buffer);
@@ -1113,10 +1164,11 @@ impl<'a> TiledPolygonizer<'a> {
                 unresolved_owned_polygon_count: result.1.coverage_issues.len(),
                 unresolved_input_geometry_count: result.1.input_boundary_issues.len(),
                 unresolved_component_count: result.1.excluded_component_issues.len(),
+                unresolved_ownership_domain_count: result.1.ownership_domain_issues.len(),
                 resolved,
             });
         }
-        result.1.retry_exhausted = Self::report_is_unresolved(&result.1);
+        result.1.retry_exhausted = Self::report_has_retry_evidence(&result.1);
         result.1.retry_attempts = retry_attempts;
         result.3 = capture_truncated;
         Ok(result)
@@ -1488,6 +1540,7 @@ impl<'a> TiledPolygonizer<'a> {
                 !result.stitching_report.untiled_fallback_used
                     && !result.stitching_report.component_fallback_used
                     && (result.stitching_report.unresolved_owned_polygon_count != 0
+                        || result.stitching_report.unresolved_ownership_domain_count != 0
                         || result.stitching_report.unresolved_input_geometry_count != 0
                         || result.stitching_report.unresolved_component_count != 0)
             }
@@ -1498,6 +1551,12 @@ impl<'a> TiledPolygonizer<'a> {
                 unresolved_owned_polygon_count: result
                     .stitching_report
                     .unresolved_owned_polygon_count,
+                unresolved_ownership_domain_tile_count: result
+                    .stitching_report
+                    .unresolved_ownership_domain_tile_count,
+                unresolved_ownership_domain_count: result
+                    .stitching_report
+                    .unresolved_ownership_domain_count,
                 unresolved_input_tile_count: result.stitching_report.unresolved_input_tile_count,
                 unresolved_input_geometry_count: result
                     .stitching_report
@@ -1602,6 +1661,11 @@ impl<'a> TiledPolygonizer<'a> {
                 }
                 for issue in &report.coverage_issues {
                     if !trace.record_tile_owned_face_boundary(tile_index, issue)? {
+                        break;
+                    }
+                }
+                for issue in &report.ownership_domain_issues {
+                    if !trace.record_tile_ownership_domain(tile_index, issue)? {
                         break;
                     }
                 }
@@ -1746,6 +1810,14 @@ impl<'a> TiledPolygonizer<'a> {
             .iter()
             .map(|report| report.coverage_issues.len())
             .sum();
+        let unresolved_ownership_domain_tile_count = tile_reports
+            .iter()
+            .filter(|report| !report.ownership_domain_issues.is_empty())
+            .count();
+        let unresolved_ownership_domain_count =
+            tile_reports.iter().fold(0usize, |total, report| {
+                total.saturating_add(report.ownership_domain_issues.len())
+            });
         let unresolved_input_tile_count = tile_reports
             .iter()
             .filter(|report| !report.input_boundary_issues.is_empty())
@@ -1786,6 +1858,8 @@ impl<'a> TiledPolygonizer<'a> {
                 component_fallback_decline_reason,
                 unresolved_tile_count,
                 unresolved_owned_polygon_count,
+                unresolved_ownership_domain_tile_count,
+                unresolved_ownership_domain_count,
                 unresolved_input_tile_count,
                 unresolved_input_geometry_count,
                 unresolved_component_tile_count,
@@ -1801,6 +1875,7 @@ impl<'a> TiledPolygonizer<'a> {
             if let Some(trace) = trace.as_deref_mut() {
                 trace.record_tile_component_fallback_declined(
                     result.stitching_report.unresolved_owned_polygon_count,
+                    result.stitching_report.unresolved_ownership_domain_count,
                     result.stitching_report.unresolved_input_geometry_count,
                     result.stitching_report.unresolved_component_count,
                     reason,
@@ -1826,6 +1901,7 @@ impl<'a> TiledPolygonizer<'a> {
                     self.geometries.len(),
                     result.stitching_report.output_polygon_count,
                     result.stitching_report.unresolved_owned_polygon_count,
+                    result.stitching_report.unresolved_ownership_domain_count,
                     result.stitching_report.unresolved_input_geometry_count,
                     result.stitching_report.unresolved_component_count,
                 );

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -1317,6 +1317,7 @@ mod tests {
                 aggregate_source_line_ids: vec![],
                 aggregate_source_line_ids_complete: false,
             }],
+            ownership_domain_issues: vec![],
             input_boundary_issues: vec![],
             excluded_component_issues: vec![TileExcludedComponentIssue {
                 input_geometry_indices: vec![0, 1],
@@ -1363,6 +1364,7 @@ mod tests {
             cut_edge_count: 0,
             invalid_ring_count: 0,
             coverage_issues: Vec::new(),
+            ownership_domain_issues: Vec::new(),
             input_boundary_issues: Vec::new(),
             excluded_component_issues: vec![TileExcludedComponentIssue {
                 input_geometry_indices: component_indices.clone(),
@@ -1415,6 +1417,7 @@ mod tests {
             cut_edge_count: 0,
             invalid_ring_count: 0,
             coverage_issues: Vec::new(),
+            ownership_domain_issues: Vec::new(),
             input_boundary_issues: Vec::new(),
             excluded_component_issues: vec![TileExcludedComponentIssue {
                 input_geometry_indices: component_indices.clone(),
@@ -2989,8 +2992,10 @@ fn canonical_dedup_key_compares_exact_geometry() {
 }
 
 #[test]
-fn documents_single_geometry_region_excluded_from_every_halo() {
-    use crate::{Polygonizer, TiledPolygonizer};
+fn reports_single_geometry_face_outside_ownership_domain() {
+    use crate::{
+        Polygonizer, TileCoverageGuarantee, TileRetryPolicy, TiledPolygonizeError, TiledPolygonizer,
+    };
     use geo::{Coord, Geometry, LineString, Rect};
 
     let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 32.0, y: 32.0 });
@@ -3006,7 +3011,8 @@ fn documents_single_geometry_region_excluded_from_every_halo() {
     let mut tiled = TiledPolygonizer::new(bbox, 16.0).with_buffer(0.0);
     tiled.add_geometry(&boundary);
 
-    assert_eq!(untiled.polygonize().unwrap().polygons.len(), 1);
+    let expected = untiled.polygonize().unwrap();
+    assert_eq!(expected.polygons.len(), 1);
     assert!(tiled.input_components().unwrap().is_empty());
     let observed = tiled.polygonize().unwrap();
     assert!(observed.polygons.is_empty());
@@ -3019,29 +3025,89 @@ fn documents_single_geometry_region_excluded_from_every_halo() {
             && report.input_boundary_issues.is_empty()
             && report.excluded_component_issues.is_empty()
     }));
+    let ownership_domain_issues = observed
+        .tile_reports
+        .iter()
+        .flat_map(|report| &report.ownership_domain_issues)
+        .collect::<Vec<_>>();
+    assert_eq!(ownership_domain_issues.len(), 1);
+    assert_eq!(
+        ownership_domain_issues[0].ownership_point,
+        crate::Coord3D::new(35.0, 29.0, 0.0)
+    );
     assert_eq!(observed.stitching_report.unresolved_input_geometry_count, 0);
     assert_eq!(observed.stitching_report.unresolved_component_count, 0);
-    assert!(tiled
-        .polygonize_with_coverage_guarantee(crate::TileCoverageGuarantee::ValidateObservedCoverage)
-        .is_ok());
+    assert_eq!(
+        observed
+            .stitching_report
+            .unresolved_ownership_domain_tile_count,
+        1
+    );
+    assert_eq!(
+        observed.stitching_report.unresolved_ownership_domain_count,
+        1
+    );
+    assert_eq!(observed.stitching_report.retry_attempt_count, 0);
+    assert!(matches!(
+        tiled.polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateObservedCoverage),
+        Err(TiledPolygonizeError::CoverageIncomplete {
+            unresolved_tile_count: 0,
+            unresolved_ownership_domain_tile_count: 1,
+            unresolved_ownership_domain_count: 1,
+            unresolved_input_geometry_count: 0,
+            unresolved_component_count: 0,
+            ..
+        })
+    ));
 
     let mut fallback = TiledPolygonizer::new(bbox, 16.0)
         .with_buffer(0.0)
+        .with_retry_policy(TileRetryPolicy {
+            max_attempts: 3,
+            buffer_increment: 4.0,
+            max_buffer: 12.0,
+        })
         .with_untiled_fallback();
     fallback.add_geometry(&boundary);
     let fallback_result = fallback
         .polygonize_with_coverage_guarantee(crate::TileCoverageGuarantee::ValidateObservedCoverage)
         .unwrap();
-    assert!(fallback_result.polygons.is_empty());
-    assert!(!fallback_result.stitching_report.untiled_fallback_used);
+    assert_eq!(
+        fallback_result
+            .polygons
+            .iter()
+            .map(crate::tiling::canonical_polygon_key)
+            .collect::<Vec<_>>(),
+        expected
+            .polygons
+            .iter()
+            .map(crate::tiling::canonical_polygon_key)
+            .collect::<Vec<_>>()
+    );
+    assert!(fallback_result.stitching_report.untiled_fallback_used);
+    assert_eq!(fallback_result.stitching_report.retry_attempt_count, 0);
     let traced = fallback
         .polygonize_with_trace(crate::trace::TraceLevelV1::Full, usize::MAX)
         .unwrap();
-    assert!(!traced
+    assert_eq!(
+        traced
+            .trace
+            .events
+            .iter()
+            .filter(|event| event.kind == "tile_ownership_domain")
+            .count(),
+        1
+    );
+    let fallback_event = traced
         .trace
         .events
         .iter()
-        .any(|event| event.kind == "tile_untiled_fallback"));
+        .find(|event| event.kind == "tile_untiled_fallback")
+        .expect("ownership-domain evidence triggers global fallback");
+    assert_eq!(
+        fallback_event.payload["unresolved_ownership_domain_count"],
+        1
+    );
 }
 
 #[test]

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -289,6 +289,15 @@ pub struct TileInputBoundaryTraceV1 {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct TileOwnershipDomainTraceV1 {
+    pub tile_index: usize,
+    pub polygon_index: usize,
+    pub polygon_min: CoordinateFingerprintV1,
+    pub polygon_max: CoordinateFingerprintV1,
+    pub ownership_point: CoordinateFingerprintV1,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct TileExcludedEndpointComponentTraceV1 {
     pub tile_index: usize,
     pub input_geometry_indices: Vec<usize>,
@@ -328,6 +337,7 @@ pub struct TileHaloRetryTraceV1 {
     pub unresolved_owned_polygon_count: usize,
     pub unresolved_input_geometry_count: usize,
     pub unresolved_component_count: usize,
+    pub unresolved_ownership_domain_count: usize,
     pub resolved: bool,
 }
 
@@ -336,6 +346,7 @@ pub struct TileUntiledFallbackTraceV1 {
     pub input_geometry_count: usize,
     pub output_polygon_count: usize,
     pub unresolved_owned_polygon_count: usize,
+    pub unresolved_ownership_domain_count: usize,
     pub unresolved_input_geometry_count: usize,
     pub unresolved_component_count: usize,
 }
@@ -353,6 +364,7 @@ pub struct TileComponentFallbackTraceV1 {
 pub struct TileComponentFallbackDeclinedTraceV1 {
     pub reason: String,
     pub unresolved_owned_polygon_count: usize,
+    pub unresolved_ownership_domain_count: usize,
     pub unresolved_input_geometry_count: usize,
     pub unresolved_component_count: usize,
 }
@@ -1137,6 +1149,27 @@ impl TraceRecorderV1 {
         ))
     }
 
+    pub(crate) fn record_tile_ownership_domain(
+        &mut self,
+        tile_index: usize,
+        issue: &crate::tiling::TileOwnershipDomainIssue,
+    ) -> crate::Result<bool> {
+        let min = issue.polygon_bbox.min();
+        let max = issue.polygon_bbox.max();
+        Ok(self.record(
+            TraceStageV1::Output,
+            "tile_ownership_domain",
+            serde_json::to_value(TileOwnershipDomainTraceV1 {
+                tile_index,
+                polygon_index: issue.polygon_index,
+                polygon_min: coordinate_fingerprint(crate::Coord3D::new(min.x, min.y, 0.0))?,
+                polygon_max: coordinate_fingerprint(crate::Coord3D::new(max.x, max.y, 0.0))?,
+                ownership_point: coordinate_fingerprint(issue.ownership_point)?,
+            })
+            .expect("tile ownership-domain trace event serializes"),
+        ))
+    }
+
     pub(crate) fn record_tile_owned_face_boundary(
         &mut self,
         tile_index: usize,
@@ -1263,6 +1296,7 @@ impl TraceRecorderV1 {
                 unresolved_owned_polygon_count: attempt.unresolved_owned_polygon_count,
                 unresolved_input_geometry_count: attempt.unresolved_input_geometry_count,
                 unresolved_component_count: attempt.unresolved_component_count,
+                unresolved_ownership_domain_count: attempt.unresolved_ownership_domain_count,
                 resolved: attempt.resolved,
             })
             .expect("tile halo-retry trace event serializes"),
@@ -1274,6 +1308,7 @@ impl TraceRecorderV1 {
         input_geometry_count: usize,
         output_polygon_count: usize,
         unresolved_owned_polygon_count: usize,
+        unresolved_ownership_domain_count: usize,
         unresolved_input_geometry_count: usize,
         unresolved_component_count: usize,
     ) -> bool {
@@ -1284,6 +1319,7 @@ impl TraceRecorderV1 {
                 input_geometry_count,
                 output_polygon_count,
                 unresolved_owned_polygon_count,
+                unresolved_ownership_domain_count,
                 unresolved_input_geometry_count,
                 unresolved_component_count,
             })
@@ -1316,6 +1352,7 @@ impl TraceRecorderV1 {
     pub(crate) fn record_tile_component_fallback_declined(
         &mut self,
         unresolved_owned_polygon_count: usize,
+        unresolved_ownership_domain_count: usize,
         unresolved_input_geometry_count: usize,
         unresolved_component_count: usize,
         reason: &str,
@@ -1326,6 +1363,7 @@ impl TraceRecorderV1 {
             serde_json::to_value(TileComponentFallbackDeclinedTraceV1 {
                 reason: reason.to_string(),
                 unresolved_owned_polygon_count,
+                unresolved_ownership_domain_count,
                 unresolved_input_geometry_count,
                 unresolved_component_count,
             })

--- a/docs/guide/tiling.md
+++ b/docs/guide/tiling.md
@@ -32,15 +32,24 @@ affected tiles and faces. Absence of this definite witness does not certify
 coverage because missing external linework may leave no reconstructed face to
 inspect.
 
+`TileReport::ownership_domain_issues` reports a reconstructed face whose
+selected ownership point falls outside the configured ownership bounding box
+while the face envelope overlaps that box. No generated tile can own that
+face. This is evidence only: tiled BestEffort output remains domain-scoped and
+does not clip or append the face implicitly. `ValidateObservedCoverage`
+rejects the evidence, while `with_untiled_fallback` can opt into the existing
+whole-input result, which preserves the complete untiled face.
+
 `TileReport::input_boundary_issues` also records the stable input geometry index,
 envelope, and internal halo sides for each included geometry whose envelope
 reaches beyond that halo. This conservative witness remains available when no
 local face is reconstructed, so it catches split-boundary cases that face-only
 evidence cannot see. It reports unresolved connectivity, not a confirmed missing
 face: whole input geometries are replicated and may already contain everything
-needed locally. Full output traces record both evidence families as bounded
-`tile_input_boundary` and `tile_owned_face_boundary` events without rescanning
-inputs or reconstructed faces.
+needed locally. Full output traces record the three evidence families as
+bounded `tile_input_boundary`, `tile_owned_face_boundary`, and
+`tile_ownership_domain` events without rescanning inputs or reconstructed
+faces.
 
 `TileReport::excluded_component_issues` covers one additional missing-input
 case. Separate input geometries that share exact endpoints are grouped. When
@@ -96,7 +105,8 @@ returned to the caller.
 - `ValidateOwnedFaces` returns `TiledPolygonizeError::CoverageIncomplete` instead
   of polygons when a reconstructed owned face reaches an internal halo boundary.
 - `ValidateObservedCoverage` returns that typed error when owned-face,
-  conservative input-boundary, or excluded component evidence is present.
+  ownership-domain, conservative input-boundary, or excluded component
+  evidence is present.
 
 Both validation modes are deliberately narrower than coverage certification.
 `with_execution_policy` applies segment, candidate, exact-predicate, and
@@ -114,6 +124,8 @@ evidence. Each attempt adds `buffer_increment` up to `max_attempts` and
 `max_buffer`, replaces that tile's earlier polygons and report, and records the
 attempt in `TileReport` and `StitchingReport`. Strict validation returns the
 typed coverage error with retry counts when the bounded schedule is exhausted.
+Ownership-domain evidence is not retried because increasing a halo cannot move
+an ownership point into the configured domain.
 Retries reuse the same execution policy independently per attempt. Full output
 traces record bounded `tile_halo_retry` events directly from the physical retry
 history. `with_component_fallback` enables conservative recovery for excluded
@@ -132,14 +144,15 @@ input-boundary evidence, every owned-face witness must intersect an
 envelope-closed recovery region; a witness outside those regions declines
 component recovery rather than replacing unrelated retained output.
 `with_untiled_fallback` remains the containment-safe escape hatch for observed
-cases that decline region-local recovery. General boundary-graph stitching
-remains unavailable. When enabled for unresolved output, a declined component
-recovery is marked in `StitchingReport` and recorded as a bounded
+cases that decline region-local recovery, including a reconstructed face that
+cannot be owned by any tile. General boundary-graph stitching remains
+unavailable. When enabled for unresolved output, a declined component recovery
+is marked in `StitchingReport` and recorded as a bounded
 `tile_component_fallback_declined` trace event before the
 `tile_untiled_fallback` event. The whole-input fallback only runs when tile
 reports contain observed unresolved evidence. It cannot detect an unowned
-single-geometry face whose representative ownership point falls outside the
-configured ownership domain, and it never clips that input implicitly.
+single-geometry face whose envelope never overlaps the configured ownership
+domain, and it never clips that input implicitly.
 Component fallback checks the execution policy before region selection and
 before each recovery region, so cancellation does not get lost between tile
 processing and the bounded region polygonizer. The same policy is checked while


### PR DESCRIPTION
## Stack

Parent: none (root from `origin/main` at `b2d8ee0c2a8ad5436a5fe160d6a962c0b8dc9223`).
Children: #1223 `test(core): matrix tiled ownership-domain evidence` (`agent/p3-ownership-domain-matrix`).

## Delivered

- Add conservative `TileOwnershipDomainIssue` evidence when a reconstructed face overlaps the configured ownership domain but its selected ownership point is outside every tile.
- Include ownership-domain evidence in `StitchingReport`, strict `ValidateObservedCoverage`, typed errors, bounded retry/fallback trace payloads, and a dedicated `tile_ownership_domain` event.
- Keep BestEffort output domain-scoped; enable the existing opt-in whole-input fallback to repair the observed case with exact untiled output.
- Update the tiling guide, roadmap contract, and regression coverage.

## Contract impact

- BestEffort geometry remains unchanged for the ownership-domain case.
- `ValidateObservedCoverage` now rejects observed ownership-domain gaps unless component or whole-input fallback supplies the result.
- Ownership-domain evidence is not halo-retried because buffer growth cannot move the ownership point into the domain.
- No implicit clipping or boundary-graph stitching is introduced.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p geo-polygonize-core reports_single_geometry_face_outside_ownership_domain --quiet`
- `cargo test -p geo-polygonize-core tiling --quiet` (48 passed)
- `cargo test -p geo-polygonize-core --quiet` (248 core unit tests plus integration suites passed)
- `git diff --check`

## Agent handoff

Parent: none.
Children: #1223.
Next branch after this stack: continue the broad P3.1 undetected connected-region search; do not claim P3.2 non-envelope region-local reconciliation or start P3.3 graph stitching.