### PR TITLE
refactor(core): track tiled coverage resolution explicitly

### DIFF
--- a/crates/geo-polygonize-core/src/lib.rs
+++ b/crates/geo-polygonize-core/src/lib.rs
@@ -66,7 +66,8 @@ pub use polygonizer::{
 #[doc(hidden)]
 pub use tiling::{
     StitchingReport, TileBoundarySide, TileComponentConnection, TileCoverageGuarantee,
-    TileCoverageIssue, TileExcludedComponentIssue, TileExecutionPolicy, TileInputBoundaryIssue,
+    TileCoverageIssue, TileCoverageResolution, TileCoverageResolutionKind,
+    TileExcludedComponentIssue, TileExecutionPolicy, TileInputBoundaryIssue,
     TileOwnershipDomainIssue, TileReport, TileRetryAttempt, TileRetryPolicy, TiledPolygonizeError,
     TiledPolygonizeResult, TiledPolygonizer, TracedTiledPolygonizeResultV1,
 };

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -174,6 +174,43 @@ pub struct TileReport {
     pub retry_exhausted: bool,
 }
 
+/// Outcome of resolving the observed coverage evidence for one tiled call.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TileCoverageResolution {
+    pub observed_issue_count: usize,
+    pub resolved_issue_count: usize,
+    pub unresolved_issue_count: usize,
+    pub resolution: TileCoverageResolutionKind,
+    /// Deterministic indexes of component-fallback regions that contributed to
+    /// the resolution. Untiled fallback does not use region indexes.
+    pub recovered_region_ids: Vec<usize>,
+}
+
+/// Classification of the tiled coverage-resolution ledger.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TileCoverageResolutionKind {
+    NoIssues,
+    ComponentFallback,
+    UntiledFallback,
+    Partial,
+    Unresolved,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+enum TileCoverageIssueKind {
+    OwnedFace,
+    OwnershipDomain,
+    InputBoundary,
+    ExcludedComponent,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+struct TileCoverageIssueId {
+    tile_index: usize,
+    kind: TileCoverageIssueKind,
+    issue_index: usize,
+}
+
 /// Counts from merging and deduplicating owned tile polygons.
 ///
 /// These counts do not certify that the configured buffer was sufficient.
@@ -208,9 +245,17 @@ pub struct StitchingReport {
     pub retry_attempt_count: usize,
     pub retry_exhausted_tile_count: usize,
     /// Whether indexed components were recovered by component or region fallback.
+    /// This is operational metadata; strict validation uses `coverage_resolution`.
     pub component_fallback_used: bool,
-    /// Whether unresolved tiled output was replaced by one untiled pass over all input.
+    /// Whether the whole-input fallback was selected for execution.
+    pub untiled_fallback_attempted: bool,
+    /// Whether the whole-input fallback completed and is authoritative.
+    pub untiled_fallback_authoritative: bool,
+    /// Polygon count produced by an authoritative whole-input fallback.
+    pub untiled_fallback_output_polygon_count: usize,
+    /// Backward-compatible alias for `untiled_fallback_authoritative`.
     pub untiled_fallback_used: bool,
+    pub coverage_resolution: TileCoverageResolution,
 }
 
 /// Experimental tiled output with per-tile and merge diagnostics.
@@ -262,7 +307,8 @@ pub enum TiledPolygonizeError {
         retry_attempt_count: usize,
         retry_exhausted_tile_count: usize,
         component_fallback_decline_reason: Option<&'static str>,
-        tile_reports: Vec<TileReport>,
+        coverage_resolution: Box<TileCoverageResolution>,
+        tile_reports: Box<Vec<TileReport>>,
     },
 }
 
@@ -322,6 +368,96 @@ impl ComponentFallbackDeclineReason {
 enum ComponentFallbackDecision {
     Recovered(ComponentFallbackResult),
     Declined(ComponentFallbackDeclineReason),
+}
+
+fn build_coverage_resolution(
+    tile_reports: &[TileReport],
+    component_fallback_used: bool,
+    region_bboxes: &[Rect<f64>],
+    untiled_fallback_authoritative: bool,
+) -> TileCoverageResolution {
+    let mut observed_issue_ids = HashSet::new();
+    let mut resolved_issue_ids = HashSet::new();
+    let mut record_issue =
+        |tile_index: usize, kind: TileCoverageIssueKind, issue_index: usize, bbox: Rect<f64>| {
+            let issue_id = TileCoverageIssueId {
+                tile_index,
+                kind,
+                issue_index,
+            };
+            observed_issue_ids.insert(issue_id);
+            let resolved = untiled_fallback_authoritative
+                || (component_fallback_used
+                    && kind != TileCoverageIssueKind::OwnershipDomain
+                    && region_bboxes
+                        .iter()
+                        .any(|region_bbox| bbox.intersects(region_bbox)));
+            if resolved {
+                resolved_issue_ids.insert(issue_id);
+            }
+        };
+
+    for (tile_index, report) in tile_reports.iter().enumerate() {
+        for (issue_index, issue) in report.coverage_issues.iter().enumerate() {
+            record_issue(
+                tile_index,
+                TileCoverageIssueKind::OwnedFace,
+                issue_index,
+                issue.polygon_bbox,
+            );
+        }
+        for (issue_index, issue) in report.ownership_domain_issues.iter().enumerate() {
+            record_issue(
+                tile_index,
+                TileCoverageIssueKind::OwnershipDomain,
+                issue_index,
+                issue.polygon_bbox,
+            );
+        }
+        for (issue_index, issue) in report.input_boundary_issues.iter().enumerate() {
+            record_issue(
+                tile_index,
+                TileCoverageIssueKind::InputBoundary,
+                issue_index,
+                issue.geometry_bbox,
+            );
+        }
+        for (issue_index, issue) in report.excluded_component_issues.iter().enumerate() {
+            record_issue(
+                tile_index,
+                TileCoverageIssueKind::ExcludedComponent,
+                issue_index,
+                issue.component_bbox,
+            );
+        }
+    }
+
+    let observed_issue_count = observed_issue_ids.len();
+    let resolved_issue_count = resolved_issue_ids.len();
+    let unresolved_issue_count = observed_issue_count - resolved_issue_count;
+    let resolution = match (observed_issue_count, resolved_issue_count) {
+        (0, _) => TileCoverageResolutionKind::NoIssues,
+        (_, 0) => TileCoverageResolutionKind::Unresolved,
+        (_, resolved) if resolved == observed_issue_count => {
+            if untiled_fallback_authoritative {
+                TileCoverageResolutionKind::UntiledFallback
+            } else {
+                TileCoverageResolutionKind::ComponentFallback
+            }
+        }
+        _ => TileCoverageResolutionKind::Partial,
+    };
+    TileCoverageResolution {
+        observed_issue_count,
+        resolved_issue_count,
+        unresolved_issue_count,
+        resolution,
+        recovered_region_ids: if component_fallback_used {
+            (0..region_bboxes.len()).collect()
+        } else {
+            Vec::new()
+        },
+    }
 }
 
 fn account_polygon_output(
@@ -1770,16 +1906,15 @@ impl<'a> TiledPolygonizer<'a> {
         let reject = match guarantee {
             TileCoverageGuarantee::BestEffort => false,
             TileCoverageGuarantee::ValidateOwnedFaces => {
-                !result.stitching_report.untiled_fallback_used
+                !result.stitching_report.untiled_fallback_authoritative
                     && result.stitching_report.unresolved_owned_polygon_count != 0
             }
             TileCoverageGuarantee::ValidateObservedCoverage => {
-                !result.stitching_report.untiled_fallback_used
-                    && !result.stitching_report.component_fallback_used
-                    && (result.stitching_report.unresolved_owned_polygon_count != 0
-                        || result.stitching_report.unresolved_ownership_domain_count != 0
-                        || result.stitching_report.unresolved_input_geometry_count != 0
-                        || result.stitching_report.unresolved_component_count != 0)
+                result
+                    .stitching_report
+                    .coverage_resolution
+                    .unresolved_issue_count
+                    != 0
             }
         };
         if reject {
@@ -1807,7 +1942,8 @@ impl<'a> TiledPolygonizer<'a> {
                 component_fallback_decline_reason: result
                     .stitching_report
                     .component_fallback_decline_reason,
-                tile_reports: result.tile_reports,
+                coverage_resolution: Box::new(result.stitching_report.coverage_resolution.clone()),
+                tile_reports: Box::new(result.tile_reports),
             });
         }
         Ok(result)
@@ -2018,32 +2154,49 @@ impl<'a> TiledPolygonizer<'a> {
             .iter()
             .map(|event| event.replaced_retained_polygon_count)
             .sum();
-        let untiled_fallback_used = self.untiled_fallback && unresolved && !component_fallback_used;
-        let result_polygons: Vec<Polygon3D> = if untiled_fallback_used {
-            let mut polygonizer = Polygonizer::with_options(self.options.clone())
-                .with_execution_policy(self.execution_policy.clone());
-            for (geometry, _) in &self.geometries {
-                polygonizer.add_borrowed_geometry(geometry);
-            }
-            let polygons = polygonizer.polygonize()?.polygons;
-            let mut polygon_count = 0;
-            let mut coordinate_count = 0;
-            for polygon in &polygons {
-                account_polygon_output(
-                    &self.execution_policy,
-                    &mut polygon_count,
-                    &mut coordinate_count,
-                    polygon,
-                )?;
-            }
-            polygons
+        let untiled_fallback_attempted =
+            self.untiled_fallback && unresolved && !component_fallback_used;
+        let (result_polygons, untiled_fallback_authoritative): (Vec<Polygon3D>, bool) =
+            if untiled_fallback_attempted {
+                let mut polygonizer = Polygonizer::with_options(self.options.clone())
+                    .with_execution_policy(self.execution_policy.clone());
+                for (geometry, _) in &self.geometries {
+                    polygonizer.add_borrowed_geometry(geometry);
+                }
+                let polygons = polygonizer.polygonize()?.polygons;
+                let mut polygon_count = 0;
+                let mut coordinate_count = 0;
+                for polygon in &polygons {
+                    account_polygon_output(
+                        &self.execution_policy,
+                        &mut polygon_count,
+                        &mut coordinate_count,
+                        polygon,
+                    )?;
+                }
+                (polygons, true)
+            } else {
+                (
+                    self.merge_fallback_polygons(
+                        tile_polygons,
+                        &region_bboxes,
+                        component_fallback_polygons,
+                    )?,
+                    false,
+                )
+            };
+        let untiled_fallback_output_polygon_count = if untiled_fallback_authoritative {
+            result_polygons.len()
         } else {
-            self.merge_fallback_polygons(
-                tile_polygons,
-                &region_bboxes,
-                component_fallback_polygons,
-            )?
+            0
         };
+        let untiled_fallback_used = untiled_fallback_authoritative;
+        let coverage_resolution = build_coverage_resolution(
+            &tile_reports,
+            component_fallback_used,
+            &region_bboxes,
+            untiled_fallback_authoritative,
+        );
         let merged_polygon_count = result_polygons.len();
 
         let polygons = if untiled_fallback_used {
@@ -2184,7 +2337,11 @@ impl<'a> TiledPolygonizer<'a> {
                 retry_attempt_count,
                 retry_exhausted_tile_count,
                 component_fallback_used,
+                untiled_fallback_attempted,
+                untiled_fallback_authoritative,
+                untiled_fallback_output_polygon_count,
                 untiled_fallback_used,
+                coverage_resolution,
             },
         };
         if let Some(reason) = component_fallback_decline_reason {

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -9,8 +9,8 @@ mod tests {
         NodingGuarantee, NodingOptions, Polygon3D, PolygonizeError, Polygonizer,
         PolygonizerOptions, PrecisionModel, ProvenanceOptions, TileBoundarySide,
         TileComponentConnection, TileCoverageGuarantee, TileCoverageIssue,
-        TileExcludedComponentIssue, TileExecutionPolicy, TileReport, TileRetryPolicy,
-        TiledPolygonizeError, TiledPolygonizer,
+        TileCoverageResolutionKind, TileExcludedComponentIssue, TileExecutionPolicy, TileReport,
+        TileRetryPolicy, TiledPolygonizeError, TiledPolygonizer,
     };
     use geo::{Contains, Coord, Geometry, LineString, MultiLineString, Rect};
 
@@ -659,6 +659,17 @@ mod tests {
         assert_eq!(result.polygons.len(), 1);
         assert!(result.stitching_report.component_fallback_attempted);
         assert!(result.stitching_report.component_fallback_used);
+        assert_eq!(
+            result.stitching_report.coverage_resolution.resolution,
+            TileCoverageResolutionKind::ComponentFallback
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .coverage_resolution
+                .unresolved_issue_count,
+            0
+        );
         assert_eq!(result.stitching_report.component_fallback_count, 1);
         assert_eq!(result.stitching_report.component_fallback_polygon_count, 1);
         assert_eq!(
@@ -704,6 +715,59 @@ mod tests {
                 limit: 0,
                 observed: 1,
             }) if stage == "tile_fallback_regions"
+        ));
+    }
+
+    #[test]
+    fn component_fallback_does_not_authorize_unresolved_ownership_domain_evidence() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 20.0, y: 10.0 });
+        let recovered_face = Geometry::LineString(LineString::new(vec![
+            Coord { x: 1.0, y: 2.0 },
+            Coord { x: 19.0, y: 2.0 },
+            Coord { x: 19.0, y: 8.0 },
+            Coord { x: 1.0, y: 8.0 },
+            Coord { x: 1.0, y: 2.0 },
+        ]));
+        let out_of_domain_face = Geometry::LineString(LineString::new(vec![
+            Coord { x: 16.0, y: 2.0 },
+            Coord { x: 26.0, y: 2.0 },
+            Coord { x: 26.0, y: 8.0 },
+            Coord { x: 16.0, y: 8.0 },
+            Coord { x: 16.0, y: 2.0 },
+        ]));
+        let mut tiled = TiledPolygonizer::new(bbox, 10.0)
+            .with_buffer(2.0)
+            .with_component_fallback();
+        tiled.add_geometry(&recovered_face);
+        tiled.add_geometry(&out_of_domain_face);
+
+        let observed = tiled.polygonize().unwrap();
+        assert!(observed.stitching_report.component_fallback_used);
+        assert!(observed.stitching_report.unresolved_ownership_domain_count > 0);
+        assert!(
+            observed
+                .stitching_report
+                .coverage_resolution
+                .resolved_issue_count
+                > 0
+        );
+        assert!(
+            observed
+                .stitching_report
+                .coverage_resolution
+                .unresolved_issue_count
+                > 0
+        );
+        assert_eq!(
+            observed.stitching_report.coverage_resolution.resolution,
+            TileCoverageResolutionKind::Partial
+        );
+        assert!(matches!(
+            tiled.polygonize_with_coverage_guarantee(TileCoverageGuarantee::ValidateObservedCoverage),
+            Err(TiledPolygonizeError::CoverageIncomplete {
+                coverage_resolution,
+                ..
+            }) if coverage_resolution.unresolved_issue_count > 0
         ));
     }
 
@@ -870,7 +934,26 @@ mod tests {
         globally_fallback.add_geometry(&degenerate_closed);
         let result = globally_fallback.polygonize().unwrap();
         assert!(result.polygons.is_empty());
+        assert!(result.stitching_report.untiled_fallback_attempted);
+        assert!(result.stitching_report.untiled_fallback_authoritative);
+        assert_eq!(
+            result
+                .stitching_report
+                .untiled_fallback_output_polygon_count,
+            0
+        );
         assert!(result.stitching_report.untiled_fallback_used);
+        assert_eq!(
+            result.stitching_report.coverage_resolution.resolution,
+            TileCoverageResolutionKind::UntiledFallback
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .coverage_resolution
+                .unresolved_issue_count,
+            0
+        );
         assert_eq!(
             result.stitching_report.component_fallback_decline_reason,
             Some("empty_recovery_output")
@@ -2941,6 +3024,14 @@ mod tests {
                 .iter()
                 .map(crate::tiling::canonical_polygon_key)
                 .collect::<Vec<_>>()
+        );
+        assert!(result.stitching_report.untiled_fallback_attempted);
+        assert!(result.stitching_report.untiled_fallback_authoritative);
+        assert_eq!(
+            result
+                .stitching_report
+                .untiled_fallback_output_polygon_count,
+            2
         );
         assert!(result.stitching_report.untiled_fallback_used);
         assert_eq!(result.stitching_report.retry_exhausted_tile_count, 4);

--- a/docs/guide/tiling.md
+++ b/docs/guide/tiling.md
@@ -146,8 +146,9 @@ other connected component envelopes, then polygonizes that complete region once.
 Retained polygons intersecting the recovered region are replaced before the
 existing canonical deduplication and ordering pass, preserving containment for
 the envelope-closed class without independently appending nested output. The
-recovery records `component_fallback_used`, retained/recovered/replaced counts
-in `StitchingReport`, and a bounded `tile_component_fallback` event containing
+recovery records retained/recovered/replaced counts and a
+`TileCoverageResolution` ledger in `StitchingReport`, plus a bounded
+`tile_component_fallback` event containing
 the region input indexes, recovered component count, and replacement count.
 When owned-face coverage evidence co-occurs with indexed component or
 input-boundary evidence, every owned-face witness must intersect an
@@ -163,6 +164,13 @@ is marked in `StitchingReport` and recorded as a bounded
 reports contain observed unresolved evidence. It cannot detect an unowned
 single-geometry face whose envelope never overlaps the configured ownership
 domain, and it never clips that input implicitly.
+`StitchingReport` separates `untiled_fallback_attempted`,
+`untiled_fallback_authoritative`, and `untiled_fallback_output_polygon_count`;
+the older `untiled_fallback_used` field is an alias for authoritative state.
+The coverage ledger assigns each observed issue a deterministic
+tile/family/index identity and records resolved versus unresolved counts.
+`ValidateObservedCoverage` rejects whenever its `unresolved_issue_count` is
+nonzero, including partial component recovery.
 Component fallback checks the execution policy before region selection and
 before each recovery region, so cancellation does not get lost between tile
 processing and the bounded region polygonizer. The same policy is checked while


### PR DESCRIPTION
## Summary
- replace fallback-wide observed-coverage acceptance with an explicit per-issue resolution ledger
- distinguish untiled fallback attempted, authoritative, and output polygon count
- keep partial component recovery strict and document the experimental contract

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p geo-polygonize-core`
- `cargo test -p geo-polygonize-core --no-default-features`
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings`
- `cargo test -p geo-polygonize-core tiling -- --nocapture`
- `cargo test -p geo-polygonize-core --test tiling_equivalence`

Stacked on the merged tiled cardinality and provenance slices.