### PR TITLE
test(core): validate grouped tiled evidence

### DIFF
--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -420,6 +420,51 @@ mod tests {
     }
 
     #[test]
+    fn grouped_line_containers_preserve_observed_coverage_contract() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 10.0 });
+        let grouped = [
+            Geometry::MultiLineString(MultiLineString::new(vec![
+                LineString::new(vec![Coord { x: 1.0, y: 2.0 }, Coord { x: 19.0, y: 2.0 }]),
+                LineString::new(vec![Coord { x: 19.0, y: 8.0 }, Coord { x: 1.0, y: 8.0 }]),
+            ])),
+            Geometry::MultiLineString(MultiLineString::new(vec![
+                LineString::new(vec![Coord { x: 19.0, y: 2.0 }, Coord { x: 19.0, y: 8.0 }]),
+                LineString::new(vec![Coord { x: 1.0, y: 8.0 }, Coord { x: 1.0, y: 2.0 }]),
+            ])),
+        ];
+        let mut tiled = TiledPolygonizer::new(bbox, 10.0).with_buffer(2.0);
+        for geometry in &grouped {
+            tiled.add_geometry(geometry);
+        }
+
+        let result = tiled.polygonize().unwrap();
+        assert_eq!(result.polygons.len(), 1);
+        assert_eq!(result.tile_reports.len(), 2);
+        assert!(result
+            .tile_reports
+            .iter()
+            .all(|report| report.input_geometry_count == grouped.len()));
+        assert!(result
+            .tile_reports
+            .iter()
+            .any(|report| !report.coverage_issues.is_empty()));
+
+        assert!(matches!(
+            tiled.polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateOwnedFaces),
+            Err(TiledPolygonizeError::CoverageIncomplete {
+                unresolved_owned_polygon_count: 1,
+                ..
+            })
+        ));
+        assert!(matches!(
+            tiled.polygonize_with_coverage_guarantee(
+                TileCoverageGuarantee::ValidateObservedCoverage
+            ),
+            Err(TiledPolygonizeError::CoverageIncomplete { .. })
+        ));
+    }
+
+    #[test]
     fn component_fallback_recovers_closed_boundary_region() {
         let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 10.0 });
         let face = Geometry::LineString(LineString::new(vec![


### PR DESCRIPTION
## Stack

- Parent: #1227 `test(core): broaden tiled differential containers`
- Children: #1230 `test(core): fuzz nested tiled containers`

## Delivered

- Add a core regression using two grouped `MultiLineString` inputs whose owned face reaches the internal halo.
- Verify grouped containers still retain deterministic input counts and conservative owned-face coverage evidence.
- Verify both `ValidateOwnedFaces` and `ValidateObservedCoverage` return typed `CoverageIncomplete` errors for the observed gap.

## Contract impact

- No production algorithm or public API behavior changes.
- This closes the grouped-container regression contract only; it does not certify arbitrary missing-region detection or introduce graph stitching.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p geo-polygonize-core tiling --quiet`: 51 passed
- Parent #1227 full workspace checkpoint passed:
  - `cargo test --workspace --quiet`
  - `cargo test -p geo-polygonize-core --no-default-features --quiet`
  - `cargo clippy --workspace --all-targets -- -D warnings`
  - `RUSTDOCFLAGS='-D warnings' cargo doc -p geo-polygonize-core --no-deps`
  - `npm test`: 11 files, 54 tests passed
  - `npm run docs:build` passed with generated artifacts restored

## Agent handoff

- Parent: #1227
- Children: #1230
- Branch: `agent/p3-grouped-evidence-contract`
- Commit: `1418928e12ada5f7d93a4d50d23e73dccb31841a`
- Disproved finding: grouped input containers did not expose an undetected halo mismatch in the pinned adversarial case.
- Remaining risk: arbitrary single-geometry envelope-only faces and non-envelope-connected regions remain observational gaps; broad P3.1 detection and P3.2 non-envelope reconciliation remain open.
- Exact next branch: `agent/p3-coverage-blind-spot-search`, based on this child.