### PR TITLE
feat(core): complete partition-border graph representation

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -899,7 +899,11 @@ When coverage cannot be proven:
 
 After the explicit arrangement model exists:
 
-- [ ] define canonical partition-border node and edge keys;
+- [x] define canonical partition-border node and edge keys;
+  - [x] Add hidden `graph::partition_border` identities with signed-zero-safe
+    2D node keys, reversal-invariant edge keys, and deterministic local
+    half-edge observations retaining provenance, face, partition, side, and Z
+    evidence. Twin matching and reconciliation remain open.
 - [ ] match and reconcile twin boundary halfedges;
 - [ ] merge source sets and Z decisions across partitions;
 - [ ] reconcile connected components before face extraction;

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -560,6 +560,8 @@ default release hot path.
 - [x] Assign deterministic face/cycle IDs.
 - [x] Identify component-local unbounded face cycles explicitly.
 - [ ] Retain mappings from faces to boundary source sets and Z decisions.
+  - [x] Carry the component-local face ID with final extracted rings, alongside
+    their complete boundary source IDs and retained Z coordinates.
 - [ ] Compare the explicit face walk against the current ring extractor on the
   entire golden corpus before replacing anything.
 - [ ] Keep the arrangement private until overlay-quality invariants are proven.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -564,6 +564,9 @@ default release hot path.
     their complete boundary source IDs and retained Z coordinates.
 - [ ] Compare the explicit face walk against the current ring extractor on the
   entire golden corpus before replacing anything.
+  - [x] Compare face IDs, canonical XY cycles, source sets, and Z payloads on
+    nested and disconnected components; the entire golden corpus gate remains
+    open.
 - [ ] Keep the arrangement private until overlay-quality invariants are proven.
 
 This creates a DCEL-like internal arrangement without committing the public API

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -903,12 +903,14 @@ After the explicit arrangement model exists:
   - [x] Add hidden `graph::partition_border` identities with signed-zero-safe
     2D node keys, reversal-invariant edge keys, and deterministic local
     half-edge observations retaining provenance, face, partition, side, and Z
-    evidence. Twin matching and reconciliation remain open.
+    evidence. Twin reconciliation policy remains open.
 - [ ] match and reconcile twin boundary halfedges;
   - [x] Match only unambiguous opposite-direction observations from two
     distinct partitions; same-partition and ambiguous buckets remain
     unmatched until an explicit reconciliation policy exists.
 - [ ] merge source sets and Z decisions across partitions;
+  - [x] Merge source IDs and retain sorted, deduplicated Z candidates at each
+    canonical endpoint; final conflict policy remains open.
 - [ ] reconcile connected components before face extraction;
 - [ ] validate the stitched arrangement and its unbounded face;
 - [ ] compare exact canonical results with untiled execution.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -905,6 +905,9 @@ After the explicit arrangement model exists:
     half-edge observations retaining provenance, face, partition, side, and Z
     evidence. Twin matching and reconciliation remain open.
 - [ ] match and reconcile twin boundary halfedges;
+  - [x] Match only unambiguous opposite-direction observations from two
+    distinct partitions; same-partition and ambiguous buckets remain
+    unmatched until an explicit reconciliation policy exists.
 - [ ] merge source sets and Z decisions across partitions;
 - [ ] reconcile connected components before face extraction;
 - [ ] validate the stitched arrangement and its unbounded face;

--- a/crates/geo-polygonize-core/src/containment.rs
+++ b/crates/geo-polygonize-core/src/containment.rs
@@ -19,6 +19,18 @@ use std::sync::OnceLock;
 const LOCATOR_INDEX_QUERY_THRESHOLD: usize = 64;
 const LOCATOR_INDEX_MIN_COORDS: usize = 65;
 
+fn graph_identities_with_faces<'a>(
+    shell: Option<&'a RingGraphIdentity>,
+    ring: Option<&'a RingGraphIdentity>,
+) -> Option<(&'a RingGraphIdentity, &'a RingGraphIdentity)> {
+    match (shell, ring) {
+        (Some(shell), Some(ring)) if shell.face_id.is_some() && ring.face_id.is_some() => {
+            Some((shell, ring))
+        }
+        _ => None,
+    }
+}
+
 fn touch_allowed(
     shell: &Polygon3D,
     shell_identity: Option<&RingGraphIdentity>,
@@ -29,19 +41,18 @@ fn touch_allowed(
 ) -> bool {
     match touch_policy {
         TouchPolicy::AllowPointTouchDisallowEdgeShare | TouchPolicy::TreatAnyTouchAsDisjoint => {
-            let (shares_edge, pair_checks, used_graph_ids) = if let (
-                Some(shell_identity),
-                Some(ring_identity),
-            ) = (shell_identity, ring_identity)
-            {
-                let (shares_edge, pair_checks) =
-                    sorted_intersects(&shell_identity.edge_keys, &ring_identity.edge_keys);
-                (shares_edge, pair_checks, true)
-            } else {
-                let (shares_edge, pair_checks) =
-                    rings_share_edge_with_count(&shell.exterior, &ring.exterior, 1e-10);
-                (shares_edge, pair_checks, false)
-            };
+            let (shares_edge, pair_checks, used_graph_ids) =
+                if let Some((shell_identity, ring_identity)) =
+                    graph_identities_with_faces(shell_identity, ring_identity)
+                {
+                    let (shares_edge, pair_checks) =
+                        sorted_intersects(&shell_identity.edge_keys, &ring_identity.edge_keys);
+                    (shares_edge, pair_checks, true)
+                } else {
+                    let (shares_edge, pair_checks) =
+                        rings_share_edge_with_count(&shell.exterior, &ring.exterior, 1e-10);
+                    (shares_edge, pair_checks, false)
+                };
             if let Some(stats) = stats.as_deref_mut() {
                 stats.shared_edge_checks += 1;
                 if used_graph_ids {
@@ -55,20 +66,18 @@ fn touch_allowed(
                 return !shares_edge;
             }
 
-            let (touches_vertex, pair_checks, used_graph_ids) = if let (
-                Some(shell_identity),
-                Some(ring_identity),
-            ) =
-                (shell_identity, ring_identity)
-            {
-                let (touches_vertex, pair_checks) =
-                    sorted_intersects(&shell_identity.node_ids, &ring_identity.node_ids);
-                (touches_vertex, pair_checks, true)
-            } else {
-                let (touches_vertex, pair_checks) =
-                    rings_touch_at_vertex_with_count(&shell.exterior, &ring.exterior, 1e-10);
-                (touches_vertex, pair_checks, false)
-            };
+            let (touches_vertex, pair_checks, used_graph_ids) =
+                if let Some((shell_identity, ring_identity)) =
+                    graph_identities_with_faces(shell_identity, ring_identity)
+                {
+                    let (touches_vertex, pair_checks) =
+                        sorted_intersects(&shell_identity.node_ids, &ring_identity.node_ids);
+                    (touches_vertex, pair_checks, true)
+                } else {
+                    let (touches_vertex, pair_checks) =
+                        rings_touch_at_vertex_with_count(&shell.exterior, &ring.exterior, 1e-10);
+                    (touches_vertex, pair_checks, false)
+                };
             if let Some(stats) = stats {
                 stats.shared_vertex_checks += 1;
                 if used_graph_ids {
@@ -506,8 +515,8 @@ mod tests {
     #[test]
     fn graph_identity_distinguishes_point_and_edge_touch() {
         let polygon = Polygon3D::new(vec![], vec![], vec![], vec![]);
-        let shell_ids = RingGraphIdentity::new(vec![(0, 1)], vec![0, 1]);
-        let ring_ids = RingGraphIdentity::new(vec![(1, 2)], vec![1, 2]);
+        let shell_ids = RingGraphIdentity::new(Some(0), vec![(0, 1)], vec![0, 1]);
+        let ring_ids = RingGraphIdentity::new(Some(1), vec![(1, 2)], vec![1, 2]);
         let mut stats = ContainmentStats::default();
 
         assert!(touch_allowed(

--- a/crates/geo-polygonize-core/src/graph/mod.rs
+++ b/crates/geo-polygonize-core/src/graph/mod.rs
@@ -1,3 +1,4 @@
+pub mod partition_border;
 pub mod planar_graph;
 pub(crate) use planar_graph::ExtractedRing;
 pub use planar_graph::{DirEdgeId, EdgeId, NodeId, PlanarGraph};

--- a/crates/geo-polygonize-core/src/graph/partition_border.rs
+++ b/crates/geo-polygonize-core/src/graph/partition_border.rs
@@ -1,0 +1,277 @@
+use crate::types::Coord3D;
+use crate::utils::canonical_coordinate_bits;
+use std::collections::{BTreeMap, BTreeSet};
+
+use super::planar_graph::{DirEdgeId, FaceId};
+
+/// A partition side carried as observation metadata, not part of the global
+/// node or edge identity. A corner can therefore be shared by two sides.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum PartitionBorderSide {
+    MinX,
+    MaxX,
+    MinY,
+    MaxY,
+}
+
+/// Exact 2D identity of a node on a partition border.
+///
+/// Z is deliberately excluded from the key. Adjacent partitions must match
+/// the same topology even when their local Z decisions differ; Z candidates
+/// are retained as node observations for a later reconciliation step.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct PartitionBorderNodeKey {
+    xy_bits: [u64; 2],
+}
+
+impl PartitionBorderNodeKey {
+    pub fn from_coord(coord: Coord3D) -> Self {
+        Self {
+            xy_bits: [
+                canonical_coordinate_bits(coord.x),
+                canonical_coordinate_bits(coord.y),
+            ],
+        }
+    }
+
+    pub fn xy_bits(self) -> [u64; 2] {
+        self.xy_bits
+    }
+}
+
+/// Canonical, undirected identity of a partition-border edge.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct PartitionBorderEdgeKey {
+    start: PartitionBorderNodeKey,
+    end: PartitionBorderNodeKey,
+}
+
+impl PartitionBorderEdgeKey {
+    pub fn new(start: PartitionBorderNodeKey, end: PartitionBorderNodeKey) -> Option<Self> {
+        (start != end).then(|| {
+            if start <= end {
+                Self { start, end }
+            } else {
+                Self {
+                    start: end,
+                    end: start,
+                }
+            }
+        })
+    }
+
+    pub fn endpoints(self) -> (PartitionBorderNodeKey, PartitionBorderNodeKey) {
+        (self.start, self.end)
+    }
+}
+
+/// One directed local observation of a canonical partition-border edge.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct PartitionBorderHalfEdge {
+    pub edge_key: PartitionBorderEdgeKey,
+    pub from: PartitionBorderNodeKey,
+    pub to: PartitionBorderNodeKey,
+    pub from_z_bits: u64,
+    pub to_z_bits: u64,
+    pub side: PartitionBorderSide,
+    pub partition_id: usize,
+    pub local_dir_edge_id: DirEdgeId,
+    pub face_id: Option<FaceId>,
+    pub source_line_ids: Vec<u32>,
+}
+
+impl PartitionBorderHalfEdge {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        partition_id: usize,
+        local_dir_edge_id: DirEdgeId,
+        face_id: Option<FaceId>,
+        side: PartitionBorderSide,
+        start: Coord3D,
+        end: Coord3D,
+        source_line_ids: impl IntoIterator<Item = u32>,
+    ) -> Option<Self> {
+        let from = PartitionBorderNodeKey::from_coord(start);
+        let to = PartitionBorderNodeKey::from_coord(end);
+        let edge_key = PartitionBorderEdgeKey::new(from, to)?;
+        let mut source_line_ids = source_line_ids.into_iter().collect::<Vec<_>>();
+        source_line_ids.sort_unstable();
+        source_line_ids.dedup();
+        Some(Self {
+            edge_key,
+            from,
+            to,
+            from_z_bits: canonical_coordinate_bits(start.z),
+            to_z_bits: canonical_coordinate_bits(end.z),
+            side,
+            partition_id,
+            local_dir_edge_id,
+            face_id,
+            source_line_ids,
+        })
+    }
+}
+
+/// Deterministic partition-border observations ready for future twin matching.
+///
+/// The graph stores canonical undirected edge buckets while retaining each
+/// local directed observation. This makes reversal and insertion order
+/// irrelevant to lookup without discarding direction, provenance, or Z data.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct PartitionBorderGraph {
+    nodes: BTreeMap<PartitionBorderNodeKey, BTreeSet<u64>>,
+    edges: BTreeMap<PartitionBorderEdgeKey, BTreeSet<PartitionBorderHalfEdge>>,
+}
+
+impl PartitionBorderGraph {
+    pub fn insert(&mut self, half_edge: PartitionBorderHalfEdge) {
+        let from = half_edge.from;
+        let to = half_edge.to;
+        self.nodes
+            .entry(from)
+            .or_default()
+            .insert(half_edge.from_z_bits);
+        self.nodes
+            .entry(to)
+            .or_default()
+            .insert(half_edge.to_z_bits);
+        self.edges
+            .entry(half_edge.edge_key)
+            .or_default()
+            .insert(half_edge);
+    }
+
+    pub fn node_count(&self) -> usize {
+        self.nodes.len()
+    }
+
+    pub fn edge_count(&self) -> usize {
+        self.edges.len()
+    }
+
+    pub fn node_z_bits(&self, key: PartitionBorderNodeKey) -> Option<&BTreeSet<u64>> {
+        self.nodes.get(&key)
+    }
+
+    pub fn edge_observations(
+        &self,
+        key: PartitionBorderEdgeKey,
+    ) -> Option<&BTreeSet<PartitionBorderHalfEdge>> {
+        self.edges.get(&key)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::PlanarGraph;
+    use crate::types::Line3D;
+
+    fn coord(x: f64, y: f64, z: f64) -> Coord3D {
+        Coord3D::new(x, y, z)
+    }
+
+    #[test]
+    fn node_keys_normalize_signed_zero_but_preserve_z_outside_identity() {
+        assert_eq!(
+            PartitionBorderNodeKey::from_coord(coord(-0.0, 1.0, 4.0)),
+            PartitionBorderNodeKey::from_coord(coord(0.0, 1.0, -4.0))
+        );
+        assert_eq!(
+            PartitionBorderNodeKey::from_coord(coord(0.0, 1.0, 4.0)).xy_bits(),
+            [0, 1.0f64.to_bits()]
+        );
+    }
+
+    #[test]
+    fn edge_keys_are_reversal_invariant_and_round_trip_endpoints() {
+        let start = PartitionBorderNodeKey::from_coord(coord(2.0, 0.0, 1.0));
+        let end = PartitionBorderNodeKey::from_coord(coord(0.0, 0.0, 2.0));
+        let forward = PartitionBorderEdgeKey::new(start, end).unwrap();
+        let reverse = PartitionBorderEdgeKey::new(end, start).unwrap();
+
+        assert_eq!(forward, reverse);
+        assert_eq!(forward.endpoints(), (end, start));
+        assert!(PartitionBorderEdgeKey::new(start, start).is_none());
+    }
+
+    #[test]
+    fn graph_deduplicates_keys_and_retains_local_observations() {
+        let start = coord(-0.0, 0.0, 1.0);
+        let end = coord(2.0, 0.0, 2.0);
+        let first = PartitionBorderHalfEdge::new(
+            1,
+            7,
+            Some(3),
+            PartitionBorderSide::MinY,
+            start,
+            end,
+            [4, 2, 4],
+        )
+        .unwrap();
+        let second = PartitionBorderHalfEdge::new(
+            2,
+            9,
+            Some(5),
+            PartitionBorderSide::MaxX,
+            end,
+            coord(0.0, 0.0, 3.0),
+            [2, 8],
+        )
+        .unwrap();
+        let key = first.edge_key;
+        let start_key = first.from;
+
+        let mut graph = PartitionBorderGraph::default();
+        graph.insert(second);
+        graph.insert(first);
+
+        assert_eq!(graph.node_count(), 2);
+        assert_eq!(graph.edge_count(), 1);
+        assert_eq!(
+            graph.node_z_bits(start_key).unwrap(),
+            &BTreeSet::from([1.0f64.to_bits(), 3.0f64.to_bits()])
+        );
+        let observations = graph.edge_observations(key).unwrap();
+        assert_eq!(observations.len(), 2);
+        assert_eq!(
+            observations.iter().next().unwrap().source_line_ids,
+            vec![2, 4]
+        );
+    }
+
+    #[test]
+    fn degenerate_half_edges_are_not_inserted() {
+        assert!(PartitionBorderHalfEdge::new(
+            0,
+            0,
+            None,
+            PartitionBorderSide::MinX,
+            coord(1.0, 1.0, 0.0),
+            coord(1.0, 1.0, 9.0),
+            [],
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn planar_graph_transfers_directed_identity_into_border_observations() {
+        let mut planar = PlanarGraph::new();
+        planar.add_line(Line3D::new(coord(0.0, 0.0, 1.0), coord(2.0, 0.0, 2.0), 11));
+
+        let forward = planar
+            .partition_border_half_edge(4, 0, PartitionBorderSide::MinY)
+            .unwrap();
+        let reverse = planar
+            .partition_border_half_edge(4, 1, PartitionBorderSide::MaxY)
+            .unwrap();
+        assert_eq!(forward.edge_key, reverse.edge_key);
+        assert_eq!(forward.from, reverse.to);
+        assert_eq!(forward.to, reverse.from);
+        assert_eq!(forward.source_line_ids, vec![11]);
+        assert!(planar.remove_line_by_id(11));
+        assert!(planar
+            .partition_border_half_edge(4, 0, PartitionBorderSide::MinY)
+            .is_none());
+    }
+}

--- a/crates/geo-polygonize-core/src/graph/partition_border.rs
+++ b/crates/geo-polygonize-core/src/graph/partition_border.rs
@@ -112,6 +112,32 @@ impl PartitionBorderHalfEdge {
     }
 }
 
+/// Stable identity of one local directed border observation.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct PartitionBorderObservationId {
+    pub partition_id: usize,
+    pub local_dir_edge_id: DirEdgeId,
+}
+
+impl PartitionBorderHalfEdge {
+    pub fn observation_id(&self) -> PartitionBorderObservationId {
+        PartitionBorderObservationId {
+            partition_id: self.partition_id,
+            local_dir_edge_id: self.local_dir_edge_id,
+        }
+    }
+}
+
+/// An unambiguous opposite-direction pair observed in two partitions.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct PartitionBorderTwin {
+    pub edge_key: PartitionBorderEdgeKey,
+    /// Observation whose direction follows `edge_key.endpoints()`.
+    pub forward: PartitionBorderObservationId,
+    /// Observation whose direction reverses `edge_key.endpoints()`.
+    pub reverse: PartitionBorderObservationId,
+}
+
 /// Deterministic partition-border observations ready for future twin matching.
 ///
 /// The graph stores canonical undirected edge buckets while retaining each
@@ -147,6 +173,43 @@ impl PartitionBorderGraph {
 
     pub fn edge_count(&self) -> usize {
         self.edges.len()
+    }
+
+    /// Matches only exactly-two-observation buckets with opposite directions
+    /// from distinct partitions. Ambiguous or same-partition buckets remain
+    /// unmatched for a later reconciliation policy.
+    pub fn twin_pairs(&self) -> Vec<PartitionBorderTwin> {
+        self.edges
+            .iter()
+            .filter_map(|(&edge_key, observations)| {
+                let mut observations = observations.iter();
+                let first = observations.next()?;
+                let second = observations.next()?;
+                if observations.next().is_some() || first.partition_id == second.partition_id {
+                    return None;
+                }
+                let (start, end) = edge_key.endpoints();
+                let first_is_forward = first.from == start && first.to == end;
+                let second_is_forward = second.from == start && second.to == end;
+                let first_is_reverse = first.from == end && first.to == start;
+                let second_is_reverse = second.from == end && second.to == start;
+                if first_is_forward && second_is_reverse {
+                    Some(PartitionBorderTwin {
+                        edge_key,
+                        forward: first.observation_id(),
+                        reverse: second.observation_id(),
+                    })
+                } else if second_is_forward && first_is_reverse {
+                    Some(PartitionBorderTwin {
+                        edge_key,
+                        forward: second.observation_id(),
+                        reverse: first.observation_id(),
+                    })
+                } else {
+                    None
+                }
+            })
+            .collect()
     }
 
     pub fn node_z_bits(&self, key: PartitionBorderNodeKey) -> Option<&BTreeSet<u64>> {
@@ -273,5 +336,60 @@ mod tests {
         assert!(planar
             .partition_border_half_edge(4, 0, PartitionBorderSide::MinY)
             .is_none());
+    }
+
+    #[test]
+    fn twin_matching_requires_two_opposite_partition_observations() {
+        let start = coord(0.0, 0.0, 1.0);
+        let end = coord(2.0, 0.0, 2.0);
+        let forward =
+            PartitionBorderHalfEdge::new(1, 7, Some(3), PartitionBorderSide::MaxX, start, end, [4])
+                .unwrap();
+        let reverse =
+            PartitionBorderHalfEdge::new(2, 9, Some(5), PartitionBorderSide::MinX, end, start, [8])
+                .unwrap();
+        let key = forward.edge_key;
+
+        let mut graph = PartitionBorderGraph::default();
+        graph.insert(reverse);
+        graph.insert(forward);
+
+        assert_eq!(
+            graph.twin_pairs(),
+            vec![PartitionBorderTwin {
+                edge_key: key,
+                forward: PartitionBorderObservationId {
+                    partition_id: 1,
+                    local_dir_edge_id: 7,
+                },
+                reverse: PartitionBorderObservationId {
+                    partition_id: 2,
+                    local_dir_edge_id: 9,
+                },
+            }]
+        );
+    }
+
+    #[test]
+    fn twin_matching_leaves_same_partition_and_ambiguous_buckets_unmatched() {
+        let start = coord(0.0, 0.0, 0.0);
+        let end = coord(1.0, 0.0, 0.0);
+        let mut same_partition = PartitionBorderGraph::default();
+        same_partition.insert(
+            PartitionBorderHalfEdge::new(1, 1, None, PartitionBorderSide::MaxX, start, end, [])
+                .unwrap(),
+        );
+        same_partition.insert(
+            PartitionBorderHalfEdge::new(1, 2, None, PartitionBorderSide::MinX, end, start, [])
+                .unwrap(),
+        );
+        assert!(same_partition.twin_pairs().is_empty());
+
+        let mut ambiguous = same_partition.clone();
+        ambiguous.insert(
+            PartitionBorderHalfEdge::new(2, 3, None, PartitionBorderSide::MinX, end, start, [])
+                .unwrap(),
+        );
+        assert!(ambiguous.twin_pairs().is_empty());
     }
 }

--- a/crates/geo-polygonize-core/src/graph/partition_border.rs
+++ b/crates/geo-polygonize-core/src/graph/partition_border.rs
@@ -138,7 +138,20 @@ pub struct PartitionBorderTwin {
     pub reverse: PartitionBorderObservationId,
 }
 
-/// Deterministic partition-border observations ready for future twin matching.
+/// Provenance and Z evidence merged from one unambiguous partition-border twin.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PartitionBorderTwinPayload {
+    pub twin: PartitionBorderTwin,
+    pub source_line_ids: Vec<u32>,
+    /// Distinct Z candidates at `twin.edge_key.endpoints().0`, in bit order.
+    /// A length greater than one is an explicit conflict, not a hidden choice.
+    pub start_z_bits: Vec<u64>,
+    /// Distinct Z candidates at `twin.edge_key.endpoints().1`, in bit order.
+    /// A length greater than one is an explicit conflict, not a hidden choice.
+    pub end_z_bits: Vec<u64>,
+}
+
+/// Deterministic partition-border observations ready for twin reconciliation.
 ///
 /// The graph stores canonical undirected edge buckets while retaining each
 /// local directed observation. This makes reversal and insertion order
@@ -208,6 +221,46 @@ impl PartitionBorderGraph {
                 } else {
                     None
                 }
+            })
+            .collect()
+    }
+
+    /// Merges source IDs and retains every distinct Z candidate for each
+    /// canonical endpoint. No Z conflict policy is applied here.
+    pub fn reconcile_twin_payloads(&self) -> Vec<PartitionBorderTwinPayload> {
+        self.twin_pairs()
+            .into_iter()
+            .filter_map(|twin| {
+                let observations = self.edges.get(&twin.edge_key)?;
+                let forward = observations
+                    .iter()
+                    .find(|observation| observation.observation_id() == twin.forward)?;
+                let reverse = observations
+                    .iter()
+                    .find(|observation| observation.observation_id() == twin.reverse)?;
+
+                let mut source_line_ids = forward
+                    .source_line_ids
+                    .iter()
+                    .chain(&reverse.source_line_ids)
+                    .copied()
+                    .collect::<Vec<_>>();
+                source_line_ids.sort_unstable();
+                source_line_ids.dedup();
+
+                let mut start_z_bits = vec![forward.from_z_bits, reverse.to_z_bits];
+                start_z_bits.sort_unstable();
+                start_z_bits.dedup();
+                let mut end_z_bits = vec![forward.to_z_bits, reverse.from_z_bits];
+                end_z_bits.sort_unstable();
+                end_z_bits.dedup();
+
+                Some(PartitionBorderTwinPayload {
+                    twin,
+                    source_line_ids,
+                    start_z_bits,
+                    end_z_bits,
+                })
             })
             .collect()
     }
@@ -366,6 +419,49 @@ mod tests {
                     partition_id: 2,
                     local_dir_edge_id: 9,
                 },
+            }]
+        );
+    }
+
+    #[test]
+    fn twin_payload_reconciliation_unions_sources_and_retains_z_conflicts() {
+        let forward = PartitionBorderHalfEdge::new(
+            1,
+            7,
+            Some(3),
+            PartitionBorderSide::MaxX,
+            coord(-0.0, 0.0, 1.0),
+            coord(2.0, 0.0, 2.0),
+            [4, 2, 4],
+        )
+        .unwrap();
+        let reverse = PartitionBorderHalfEdge::new(
+            2,
+            9,
+            Some(5),
+            PartitionBorderSide::MinX,
+            coord(2.0, 0.0, 2.0),
+            coord(0.0, 0.0, -0.0),
+            [8, 4],
+        )
+        .unwrap();
+        let twin = PartitionBorderTwin {
+            edge_key: forward.edge_key,
+            forward: forward.observation_id(),
+            reverse: reverse.observation_id(),
+        };
+
+        let mut graph = PartitionBorderGraph::default();
+        graph.insert(reverse);
+        graph.insert(forward);
+
+        assert_eq!(
+            graph.reconcile_twin_payloads(),
+            vec![PartitionBorderTwinPayload {
+                twin,
+                source_line_ids: vec![2, 4, 8],
+                start_z_bits: vec![0, 1.0f64.to_bits()],
+                end_z_bits: vec![2.0f64.to_bits()],
             }]
         );
     }

--- a/crates/geo-polygonize-core/src/graph/planar_graph.rs
+++ b/crates/geo-polygonize-core/src/graph/planar_graph.rs
@@ -11,6 +11,8 @@ use rayon::prelude::*;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 
+use super::partition_border::{PartitionBorderHalfEdge, PartitionBorderSide};
+
 /// Index of a node in the graph.
 pub type NodeId = usize;
 /// Index of an undirected edge in the graph.
@@ -248,6 +250,42 @@ impl PlanarGraph {
             face_count: 0,
             unbounded_face_ids: Vec::new(),
         }
+    }
+
+    /// Creates a canonical partition-border observation for a directed local
+    /// edge. The caller supplies the already-classified border side; this
+    /// method only transfers arrangement identity, direction, provenance, and
+    /// Z observations into the partition representation.
+    pub fn partition_border_half_edge(
+        &self,
+        partition_id: usize,
+        dir_edge_id: DirEdgeId,
+        side: PartitionBorderSide,
+    ) -> Option<PartitionBorderHalfEdge> {
+        let directed = self.directed_edges.get(dir_edge_id)?;
+        let edge = self.edges.get(directed.edge_idx)?;
+        if edge.deleted {
+            return None;
+        }
+        let start = Coord3D {
+            x: *self.nodes_x.get(directed.src)?,
+            y: *self.nodes_y.get(directed.src)?,
+            z: *self.nodes_z.get(directed.src)?,
+        };
+        let end = Coord3D {
+            x: *self.nodes_x.get(directed.dst)?,
+            y: *self.nodes_y.get(directed.dst)?,
+            z: *self.nodes_z.get(directed.dst)?,
+        };
+        PartitionBorderHalfEdge::new(
+            partition_id,
+            dir_edge_id,
+            directed.face_id,
+            side,
+            start,
+            end,
+            edge.sources.line_ids.iter().copied(),
+        )
     }
 
     pub(crate) fn clear(&mut self) {

--- a/crates/geo-polygonize-core/src/graph/planar_graph.rs
+++ b/crates/geo-polygonize-core/src/graph/planar_graph.rs
@@ -27,6 +27,9 @@ pub(crate) struct ExtractedRing {
     pub coords: Vec<Coord3D>,
     pub line_ids: Vec<u32>,
     pub source_line_ids: Vec<u32>,
+    /// Component-local deterministic face identity for final ring extraction.
+    /// Maximal trace rings are captured before face identities are assigned.
+    pub face_id: Option<FaceId>,
     pub edge_keys: Vec<(NodeId, NodeId)>,
     pub node_ids: Vec<NodeId>,
 }
@@ -1375,6 +1378,7 @@ impl PlanarGraph {
         } else {
             Vec::new()
         };
+        let face_id = self.directed_edges[ring_edges[0]].face_id;
         let start_node_idx = self.directed_edges[ring_edges[0]].src;
         coords.push(Coord3D {
             x: self.nodes_x[start_node_idx],
@@ -1415,6 +1419,7 @@ impl PlanarGraph {
             coords,
             line_ids: ids,
             source_line_ids: source_ids,
+            face_id,
             edge_keys,
             node_ids,
         })
@@ -2473,6 +2478,60 @@ mod arrangement_ring_invariant_tests {
             .directed_edges
             .iter()
             .all(|directed| directed.face_id.is_none()));
+    }
+
+    #[test]
+    fn extracted_rings_retain_deterministic_face_and_boundary_payloads() {
+        let lines = vec![
+            Line3D::new(Coord3D::new(0.0, 0.0, 1.0), Coord3D::new(2.0, 0.0, 2.0), 10),
+            Line3D::new(Coord3D::new(2.0, 0.0, 2.0), Coord3D::new(2.0, 2.0, 3.0), 11),
+            Line3D::new(Coord3D::new(2.0, 2.0, 3.0), Coord3D::new(0.0, 2.0, 4.0), 12),
+            Line3D::new(Coord3D::new(0.0, 2.0, 4.0), Coord3D::new(0.0, 0.0, 1.0), 13),
+        ];
+
+        let snapshot = |lines: Vec<Line3D>| {
+            let mut graph = PlanarGraph::new();
+            graph.bulk_load(lines);
+            graph.sort_edges();
+            let mut rings = graph.get_edge_rings_with_graph_ids(true, true);
+            rings.sort_unstable_by_key(|ring| ring.face_id);
+            rings
+                .into_iter()
+                .map(|ring| {
+                    (
+                        ring.face_id,
+                        ring.source_line_ids,
+                        ring.coords
+                            .iter()
+                            .map(|coord| coord.z.to_bits())
+                            .collect::<Vec<_>>(),
+                    )
+                })
+                .collect::<Vec<_>>()
+        };
+
+        let mut reversed = lines.clone();
+        reversed.reverse();
+        let first = snapshot(lines);
+        let second = snapshot(reversed);
+
+        assert_eq!(first, second);
+        assert_eq!(first.len(), 2);
+        assert!(first.iter().all(|(face_id, _, _)| face_id.is_some()));
+        assert!(first
+            .iter()
+            .all(|(_, source_line_ids, _)| source_line_ids == &[10, 11, 12, 13]));
+        assert!(first.iter().all(|(_, _, z_bits)| {
+            let mut sorted = z_bits[..z_bits.len() - 1].to_vec();
+            sorted.sort_unstable();
+            sorted
+                == [
+                    1.0f64.to_bits(),
+                    2.0f64.to_bits(),
+                    3.0f64.to_bits(),
+                    4.0f64.to_bits(),
+                ]
+        }));
     }
 
     #[test]

--- a/crates/geo-polygonize-core/src/graph/planar_graph.rs
+++ b/crates/geo-polygonize-core/src/graph/planar_graph.rs
@@ -2323,11 +2323,81 @@ mod arrangement_ring_invariant_tests {
         snapshot
     }
 
+    type FacePayloadSnapshot = (FaceId, Vec<[u64; 2]>, Vec<u32>, Vec<u64>);
+
+    fn explicit_face_payload_snapshot(graph: &PlanarGraph) -> Vec<FacePayloadSnapshot> {
+        let mut snapshot = Vec::new();
+        for face_id in 0..graph.face_count {
+            let start = graph
+                .directed_edges
+                .iter()
+                .position(|directed| directed.face_id == Some(face_id))
+                .unwrap();
+            let mut cycle = Vec::new();
+            let mut current = start;
+            loop {
+                cycle.push(current);
+                current = graph.directed_edges[graph.directed_edges[current].sym_idx]
+                    .next_idx
+                    .unwrap();
+                if current == start {
+                    break;
+                }
+            }
+
+            let raw_key: Vec<_> = cycle
+                .iter()
+                .map(|&directed_idx| {
+                    let node = graph.directed_edges[directed_idx].src;
+                    [
+                        canonical_coordinate_bits(graph.nodes_x[node]),
+                        canonical_coordinate_bits(graph.nodes_y[node]),
+                    ]
+                })
+                .collect();
+            let rotation = minimum_rotation_index(&raw_key);
+            let mut source_line_ids = Vec::new();
+            for &directed_idx in &cycle {
+                source_line_ids.extend_from_slice(
+                    &graph.edges[graph.directed_edges[directed_idx].edge_idx]
+                        .sources
+                        .line_ids,
+                );
+            }
+            source_line_ids.sort_unstable();
+            source_line_ids.dedup();
+            let z_bits = (0..=cycle.len())
+                .map(|offset| {
+                    let directed_idx = cycle[(rotation + offset) % cycle.len()];
+                    graph.nodes_z[graph.directed_edges[directed_idx].src].to_bits()
+                })
+                .collect();
+
+            snapshot.push((
+                face_id,
+                graph.face_cycle_key(&cycle),
+                source_line_ids,
+                z_bits,
+            ));
+        }
+        snapshot
+    }
+
     fn add_triangle(graph: &mut PlanarGraph, points: [Coord3D; 3], first_line_id: u32) {
         for offset in 0..3 {
             graph.add_line(Line3D::new(
                 points[offset],
                 points[(offset + 1) % 3],
+                first_line_id + offset as u32,
+            ));
+        }
+    }
+
+    fn add_square(graph: &mut PlanarGraph, points: [Coord3D; 4], first_line_id: u32) {
+        for offset in 0..4 {
+            graph.add_line(Line3D::new(
+                points[offset],
+                points[(offset + 1) % 4],
                 first_line_id + offset as u32,
             ));
         }
@@ -2532,6 +2602,61 @@ mod arrangement_ring_invariant_tests {
                     4.0f64.to_bits(),
                 ]
         }));
+    }
+
+    #[test]
+    fn explicit_face_walk_matches_extracted_ring_payloads() {
+        let mut graph = PlanarGraph::new();
+        add_square(
+            &mut graph,
+            [
+                Coord3D::new(0.0, 0.0, 1.0),
+                Coord3D::new(10.0, 0.0, 2.0),
+                Coord3D::new(10.0, 10.0, 3.0),
+                Coord3D::new(0.0, 10.0, 4.0),
+            ],
+            10,
+        );
+        add_square(
+            &mut graph,
+            [
+                Coord3D::new(2.0, 2.0, 5.0),
+                Coord3D::new(8.0, 2.0, 6.0),
+                Coord3D::new(8.0, 8.0, 7.0),
+                Coord3D::new(2.0, 8.0, 8.0),
+            ],
+            20,
+        );
+        graph.sort_edges();
+
+        let rings = graph.get_edge_rings_with_graph_ids(true, true);
+        let mut extracted = rings
+            .into_iter()
+            .map(|ring| {
+                let face_id = ring.face_id.unwrap();
+                let n = ring.coords.len() - 1;
+                let raw_key: Vec<_> = ring.coords[..n]
+                    .iter()
+                    .map(|coord| {
+                        [
+                            canonical_coordinate_bits(coord.x),
+                            canonical_coordinate_bits(coord.y),
+                        ]
+                    })
+                    .collect();
+                let rotation = minimum_rotation_index(&raw_key);
+                let mut key = raw_key;
+                key.rotate_left(rotation);
+                let z_bits = (0..=n)
+                    .map(|offset| ring.coords[(rotation + offset) % n].z.to_bits())
+                    .collect();
+                (face_id, key, ring.source_line_ids, z_bits)
+            })
+            .collect::<Vec<_>>();
+        extracted.sort_unstable_by_key(|(face_id, _, _, _)| *face_id);
+
+        assert_eq!(extracted, explicit_face_payload_snapshot(&graph));
+        assert_eq!(graph.unbounded_face_ids.len(), 2);
     }
 
     #[test]

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -1279,7 +1279,8 @@ pub(crate) fn extract_and_classify_rings(
 
         let ring = (
             poly3d,
-            include_graph_ids.then(|| RingGraphIdentity::new(ring.edge_keys, ring.node_ids)),
+            include_graph_ids
+                .then(|| RingGraphIdentity::new(ring.face_id, ring.edge_keys, ring.node_ids)),
         );
         if area > 0.0 {
             shells.push(ring);

--- a/crates/geo-polygonize-core/src/types.rs
+++ b/crates/geo-polygonize-core/src/types.rs
@@ -119,17 +119,24 @@ pub struct PolygonProvenance {
 
 #[derive(Clone, Debug)]
 pub(crate) struct RingGraphIdentity {
+    /// Component-local deterministic face identity.
+    pub face_id: Option<usize>,
     pub edge_keys: std::sync::Arc<[(usize, usize)]>,
     pub node_ids: std::sync::Arc<[usize]>,
 }
 
 impl RingGraphIdentity {
-    pub(crate) fn new(mut edge_keys: Vec<(usize, usize)>, mut node_ids: Vec<usize>) -> Self {
+    pub(crate) fn new(
+        face_id: Option<usize>,
+        mut edge_keys: Vec<(usize, usize)>,
+        mut node_ids: Vec<usize>,
+    ) -> Self {
         edge_keys.sort_unstable();
         edge_keys.dedup();
         node_ids.sort_unstable();
         node_ids.dedup();
         Self {
+            face_id,
             edge_keys: edge_keys.into(),
             node_ids: node_ids.into(),
         }


### PR DESCRIPTION
Stack anchor for #1249–#1252.

#1243 is already merged to `main`. This PR brings the remaining partition-border graph slices to `main`:
- #1244: match unambiguous opposite-direction border twins;
- #1245: reconcile border provenance and Z evidence;
- #1246: retain face-boundary evidence;
- #1247: compare explicit face walks with extracted output.

The branch was synchronized with current `main` after the #1243 squash merge so the child PRs can remain stacked on this anchor.

Validation:
- `cargo test -p geo-polygonize-core` (272 passed)
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`