### PR TITLE
test(core): sweep tiled coverage blind spots

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -792,6 +792,9 @@ opt-in whole-input fallback handle the evidence explicitly.
     observed evidence remain fatal.
   - [x] Exercise nested `GeometryCollection` line containers in the same
     bounded tiled differential contract.
+  - [x] Sweep bounded single-geometry envelope placements across tile sizes
+    and buffers; any in-domain mismatch without observed evidence remains
+    fatal.
 - [x] Expand exact tiled/untiled fixtures for nested disconnected rings, long
   faces, narrow concavities, holes crossing boundaries, dangles, cut edges,
   overlaps, and dirty boundary intersections.

--- a/crates/geo-polygonize-core/tests/tiling_equivalence.rs
+++ b/crates/geo-polygonize-core/tests/tiling_equivalence.rs
@@ -1,5 +1,5 @@
 use geo_polygonize_core::{
-    polygonize, Coord3D, DedupPolicy, Line3D, PolygonizerOptions, TileCoverageGuarantee,
+    polygonize, Coord3D, DedupPolicy, Line3D, Polygon3D, PolygonizerOptions, TileCoverageGuarantee,
     TileOwnershipPolicy, TileRetryPolicy, TiledPolygonizer,
 };
 use geo_types::{Coord, Geometry, LineString, Rect};
@@ -176,6 +176,82 @@ fn in_domain_tiled_mismatches_have_observed_coverage_evidence() {
             }
         }
     }
+}
+
+#[test]
+fn bounded_single_geometry_envelope_sweep_keeps_in_domain_mismatches_observed() {
+    let bounds = world(32.0);
+    let options = PolygonizerOptions {
+        node_input: true,
+        ..Default::default()
+    };
+    let mut checked_cases = 0;
+
+    for min_x in [-16.0, -8.0, 0.0, 8.0, 16.0, 24.0, 32.0] {
+        for min_y in [-16.0, -8.0, 0.0, 8.0, 16.0, 24.0, 32.0] {
+            for width in [4.0, 8.0, 16.0, 24.0, 40.0] {
+                let max_x = min_x + width;
+                let max_y = min_y + width;
+                let lines = ring(&[
+                    (min_x, min_y),
+                    (max_x, min_y),
+                    (max_x, max_y),
+                    (min_x, max_y),
+                ]);
+                let expected = polygonize(lines.iter().copied(), &options).unwrap();
+                if expected.polygons.is_empty()
+                    || expected
+                        .polygons
+                        .iter()
+                        .any(|polygon| !polygon_overlaps(&bounds, polygon))
+                {
+                    continue;
+                }
+                checked_cases += 1;
+                let geometry = Geometry::LineString(LineString::new(
+                    lines
+                        .iter()
+                        .map(|line| line.start.to_coord_2d())
+                        .chain(std::iter::once(lines[0].start.to_coord_2d()))
+                        .collect(),
+                ));
+
+                for tile_size in [4.0, 8.0, 16.0] {
+                    for buffer in [0.0, 1.0, 4.0] {
+                        let mut tiled = TiledPolygonizer::new(bounds, tile_size)
+                            .with_buffer(buffer)
+                            .with_options(options.clone())
+                            .with_ownership_policy(
+                                TileOwnershipPolicy::RepresentativePointInsidePolygon,
+                            )
+                            .with_dedup_policy(DedupPolicy::CanonicalRingHash);
+                        tiled.add_geometry(&geometry);
+                        let actual = tiled.polygonize().unwrap();
+                        let equivalent = actual.polygons.len() == expected.polygons.len()
+                            && actual.polygons.iter().zip(&expected.polygons).all(
+                                |(actual, expected)| {
+                                    actual.exterior == expected.exterior
+                                        && actual.interiors == expected.interiors
+                                },
+                            );
+                        if !equivalent {
+                            assert!(
+                                actual.tile_reports.iter().any(|report| {
+                                    !report.coverage_issues.is_empty()
+                                        || !report.ownership_domain_issues.is_empty()
+                                        || !report.input_boundary_issues.is_empty()
+                                        || !report.excluded_component_issues.is_empty()
+                                }),
+                                "undetected single-geometry mismatch: min=({min_x},{min_y}), width={width}, tile_size={tile_size}, buffer={buffer}"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    assert_eq!(checked_cases, 208);
 }
 
 #[test]
@@ -358,6 +434,23 @@ fn line(start: (f64, f64), end: (f64, f64)) -> Line3D {
 
 fn world(size: f64) -> Rect<f64> {
     Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: size, y: size })
+}
+
+fn polygon_overlaps(bounds: &Rect<f64>, polygon: &Polygon3D) -> bool {
+    let Some(first) = polygon.exterior.first() else {
+        return false;
+    };
+    let (mut min_x, mut min_y, mut max_x, mut max_y) = (first.x, first.y, first.x, first.y);
+    for coordinate in &polygon.exterior[1..] {
+        min_x = min_x.min(coordinate.x);
+        min_y = min_y.min(coordinate.y);
+        max_x = max_x.max(coordinate.x);
+        max_y = max_y.max(coordinate.y);
+    }
+    min_x <= bounds.max().x
+        && max_x >= bounds.min().x
+        && min_y <= bounds.max().y
+        && max_y >= bounds.min().y
 }
 
 fn geometries_for_grouping(lines: &[Line3D], grouping: usize, nested: bool) -> Vec<Geometry<f64>> {


### PR DESCRIPTION
## Stack

- Parent: #1230 `test(core): fuzz nested tiled containers`
- Children: none

## Delivered

- Add a bounded single-geometry envelope sweep over 208 placements that overlap the ownership domain.
- Exercise three tile sizes and three buffers for each placement, for 1,872 tiled configurations.
- Keep any topology mismatch without owned-face, ownership-domain, input-boundary, or excluded-component evidence fatal.
- Record the sweep as negative evidence in `ROADMAP.md`; the broad P3.1 umbrella remains open.

## Contract impact

- No production algorithm or public API behavior changes.
- The sweep strengthens the observational evidence contract for single closed geometries near the ownership envelope; it does not infer implicit clipping, certify arbitrary missing regions, or add graph stitching.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p geo-polygonize-core --test tiling_equivalence --quiet`: 7 passed, including 208 placements and 1,872 tiled configurations
- `cargo test --workspace --quiet`: 251 core unit tests passed plus workspace suites
- `cargo clippy --workspace --all-targets -- -D warnings`
- Parent #1230 focused fuzz validation passed: 10,000 runs, 0 failures, 102 exec/s, 765 MB peak RSS
- Earlier top-of-stack docs, no-default-features, npm, and docs-build checkpoints passed; generated bindings and `playground/package-lock.json` were restored

## Agent handoff

- Parent: #1230
- Children: none
- Branch: `agent/p3-coverage-no-evidence-case`
- Commit: `ab48835886de5c10550ba6e47d41589d3fb46dc7`
- Disproved finding: no new in-domain single-geometry mismatch escaped observed evidence across the 1,872-case sweep.
- Remaining risk: arbitrary connected-region boundaries and non-envelope-closed recovery remain open; this negative sweep is not a certification proof.
- Exact next branch: `agent/p3-component-reconciliation-boundary`, based on this child after the stack is merged.