### PR TITLE
fix(core): merge duplicate tiled provenance

### DIFF
--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -370,6 +370,53 @@ fn account_polygon_output(
     Ok(())
 }
 
+fn merge_duplicate_polygon_provenance(
+    retained: &mut Polygon3D,
+    duplicate: &Polygon3D,
+    profile_conflicted: bool,
+) -> bool {
+    retained
+        .boundary_source_line_ids
+        .extend_from_slice(&duplicate.boundary_source_line_ids);
+    retained.boundary_source_line_ids.sort_unstable();
+    retained.boundary_source_line_ids.dedup();
+
+    match (&mut retained.provenance, &duplicate.provenance) {
+        (Some(retained_provenance), Some(duplicate_provenance)) => {
+            retained_provenance
+                .boundary_line_ids
+                .extend_from_slice(&duplicate_provenance.boundary_line_ids);
+            retained_provenance.boundary_line_ids.sort_unstable();
+            retained_provenance.boundary_line_ids.dedup();
+
+            if !profile_conflicted {
+                let conflicting_profiles = matches!(
+                    (
+                        &retained_provenance.input_profile_id,
+                        &duplicate_provenance.input_profile_id
+                    ),
+                    (Some(retained), Some(duplicate)) if retained != duplicate
+                );
+                if conflicting_profiles {
+                    retained_provenance.input_profile_id = None;
+                    return true;
+                } else if retained_provenance.input_profile_id.is_none() {
+                    retained_provenance.input_profile_id =
+                        duplicate_provenance.input_profile_id.clone();
+                }
+            }
+        }
+        (None, Some(duplicate_provenance)) if !profile_conflicted => {
+            retained.provenance = Some(duplicate_provenance.clone());
+        }
+        _ => {}
+    }
+
+    // The first exact duplicate remains the deterministic representative for
+    // per-edge IDs; aggregate source sets above retain all provenance evidence.
+    profile_conflicted
+}
+
 #[derive(Clone, Copy, Debug)]
 struct InputSegment {
     line: Line<f64>,
@@ -2017,17 +2064,28 @@ impl<'a> TiledPolygonizer<'a> {
                 }
                 DedupPolicy::CanonicalRingHash => {
                     let mut unique_polygons = Vec::new();
-                    let mut seen = HashSet::new();
+                    let mut seen = HashMap::new();
+                    let mut profile_conflicts = Vec::new();
 
                     for (polygon_index, poly) in result_polygons.into_iter().enumerate() {
                         self.execution_policy
                             .check_cancelled_every("tile_deduplication", polygon_index)?;
-                        let retained = seen.insert(canonical_polygon_key(&poly));
+                        let key = canonical_polygon_key(&poly);
+                        let retained = if let Some(&retained_index) = seen.get(&key) {
+                            profile_conflicts[retained_index] = merge_duplicate_polygon_provenance(
+                                &mut unique_polygons[retained_index],
+                                &poly,
+                                profile_conflicts[retained_index],
+                            );
+                            false
+                        } else {
+                            seen.insert(key, unique_polygons.len());
+                            unique_polygons.push(poly);
+                            profile_conflicts.push(false);
+                            true
+                        };
                         if let Some(trace) = trace.as_deref_mut() {
                             trace.record_tile_dedup(polygon_index, retained);
-                        }
-                        if retained {
-                            unique_polygons.push(poly);
                         }
                     }
 

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -3258,6 +3258,41 @@ fn canonical_dedup_key_compares_exact_geometry() {
 }
 
 #[test]
+fn canonical_dedup_merges_duplicate_provenance() {
+    use super::merge_duplicate_polygon_provenance;
+    use crate::types::PolygonProvenance;
+    use crate::{Coord3D, Polygon3D};
+
+    let exterior = vec![
+        Coord3D::new(0.0, 0.0, 0.0),
+        Coord3D::new(1.0, 0.0, 0.0),
+        Coord3D::new(1.0, 1.0, 0.0),
+        Coord3D::new(0.0, 1.0, 0.0),
+        Coord3D::new(0.0, 0.0, 0.0),
+    ];
+    let mut retained = Polygon3D::new(exterior.clone(), vec![], vec![10, 11], vec![]);
+    retained.set_boundary_source_line_ids(vec![3, 1]);
+    retained.provenance = Some(PolygonProvenance {
+        boundary_line_ids: vec![3, 1],
+        input_profile_id: Some("profile-a".to_string()),
+    });
+    let mut duplicate = Polygon3D::new(exterior, vec![], vec![20, 21], vec![]);
+    duplicate.set_boundary_source_line_ids(vec![2, 3]);
+    duplicate.provenance = Some(PolygonProvenance {
+        boundary_line_ids: vec![4, 2],
+        input_profile_id: Some("profile-b".to_string()),
+    });
+
+    merge_duplicate_polygon_provenance(&mut retained, &duplicate, false);
+
+    assert_eq!(retained.boundary_source_line_ids, vec![1, 2, 3]);
+    let provenance = retained.provenance.unwrap();
+    assert_eq!(provenance.boundary_line_ids, vec![1, 2, 3, 4]);
+    assert_eq!(provenance.input_profile_id, None);
+    assert_eq!(retained.exterior_ids, vec![10, 11]);
+}
+
+#[test]
 fn reports_single_geometry_face_outside_ownership_domain() {
     use crate::{
         Polygonizer, TileCoverageGuarantee, TileRetryPolicy, TiledPolygonizeError, TiledPolygonizer,

--- a/docs/guide/tiling.md
+++ b/docs/guide/tiling.md
@@ -86,8 +86,9 @@ for that test:
 `KeepAll` performs no duplicate removal. `CanonicalRingHash` removes exact
 duplicate polygon geometry after canonicalizing ring direction and start; its
 key contains exact XYZ bits with signed zero normalized, not a tolerance. It
-does not merge distinct provenance payloads, so callers requiring provenance
-equivalence must verify the retained polygon against untiled output.
+merges duplicate aggregate boundary source sets and compatible input profiles.
+If profiles conflict, the merged profile is unset. The first duplicate remains
+the deterministic representative for per-edge IDs.
 
 Canonical output options apply the normal final ordering pass after tile merge.
 The untraced path may process tiles in parallel, while bounded tracing processes


### PR DESCRIPTION
## Summary

- merge aggregate boundary source IDs when CanonicalRingHash drops an exact duplicate
- retain compatible input profiles and clear the profile on conflict
- keep the first exact duplicate as the deterministic representative for per-edge IDs

## Root cause

Tiled canonical deduplication discarded every duplicate polygon payload after comparing geometry only. Duplicate faces could therefore lose boundary-source evidence or retain a provenance payload that was not representative of all tile observations.

## Validation

- cargo fmt --all -- --check
- cargo test -p geo-polygonize-core
- cargo test -p geo-polygonize-core --no-default-features
- cargo clippy -p geo-polygonize-core --all-targets -- -D warnings