### PR TITLE
test(core): fuzz nested tiled containers

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -790,6 +790,8 @@ opt-in whole-input fallback handle the evidence explicitly.
   - [x] Exercise independent, fully grouped, and partially grouped line
     containers in the tiled differential contract; mismatches without any
     observed evidence remain fatal.
+  - [x] Exercise nested `GeometryCollection` line containers in the same
+    bounded tiled differential contract.
 - [x] Expand exact tiled/untiled fixtures for nested disconnected rings, long
   faces, narrow concavities, holes crossing boundaries, dangles, cut edges,
   overlaps, and dirty boundary intersections.

--- a/crates/geo-polygonize-core/fuzz/fuzz_targets/tile_ownership_dedup.rs
+++ b/crates/geo-polygonize-core/fuzz/fuzz_targets/tile_ownership_dedup.rs
@@ -1,7 +1,7 @@
 #![no_main]
 
 use arbitrary::Arbitrary;
-use geo::{Coord, Geometry, LineString, MultiLineString, Rect};
+use geo::{Coord, Geometry, GeometryCollection, LineString, MultiLineString, Rect};
 use geo_polygonize_core::{
     polygonize, Coord3D, DedupPolicy, Line3D, Polygon3D, PolygonizerOptions,
     TileOwnershipPolicy, TiledPolygonizer,
@@ -16,6 +16,7 @@ struct FuzzInput {
     reverse_input: bool,
     group_lines: bool,
     geometry_grouping: u8,
+    nested_geometry_collection: bool,
     ownership_domain_gap: bool,
 }
 
@@ -135,6 +136,11 @@ fuzz_target!(|input: FuzzInput| {
     } else {
         parts.into_iter().map(Geometry::LineString).collect()
     };
+    let geometries = if input.nested_geometry_collection {
+        vec![Geometry::GeometryCollection(GeometryCollection::new_from(geometries))]
+    } else {
+        geometries
+    };
     let mut tiled = TiledPolygonizer::new(world(), 1.0 + f64::from(input.tile_size % 16))
         .with_buffer(f64::from(input.buffer % 17))
         .with_options(options)
@@ -152,10 +158,11 @@ fuzz_target!(|input: FuzzInput| {
     }
 
     panic!(
-        "undetected tiled mismatch: lines={}, tile_size={}, buffer={}, untiled_polygons={}, tiled_polygons={}",
+        "undetected tiled mismatch: lines={}, tile_size={}, buffer={}, nested_collection={}, untiled_polygons={}, tiled_polygons={}",
         lines.len(),
         1 + (input.tile_size % 16),
         input.buffer % 17,
+        input.nested_geometry_collection,
         expected.polygons.len(),
         actual.polygons.len(),
     );

--- a/crates/geo-polygonize-core/tests/tiling_equivalence.rs
+++ b/crates/geo-polygonize-core/tests/tiling_equivalence.rs
@@ -228,48 +228,51 @@ fn adversarial_in_domain_mismatches_keep_coverage_evidence_under_permutations() 
     for (case_index, (name, lines, bbox)) in cases.into_iter().enumerate() {
         let expected = polygonize(lines.iter().copied(), &options)
             .unwrap_or_else(|error| panic!("{name} untiled: {error}"));
-        for grouping in 0..=3 {
-            let base_geometries = geometries_for_grouping(&lines, grouping);
-            for (tile_index, tile_size) in [5.0, 7.0, 10.0].into_iter().enumerate() {
-                for buffer in [0.0, 1.0, 3.0] {
-                    for permutation in 0..2 {
-                        let mut geometries = base_geometries.clone();
-                        let rotation = (case_index + tile_index + permutation) % geometries.len();
-                        geometries.rotate_left(rotation);
-                        if permutation == 1 {
-                            geometries.reverse();
-                        }
+        for nested in [false, true] {
+            for grouping in 0..=3 {
+                let base_geometries = geometries_for_grouping(&lines, grouping, nested);
+                for (tile_index, tile_size) in [5.0, 7.0, 10.0].into_iter().enumerate() {
+                    for buffer in [0.0, 1.0, 3.0] {
+                        for permutation in 0..2 {
+                            let mut geometries = base_geometries.clone();
+                            let rotation =
+                                (case_index + tile_index + permutation) % geometries.len();
+                            geometries.rotate_left(rotation);
+                            if permutation == 1 {
+                                geometries.reverse();
+                            }
 
-                        let mut tiled = TiledPolygonizer::new(bbox, tile_size)
-                            .with_buffer(buffer)
-                            .with_options(options.clone())
-                            .with_ownership_policy(
-                                TileOwnershipPolicy::RepresentativePointInsidePolygon,
-                            )
-                            .with_dedup_policy(DedupPolicy::CanonicalRingHash);
-                        for geometry in &geometries {
-                            tiled.add_geometry(geometry);
-                        }
-                        let actual = tiled.polygonize().unwrap_or_else(|error| {
-                            panic!("{name}, grouping {grouping}, tile size {tile_size}, buffer {buffer}: {error}")
-                        });
-                        let equivalent = actual.polygons.len() == expected.polygons.len()
-                            && actual.polygons.iter().zip(&expected.polygons).all(
-                                |(actual, expected)| {
-                                    actual.exterior == expected.exterior
-                                        && actual.interiors == expected.interiors
-                                },
-                            );
-                        if !equivalent {
-                            assert!(
-                                actual.tile_reports.iter().any(|report| {
-                                    !report.coverage_issues.is_empty()
-                                        || !report.ownership_domain_issues.is_empty()
-                                        || !report.input_boundary_issues.is_empty()
-                                        || !report.excluded_component_issues.is_empty()
-                                }),
-                                "undetected {name} mismatch for grouping {grouping}, tile size {tile_size}, buffer {buffer}, permutation {permutation}"
-                            );
+                            let mut tiled = TiledPolygonizer::new(bbox, tile_size)
+                                .with_buffer(buffer)
+                                .with_options(options.clone())
+                                .with_ownership_policy(
+                                    TileOwnershipPolicy::RepresentativePointInsidePolygon,
+                                )
+                                .with_dedup_policy(DedupPolicy::CanonicalRingHash);
+                            for geometry in &geometries {
+                                tiled.add_geometry(geometry);
+                            }
+                            let actual = tiled.polygonize().unwrap_or_else(|error| {
+                                panic!("{name}, nested {nested}, grouping {grouping}, tile size {tile_size}, buffer {buffer}: {error}")
+                            });
+                            let equivalent = actual.polygons.len() == expected.polygons.len()
+                                && actual.polygons.iter().zip(&expected.polygons).all(
+                                    |(actual, expected)| {
+                                        actual.exterior == expected.exterior
+                                            && actual.interiors == expected.interiors
+                                    },
+                                );
+                            if !equivalent {
+                                assert!(
+                                    actual.tile_reports.iter().any(|report| {
+                                        !report.coverage_issues.is_empty()
+                                            || !report.ownership_domain_issues.is_empty()
+                                            || !report.input_boundary_issues.is_empty()
+                                            || !report.excluded_component_issues.is_empty()
+                                    }),
+                                    "undetected {name} mismatch for nested {nested}, grouping {grouping}, tile size {tile_size}, buffer {buffer}, permutation {permutation}"
+                                );
+                            }
                         }
                     }
                 }
@@ -357,25 +360,32 @@ fn world(size: f64) -> Rect<f64> {
     Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: size, y: size })
 }
 
-fn geometries_for_grouping(lines: &[Line3D], grouping: usize) -> Vec<Geometry<f64>> {
+fn geometries_for_grouping(lines: &[Line3D], grouping: usize, nested: bool) -> Vec<Geometry<f64>> {
     let parts = lines
         .iter()
         .map(|line| LineString::new(vec![line.start.to_coord_2d(), line.end.to_coord_2d()]))
         .collect::<Vec<_>>();
-    if grouping == 0 {
-        return parts.into_iter().map(Geometry::LineString).collect();
+    let geometries = if grouping == 0 {
+        parts.into_iter().map(Geometry::LineString).collect()
+    } else {
+        let group_count = grouping.min(parts.len()).max(1);
+        let mut groups = vec![Vec::new(); group_count];
+        for (part_index, part) in parts.into_iter().enumerate() {
+            groups[part_index % group_count].push(part);
+        }
+        groups
+            .into_iter()
+            .filter(|parts| !parts.is_empty())
+            .map(|parts| Geometry::MultiLineString(geo_types::MultiLineString::new(parts)))
+            .collect()
+    };
+    if nested {
+        vec![Geometry::GeometryCollection(
+            geo_types::GeometryCollection::new_from(geometries),
+        )]
+    } else {
+        geometries
     }
-
-    let group_count = grouping.min(parts.len()).max(1);
-    let mut groups = vec![Vec::new(); group_count];
-    for (part_index, part) in parts.into_iter().enumerate() {
-        groups[part_index % group_count].push(part);
-    }
-    groups
-        .into_iter()
-        .filter(|parts| !parts.is_empty())
-        .map(|parts| Geometry::MultiLineString(geo_types::MultiLineString::new(parts)))
-        .collect()
 }
 
 #[test]


### PR DESCRIPTION
## Stack

- Parent: #1228 `test(core): validate grouped tiled evidence`
- Children: #1231 `test(core): sweep tiled coverage blind spots`

## Delivered

- Extend the tiled differential fuzz input with nested `GeometryCollection` line containers around independent and grouped linework.
- Extend the deterministic adversarial tiled equivalence contract across nested and non-nested container shapes, grouping modes, tile sizes, buffers, and input permutations.
- Keep any mismatch without coverage, input-boundary, excluded-component, or ownership-domain evidence fatal.
- Record nested-container coverage in `ROADMAP.md`.

## Contract impact

- No production algorithm or public API behavior changes.
- This broadens evidence for supported input container shapes only; the P3.1 umbrella remains open and no graph stitching or implicit clipping is introduced.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p geo-polygonize-core --test tiling_equivalence --quiet`: 6 passed
- `cargo check --manifest-path crates/geo-polygonize-core/fuzz/Cargo.toml --bin tile_ownership_dedup --locked`
- `cargo +nightly-2026-07-15 fuzz run tile_ownership_dedup -- -runs=10000 -print_final_stats=1`: 10,000 runs, 0 failures, 102 exec/s, 765 MB peak RSS
- `cargo test --workspace --quiet`: 251 core unit tests passed plus workspace suites
- `cargo clippy --workspace --all-targets -- -D warnings`
- Parent #1227 full checkpoint also passed docs, no-default-features, npm, and docs build; generated artifacts were restored

## Agent handoff

- Parent: #1228
- Children: #1231
- Branch: `agent/p3-coverage-blind-spot-search`
- Commit: `a2545cb46610b50ba3a30b36e6691fe49733b501`
- Disproved finding: nested `GeometryCollection` containers did not expose a new undetected mismatch in the bounded differential search.
- Remaining risk: arbitrary single-geometry envelope-only faces and non-envelope-connected regions remain observational gaps; broad P3.1 detection and P3.2 non-envelope reconciliation remain open.
- Exact next branch: `agent/p3-coverage-no-evidence-case`, based on this child.