### PR TITLE
ci(github): speed up PR workflows

### DIFF
--- a/.github/workflows/benchmark-evidence.yml
+++ b/.github/workflows/benchmark-evidence.yml
@@ -26,6 +26,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   geos-reference:
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,6 +234,7 @@ jobs:
         if: matrix.variant == 'threads'
         uses: dtolnay/rust-toolchain@nightly
         with:
+          toolchain: "nightly-2026-07-15"
           components: rust-src
           targets: wasm32-unknown-unknown
 
@@ -253,13 +254,12 @@ jobs:
           node-version: '22'
           cache: 'npm'
 
-      - name: Install NPM dependencies
-        run: npm ci
-
       - name: Install cargo-binstall
         uses: cargo-bins/cargo-binstall@main
 
       - name: Build WASM package
+        env:
+          THREADS_TOOLCHAIN: nightly-2026-07-15
         run: ./scripts/build_wasm.sh --variant "${{ matrix.variant }}" --no-bundle
 
       - name: Upload WASM package
@@ -278,21 +278,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache Rust
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: rust-debug
-          workspaces: |
-            . -> target
-
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '22'
           cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            playground/package-lock.json
 
       - name: Install NPM dependencies
         run: |

--- a/.github/workflows/codex-task.yml
+++ b/.github/workflows/codex-task.yml
@@ -74,7 +74,6 @@ jobs:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           prompt-file: .codex-task-prompt.md
           output-file: ${{ runner.temp }}/codex-summary.md
-          permission-profile: ":workspace"
           safety-strategy: drop-sudo
 
       - name: Capture patch

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -10,9 +10,15 @@ on:
     paths:
       - '.github/workflows/docs-pages.yml'
       - 'README.md'
-      - 'crates/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'playground/package.json'
+      - 'playground/package-lock.json'
+      - 'crates/geo-polygonize-core/**'
+      - 'crates/geo-polygonize-wasm/**'
       - 'python/**'
       - 'docs/**'
+      - 'scripts/build_wasm.sh'
       - 'scripts/docs/**'
       - 'xtask/**'
 
@@ -22,11 +28,10 @@ permissions:
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+# Keep production deployments serialized while allowing independent PR builds and canceling stale PR runs.
 concurrency:
-  group: pages
-  cancel-in-progress: false
+  group: docs-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build_docs:
@@ -36,11 +41,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Nightly Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly
-          target: wasm32-unknown-unknown
-          override: true
+          toolchain: "nightly-2026-07-15"
+          targets: wasm32-unknown-unknown
           components: rust-src
 
       - name: Cache Rust
@@ -57,6 +61,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            playground/package-lock.json
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -2,15 +2,22 @@ name: Maintenance
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'crates/geo-polygonize-core/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/maintenance.yml'
   pull_request:
     branches:
       - main
       - develop
     paths:
-      - 'crates/**'
+      - 'crates/geo-polygonize-core/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
-      - 'scripts/**'
       - '.github/workflows/maintenance.yml'
 
 permissions:
@@ -50,20 +57,22 @@ jobs:
           pip install Shapely==2.1.2 numpy==2.3.2
 
       - name: Set up Node.js
+        if: github.event_name != 'pull_request'
         uses: actions/setup-node@v4
         with:
           node-version: '22.17.1'
           cache: 'npm'
 
       - name: Install Wasm tools
+        if: github.event_name != 'pull_request'
         run: npm install -g wasm-pack@0.13.1
 
       - name: Run Benchmarks
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            bash crates/geo-polygonize-core/benches/run_comparison.sh --fast-ci
-          else
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             bash crates/geo-polygonize-core/benches/run_comparison.sh
+          else
+            bash crates/geo-polygonize-core/benches/run_comparison.sh --fast-ci
           fi
 
       - name: Generate Benchmark Report
@@ -76,5 +85,5 @@ jobs:
         run: gh pr comment ${{ github.event.pull_request.number }} --edit-last --create-if-none --body-file benchmark_report.md
 
       - name: Add report to workflow summary
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name != 'pull_request'
         run: cat benchmark_report.md >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -5,10 +5,20 @@ on:
     branches:
       - main
       - develop
+    paths:
+      - '.github/workflows/perf.yml'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'crates/geo-polygonize-core/**'
   pull_request:
     branches:
       - main
       - develop
+    paths:
+      - '.github/workflows/perf.yml'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'crates/geo-polygonize-core/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Publish geo-polygonize-arrow to crates.io
         run: |
           for i in 1 2 3 4 5 6; do
+            echo "Publish attempt $i"
             cargo publish -p geo-polygonize-arrow && exit 0
             echo "Publish failed, waiting before retrying..."
             sleep 30
@@ -34,6 +35,7 @@ jobs:
       - name: Publish geo-polygonize-flatgeobuf to crates.io
         run: |
           for i in 1 2 3 4 5 6; do
+            echo "Publish attempt $i"
             cargo publish -p geo-polygonize-flatgeobuf && exit 0
             echo "Publish failed, waiting before retrying..."
             sleep 30
@@ -43,6 +45,7 @@ jobs:
       - name: Publish geo-polygonize-wasm to crates.io
         run: |
           for i in 1 2 3 4 5 6; do
+            echo "Publish attempt $i"
             cargo publish -p geo-polygonize-wasm && exit 0
             echo "Publish failed, waiting before retrying..."
             sleep 30

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -3,8 +3,24 @@ name: Differential Fuzzer
 on:
   push:
     branches: [ "main" ]
+    paths:
+      - ".github/workflows/python-tests.yml"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "crates/geo-polygonize-core/**"
+      - "tests/differential_shapely.py"
   pull_request:
     branches: [ "main" ]
+    paths:
+      - ".github/workflows/python-tests.yml"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "crates/geo-polygonize-core/**"
+      - "tests/differential_shapely.py"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
@@ -14,6 +30,13 @@ jobs:
 
     - name: Set up Rust
       uses: dtolnay/rust-toolchain@stable
+
+    - name: Cache Rust
+      uses: Swatinem/rust-cache@v2
+      with:
+        shared-key: rust-release
+        workspaces: |
+          . -> target
 
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/.github/workflows/unsafe-boundaries.yml
+++ b/.github/workflows/unsafe-boundaries.yml
@@ -14,6 +14,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   miri-core:
     runs-on: ubuntu-24.04

--- a/scripts/build_wasm.sh
+++ b/scripts/build_wasm.sh
@@ -6,6 +6,7 @@ export PATH="${CARGO_HOME:-$HOME/.cargo}/bin:$PATH"
 WASM_BINDGEN_VERSION="0.2.114"
 TARGET="wasm32-unknown-unknown"
 SITE_BUILD="${SITE_BUILD:-${BUILD_WASM_SITE:-0}}"
+THREADS_TOOLCHAIN="${THREADS_TOOLCHAIN:-nightly}"
 VARIANT=""
 NO_BUNDLE=0
 BUNDLE_ONLY=0
@@ -102,9 +103,9 @@ build_variant_threads() {
 
     echo "Building Threads version..."
     echo "Installing rust-src for nightly..."
-    rustup component add rust-src --toolchain nightly
+    rustup component add rust-src --toolchain "$THREADS_TOOLCHAIN"
 
-    RUSTFLAGS="$flags" cargo +nightly build -p geo-polygonize-wasm \
+    RUSTFLAGS="$flags" cargo "+$THREADS_TOOLCHAIN" build -p geo-polygonize-wasm \
         --locked \
         --target $TARGET \
         --release \


### PR DESCRIPTION
## Summary

- remove redundant Rust-cache and npm-install work from the required WASM/JS path
- pin the threaded WASM and Docs nightly toolchain for reusable Rust caches
- cache both Node lockfiles and share the release Rust cache with the differential fuzzer
- narrow optional PR workflows to relevant paths and cancel stale runs
- warm Maintenance's trusted main-branch cache with fast benchmark runs
- replace the obsolete Docs Rust action and remove the invalid Codex action input
- make the existing crates.io retry loops ShellCheck-clean

## Validation

- `actionlint`
- `python3 -m pytest -q tests/test_ci_workflow.py tests/test_benchmark_workflow_pins.py tests/test_benchmark_artifacts.py tests/test_automerge_workflow.py` — 10 passed
- `bash -n scripts/build_wasm.sh`
- `git diff --check`

The PR is intentionally draft pending remote workflow validation.