### PR TITLE
feat(core): retain source chain boundaries

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -612,9 +612,8 @@ Certified fixed precision remains the hot-pixel contract.
 
 - [x] Separate broad-phase candidate enumeration from robust exact
   intersection, split accumulation, normalization, and dissolve.
-- [ ] Preserve source line-string/segment-string boundaries internally; flattened
-  independent segments discard the monotone-chain structure needed by some
-  indexes.
+- [x] Preserve source line-string/segment-string boundaries internally; the
+  ingestion layout and bounded input trace retain each chain's segment range.
 - [ ] Add deterministic workload descriptors:
   - segment and line-string counts;
   - average/max chain length;
@@ -627,8 +626,9 @@ Certified fixed precision remains the hot-pixel contract.
 
 Floating SIMD and uniform-grid noding now expose an internal candidate-pair
 boundary before exact intersection and split accumulation. Certified hot-pixel
-noding already follows the same indexed-candidate-then-exact shape; preserving
-line-string boundaries and adding workload descriptors remain open.
+noding already follows the same indexed-candidate-then-exact shape. Candidate
+backends do not consume the retained chain layout yet; deterministic workload
+descriptors remain open.
 
 ### P2.5 Evaluate sparse and long-line backends
 

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -14,13 +14,13 @@ use crate::trace::{
     TraceByteLimitsV1, TraceCaptureBudget, TraceLevelV1, TraceRecorderV1, TraceStageV1,
     TracedPolygonizerResultV1, ZReconciliationCandidateTraceV1, ZReconciliationTraceV1,
 };
-use crate::types::{Coord3D, Line3D, Polygon3D, RingGraphIdentity};
+use crate::types::{Coord3D, Line3D, Polygon3D, RingGraphIdentity, SourceLineString};
 use crate::utils::simd::SimdRing;
 use crate::utils::{canonical_coordinate_bits, z_order_index};
 use float_next_after::NextAfter;
 use geo::Contains;
 use geo_traits::{CoordTrait, LineStringTrait};
-use geo_types::{Coord, Geometry, MultiPolygon, Polygon};
+use geo_types::{Coord, Geometry, LineString, MultiPolygon, Polygon};
 use std::collections::HashMap;
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -45,6 +45,7 @@ pub struct Polygonizer {
     options: PolygonizerOptions,
     execution_policy: ExecutionPolicy,
     input_lines: Vec<Line3D>,
+    input_line_strings: Vec<SourceLineString>,
     trace: Option<TraceRecorderV1>,
 }
 
@@ -103,10 +104,11 @@ pub fn polygonize_with_execution_policy(
     options: &PolygonizerOptions,
     execution_policy: &ExecutionPolicy,
 ) -> Result<PolygonizerResult> {
-    let collected = collect_owned_lines(lines, execution_policy)?;
-    Polygonizer::with_options(options.clone())
-        .with_execution_policy(execution_policy.clone())
-        .polygonize_owned(collected)
+    let (collected, source_line_strings) = collect_owned_lines(lines, execution_policy)?;
+    let mut polygonizer =
+        Polygonizer::with_options(options.clone()).with_execution_policy(execution_policy.clone());
+    polygonizer.input_line_strings = source_line_strings;
+    polygonizer.polygonize_owned(collected)
 }
 
 /// Polygonize an owned stream while recording a bounded topology trace.
@@ -136,10 +138,11 @@ pub fn polygonize_with_trace_limits(
     level: TraceLevelV1,
     limits: TraceByteLimitsV1,
 ) -> Result<TracedPolygonizerResultV1> {
-    let collected = collect_owned_lines(lines, execution_policy)?;
+    let (collected, source_line_strings) = collect_owned_lines(lines, execution_policy)?;
     let mut runner = Polygonizer::with_options(options.clone())
         .with_execution_policy(execution_policy.clone())
         .with_trace(TraceRecorderV1::new_with_limits(Some(level), limits, options).unwrap());
+    runner.input_line_strings = source_line_strings;
     let result = runner.polygonize_owned(collected)?;
     Ok(TracedPolygonizerResultV1 {
         result,
@@ -150,9 +153,10 @@ pub fn polygonize_with_trace_limits(
 fn collect_owned_lines(
     lines: impl IntoIterator<Item = Line3D>,
     execution_policy: &ExecutionPolicy,
-) -> Result<Vec<Line3D>> {
+) -> Result<(Vec<Line3D>, Vec<SourceLineString>)> {
     execution_policy.check_cancelled("ingest")?;
     let mut collected = Vec::new();
+    let mut source_line_strings = Vec::new();
     for line in lines {
         let observed = collected.len().checked_add(1).ok_or_else(|| {
             PolygonizeError::InternalInvariantViolation {
@@ -176,9 +180,13 @@ fn collect_owned_lines(
             coordinates,
         )?;
         execution_policy.check_cancelled_every("ingest", observed)?;
+        source_line_strings.push(SourceLineString {
+            segment_start: collected.len(),
+            segment_count: 1,
+        });
         collected.push(line);
     }
-    Ok(collected)
+    Ok((collected, source_line_strings))
 }
 
 /// Polygonize borrowed or owned GeoRust line strings without first building [`Line3D`] values.
@@ -212,6 +220,7 @@ where
 {
     execution_policy.check_cancelled("ingest")?;
     let mut segments = Vec::new();
+    let mut source_line_strings = Vec::new();
     let mut coordinate_count: usize = 0;
     for (line_id, line_string) in line_strings.into_iter().enumerate() {
         execution_policy.check_cancelled_every("ingest", line_id)?;
@@ -223,8 +232,13 @@ where
         let line_id = u32::try_from(line_id).map_err(|_| PolygonizeError::InvalidGeometry {
             reason: "more than u32::MAX input line strings".to_string(),
         })?;
+        let segment_start = segments.len();
         let mut coordinates = line_string.coords();
         let Some(first) = coordinates.next() else {
+            source_line_strings.push(SourceLineString {
+                segment_start,
+                segment_count: 0,
+            });
             continue;
         };
         coordinate_count = coordinate_count.checked_add(1).ok_or_else(|| {
@@ -264,10 +278,15 @@ where
             segments.push(Line3D::new(previous, current, line_id));
             previous = current;
         }
+        source_line_strings.push(SourceLineString {
+            segment_start,
+            segment_count: segments.len() - segment_start,
+        });
     }
-    Polygonizer::with_options(options.clone())
-        .with_execution_policy(execution_policy.clone())
-        .polygonize_owned(segments)
+    let mut polygonizer =
+        Polygonizer::with_options(options.clone()).with_execution_policy(execution_policy.clone());
+    polygonizer.input_line_strings = source_line_strings;
+    polygonizer.polygonize_owned(segments)
 }
 
 /// Polygonize line segments and return only the GeoRust polygon output.
@@ -319,8 +338,10 @@ pub fn polygonize_with_workspace_and_execution_policy(
         options: options.clone(),
         execution_policy: execution_policy.clone(),
         input_lines: Vec::new(),
+        input_line_strings: Vec::new(),
         trace: None,
     };
+    runner.input_line_strings = source_line_strings_for_segments(lines);
     let result = runner.polygonize_owned(lines.to_vec());
     runner.graph.clear();
     workspace.graph = runner.graph;
@@ -335,6 +356,7 @@ impl Polygonizer {
             options: PolygonizerOptions::default(),
             execution_policy: ExecutionPolicy::default(),
             input_lines: Vec::new(),
+            input_line_strings: Vec::new(),
             trace: None,
         }
     }
@@ -345,6 +367,7 @@ impl Polygonizer {
             options,
             execution_policy: ExecutionPolicy::default(),
             input_lines: Vec::new(),
+            input_line_strings: Vec::new(),
             trace: None,
         }
     }
@@ -376,16 +399,18 @@ impl Polygonizer {
 
     /// Adds a 2D geometry to the graph (Z=0).
     pub fn add_geometry(&mut self, geom: Geometry<f64>) {
-        extract_segments(&geom, &mut self.input_lines);
+        extract_segments(&geom, &mut self.input_lines, &mut self.input_line_strings);
     }
 
     /// Adds a 2D geometry to the graph (Z=0) from a reference.
     pub fn add_borrowed_geometry(&mut self, geom: &Geometry<f64>) {
-        extract_segments(geom, &mut self.input_lines);
+        extract_segments(geom, &mut self.input_lines, &mut self.input_line_strings);
     }
 
     /// Adds explicit 3D lines.
     pub fn add_lines(&mut self, lines: Vec<Line3D>) {
+        self.input_line_strings
+            .extend(source_line_strings_for_segments(&lines));
         self.input_lines.extend(lines);
     }
 
@@ -735,6 +760,9 @@ impl Polygonizer {
     fn polygonize_owned(&mut self, input_lines: Vec<Line3D>) -> Result<PolygonizerResult> {
         self.options.validate()?;
         self.execution_policy.check_cancelled("ingest")?;
+        if self.input_line_strings.is_empty() && !input_lines.is_empty() {
+            self.input_line_strings = source_line_strings_for_segments(&input_lines);
+        }
         self.execution_policy.check(
             "input_segments",
             self.execution_policy.max_input_segments,
@@ -742,7 +770,7 @@ impl Polygonizer {
         )?;
         validate_lines(&input_lines, &self.execution_policy)?;
         if let Some(trace) = self.trace.as_mut() {
-            trace.record_input_segments(&input_lines)?;
+            trace.record_input_segments(&input_lines, &self.input_line_strings)?;
         }
 
         let return_diagnostics =
@@ -2403,44 +2431,59 @@ fn segments_overlap_with_length(
     overlap_len * overlap_len * a_len_sq > eps * eps
 }
 
-fn extract_segments(geom: &Geometry<f64>, out: &mut Vec<Line3D>) {
+fn source_line_strings_for_segments(lines: &[Line3D]) -> Vec<SourceLineString> {
+    lines
+        .iter()
+        .enumerate()
+        .map(|(segment_start, _)| SourceLineString {
+            segment_start,
+            segment_count: 1,
+        })
+        .collect()
+}
+
+fn append_line_string(
+    line_string: &LineString<f64>,
+    out: &mut Vec<Line3D>,
+    source_line_strings: &mut Vec<SourceLineString>,
+) {
+    let segment_start = out.len();
+    out.reserve(line_string.0.len().saturating_sub(1));
+    out.extend(line_string.lines().map(Line3D::from));
+    source_line_strings.push(SourceLineString {
+        segment_start,
+        segment_count: out.len() - segment_start,
+    });
+}
+
+fn extract_segments(
+    geom: &Geometry<f64>,
+    out: &mut Vec<Line3D>,
+    source_line_strings: &mut Vec<SourceLineString>,
+) {
     let mut stack = smallvec::SmallVec::<[&Geometry<f64>; 16]>::new();
     stack.push(geom);
     while let Some(current) = stack.pop() {
         match current {
-            Geometry::LineString(ls) => {
-                let len = ls.0.len().saturating_sub(1);
-                out.reserve(len);
-                out.extend(ls.lines().map(Line3D::from));
-            }
+            Geometry::LineString(ls) => append_line_string(ls, out, source_line_strings),
             Geometry::MultiLineString(mls) => {
                 for ls in &mls.0 {
-                    let len = ls.0.len().saturating_sub(1);
-                    out.reserve(len);
-                    out.extend(ls.lines().map(Line3D::from));
+                    append_line_string(ls, out, source_line_strings);
                 }
             }
             Geometry::Polygon(poly) => {
                 let ext = poly.exterior();
-                let len = ext.0.len().saturating_sub(1);
-                out.reserve(len);
-                out.extend(ext.lines().map(Line3D::from));
+                append_line_string(ext, out, source_line_strings);
                 for interior in poly.interiors() {
-                    let len = interior.0.len().saturating_sub(1);
-                    out.reserve(len);
-                    out.extend(interior.lines().map(Line3D::from));
+                    append_line_string(interior, out, source_line_strings);
                 }
             }
             Geometry::MultiPolygon(mpoly) => {
                 for poly in mpoly {
                     let ext = poly.exterior();
-                    let len = ext.0.len().saturating_sub(1);
-                    out.reserve(len);
-                    out.extend(ext.lines().map(Line3D::from));
+                    append_line_string(ext, out, source_line_strings);
                     for interior in poly.interiors() {
-                        let len = interior.0.len().saturating_sub(1);
-                        out.reserve(len);
-                        out.extend(interior.lines().map(Line3D::from));
+                        append_line_string(interior, out, source_line_strings);
                     }
                 }
             }

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -9,6 +9,7 @@ use crate::noding::hot_pixel::{
     HotPixelCandidateTrace, HotPixelIntersectionTrace, HotPixelSplitTrace,
 };
 use crate::noding::snap::{FloatingCandidateTrace, FloatingIntersectionTrace, FloatingSplitTrace};
+use crate::types::SourceLineString;
 use crate::{
     CoordinateFingerprintV1, Line3D, Polygon3D, PolygonizerDiagnostics, PolygonizerOptions,
     PolygonizerResult, ZPolicy,
@@ -88,6 +89,12 @@ pub struct InputSegmentTraceV1 {
     pub start: CoordinateFingerprintV1,
     pub end: CoordinateFingerprintV1,
     pub source_ids: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_chain_index: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub chain_segment_index: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub chain_segment_count: Option<usize>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
@@ -611,8 +618,16 @@ impl TraceRecorderV1 {
         }
     }
 
-    pub(crate) fn record_input_segments(&mut self, lines: &[Line3D]) -> crate::Result<()> {
-        self.record_noding_segments("normalized_input_segment", lines)
+    pub(crate) fn record_input_segments(
+        &mut self,
+        lines: &[Line3D],
+        source_line_strings: &[SourceLineString],
+    ) -> crate::Result<()> {
+        self.record_noding_segments_with_chains(
+            "normalized_input_segment",
+            lines,
+            Some(source_line_strings),
+        )
     }
 
     pub(crate) fn record_noding_segments(
@@ -620,15 +635,55 @@ impl TraceRecorderV1 {
         kind: &'static str,
         lines: &[Line3D],
     ) -> crate::Result<()> {
+        self.record_noding_segments_with_chains(kind, lines, None)
+    }
+
+    fn record_noding_segments_with_chains(
+        &mut self,
+        kind: &'static str,
+        lines: &[Line3D],
+        source_line_strings: Option<&[SourceLineString]>,
+    ) -> crate::Result<()> {
         if !self.trace.level.allows(TraceStageV1::Noding) {
             return Ok(());
         }
+        let mut chain_index = 0;
         for (index, line) in lines.iter().enumerate() {
+            while let Some(chain) = source_line_strings.and_then(|chains| chains.get(chain_index)) {
+                let chain_end = chain.segment_start.checked_add(chain.segment_count).ok_or(
+                    crate::PolygonizeError::InternalInvariantViolation {
+                        reason: "source line-string range overflow".to_string(),
+                    },
+                )?;
+                if index < chain_end {
+                    break;
+                }
+                chain_index += 1;
+            }
+            let chain_metadata = source_line_strings
+                .and_then(|chains| chains.get(chain_index))
+                .and_then(|chain| {
+                    chain
+                        .segment_start
+                        .checked_add(chain.segment_count)
+                        .filter(|&chain_end| chain.segment_start <= index && index < chain_end)
+                        .map(|_| {
+                            (
+                                Some(chain_index),
+                                Some(index - chain.segment_start),
+                                Some(chain.segment_count),
+                            )
+                        })
+                })
+                .unwrap_or((None, None, None));
             let payload = serde_json::to_value(InputSegmentTraceV1 {
                 index,
                 start: coordinate_fingerprint(line.start)?,
                 end: coordinate_fingerprint(line.end)?,
                 source_ids: vec![format!("0x{:08x}", line.line_id)],
+                source_chain_index: chain_metadata.0,
+                chain_segment_index: chain_metadata.1,
+                chain_segment_count: chain_metadata.2,
             })
             .expect("input trace event serializes");
             if !self.record(TraceStageV1::Noding, kind, payload) {
@@ -1443,6 +1498,7 @@ mod tests {
         polygonize, polygonize_with_trace, polygonize_with_trace_limits, Coord3D, ExecutionPolicy,
         TopologyFingerprintV1,
     };
+    use geo_types::{Geometry, LineString, MultiLineString};
     use serde_json::json;
 
     #[test]
@@ -1625,6 +1681,48 @@ mod tests {
         assert_eq!(
             TopologyFingerprintV1::try_from_result(&traced.result, &options).unwrap(),
             TopologyFingerprintV1::try_from_result(&expected, &options).unwrap()
+        );
+    }
+
+    #[test]
+    fn trace_retains_source_line_string_boundaries() {
+        let mut polygonizer = crate::Polygonizer::new();
+        polygonizer.add_geometry(Geometry::MultiLineString(MultiLineString(vec![
+            LineString::from(vec![(0.0, 0.0), (1.0, 0.0), (2.0, 0.0)]),
+            LineString::from(vec![(2.0, 0.0), (2.0, 1.0)]),
+        ])));
+
+        let traced = polygonizer
+            .polygonize_with_trace(TraceLevelV1::Noding, usize::MAX)
+            .unwrap();
+        let input_events: Vec<_> = traced
+            .trace
+            .events
+            .iter()
+            .filter(|event| event.kind == "normalized_input_segment")
+            .collect();
+
+        assert_eq!(input_events.len(), 3);
+        assert_eq!(
+            input_events
+                .iter()
+                .map(|event| event.payload["source_chain_index"].as_u64())
+                .collect::<Vec<_>>(),
+            vec![Some(0), Some(0), Some(1)]
+        );
+        assert_eq!(
+            input_events
+                .iter()
+                .map(|event| event.payload["chain_segment_index"].as_u64())
+                .collect::<Vec<_>>(),
+            vec![Some(0), Some(1), Some(0)]
+        );
+        assert_eq!(
+            input_events
+                .iter()
+                .map(|event| event.payload["chain_segment_count"].as_u64())
+                .collect::<Vec<_>>(),
+            vec![Some(2), Some(2), Some(1)]
         );
     }
 

--- a/crates/geo-polygonize-core/src/types.rs
+++ b/crates/geo-polygonize-core/src/types.rs
@@ -52,6 +52,13 @@ pub struct Line3D {
     pub line_id: u32,
 }
 
+/// The original line-string boundary for a contiguous range of flattened segments.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct SourceLineString {
+    pub(crate) segment_start: usize,
+    pub(crate) segment_count: usize,
+}
+
 /// Sorted, unique input line identifiers contributing to a graph edge.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub(crate) struct EdgeSources {


### PR DESCRIPTION
Stacked on #1249.

Retains contiguous source line-string ranges through every polygonizer ingestion path, including GeoRust line strings, geometry containers, explicit segment streams, and reusable workspaces. The bounded input trace now records source-chain index, within-chain segment index, and chain length, so future monotone-chain candidate backends have deterministic boundary evidence without changing topology or the stable public API.

Validation:
- cargo test -p geo-polygonize-core (273 passed)
- cargo clippy -p geo-polygonize-core --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check