### PR TITLE
test(core): sweep tiled ownership policies

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -795,6 +795,8 @@ opt-in whole-input fallback handle the evidence explicitly.
   - [x] Sweep bounded single-geometry envelope placements across tile sizes
     and buffers; any in-domain mismatch without observed evidence remains
     fatal.
+    - [x] Repeat the sweep under all three ownership policies; each policy
+      preserves the same evidence gate for in-domain mismatches.
 - [x] Expand exact tiled/untiled fixtures for nested disconnected rings, long
   faces, narrow concavities, holes crossing boundaries, dangles, cut edges,
   overlaps, and dirty boundary intersections.

--- a/crates/geo-polygonize-core/tests/tiling_equivalence.rs
+++ b/crates/geo-polygonize-core/tests/tiling_equivalence.rs
@@ -216,34 +216,40 @@ fn bounded_single_geometry_envelope_sweep_keeps_in_domain_mismatches_observed() 
                         .collect(),
                 ));
 
-                for tile_size in [4.0, 8.0, 16.0] {
-                    for buffer in [0.0, 1.0, 4.0] {
-                        let mut tiled = TiledPolygonizer::new(bounds, tile_size)
-                            .with_buffer(buffer)
-                            .with_options(options.clone())
-                            .with_ownership_policy(
-                                TileOwnershipPolicy::RepresentativePointInsidePolygon,
-                            )
-                            .with_dedup_policy(DedupPolicy::CanonicalRingHash);
-                        tiled.add_geometry(&geometry);
-                        let actual = tiled.polygonize().unwrap();
-                        let equivalent = actual.polygons.len() == expected.polygons.len()
-                            && actual.polygons.iter().zip(&expected.polygons).all(
-                                |(actual, expected)| {
-                                    actual.exterior == expected.exterior
-                                        && actual.interiors == expected.interiors
-                                },
-                            );
-                        if !equivalent {
-                            assert!(
-                                actual.tile_reports.iter().any(|report| {
-                                    !report.coverage_issues.is_empty()
-                                        || !report.ownership_domain_issues.is_empty()
-                                        || !report.input_boundary_issues.is_empty()
-                                        || !report.excluded_component_issues.is_empty()
-                                }),
-                                "undetected single-geometry mismatch: min=({min_x},{min_y}), width={width}, tile_size={tile_size}, buffer={buffer}"
-                            );
+                for ownership_policy in [
+                    TileOwnershipPolicy::Centroid,
+                    TileOwnershipPolicy::RepresentativePointInsidePolygon,
+                    TileOwnershipPolicy::LexicographicMinVertex,
+                ]
+                .iter()
+                {
+                    for tile_size in [4.0, 8.0, 16.0] {
+                        for buffer in [0.0, 1.0, 4.0] {
+                            let mut tiled = TiledPolygonizer::new(bounds, tile_size)
+                                .with_buffer(buffer)
+                                .with_options(options.clone())
+                                .with_ownership_policy(ownership_policy.clone())
+                                .with_dedup_policy(DedupPolicy::CanonicalRingHash);
+                            tiled.add_geometry(&geometry);
+                            let actual = tiled.polygonize().unwrap();
+                            let equivalent = actual.polygons.len() == expected.polygons.len()
+                                && actual.polygons.iter().zip(&expected.polygons).all(
+                                    |(actual, expected)| {
+                                        actual.exterior == expected.exterior
+                                            && actual.interiors == expected.interiors
+                                    },
+                                );
+                            if !equivalent {
+                                assert!(
+                                    actual.tile_reports.iter().any(|report| {
+                                        !report.coverage_issues.is_empty()
+                                            || !report.ownership_domain_issues.is_empty()
+                                            || !report.input_boundary_issues.is_empty()
+                                            || !report.excluded_component_issues.is_empty()
+                                    }),
+                                    "undetected single-geometry mismatch: policy={ownership_policy:?}, min=({min_x},{min_y}), width={width}, tile_size={tile_size}, buffer={buffer}"
+                                );
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Stack

- Parent: PR #1232 `feat(core): bound tiled retry attempts`, branch `agent/p3-retry-execution-budget`, head `d71cced`.
- Children: none.

## Delivered

- Extended the existing bounded single-geometry envelope differential sweep across all three `TileOwnershipPolicy` values.
- Kept the in-domain mismatch evidence gate unchanged: any mismatch must report owned-face, ownership-domain, input-boundary, or excluded-component evidence.
- Recorded the policy dimension in the failure witness.
- Updated P3.1 with the exact evidence boundary; the broad missing-region umbrella remains open.

## Contract impact

- Test/evidence only; no runtime behavior or public API changes.
- The sweep covers 208 qualifying envelope placements × 3 ownership policies × 3 tile sizes × 3 buffers.
- No in-domain undetected mismatch was found in this matrix.
- This does not certify arbitrary geometry, connected-region detection, region-local reconciliation, or graph stitching.

## Validation

- PASS: `cargo fmt --all -- --check`
- PASS: `cargo test -p geo-polygonize-core --test tiling_equivalence --quiet` (7 tests)
- PASS: `cargo test --workspace --quiet`
- PASS: `cargo test -p geo-polygonize-core --no-default-features --quiet`
- PASS: `cargo clippy --workspace --all-targets -- -D warnings`
- PASS: `cargo doc -p geo-polygonize-core --no-deps`
- PASS: `npm test` (11 files, 54 tests)
- PASS: `npm run docs:build` (known npm-audit, MUI client-directive, and large-chunk warnings).
- BLOCKED by environment: attempted `cargo fuzz run tile_ownership_dedup -- -runs=10000`, but stable Rust rejected the nightly-only `-Zsanitizer` flag before building the target.
- Restored generated bindings and `playground/package-lock.json`.

## Agent handoff

- Current branch/commit: `agent/p3-coverage-container-boundary-sweep` / `9fd8a32`.
- Parent/children are exact: parent PR #1232; children none.
- Next executable slice: safe region-local recovery evidence or a bounded P2 work item; do not append independently polygonized connected components.
- Remaining risks: broad undetected connected-region boundaries, containment-safe region-local reconciliation/canonical partial merging, and true graph stitching remain open.