### PR TITLE
feat(core): reconcile partition-border payloads

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -903,12 +903,14 @@ After the explicit arrangement model exists:
   - [x] Add hidden `graph::partition_border` identities with signed-zero-safe
     2D node keys, reversal-invariant edge keys, and deterministic local
     half-edge observations retaining provenance, face, partition, side, and Z
-    evidence. Twin matching and reconciliation remain open.
+    evidence. Twin reconciliation policy remains open.
 - [ ] match and reconcile twin boundary halfedges;
   - [x] Match only unambiguous opposite-direction observations from two
     distinct partitions; same-partition and ambiguous buckets remain
     unmatched until an explicit reconciliation policy exists.
 - [ ] merge source sets and Z decisions across partitions;
+  - [x] Merge source IDs and retain sorted, deduplicated Z candidates at each
+    canonical endpoint; final conflict policy remains open.
 - [ ] reconcile connected components before face extraction;
 - [ ] validate the stitched arrangement and its unbounded face;
 - [ ] compare exact canonical results with untiled execution.

--- a/crates/geo-polygonize-core/src/graph/partition_border.rs
+++ b/crates/geo-polygonize-core/src/graph/partition_border.rs
@@ -138,7 +138,20 @@ pub struct PartitionBorderTwin {
     pub reverse: PartitionBorderObservationId,
 }
 
-/// Deterministic partition-border observations ready for future twin matching.
+/// Provenance and Z evidence merged from one unambiguous partition-border twin.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PartitionBorderTwinPayload {
+    pub twin: PartitionBorderTwin,
+    pub source_line_ids: Vec<u32>,
+    /// Distinct Z candidates at `twin.edge_key.endpoints().0`, in bit order.
+    /// A length greater than one is an explicit conflict, not a hidden choice.
+    pub start_z_bits: Vec<u64>,
+    /// Distinct Z candidates at `twin.edge_key.endpoints().1`, in bit order.
+    /// A length greater than one is an explicit conflict, not a hidden choice.
+    pub end_z_bits: Vec<u64>,
+}
+
+/// Deterministic partition-border observations ready for twin reconciliation.
 ///
 /// The graph stores canonical undirected edge buckets while retaining each
 /// local directed observation. This makes reversal and insertion order
@@ -208,6 +221,46 @@ impl PartitionBorderGraph {
                 } else {
                     None
                 }
+            })
+            .collect()
+    }
+
+    /// Merges source IDs and retains every distinct Z candidate for each
+    /// canonical endpoint. No Z conflict policy is applied here.
+    pub fn reconcile_twin_payloads(&self) -> Vec<PartitionBorderTwinPayload> {
+        self.twin_pairs()
+            .into_iter()
+            .filter_map(|twin| {
+                let observations = self.edges.get(&twin.edge_key)?;
+                let forward = observations
+                    .iter()
+                    .find(|observation| observation.observation_id() == twin.forward)?;
+                let reverse = observations
+                    .iter()
+                    .find(|observation| observation.observation_id() == twin.reverse)?;
+
+                let mut source_line_ids = forward
+                    .source_line_ids
+                    .iter()
+                    .chain(&reverse.source_line_ids)
+                    .copied()
+                    .collect::<Vec<_>>();
+                source_line_ids.sort_unstable();
+                source_line_ids.dedup();
+
+                let mut start_z_bits = vec![forward.from_z_bits, reverse.to_z_bits];
+                start_z_bits.sort_unstable();
+                start_z_bits.dedup();
+                let mut end_z_bits = vec![forward.to_z_bits, reverse.from_z_bits];
+                end_z_bits.sort_unstable();
+                end_z_bits.dedup();
+
+                Some(PartitionBorderTwinPayload {
+                    twin,
+                    source_line_ids,
+                    start_z_bits,
+                    end_z_bits,
+                })
             })
             .collect()
     }
@@ -366,6 +419,49 @@ mod tests {
                     partition_id: 2,
                     local_dir_edge_id: 9,
                 },
+            }]
+        );
+    }
+
+    #[test]
+    fn twin_payload_reconciliation_unions_sources_and_retains_z_conflicts() {
+        let forward = PartitionBorderHalfEdge::new(
+            1,
+            7,
+            Some(3),
+            PartitionBorderSide::MaxX,
+            coord(-0.0, 0.0, 1.0),
+            coord(2.0, 0.0, 2.0),
+            [4, 2, 4],
+        )
+        .unwrap();
+        let reverse = PartitionBorderHalfEdge::new(
+            2,
+            9,
+            Some(5),
+            PartitionBorderSide::MinX,
+            coord(2.0, 0.0, 2.0),
+            coord(0.0, 0.0, -0.0),
+            [8, 4],
+        )
+        .unwrap();
+        let twin = PartitionBorderTwin {
+            edge_key: forward.edge_key,
+            forward: forward.observation_id(),
+            reverse: reverse.observation_id(),
+        };
+
+        let mut graph = PartitionBorderGraph::default();
+        graph.insert(reverse);
+        graph.insert(forward);
+
+        assert_eq!(
+            graph.reconcile_twin_payloads(),
+            vec![PartitionBorderTwinPayload {
+                twin,
+                source_line_ids: vec![2, 4, 8],
+                start_z_bits: vec![0, 1.0f64.to_bits()],
+                end_z_bits: vec![2.0f64.to_bits()],
             }]
         );
     }


### PR DESCRIPTION
Stacked on the merged twin-matching slice (#1244).

## Summary

- Add a hidden partition-border payload containing the union of source line IDs from an unambiguous twin.
- Retain sorted, deduplicated Z candidates for each canonical endpoint, preserving conflicts instead of silently selecting a value.
- Add a focused signed-zero and reversed-orientation regression and update the P3.3 roadmap evidence.

Stable polygonizer output and the supported root facade are unchanged.

## Validation

- cargo test -p geo-polygonize-core
- cargo clippy -p geo-polygonize-core --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check