### PR TITLE
fix(core): bound tiled call cardinality

### DIFF
--- a/crates/geo-polygonize-core/src/fingerprint.rs
+++ b/crates/geo-polygonize-core/src/fingerprint.rs
@@ -3,6 +3,7 @@
 //! This is intentionally `#[doc(hidden)]`: it is a shared contract for the
 //! repository's adapters, not an additional stable polygonization entrypoint.
 
+use crate::utils::canonical_coordinate_bits;
 use crate::{
     Coord3D, NodingValidationKind, PolygonizeError, PolygonizerOptions, PolygonizerResult,
 };
@@ -439,10 +440,7 @@ pub(crate) fn float_bits(value: f64) -> crate::Result<String> {
             reason: "fingerprint coordinates must be finite".to_string(),
         });
     }
-    Ok(format!(
-        "0x{:016x}",
-        if value == 0.0 { 0 } else { value.to_bits() }
-    ))
+    Ok(format!("0x{:016x}", canonical_coordinate_bits(value)))
 }
 
 fn id32(value: u32) -> String {

--- a/crates/geo-polygonize-core/src/lib.rs
+++ b/crates/geo-polygonize-core/src/lib.rs
@@ -66,7 +66,7 @@ pub use polygonizer::{
 #[doc(hidden)]
 pub use tiling::{
     StitchingReport, TileBoundarySide, TileComponentConnection, TileCoverageGuarantee,
-    TileCoverageIssue, TileExcludedComponentIssue, TileInputBoundaryIssue,
+    TileCoverageIssue, TileExcludedComponentIssue, TileExecutionPolicy, TileInputBoundaryIssue,
     TileOwnershipDomainIssue, TileReport, TileRetryAttempt, TileRetryPolicy, TiledPolygonizeError,
     TiledPolygonizeResult, TiledPolygonizer, TracedTiledPolygonizeResultV1,
 };

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -16,7 +16,7 @@ use crate::trace::{
 };
 use crate::types::{Coord3D, Line3D, Polygon3D, RingGraphIdentity};
 use crate::utils::simd::SimdRing;
-use crate::utils::z_order_index;
+use crate::utils::{canonical_coordinate_bits, z_order_index};
 use float_next_after::NextAfter;
 use geo::Contains;
 use geo_traits::{CoordTrait, LineStringTrait};
@@ -1203,9 +1203,10 @@ fn restored_coordinates(
 }
 
 fn coordinate_key(coord: Coord3D) -> (u64, u64) {
-    let x = if coord.x == 0.0 { 0.0 } else { coord.x };
-    let y = if coord.y == 0.0 { 0.0 } else { coord.y };
-    (x.to_bits(), y.to_bits())
+    (
+        canonical_coordinate_bits(coord.x),
+        canonical_coordinate_bits(coord.y),
+    )
 }
 
 fn restore_noded_coordinates(

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -9,6 +9,7 @@ use crate::trace::{
     TraceStageV1,
 };
 use crate::types::{Coord3D, Line3D, Polygon3D};
+use crate::utils::canonical_coordinate_bits;
 use crate::{PolygonizeError, Polygonizer, PolygonizerOptions, Result};
 use geo::algorithm::line_intersection::line_intersection;
 use geo::bounding_rect::BoundingRect;
@@ -16,16 +17,26 @@ use geo::intersects::Intersects;
 use geo::InteriorPoint;
 use geo_types::{Coord, Geometry, Line, LineString, Point, Rect};
 #[cfg(feature = "parallel")]
-use rayon::prelude::*;
+use rayon::{prelude::*, ThreadPoolBuilder};
 use rstar::AABB;
 use std::collections::{HashMap, HashSet};
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
 use thiserror::Error;
 
 fn canonical_ring_key(ring: &[Coord3D]) -> Vec<[u64; 3]> {
     let key = |mut ring: Vec<Coord3D>| {
         canonicalize_ring(&mut ring, None);
         ring.into_iter()
-            .map(|coord| [coord.x.to_bits(), coord.y.to_bits(), coord.z.to_bits()])
+            .map(|coord| {
+                [
+                    canonical_coordinate_bits(coord.x),
+                    canonical_coordinate_bits(coord.y),
+                    canonical_coordinate_bits(coord.z),
+                ]
+            })
             .collect::<Vec<_>>()
     };
     key(ring.to_vec()).min(key(ring.iter().rev().copied().collect()))
@@ -114,6 +125,17 @@ pub struct TileRetryPolicy {
     pub max_attempts: usize,
     pub buffer_increment: f64,
     pub max_buffer: f64,
+}
+
+/// Limits for work owned by one experimental tiled polygonization call.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct TileExecutionPolicy {
+    pub max_tiles: Option<usize>,
+    pub max_input_geometries: Option<usize>,
+    pub max_tile_geometry_assignments: Option<usize>,
+    pub max_retry_attempts_total: Option<usize>,
+    pub max_fallback_regions: Option<usize>,
+    pub max_parallel_tiles: Option<usize>,
 }
 
 /// Result of one larger-halo retry for a tile.
@@ -302,18 +324,56 @@ enum ComponentFallbackDecision {
     Declined(ComponentFallbackDeclineReason),
 }
 
+fn account_polygon_output(
+    policy: &ExecutionPolicy,
+    polygon_count: &mut usize,
+    coordinate_count: &mut usize,
+    polygon: &Polygon3D,
+) -> Result<()> {
+    let next_polygon_count = polygon_count.checked_add(1).ok_or_else(|| {
+        PolygonizeError::InternalInvariantViolation {
+            reason: "tiled output polygon count overflow".to_string(),
+        }
+    })?;
+    let polygon_coordinates = polygon
+        .exterior
+        .len()
+        .checked_add(
+            polygon
+                .interiors
+                .iter()
+                .try_fold(0usize, |count, ring| count.checked_add(ring.len()))
+                .ok_or_else(|| PolygonizeError::InternalInvariantViolation {
+                    reason: "tiled polygon coordinate count overflow".to_string(),
+                })?,
+        )
+        .ok_or_else(|| PolygonizeError::InternalInvariantViolation {
+            reason: "tiled polygon coordinate count overflow".to_string(),
+        })?;
+    let next_coordinate_count = coordinate_count
+        .checked_add(polygon_coordinates)
+        .ok_or_else(|| PolygonizeError::InternalInvariantViolation {
+            reason: "tiled output coordinate count overflow".to_string(),
+        })?;
+    policy.check(
+        "output_polygons",
+        policy.max_output_polygons,
+        next_polygon_count,
+    )?;
+    policy.check(
+        "output_coordinates",
+        policy.max_output_coordinates,
+        next_coordinate_count,
+    )?;
+    *polygon_count = next_polygon_count;
+    *coordinate_count = next_coordinate_count;
+    Ok(())
+}
+
 #[derive(Clone, Copy, Debug)]
 struct InputSegment {
     line: Line<f64>,
     geometry_index: usize,
-}
-
-fn endpoint_bits(value: f64) -> u64 {
-    if value == 0.0 {
-        0.0f64.to_bits()
-    } else {
-        value.to_bits()
-    }
 }
 
 fn line_string_segments(
@@ -475,6 +535,7 @@ pub struct TiledPolygonizer<'a> {
     dedup_policy: DedupPolicy,
     options: PolygonizerOptions,
     execution_policy: ExecutionPolicy,
+    tile_execution_policy: TileExecutionPolicy,
     retry_policy: Option<TileRetryPolicy>,
     component_fallback: bool,
     untiled_fallback: bool,
@@ -495,6 +556,7 @@ impl<'a> TiledPolygonizer<'a> {
             dedup_policy: DedupPolicy::KeepAll,
             options,
             execution_policy: ExecutionPolicy::default(),
+            tile_execution_policy: TileExecutionPolicy::default(),
             retry_policy: None,
             component_fallback: false,
             untiled_fallback: false,
@@ -527,6 +589,14 @@ impl<'a> TiledPolygonizer<'a> {
         self
     }
 
+    pub fn with_tile_execution_policy(
+        mut self,
+        tile_execution_policy: TileExecutionPolicy,
+    ) -> Self {
+        self.tile_execution_policy = tile_execution_policy;
+        self
+    }
+
     pub fn with_retry_policy(mut self, retry_policy: TileRetryPolicy) -> Self {
         self.retry_policy = Some(retry_policy);
         self
@@ -553,6 +623,19 @@ impl<'a> TiledPolygonizer<'a> {
         self.geometries.push((geom, bbox));
     }
 
+    fn buffered_bbox(&self, tile_bbox: Rect<f64>, buffer: f64) -> Rect<f64> {
+        Rect::new(
+            Coord {
+                x: tile_bbox.min().x - buffer,
+                y: tile_bbox.min().y - buffer,
+            },
+            Coord {
+                x: tile_bbox.max().x + buffer,
+                y: tile_bbox.max().y + buffer,
+            },
+        )
+    }
+
     fn process_tile(
         &self,
         tile_bbox: Rect<f64>,
@@ -566,16 +649,7 @@ impl<'a> TiledPolygonizer<'a> {
             .with_execution_policy(self.execution_policy.clone());
 
         // Define buffered bbox
-        let buffered_bbox = Rect::new(
-            Coord {
-                x: tile_bbox.min().x - buffer,
-                y: tile_bbox.min().y - buffer,
-            },
-            Coord {
-                x: tile_bbox.max().x + buffer,
-                y: tile_bbox.max().y + buffer,
-            },
-        );
+        let buffered_bbox = self.buffered_bbox(tile_bbox, buffer);
 
         // Filter geometries intersecting the BUFFERED tile
         let mut relevant_lines = 0;
@@ -1104,6 +1178,8 @@ impl<'a> TiledPolygonizer<'a> {
         self.execution_policy
             .check_cancelled("tile_fallback_merge")?;
         let mut result = Vec::new();
+        let mut output_polygon_count = 0;
+        let mut output_coordinate_count = 0;
         let mut work_items = 0;
         for polygons in tile_polygons {
             for polygon in polygons {
@@ -1123,6 +1199,12 @@ impl<'a> TiledPolygonizer<'a> {
                     }
                 }
                 if !replaced {
+                    account_polygon_output(
+                        &self.execution_policy,
+                        &mut output_polygon_count,
+                        &mut output_coordinate_count,
+                        &polygon,
+                    )?;
                     result.push(polygon);
                 }
             }
@@ -1131,6 +1213,12 @@ impl<'a> TiledPolygonizer<'a> {
             self.execution_policy
                 .check_cancelled_every("tile_fallback_merge", work_items)?;
             work_items = work_items.saturating_add(1);
+            account_polygon_output(
+                &self.execution_policy,
+                &mut output_polygon_count,
+                &mut output_coordinate_count,
+                &polygon,
+            )?;
             result.push(polygon);
         }
         Ok(result)
@@ -1141,6 +1229,7 @@ impl<'a> TiledPolygonizer<'a> {
         tile_bbox: Rect<f64>,
         input_components: &[InputComponent],
         capture_byte_limit: Option<usize>,
+        retry_attempt_counter: &AtomicUsize,
     ) -> Result<TileProcessResult> {
         let mut buffer = self.buffer;
         let mut result =
@@ -1158,6 +1247,22 @@ impl<'a> TiledPolygonizer<'a> {
                 "tile_retry_attempts",
                 self.execution_policy.max_tile_retry_attempts,
                 attempt,
+            )?;
+            let observed_attempts = retry_attempt_counter
+                .fetch_update(Ordering::AcqRel, Ordering::Acquire, |attempts| {
+                    attempts.checked_add(1)
+                })
+                .map_err(|_| PolygonizeError::InternalInvariantViolation {
+                    reason: "tiled retry attempt counter overflow".to_string(),
+                })?
+                .checked_add(1)
+                .ok_or_else(|| PolygonizeError::InternalInvariantViolation {
+                    reason: "tiled retry attempt counter overflow".to_string(),
+                })?;
+            self.execution_policy.check(
+                "tile_retry_attempts_total",
+                self.tile_execution_policy.max_retry_attempts_total,
+                observed_attempts,
             )?;
             buffer = (buffer + policy.buffer_increment).min(policy.max_buffer);
             result = self.process_tile(tile_bbox, input_components, buffer, capture_byte_limit)?;
@@ -1263,27 +1368,104 @@ impl<'a> TiledPolygonizer<'a> {
         unresolved_sides
     }
 
-    fn generate_tiles(&self) -> Vec<Rect<f64>> {
+    fn generate_tiles(&self) -> Result<Vec<Rect<f64>>> {
         let min = self.bbox.min();
         let max = self.bbox.max();
         let width = max.x - min.x;
         let height = max.y - min.y;
 
-        let cols = (width / self.tile_size).ceil() as usize;
-        let rows = (height / self.tile_size).ceil() as usize;
+        let checked_axis_count = |length: f64| {
+            let count = (length / self.tile_size).ceil();
+            if !count.is_finite() || count >= usize::MAX as f64 {
+                return Err(PolygonizeError::ResourceLimitExceeded {
+                    stage: "tile_count".to_string(),
+                    limit: usize::MAX - 1,
+                    observed: usize::MAX,
+                });
+            }
+            Ok(count as usize)
+        };
+        let cols = checked_axis_count(width)?;
+        let rows = checked_axis_count(height)?;
+        let tile_count =
+            rows.checked_mul(cols)
+                .ok_or_else(|| PolygonizeError::ResourceLimitExceeded {
+                    stage: "tile_count".to_string(),
+                    limit: self
+                        .tile_execution_policy
+                        .max_tiles
+                        .unwrap_or(usize::MAX - 1),
+                    observed: usize::MAX,
+                })?;
+        self.execution_policy.check(
+            "tile_count",
+            self.tile_execution_policy.max_tiles,
+            tile_count,
+        )?;
 
-        let mut tiles = Vec::new();
-        for r in 0..rows {
-            for c in 0..cols {
-                let x0 = min.x + c as f64 * self.tile_size;
-                let y0 = min.y + r as f64 * self.tile_size;
-                let x1 = (x0 + self.tile_size).min(max.x);
-                let y1 = (y0 + self.tile_size).min(max.y);
-
-                tiles.push(Rect::new(Coord { x: x0, y: y0 }, Coord { x: x1, y: y1 }));
+        let tile_rect = |r: usize, c: usize| {
+            let x0 = min.x + c as f64 * self.tile_size;
+            let y0 = min.y + r as f64 * self.tile_size;
+            let x1 = (x0 + self.tile_size).min(max.x);
+            let y1 = (y0 + self.tile_size).min(max.y);
+            Rect::new(Coord { x: x0, y: y0 }, Coord { x: x1, y: y1 })
+        };
+        let mut assignment_count = 0usize;
+        if self
+            .tile_execution_policy
+            .max_tile_geometry_assignments
+            .is_some()
+        {
+            for r in 0..rows {
+                for c in 0..cols {
+                    self.execution_policy
+                        .check_cancelled_every("tile_assignment_preflight", r * cols + c)?;
+                    let buffered_bbox = self.buffered_bbox(tile_rect(r, c), self.buffer);
+                    let tile_assignments = self
+                        .geometries
+                        .iter()
+                        .filter(|(_, bbox)| {
+                            bbox.is_some_and(|geometry_bbox| {
+                                geometry_bbox.intersects(&buffered_bbox)
+                            })
+                        })
+                        .count();
+                    assignment_count =
+                        assignment_count
+                            .checked_add(tile_assignments)
+                            .ok_or_else(|| PolygonizeError::ResourceLimitExceeded {
+                                stage: "tile_geometry_assignments".to_string(),
+                                limit: self
+                                    .tile_execution_policy
+                                    .max_tile_geometry_assignments
+                                    .unwrap_or(usize::MAX - 1),
+                                observed: usize::MAX,
+                            })?;
+                    self.execution_policy.check(
+                        "tile_geometry_assignments",
+                        self.tile_execution_policy.max_tile_geometry_assignments,
+                        assignment_count,
+                    )?;
+                }
             }
         }
-        tiles
+
+        let mut tiles = Vec::new();
+        tiles.try_reserve_exact(tile_count).map_err(|_| {
+            PolygonizeError::ResourceLimitExceeded {
+                stage: "tile_allocation".to_string(),
+                limit: tile_count,
+                observed: usize::MAX,
+            }
+        })?;
+        for r in 0..rows {
+            for c in 0..cols {
+                self.execution_policy
+                    .check_cancelled_every("tile_generation", r * cols + c)?;
+                tiles.push(tile_rect(r, c));
+            }
+        }
+        Ok(tiles)
     }
 
     fn input_components(&self) -> Result<Vec<InputComponent>> {
@@ -1404,7 +1586,10 @@ impl<'a> TiledPolygonizer<'a> {
         }
         for segment in &segments {
             for endpoint in [segment.line.start, segment.line.end] {
-                let key = (endpoint_bits(endpoint.x), endpoint_bits(endpoint.y));
+                let key = (
+                    canonical_coordinate_bits(endpoint.x),
+                    canonical_coordinate_bits(endpoint.y),
+                );
                 if let Some(previous) = endpoint_owners.insert(key, segment.geometry_index) {
                     join_components(&mut parents, previous, segment.geometry_index);
                 }
@@ -1608,7 +1793,7 @@ impl<'a> TiledPolygonizer<'a> {
         trace: Option<&mut TraceRecorderV1>,
     ) -> Result<TiledPolygonizeResult> {
         self.validate()?;
-        let tiles = self.generate_tiles();
+        let tiles = self.generate_tiles()?;
         let input_components = self.input_components()?;
         self.polygonize_tiles(tiles, &input_components, trace)
     }
@@ -1619,6 +1804,7 @@ impl<'a> TiledPolygonizer<'a> {
         input_components: &[InputComponent],
         mut trace: Option<&mut TraceRecorderV1>,
     ) -> Result<TiledPolygonizeResult> {
+        let retry_attempt_counter = Arc::new(AtomicUsize::new(0));
         let trace_ownership = trace
             .as_ref()
             .is_some_and(|trace| trace.records_stage(TraceStageV1::Output));
@@ -1632,8 +1818,13 @@ impl<'a> TiledPolygonizer<'a> {
                         .records_stage(TraceStageV1::Output)
                         .then(|| trace.capture_byte_limit(TraceStageV1::Output))
                 });
-                let (polygons, report, ownership_decisions, capture_truncated) =
-                    self.process_tile_with_retries(tile, input_components, capture_byte_limit)?;
+                let (polygons, report, ownership_decisions, capture_truncated) = self
+                    .process_tile_with_retries(
+                        tile,
+                        input_components,
+                        capture_byte_limit,
+                        &retry_attempt_counter,
+                    )?;
                 let trace = trace.as_deref_mut().expect("tile trace exists");
                 for attempt in &report.retry_attempts {
                     if !trace.record_tile_halo_retry(tile_index, attempt) {
@@ -1690,18 +1881,55 @@ impl<'a> TiledPolygonizer<'a> {
             }
         } else {
             #[cfg(feature = "parallel")]
-            let tile_results: Vec<_> = tiles
-                .into_par_iter()
-                .map(|tile| self.process_tile_with_retries(tile, input_components, None))
-                .collect();
+            let tile_results: Result<Vec<_>> =
+                if let Some(max_parallel_tiles) = self.tile_execution_policy.max_parallel_tiles {
+                    let pool = ThreadPoolBuilder::new()
+                        .num_threads(max_parallel_tiles)
+                        .build()
+                        .map_err(|error| PolygonizeError::InternalInvariantViolation {
+                            reason: format!("failed to create tiled worker pool: {error}"),
+                        })?;
+                    pool.install(|| {
+                        tiles
+                            .into_par_iter()
+                            .map(|tile| {
+                                self.process_tile_with_retries(
+                                    tile,
+                                    input_components,
+                                    None,
+                                    &retry_attempt_counter,
+                                )
+                            })
+                            .collect()
+                    })
+                } else {
+                    tiles
+                        .into_par_iter()
+                        .map(|tile| {
+                            self.process_tile_with_retries(
+                                tile,
+                                input_components,
+                                None,
+                                &retry_attempt_counter,
+                            )
+                        })
+                        .collect()
+                };
             #[cfg(not(feature = "parallel"))]
-            let tile_results: Vec<_> = tiles
+            let tile_results: Result<Vec<_>> = tiles
                 .into_iter()
-                .map(|tile| self.process_tile_with_retries(tile, input_components, None))
+                .map(|tile| {
+                    self.process_tile_with_retries(
+                        tile,
+                        input_components,
+                        None,
+                        &retry_attempt_counter,
+                    )
+                })
                 .collect();
 
-            for result in tile_results {
-                let (polygons, report, _, _) = result?;
+            for result in tile_results? {
+                let (polygons, report, _, _) = result;
                 tile_polygons.push(polygons);
                 tile_reports.push(report);
             }
@@ -1715,7 +1943,14 @@ impl<'a> TiledPolygonizer<'a> {
                     &tile_reports,
                     input_components,
                 )? {
-                    ComponentFallbackDecision::Recovered(result) => (Some(result), None),
+                    ComponentFallbackDecision::Recovered(result) => {
+                        self.execution_policy.check(
+                            "tile_fallback_regions",
+                            self.tile_execution_policy.max_fallback_regions,
+                            result.region_bboxes.len(),
+                        )?;
+                        (Some(result), None)
+                    }
                     ComponentFallbackDecision::Declined(reason) => (None, Some(reason.as_str())),
                 }
             } else {
@@ -1743,7 +1978,18 @@ impl<'a> TiledPolygonizer<'a> {
             for (geometry, _) in &self.geometries {
                 polygonizer.add_borrowed_geometry(geometry);
             }
-            polygonizer.polygonize()?.polygons
+            let polygons = polygonizer.polygonize()?.polygons;
+            let mut polygon_count = 0;
+            let mut coordinate_count = 0;
+            for polygon in &polygons {
+                account_polygon_output(
+                    &self.execution_policy,
+                    &mut polygon_count,
+                    &mut coordinate_count,
+                    polygon,
+                )?;
+            }
+            polygons
         } else {
             self.merge_fallback_polygons(
                 tile_polygons,
@@ -1801,11 +2047,18 @@ impl<'a> TiledPolygonizer<'a> {
             &self.execution_policy,
             None,
         )?;
-        self.execution_policy.check(
-            "output_polygons",
-            self.execution_policy.max_output_polygons,
-            polygons.len(),
-        )?;
+        let mut output_polygon_count = 0;
+        let mut output_coordinate_count = 0;
+        for (polygon_index, polygon) in polygons.iter().enumerate() {
+            self.execution_policy
+                .check_cancelled_every("output_flattening", polygon_index)?;
+            account_polygon_output(
+                &self.execution_policy,
+                &mut output_polygon_count,
+                &mut output_coordinate_count,
+                polygon,
+            )?;
+        }
         let output_polygon_count = polygons.len();
         let unresolved_tile_count = tile_reports
             .iter()
@@ -1917,6 +2170,22 @@ impl<'a> TiledPolygonizer<'a> {
 
     fn validate(&self) -> Result<()> {
         self.options.validate()?;
+        self.execution_policy.check(
+            "tile_input_geometries",
+            self.tile_execution_policy.max_input_geometries,
+            self.geometries.len(),
+        )?;
+        if self
+            .tile_execution_policy
+            .max_parallel_tiles
+            .is_some_and(|parallelism| parallelism == 0)
+        {
+            return Err(PolygonizeError::InvalidArgumentType {
+                field: "tile_execution_policy.max_parallel_tiles".to_string(),
+                expected: "a positive integer".to_string(),
+                actual: "0".to_string(),
+            });
+        }
         if !self.tile_size.is_finite() || self.tile_size <= 0.0 {
             return Err(PolygonizeError::InvalidArgumentType {
                 field: "tile_size".to_string(),

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -9,8 +9,8 @@ mod tests {
         NodingGuarantee, NodingOptions, Polygon3D, PolygonizeError, Polygonizer,
         PolygonizerOptions, PrecisionModel, ProvenanceOptions, TileBoundarySide,
         TileComponentConnection, TileCoverageGuarantee, TileCoverageIssue,
-        TileExcludedComponentIssue, TileReport, TileRetryPolicy, TiledPolygonizeError,
-        TiledPolygonizer,
+        TileExcludedComponentIssue, TileExecutionPolicy, TileReport, TileRetryPolicy,
+        TiledPolygonizeError, TiledPolygonizer,
     };
     use geo::{Contains, Coord, Geometry, LineString, MultiLineString, Rect};
 
@@ -284,6 +284,126 @@ mod tests {
     }
 
     #[test]
+    fn bounds_tiled_call_cardinality_before_materializing_tiles() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 20.0 });
+        let bounded =
+            TiledPolygonizer::new(bbox, 10.0).with_tile_execution_policy(TileExecutionPolicy {
+                max_tiles: Some(1),
+                ..Default::default()
+            });
+        assert!(matches!(
+            bounded.polygonize(),
+            Err(PolygonizeError::ResourceLimitExceeded {
+                ref stage,
+                limit: 1,
+                observed: 4,
+            }) if stage == "tile_count"
+        ));
+
+        let extreme = TiledPolygonizer::new(
+            Rect::new(
+                Coord { x: 0.0, y: 0.0 },
+                Coord {
+                    x: f64::MAX,
+                    y: 1.0,
+                },
+            ),
+            1.0,
+        );
+        assert!(matches!(
+            extreme.polygonize(),
+            Err(PolygonizeError::ResourceLimitExceeded { ref stage, .. })
+                if stage == "tile_count"
+        ));
+    }
+
+    #[test]
+    fn bounds_tiled_geometry_assignments_and_input_count() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 10.0 });
+        let line = Geometry::LineString(LineString::new(vec![
+            Coord { x: 0.0, y: 5.0 },
+            Coord { x: 20.0, y: 5.0 },
+        ]));
+        let mut assignments =
+            TiledPolygonizer::new(bbox, 10.0).with_tile_execution_policy(TileExecutionPolicy {
+                max_tile_geometry_assignments: Some(1),
+                ..Default::default()
+            });
+        assignments.add_geometry(&line);
+        assert!(matches!(
+            assignments.polygonize(),
+            Err(PolygonizeError::ResourceLimitExceeded {
+                ref stage,
+                limit: 1,
+                observed: 2,
+            }) if stage == "tile_geometry_assignments"
+        ));
+
+        let mut input_bound =
+            TiledPolygonizer::new(bbox, 10.0).with_tile_execution_policy(TileExecutionPolicy {
+                max_input_geometries: Some(0),
+                ..Default::default()
+            });
+        input_bound.add_geometry(&line);
+        assert!(matches!(
+            input_bound.polygonize(),
+            Err(PolygonizeError::ResourceLimitExceeded {
+                ref stage,
+                limit: 0,
+                observed: 1,
+            }) if stage == "tile_input_geometries"
+        ));
+    }
+
+    #[test]
+    fn tile_generation_observes_cancellation_and_parallelism_validation() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 20.0 });
+        let token = CancellationToken::new();
+        token.cancel();
+        let cancelled = TiledPolygonizer::new(bbox, 10.0).with_execution_policy(ExecutionPolicy {
+            cancellation_token: Some(token),
+            ..Default::default()
+        });
+        assert!(matches!(
+            cancelled.polygonize(),
+            Err(PolygonizeError::Cancelled { ref stage }) if stage == "tile_generation"
+        ));
+
+        let invalid =
+            TiledPolygonizer::new(bbox, 10.0).with_tile_execution_policy(TileExecutionPolicy {
+                max_parallel_tiles: Some(0),
+                ..Default::default()
+            });
+        assert!(matches!(
+            invalid.polygonize(),
+            Err(PolygonizeError::InvalidArgumentType { ref field, .. })
+                if field == "tile_execution_policy.max_parallel_tiles"
+        ));
+    }
+
+    #[test]
+    fn canonical_tile_keys_normalize_signed_zero() {
+        let polygon = |zero: f64| {
+            Polygon3D::new(
+                vec![
+                    Coord3D::new(zero, 0.0, 0.0),
+                    Coord3D::new(1.0, 0.0, 0.0),
+                    Coord3D::new(1.0, 1.0, 0.0),
+                    Coord3D::new(zero, 1.0, 0.0),
+                    Coord3D::new(zero, 0.0, 0.0),
+                ],
+                vec![],
+                vec![],
+                vec![],
+            )
+        };
+        assert_eq!(
+            crate::tiling::canonical_polygon_key(&polygon(-0.0)),
+            crate::tiling::canonical_polygon_key(&polygon(0.0))
+        );
+    }
+
+    #[test]
     fn reports_tile_topology_and_merge_counts() {
         let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 2.0, y: 2.0 });
         let square = Geometry::LineString(LineString::new(vec![
@@ -349,6 +469,43 @@ mod tests {
                 limit: 1,
                 observed: 2,
             }) if stage == "output_polygons"
+        ));
+    }
+
+    #[test]
+    fn tiled_merge_applies_aggregate_coordinate_limit() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 10.0 });
+        let squares = [
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 1.0, y: 1.0 },
+                Coord { x: 3.0, y: 1.0 },
+                Coord { x: 3.0, y: 3.0 },
+                Coord { x: 1.0, y: 3.0 },
+                Coord { x: 1.0, y: 1.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 11.0, y: 1.0 },
+                Coord { x: 13.0, y: 1.0 },
+                Coord { x: 13.0, y: 3.0 },
+                Coord { x: 11.0, y: 3.0 },
+                Coord { x: 11.0, y: 1.0 },
+            ])),
+        ];
+        let mut tiled = TiledPolygonizer::new(bbox, 10.0).with_execution_policy(ExecutionPolicy {
+            max_output_coordinates: Some(5),
+            ..Default::default()
+        });
+        for square in &squares {
+            tiled.add_geometry(square);
+        }
+
+        assert!(matches!(
+            tiled.polygonize(),
+            Err(PolygonizeError::ResourceLimitExceeded {
+                ref stage,
+                limit: 5,
+                observed: 10,
+            }) if stage == "output_coordinates"
         ));
     }
 
@@ -531,6 +688,23 @@ mod tests {
             .events
             .iter()
             .any(|event| event.kind == "tile_component_fallback_declined"));
+
+        let mut limited = TiledPolygonizer::new(bbox, 10.0)
+            .with_buffer(2.0)
+            .with_component_fallback()
+            .with_tile_execution_policy(TileExecutionPolicy {
+                max_fallback_regions: Some(0),
+                ..Default::default()
+            });
+        limited.add_geometry(&face);
+        assert!(matches!(
+            limited.polygonize(),
+            Err(PolygonizeError::ResourceLimitExceeded {
+                ref stage,
+                limit: 0,
+                observed: 1,
+            }) if stage == "tile_fallback_regions"
+        ));
     }
 
     #[test]
@@ -2508,6 +2682,30 @@ mod tests {
                 observed: 2,
             }) if stage == "tile_retry_attempts"
         ));
+
+        let mut total_bound = TiledPolygonizer::new(bbox, 10.0)
+            .with_buffer(2.0)
+            .with_retry_policy(TileRetryPolicy {
+                max_attempts: 1,
+                buffer_increment: 1.0,
+                max_buffer: 3.0,
+            })
+            .with_tile_execution_policy(TileExecutionPolicy {
+                max_retry_attempts_total: Some(0),
+                max_parallel_tiles: Some(1),
+                ..Default::default()
+            });
+        for boundary in &boundaries {
+            total_bound.add_geometry(boundary);
+        }
+        assert!(matches!(
+            total_bound.polygonize(),
+            Err(PolygonizeError::ResourceLimitExceeded {
+                ref stage,
+                limit: 0,
+                observed: 1,
+            }) if stage == "tile_retry_attempts_total"
+        ));
     }
 
     #[test]
@@ -2896,7 +3094,7 @@ mod tests {
         tiler.add_geometry(&face);
 
         let forward = tiler.polygonize().unwrap();
-        let mut tiles = tiler.generate_tiles();
+        let mut tiles = tiler.generate_tiles().unwrap();
         let mut state = 0x71_1e_u64;
         for upper in (1..tiles.len()).rev() {
             state = state.wrapping_mul(6364136223846793005).wrapping_add(1);

--- a/crates/geo-polygonize-core/src/utils/mod.rs
+++ b/crates/geo-polygonize-core/src/utils/mod.rs
@@ -6,6 +6,15 @@ pub mod parallel;
 pub mod simd;
 pub mod soa;
 
+#[inline]
+pub(crate) fn canonical_coordinate_bits(value: f64) -> u64 {
+    if value == 0.0 {
+        0
+    } else {
+        value.to_bits()
+    }
+}
+
 /// Computes a Z-order curve (Morton code) index for a 2D coordinate.
 /// Maps floating point coordinates to a 64-bit integer index.
 /// This preserves locality: points close in 2D space are likely close in Z-order.

--- a/docs/guide/tiling.md
+++ b/docs/guide/tiling.md
@@ -85,9 +85,9 @@ for that test:
 
 `KeepAll` performs no duplicate removal. `CanonicalRingHash` removes exact
 duplicate polygon geometry after canonicalizing ring direction and start; its
-key contains exact XYZ bits, not a tolerance. It does not merge distinct
-provenance payloads, so callers requiring provenance equivalence must verify the
-retained polygon against untiled output.
+key contains exact XYZ bits with signed zero normalized, not a tolerance. It
+does not merge distinct provenance payloads, so callers requiring provenance
+equivalence must verify the retained polygon against untiled output.
 
 Canonical output options apply the normal final ordering pass after tile merge.
 The untraced path may process tiles in parallel, while bounded tracing processes
@@ -118,6 +118,11 @@ and each recovery region, not as one aggregate budget
 across the tiled call; the final canonical merge also enforces the configured
 aggregate output-polygon limit and observes cancellation. The component
 envelope remains conservative evidence rather than proof of a face.
+`with_tile_execution_policy` adds call-level guards for tile count, input
+geometry count, replicated geometry assignments, total retry attempts,
+fallback-region count, and optional per-call rayon parallelism. Tile generation
+checks cancellation before materialization and reserves the validated tile
+count exactly; tile failures use a result-aware parallel reduction.
 `with_retry_policy` enables deterministic tile-local halo growth for tiles whose
 final report still contains owned-face, input-boundary, or excluded-component
 evidence. Each attempt adds `buffer_increment` up to `max_attempts` and


### PR DESCRIPTION
## Summary

- bound tile generation and replicated tiled work with TileExecutionPolicy
- enforce aggregate tiled polygon and coordinate output limits
- normalize tiled canonical keys with the shared signed-zero coordinate contract
- collect tile failures through a result-aware parallel reduction

## Root cause

Tile generation previously cast unchecked floating-point counts and materialized the full grid before call-level limits could apply. Tiled output accounting did not enforce aggregate coordinate limits, and tiled deduplication disagreed with the exact fingerprint contract for signed zero.

## Validation

- cargo fmt --all -- --check
- cargo test -p geo-polygonize-core tiling -- --nocapture
- cargo test -p geo-polygonize-core --test tiling_equivalence
- cargo test -p geo-polygonize-core
- cargo test -p geo-polygonize-core --no-default-features
- cargo clippy -p geo-polygonize-core --all-targets -- -D warnings