### PR TITLE
feat(core): retain face boundary evidence

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -560,6 +560,8 @@ default release hot path.
 - [x] Assign deterministic face/cycle IDs.
 - [x] Identify component-local unbounded face cycles explicitly.
 - [ ] Retain mappings from faces to boundary source sets and Z decisions.
+  - [x] Carry the component-local face ID with final extracted rings, alongside
+    their complete boundary source IDs and retained Z coordinates.
 - [ ] Compare the explicit face walk against the current ring extractor on the
   entire golden corpus before replacing anything.
 - [ ] Keep the arrangement private until overlay-quality invariants are proven.

--- a/crates/geo-polygonize-core/src/containment.rs
+++ b/crates/geo-polygonize-core/src/containment.rs
@@ -19,6 +19,18 @@ use std::sync::OnceLock;
 const LOCATOR_INDEX_QUERY_THRESHOLD: usize = 64;
 const LOCATOR_INDEX_MIN_COORDS: usize = 65;
 
+fn graph_identities_with_faces<'a>(
+    shell: Option<&'a RingGraphIdentity>,
+    ring: Option<&'a RingGraphIdentity>,
+) -> Option<(&'a RingGraphIdentity, &'a RingGraphIdentity)> {
+    match (shell, ring) {
+        (Some(shell), Some(ring)) if shell.face_id.is_some() && ring.face_id.is_some() => {
+            Some((shell, ring))
+        }
+        _ => None,
+    }
+}
+
 fn touch_allowed(
     shell: &Polygon3D,
     shell_identity: Option<&RingGraphIdentity>,
@@ -29,19 +41,18 @@ fn touch_allowed(
 ) -> bool {
     match touch_policy {
         TouchPolicy::AllowPointTouchDisallowEdgeShare | TouchPolicy::TreatAnyTouchAsDisjoint => {
-            let (shares_edge, pair_checks, used_graph_ids) = if let (
-                Some(shell_identity),
-                Some(ring_identity),
-            ) = (shell_identity, ring_identity)
-            {
-                let (shares_edge, pair_checks) =
-                    sorted_intersects(&shell_identity.edge_keys, &ring_identity.edge_keys);
-                (shares_edge, pair_checks, true)
-            } else {
-                let (shares_edge, pair_checks) =
-                    rings_share_edge_with_count(&shell.exterior, &ring.exterior, 1e-10);
-                (shares_edge, pair_checks, false)
-            };
+            let (shares_edge, pair_checks, used_graph_ids) =
+                if let Some((shell_identity, ring_identity)) =
+                    graph_identities_with_faces(shell_identity, ring_identity)
+                {
+                    let (shares_edge, pair_checks) =
+                        sorted_intersects(&shell_identity.edge_keys, &ring_identity.edge_keys);
+                    (shares_edge, pair_checks, true)
+                } else {
+                    let (shares_edge, pair_checks) =
+                        rings_share_edge_with_count(&shell.exterior, &ring.exterior, 1e-10);
+                    (shares_edge, pair_checks, false)
+                };
             if let Some(stats) = stats.as_deref_mut() {
                 stats.shared_edge_checks += 1;
                 if used_graph_ids {
@@ -55,20 +66,18 @@ fn touch_allowed(
                 return !shares_edge;
             }
 
-            let (touches_vertex, pair_checks, used_graph_ids) = if let (
-                Some(shell_identity),
-                Some(ring_identity),
-            ) =
-                (shell_identity, ring_identity)
-            {
-                let (touches_vertex, pair_checks) =
-                    sorted_intersects(&shell_identity.node_ids, &ring_identity.node_ids);
-                (touches_vertex, pair_checks, true)
-            } else {
-                let (touches_vertex, pair_checks) =
-                    rings_touch_at_vertex_with_count(&shell.exterior, &ring.exterior, 1e-10);
-                (touches_vertex, pair_checks, false)
-            };
+            let (touches_vertex, pair_checks, used_graph_ids) =
+                if let Some((shell_identity, ring_identity)) =
+                    graph_identities_with_faces(shell_identity, ring_identity)
+                {
+                    let (touches_vertex, pair_checks) =
+                        sorted_intersects(&shell_identity.node_ids, &ring_identity.node_ids);
+                    (touches_vertex, pair_checks, true)
+                } else {
+                    let (touches_vertex, pair_checks) =
+                        rings_touch_at_vertex_with_count(&shell.exterior, &ring.exterior, 1e-10);
+                    (touches_vertex, pair_checks, false)
+                };
             if let Some(stats) = stats {
                 stats.shared_vertex_checks += 1;
                 if used_graph_ids {
@@ -506,8 +515,8 @@ mod tests {
     #[test]
     fn graph_identity_distinguishes_point_and_edge_touch() {
         let polygon = Polygon3D::new(vec![], vec![], vec![], vec![]);
-        let shell_ids = RingGraphIdentity::new(vec![(0, 1)], vec![0, 1]);
-        let ring_ids = RingGraphIdentity::new(vec![(1, 2)], vec![1, 2]);
+        let shell_ids = RingGraphIdentity::new(Some(0), vec![(0, 1)], vec![0, 1]);
+        let ring_ids = RingGraphIdentity::new(Some(1), vec![(1, 2)], vec![1, 2]);
         let mut stats = ContainmentStats::default();
 
         assert!(touch_allowed(

--- a/crates/geo-polygonize-core/src/graph/planar_graph.rs
+++ b/crates/geo-polygonize-core/src/graph/planar_graph.rs
@@ -27,6 +27,9 @@ pub(crate) struct ExtractedRing {
     pub coords: Vec<Coord3D>,
     pub line_ids: Vec<u32>,
     pub source_line_ids: Vec<u32>,
+    /// Component-local deterministic face identity for final ring extraction.
+    /// Maximal trace rings are captured before face identities are assigned.
+    pub face_id: Option<FaceId>,
     pub edge_keys: Vec<(NodeId, NodeId)>,
     pub node_ids: Vec<NodeId>,
 }
@@ -1375,6 +1378,7 @@ impl PlanarGraph {
         } else {
             Vec::new()
         };
+        let face_id = self.directed_edges[ring_edges[0]].face_id;
         let start_node_idx = self.directed_edges[ring_edges[0]].src;
         coords.push(Coord3D {
             x: self.nodes_x[start_node_idx],
@@ -1415,6 +1419,7 @@ impl PlanarGraph {
             coords,
             line_ids: ids,
             source_line_ids: source_ids,
+            face_id,
             edge_keys,
             node_ids,
         })
@@ -2473,6 +2478,60 @@ mod arrangement_ring_invariant_tests {
             .directed_edges
             .iter()
             .all(|directed| directed.face_id.is_none()));
+    }
+
+    #[test]
+    fn extracted_rings_retain_deterministic_face_and_boundary_payloads() {
+        let lines = vec![
+            Line3D::new(Coord3D::new(0.0, 0.0, 1.0), Coord3D::new(2.0, 0.0, 2.0), 10),
+            Line3D::new(Coord3D::new(2.0, 0.0, 2.0), Coord3D::new(2.0, 2.0, 3.0), 11),
+            Line3D::new(Coord3D::new(2.0, 2.0, 3.0), Coord3D::new(0.0, 2.0, 4.0), 12),
+            Line3D::new(Coord3D::new(0.0, 2.0, 4.0), Coord3D::new(0.0, 0.0, 1.0), 13),
+        ];
+
+        let snapshot = |lines: Vec<Line3D>| {
+            let mut graph = PlanarGraph::new();
+            graph.bulk_load(lines);
+            graph.sort_edges();
+            let mut rings = graph.get_edge_rings_with_graph_ids(true, true);
+            rings.sort_unstable_by_key(|ring| ring.face_id);
+            rings
+                .into_iter()
+                .map(|ring| {
+                    (
+                        ring.face_id,
+                        ring.source_line_ids,
+                        ring.coords
+                            .iter()
+                            .map(|coord| coord.z.to_bits())
+                            .collect::<Vec<_>>(),
+                    )
+                })
+                .collect::<Vec<_>>()
+        };
+
+        let mut reversed = lines.clone();
+        reversed.reverse();
+        let first = snapshot(lines);
+        let second = snapshot(reversed);
+
+        assert_eq!(first, second);
+        assert_eq!(first.len(), 2);
+        assert!(first.iter().all(|(face_id, _, _)| face_id.is_some()));
+        assert!(first
+            .iter()
+            .all(|(_, source_line_ids, _)| source_line_ids == &[10, 11, 12, 13]));
+        assert!(first.iter().all(|(_, _, z_bits)| {
+            let mut sorted = z_bits[..z_bits.len() - 1].to_vec();
+            sorted.sort_unstable();
+            sorted
+                == [
+                    1.0f64.to_bits(),
+                    2.0f64.to_bits(),
+                    3.0f64.to_bits(),
+                    4.0f64.to_bits(),
+                ]
+        }));
     }
 
     #[test]

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -1279,7 +1279,8 @@ pub(crate) fn extract_and_classify_rings(
 
         let ring = (
             poly3d,
-            include_graph_ids.then(|| RingGraphIdentity::new(ring.edge_keys, ring.node_ids)),
+            include_graph_ids
+                .then(|| RingGraphIdentity::new(ring.face_id, ring.edge_keys, ring.node_ids)),
         );
         if area > 0.0 {
             shells.push(ring);

--- a/crates/geo-polygonize-core/src/types.rs
+++ b/crates/geo-polygonize-core/src/types.rs
@@ -119,17 +119,24 @@ pub struct PolygonProvenance {
 
 #[derive(Clone, Debug)]
 pub(crate) struct RingGraphIdentity {
+    /// Component-local deterministic face identity.
+    pub face_id: Option<usize>,
     pub edge_keys: std::sync::Arc<[(usize, usize)]>,
     pub node_ids: std::sync::Arc<[usize]>,
 }
 
 impl RingGraphIdentity {
-    pub(crate) fn new(mut edge_keys: Vec<(usize, usize)>, mut node_ids: Vec<usize>) -> Self {
+    pub(crate) fn new(
+        face_id: Option<usize>,
+        mut edge_keys: Vec<(usize, usize)>,
+        mut node_ids: Vec<usize>,
+    ) -> Self {
         edge_keys.sort_unstable();
         edge_keys.dedup();
         node_ids.sort_unstable();
         node_ids.dedup();
         Self {
+            face_id,
             edge_keys: edge_keys.into(),
             node_ids: node_ids.into(),
         }


### PR DESCRIPTION
Stacked on the partition-border payload reconciliation slice (#1245).

## Summary

- Carry the component-local deterministic face ID on final extracted rings.
- Retain that face identity with the existing boundary source IDs and Z coordinates in the internal graph identity used by containment.
- Fall back to geometric touch checks if a graph identity lacks a face assignment.
- Add insertion-order and Z-payload regression coverage and update P2.2 roadmap evidence.

The supported facade, public result shape, and polygonization behavior remain unchanged.

## Validation

- cargo test -p geo-polygonize-core
- cargo clippy -p geo-polygonize-core --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check