### PR TITLE
test(core): broaden tiled differential containers

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -787,6 +787,9 @@ opt-in whole-input fallback handle the evidence explicitly.
   - [x] Exercise bounded ownership-domain-overlap cases in the tiled
     differential target; ownership-domain evidence is accepted only when every
     expected face still overlaps the configured domain.
+  - [x] Exercise independent, fully grouped, and partially grouped line
+    containers in the tiled differential contract; mismatches without any
+    observed evidence remain fatal.
 - [x] Expand exact tiled/untiled fixtures for nested disconnected rings, long
   faces, narrow concavities, holes crossing boundaries, dangles, cut edges,
   overlaps, and dirty boundary intersections.

--- a/crates/geo-polygonize-core/fuzz/fuzz_targets/tile_ownership_dedup.rs
+++ b/crates/geo-polygonize-core/fuzz/fuzz_targets/tile_ownership_dedup.rs
@@ -15,6 +15,7 @@ struct FuzzInput {
     buffer: u8,
     reverse_input: bool,
     group_lines: bool,
+    geometry_grouping: u8,
     ownership_domain_gap: bool,
 }
 
@@ -120,8 +121,17 @@ fuzz_target!(|input: FuzzInput| {
             ])
         })
         .collect::<Vec<_>>();
-    let geometries = if input.group_lines {
-        vec![Geometry::MultiLineString(MultiLineString::new(parts))]
+    let geometries: Vec<Geometry<f64>> = if input.group_lines {
+        let group_count = (1 + usize::from(input.geometry_grouping % 8)).min(parts.len().max(1));
+        let mut groups = vec![Vec::new(); group_count];
+        for (part_index, part) in parts.into_iter().enumerate() {
+            groups[part_index % group_count].push(part);
+        }
+        groups
+            .into_iter()
+            .filter(|parts| !parts.is_empty())
+            .map(|parts| Geometry::MultiLineString(MultiLineString::new(parts)))
+            .collect()
     } else {
         parts.into_iter().map(Geometry::LineString).collect()
     };

--- a/crates/geo-polygonize-core/tests/tiling_equivalence.rs
+++ b/crates/geo-polygonize-core/tests/tiling_equivalence.rs
@@ -228,55 +228,49 @@ fn adversarial_in_domain_mismatches_keep_coverage_evidence_under_permutations() 
     for (case_index, (name, lines, bbox)) in cases.into_iter().enumerate() {
         let expected = polygonize(lines.iter().copied(), &options)
             .unwrap_or_else(|error| panic!("{name} untiled: {error}"));
-        let base_geometries = lines
-            .iter()
-            .map(|line| {
-                Geometry::LineString(LineString::new(vec![
-                    line.start.to_coord_2d(),
-                    line.end.to_coord_2d(),
-                ]))
-            })
-            .collect::<Vec<_>>();
+        for grouping in 0..=3 {
+            let base_geometries = geometries_for_grouping(&lines, grouping);
+            for (tile_index, tile_size) in [5.0, 7.0, 10.0].into_iter().enumerate() {
+                for buffer in [0.0, 1.0, 3.0] {
+                    for permutation in 0..2 {
+                        let mut geometries = base_geometries.clone();
+                        let rotation = (case_index + tile_index + permutation) % geometries.len();
+                        geometries.rotate_left(rotation);
+                        if permutation == 1 {
+                            geometries.reverse();
+                        }
 
-        for (tile_index, tile_size) in [5.0, 7.0, 10.0].into_iter().enumerate() {
-            for buffer in [0.0, 1.0, 3.0] {
-                for permutation in 0..2 {
-                    let mut geometries = base_geometries.clone();
-                    let rotation = (case_index + tile_index + permutation) % geometries.len();
-                    geometries.rotate_left(rotation);
-                    if permutation == 1 {
-                        geometries.reverse();
-                    }
-
-                    let mut tiled = TiledPolygonizer::new(bbox, tile_size)
-                        .with_buffer(buffer)
-                        .with_options(options.clone())
-                        .with_ownership_policy(
-                            TileOwnershipPolicy::RepresentativePointInsidePolygon,
-                        )
-                        .with_dedup_policy(DedupPolicy::CanonicalRingHash);
-                    for geometry in &geometries {
-                        tiled.add_geometry(geometry);
-                    }
-                    let actual = tiled.polygonize().unwrap_or_else(|error| {
-                        panic!("{name}, tile size {tile_size}, buffer {buffer}: {error}")
-                    });
-                    let equivalent = actual.polygons.len() == expected.polygons.len()
-                        && actual.polygons.iter().zip(&expected.polygons).all(
-                            |(actual, expected)| {
-                                actual.exterior == expected.exterior
-                                    && actual.interiors == expected.interiors
-                            },
-                        );
-                    if !equivalent {
-                        assert!(
-                            actual.tile_reports.iter().any(|report| {
-                                !report.coverage_issues.is_empty()
-                                    || !report.input_boundary_issues.is_empty()
-                                    || !report.excluded_component_issues.is_empty()
-                            }),
-                            "undetected {name} mismatch for tile size {tile_size}, buffer {buffer}, permutation {permutation}"
-                        );
+                        let mut tiled = TiledPolygonizer::new(bbox, tile_size)
+                            .with_buffer(buffer)
+                            .with_options(options.clone())
+                            .with_ownership_policy(
+                                TileOwnershipPolicy::RepresentativePointInsidePolygon,
+                            )
+                            .with_dedup_policy(DedupPolicy::CanonicalRingHash);
+                        for geometry in &geometries {
+                            tiled.add_geometry(geometry);
+                        }
+                        let actual = tiled.polygonize().unwrap_or_else(|error| {
+                            panic!("{name}, grouping {grouping}, tile size {tile_size}, buffer {buffer}: {error}")
+                        });
+                        let equivalent = actual.polygons.len() == expected.polygons.len()
+                            && actual.polygons.iter().zip(&expected.polygons).all(
+                                |(actual, expected)| {
+                                    actual.exterior == expected.exterior
+                                        && actual.interiors == expected.interiors
+                                },
+                            );
+                        if !equivalent {
+                            assert!(
+                                actual.tile_reports.iter().any(|report| {
+                                    !report.coverage_issues.is_empty()
+                                        || !report.ownership_domain_issues.is_empty()
+                                        || !report.input_boundary_issues.is_empty()
+                                        || !report.excluded_component_issues.is_empty()
+                                }),
+                                "undetected {name} mismatch for grouping {grouping}, tile size {tile_size}, buffer {buffer}, permutation {permutation}"
+                            );
+                        }
                     }
                 }
             }
@@ -361,6 +355,27 @@ fn line(start: (f64, f64), end: (f64, f64)) -> Line3D {
 
 fn world(size: f64) -> Rect<f64> {
     Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: size, y: size })
+}
+
+fn geometries_for_grouping(lines: &[Line3D], grouping: usize) -> Vec<Geometry<f64>> {
+    let parts = lines
+        .iter()
+        .map(|line| LineString::new(vec![line.start.to_coord_2d(), line.end.to_coord_2d()]))
+        .collect::<Vec<_>>();
+    if grouping == 0 {
+        return parts.into_iter().map(Geometry::LineString).collect();
+    }
+
+    let group_count = grouping.min(parts.len()).max(1);
+    let mut groups = vec![Vec::new(); group_count];
+    for (part_index, part) in parts.into_iter().enumerate() {
+        groups[part_index % group_count].push(part);
+    }
+    groups
+        .into_iter()
+        .filter(|parts| !parts.is_empty())
+        .map(|parts| Geometry::MultiLineString(geo_types::MultiLineString::new(parts)))
+        .collect()
 }
 
 #[test]


### PR DESCRIPTION
## Stack

- Parent: none (root from `origin/main` at `accdb8cfeb08c4f024e98716ea260279fc540364`)
- Children: #1228 `test(core): validate grouped tiled evidence`

## Delivered

- Extend the tiled ownership/dedup differential fuzz input to generate independent, fully grouped, and partially grouped `LineString`/`MultiLineString` containers.
- Extend the deterministic adversarial tiled equivalence contract across the same grouping modes, tile sizes, buffers, and input permutations.
- Keep any topology mismatch without coverage, input-boundary, excluded-component, or ownership-domain evidence fatal.
- Record the new bounded container-variation evidence in `ROADMAP.md`.

## Contract impact

- No production algorithm or public API behavior changes.
- The existing conservative evidence contract now has broader input-container coverage; the P3.1 umbrella remains open because this does not certify arbitrary missing-region detection.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p geo-polygonize-core --test tiling_equivalence --quiet`: 6 passed
- `cargo check --manifest-path crates/geo-polygonize-core/fuzz/Cargo.toml --bin tile_ownership_dedup --locked`
- `cargo +nightly-2026-07-15 fuzz run tile_ownership_dedup -- -runs=10000 -print_final_stats=1`: 10,000 runs, 0 failures, 106 exec/s, 674 MB peak RSS
- `cargo test --workspace --quiet`
- `cargo test -p geo-polygonize-core --no-default-features --quiet`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p geo-polygonize-core --no-deps`
- `npm test`: 11 files, 54 tests passed
- `npm run docs:build` passed; generated bindings and `playground/package-lock.json` were restored

## Agent handoff

- Parent: none
- Children: #1228
- Branch: `agent/p3-undetected-region-fixture`
- Commit: `3095a49af175f6b8816c33f66d5ff5ee32cc8509`
- Disproved finding: the broadened 10,000-case differential probe found no new undetected mismatch.
- Remaining risk: arbitrary single-geometry envelope-only faces and non-envelope-connected regions remain observational gaps; true graph stitching and broad P3.1 certification are still intentionally open.
- Exact next branch: `agent/p3-coverage-blind-spot-search`, based on #1228 after the stack is merged.