### PR TITLE
fix(core): bound certified validation

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -630,6 +630,10 @@ Certified fixed precision remains the hot-pixel contract.
 - [ ] Feed all experimental candidates through the independent validator and the
   same split/dissolve path.
 
+Certified fixed-grid output now routes its final independent validation through
+the active execution policy, so cancellation is enforced during the validator
+as well as candidate enumeration and split application.
+
 Floating SIMD and uniform-grid noding now expose an internal candidate-pair
 boundary before exact intersection and split accumulation. Certified hot-pixel
 noding already follows the same indexed-candidate-then-exact shape. The hidden

--- a/crates/geo-polygonize-core/src/noding/hot_pixel.rs
+++ b/crates/geo-polygonize-core/src/noding/hot_pixel.rs
@@ -338,7 +338,11 @@ impl HotPixelNoder {
         }
 
         snapper.normalize_and_dedup(&mut output);
-        ValidatingNoder::new().validate(&output)?;
+        if let Some(execution_policy) = execution_policy {
+            ValidatingNoder::new().validate_with_execution_policy(&output, execution_policy)?;
+        } else {
+            ValidatingNoder::new().validate(&output)?;
+        }
         Ok((
             output,
             intersections,


### PR DESCRIPTION
Stacked on #1255.

The certified hot-pixel noder accepted an optional `ExecutionPolicy` for candidate enumeration and split application but ran its final independent `ValidatingNoder` without that policy. Cancellation could therefore stop before validation and then be lost at the final validator boundary.

The validator now receives the active policy when controls are enabled; the unlimited path is unchanged. The roadmap records the remaining broader candidate-backend equivalence work.

Validation:
- `cargo test -p geo-polygonize-core` (274 unit tests and integration suites passed)
- `cargo test -p geo-polygonize-core noding::hot_pixel::tests --lib`
- `cargo check -p geo-polygonize-core --no-default-features`
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`