### PR TITLE
feat(core): bound tiled retry attempts

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -807,6 +807,8 @@ opt-in whole-input fallback handle the evidence explicitly.
 When coverage cannot be proven:
 
 - [x] retry only the unresolved tile region with a caller-bounded larger halo;
+  - [x] bound per-tile halo retries with `ExecutionPolicy` and return a typed
+    resource-limit error before exceeding the operational budget;
 - [ ] fall back to untiled processing for the unresolved connected region;
   - [x] Pin the global-containment boundary where an excluded outer component
     spatially nests an already retained tile-local face.

--- a/crates/geo-polygonize-core/src/options.rs
+++ b/crates/geo-polygonize-core/src/options.rs
@@ -57,6 +57,11 @@ pub struct ExecutionPolicy {
     pub max_rings: Option<usize>,
     pub max_output_polygons: Option<usize>,
     pub max_output_coordinates: Option<usize>,
+    /// Maximum halo retry attempts allowed for each tiled region.
+    ///
+    /// This bounds retry work in addition to the topology and halo schedule
+    /// configured by `TileRetryPolicy`.
+    pub max_tile_retry_attempts: Option<usize>,
 }
 
 impl ExecutionPolicy {

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -1154,6 +1154,11 @@ impl<'a> TiledPolygonizer<'a> {
             if !Self::report_has_retry_evidence(&result.1) || buffer >= policy.max_buffer {
                 break;
             }
+            self.execution_policy.check(
+                "tile_retry_attempts",
+                self.execution_policy.max_tile_retry_attempts,
+                attempt,
+            )?;
             buffer = (buffer + policy.buffer_increment).min(policy.max_buffer);
             result = self.process_tile(tile_bbox, input_components, buffer, capture_byte_limit)?;
             capture_truncated |= result.3;

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -2485,6 +2485,29 @@ mod tests {
                 ..
             }) if tile_reports.iter().all(|report| report.retry_exhausted)
         ));
+
+        let mut budgeted = TiledPolygonizer::new(bbox, 10.0)
+            .with_buffer(2.0)
+            .with_retry_policy(TileRetryPolicy {
+                max_attempts: 2,
+                buffer_increment: 1.0,
+                max_buffer: 4.0,
+            })
+            .with_execution_policy(ExecutionPolicy {
+                max_tile_retry_attempts: Some(1),
+                ..Default::default()
+            });
+        for boundary in &boundaries {
+            budgeted.add_geometry(boundary);
+        }
+        assert!(matches!(
+            budgeted.polygonize(),
+            Err(PolygonizeError::ResourceLimitExceeded {
+                ref stage,
+                limit: 1,
+                observed: 2,
+            }) if stage == "tile_retry_attempts"
+        ));
     }
 
     #[test]

--- a/crates/geo-polygonize-python/src/lib.rs
+++ b/crates/geo-polygonize-python/src/lib.rs
@@ -79,6 +79,7 @@ impl PythonExecutionLimits {
             max_rings: self.max_rings,
             max_output_polygons: self.max_output_polygons,
             max_output_coordinates: self.max_output_coordinates,
+            max_tile_retry_attempts: None,
         }
     }
 }

--- a/docs/guide/tiling.md
+++ b/docs/guide/tiling.md
@@ -128,7 +128,11 @@ Ownership-domain evidence is not retried because increasing a halo cannot move
 an ownership point into the configured domain.
 Retries reuse the same execution policy independently per attempt. Full output
 traces record bounded `tile_halo_retry` events directly from the physical retry
-history. `with_component_fallback` enables conservative recovery for excluded
+history. `ExecutionPolicy::max_tile_retry_attempts` optionally caps retry
+attempts per tile; exceeding that operational budget returns the typed
+`ResourceLimitExceeded` error before the next tile attempt. The retry policy
+still controls the halo schedule. `with_component_fallback` enables
+conservative recovery for excluded
 or partially observed indexed components. It starts with each component
 identified by excluded-component or input-boundary evidence, closes the region
 over intersecting input envelopes, interacting retained polygon envelopes, and


### PR DESCRIPTION
## Stack

- Parent: none; based on `main` at `60492e8`.
- Children: PR #1233 `test(core): sweep tiled ownership policies`, branch `agent/p3-coverage-container-boundary-sweep`, head `9fd8a32`.

## Delivered

- Added optional `ExecutionPolicy::max_tile_retry_attempts` for per-tile halo retry budgets.
- Enforced the cap in the shared retry loop before each additional attempt, returning the existing typed `ResourceLimitExceeded` error.
- Added a regression covering an allowed first retry and a rejected second retry.
- Documented the operational cap and updated P3.2 without closing the broader recovery umbrella.

## Contract impact

- Default behavior is unchanged when the new field is `None`.
- Retry scheduling and halo growth remain controlled by `TileRetryPolicy`.
- Exceeding the cap aborts the tiled operation; no partial output is returned.
- Python one-shot policy construction remains unchanged and initializes the core-only field to `None`.

## Validation

- PASS: `cargo fmt --all -- --check`
- PASS: tiled unit tests (51), execution-policy integration tests (9), Python crate check.
- PASS: `cargo test --workspace --quiet`
- PASS: `cargo test -p geo-polygonize-core --no-default-features --quiet`
- PASS: `cargo clippy --workspace --all-targets -- -D warnings`
- PASS: `cargo doc -p geo-polygonize-core --no-deps`
- PASS: `npm test` (11 files, 54 tests)
- PASS: `npm run docs:build` (known npm-audit, MUI client-directive, and chunk-size warnings).
- Disproved unrelated checkpoint issue: `cargo doc --workspace --no-deps` cannot run because core and Python export the same `geo_polygonize_core` lib doc filename.
- Restored generated bindings and `playground/package-lock.json`.

## Agent handoff

- Current branch/commit: `agent/p3-retry-execution-budget` / `d71cced`.
- Parent/children are exact: parent none; child PR #1233 on `agent/p3-coverage-container-boundary-sweep` at `9fd8a32`.
- Next branch: `agent/p3-coverage-container-boundary-sweep` (published as PR #1233).
- Remaining risks: broad undetected connected-region boundaries, region-local reconciliation/canonical partial merging, and true graph stitching remain open; this PR only bounds retry work.