### PR TITLE
test(core): fuzz ownership-domain gaps

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -784,6 +784,9 @@ opt-in whole-input fallback handle the evidence explicitly.
   - [x] Exercise the scheduled tiled differential probe with `MultiLineString`
     containers as well as per-segment geometries; a topology mismatch without
     observed evidence fails the target.
+  - [x] Exercise bounded ownership-domain-overlap cases in the tiled
+    differential target; ownership-domain evidence is accepted only when every
+    expected face still overlaps the configured domain.
 - [x] Expand exact tiled/untiled fixtures for nested disconnected rings, long
   faces, narrow concavities, holes crossing boundaries, dangles, cut edges,
   overlaps, and dirty boundary intersections.

--- a/crates/geo-polygonize-core/fuzz/fuzz_targets/tile_ownership_dedup.rs
+++ b/crates/geo-polygonize-core/fuzz/fuzz_targets/tile_ownership_dedup.rs
@@ -15,6 +15,7 @@ struct FuzzInput {
     buffer: u8,
     reverse_input: bool,
     group_lines: bool,
+    ownership_domain_gap: bool,
 }
 
 fn world() -> Rect<f64> {
@@ -24,8 +25,8 @@ fn world() -> Rect<f64> {
     )
 }
 
-fn bounded_coordinate(value: i8) -> f64 {
-    f64::from(value.clamp(-24, 24))
+fn bounded_coordinate(value: i8, x_offset: f64) -> f64 {
+    f64::from(value.clamp(-24, 24)) + x_offset
 }
 
 fn same_polygons(left: &[Polygon3D], right: &[Polygon3D]) -> bool {
@@ -40,7 +41,27 @@ fn has_coverage_evidence(result: &geo_polygonize_core::TiledPolygonizeResult) ->
         !report.coverage_issues.is_empty()
             || !report.input_boundary_issues.is_empty()
             || !report.excluded_component_issues.is_empty()
+            || !report.ownership_domain_issues.is_empty()
     })
+}
+
+fn polygon_overlaps_world(polygon: &Polygon3D) -> bool {
+    let Some(first) = polygon.exterior.first() else {
+        return false;
+    };
+    let (mut min_x, mut min_y, mut max_x, mut max_y) =
+        (first.x, first.y, first.x, first.y);
+    for coordinate in &polygon.exterior[1..] {
+        min_x = min_x.min(coordinate.x);
+        min_y = min_y.min(coordinate.y);
+        max_x = max_x.max(coordinate.x);
+        max_y = max_y.max(coordinate.y);
+    }
+    let bounds = world();
+    min_x <= bounds.max().x
+        && max_x >= bounds.min().x
+        && min_y <= bounds.max().y
+        && max_y >= bounds.min().y
 }
 
 fuzz_target!(|input: FuzzInput| {
@@ -48,14 +69,23 @@ fuzz_target!(|input: FuzzInput| {
         return;
     }
 
+    let x_offset = if input.ownership_domain_gap { 24.0 } else { 0.0 };
     let mut lines = input
         .lines
         .into_iter()
         .enumerate()
         .map(|(line_id, (sx, sy, ex, ey))| {
             Line3D::new(
-                Coord3D::new(bounded_coordinate(sx), bounded_coordinate(sy), 0.0),
-                Coord3D::new(bounded_coordinate(ex), bounded_coordinate(ey), 0.0),
+                Coord3D::new(
+                    bounded_coordinate(sx, x_offset),
+                    bounded_coordinate(sy, 0.0),
+                    0.0,
+                ),
+                Coord3D::new(
+                    bounded_coordinate(ex, x_offset),
+                    bounded_coordinate(ey, 0.0),
+                    0.0,
+                ),
                 u32::try_from(line_id).unwrap(),
             )
         })
@@ -71,6 +101,15 @@ fuzz_target!(|input: FuzzInput| {
     let Ok(expected) = polygonize(lines.iter().copied(), &options) else {
         return;
     };
+    if input.ownership_domain_gap
+        && !expected.polygons.is_empty()
+        && expected
+            .polygons
+            .iter()
+            .any(|polygon| !polygon_overlaps_world(polygon))
+    {
+        return;
+    }
 
     let parts = lines
         .iter()


### PR DESCRIPTION
## Stack

Parent: #1223 `test(core): matrix tiled ownership-domain evidence` (`agent/p3-ownership-domain-matrix`).
Children: #1226 `test(core): guard ownership-domain fallback decline` (`agent/p3-ownership-domain-fallback-decline`).

## Delivered

- Extend the scheduled `tile_ownership_dedup` differential target with a bounded ownership-domain-gap input dimension.
- Shift generated X coordinates into a controlled overlap band and skip only expected faces wholly outside the ownership domain.
- Treat `TileReport::ownership_domain_issues` as valid conservative evidence when the tiled result differs from untiled output.
- Record the fuzz contract precisely in `ROADMAP.md`.

## Contract impact

- Randomized tiled-vs-untiled checks now cover ownership-domain evidence without weakening the in-domain mismatch assertion.
- No production behavior or public API changes beyond parent #1222.
- No generated corpus is checked in.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --manifest-path crates/geo-polygonize-core/fuzz/Cargo.toml --bin tile_ownership_dedup --locked`
- `cargo +nightly-2026-07-15 fuzz run tile_ownership_dedup -- -runs=100 -print_final_stats=1` (1273 executions, no failures; 1270 corpus files loaded)
- `git diff --check`

## Agent handoff

Parent: #1223.
Children: #1226.
Next branch: continue the broad P3.1 undetected connected-region search; do not claim non-envelope region-local reconciliation or start P3.3 graph stitching.