### PR TITLE
feat(core): prototype sweep intersection backend

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -647,8 +647,10 @@ retained chain layout yet.
 
 Prototype internally, without a public enum variant:
 
-- [ ] the existing `geo::Intersections` Bentley–Ottmann sweep implementation for
-  sparse-intersection workloads;
+- [x] prototype the existing `geo::Intersections` Bentley–Ottmann sweep
+  implementation for sparse-intersection workloads; the prototype is
+  benchmark-only and returns exact hits, not policy-accounted broad-phase
+  candidates;
 - [ ] a monotone-chain indexed candidate generator inspired by JTS
   `MCIndexNoder` for long sparse polylines;
 - [ ] current SIMD brute-force and uniform-grid paths as baselines;

--- a/crates/geo-polygonize-core/benches/polygonize_bench.rs
+++ b/crates/geo-polygonize-core/benches/polygonize_bench.rs
@@ -312,6 +312,7 @@ criterion_group!(
 
 // --- KERNEL BENCHES (Split finding, containment, hashing, grid build) ---
 use geo_polygonize_core::noding::grid::UniformGrid;
+use geo_polygonize_core::noding::sweep::enumerate_intersections;
 use geo_polygonize_core::Line3D;
 
 fn make_random_lines(count: usize) -> Vec<Line3D> {
@@ -403,6 +404,9 @@ fn bench_noding_workloads(c: &mut Criterion) {
 
     for (workload, lines) in make_noding_workloads() {
         group.throughput(Throughput::Elements(lines.len() as u64));
+        group.bench_with_input(BenchmarkId::new(workload, "sweep"), &lines, |b, lines| {
+            b.iter(|| criterion::black_box(enumerate_intersections(criterion::black_box(lines))));
+        });
         for (strategy_name, strategy) in [
             ("auto", NodingStrategy::Auto),
             ("grid", NodingStrategy::Grid),

--- a/crates/geo-polygonize-core/src/noding/mod.rs
+++ b/crates/geo-polygonize-core/src/noding/mod.rs
@@ -7,4 +7,5 @@ pub(crate) struct CandidatePair {
 pub mod grid;
 pub mod hot_pixel;
 pub mod snap;
+pub mod sweep;
 pub mod validate;

--- a/crates/geo-polygonize-core/src/noding/sweep.rs
+++ b/crates/geo-polygonize-core/src/noding/sweep.rs
@@ -1,0 +1,95 @@
+//! Research-only exact intersection prototype backed by `geo::Intersections`.
+
+use geo::algorithm::line_intersection::LineIntersection;
+use geo::algorithm::sweep::{Cross, Intersections};
+use geo_types::Line;
+use std::iter::FromIterator;
+
+use crate::types::Line3D;
+
+#[derive(Clone, Copy)]
+struct IndexedLine {
+    index: usize,
+    line: Line<f64>,
+}
+
+impl Cross for IndexedLine {
+    type Scalar = f64;
+
+    fn line(&self) -> Line<Self::Scalar> {
+        self.line
+    }
+}
+
+/// Enumerate intersecting input pairs in deterministic input-index order.
+///
+/// This is an exact-hit prototype, not a replacement noding backend: it does
+/// not expose envelope-overlap candidates, execution-policy accounting, or
+/// cancellation. Collinear overlaps are retained as intersection results.
+pub fn enumerate_intersections(lines: &[Line3D]) -> Vec<((usize, usize), LineIntersection<f64>)> {
+    let mut intersections: Vec<_> =
+        Intersections::from_iter(lines.iter().enumerate().map(|(index, line)| IndexedLine {
+            index,
+            line: line.to_line_2d(),
+        }))
+        .map(|(first, second, intersection)| {
+            let pair = if first.index < second.index {
+                (first.index, second.index)
+            } else {
+                (second.index, first.index)
+            };
+            (pair, intersection)
+        })
+        .collect();
+
+    intersections.sort_unstable_by_key(|(pair, _)| *pair);
+    intersections
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::Coord3D;
+    use geo::algorithm::line_intersection::line_intersection;
+
+    fn line(start: (f64, f64), end: (f64, f64)) -> Line3D {
+        Line3D::new(
+            Coord3D::new(start.0, start.1, 0.0),
+            Coord3D::new(end.0, end.1, 0.0),
+            0,
+        )
+    }
+
+    #[test]
+    fn matches_pairwise_intersections_and_retains_overlaps() {
+        let lines = [
+            line((0.0, 0.0), (10.0, 0.0)),
+            line((5.0, -1.0), (5.0, 1.0)),
+            line((2.0, 0.0), (4.0, 0.0)),
+            line((20.0, 0.0), (21.0, 0.0)),
+            line((10.0, 0.0), (10.0, 3.0)),
+        ];
+
+        let expected: Vec<_> = lines
+            .iter()
+            .enumerate()
+            .flat_map(|(first, line)| {
+                lines
+                    .iter()
+                    .enumerate()
+                    .skip(first + 1)
+                    .filter_map(move |(second, other)| {
+                        line_intersection(line.to_line_2d(), other.to_line_2d())
+                            .map(|intersection| ((first, second), intersection))
+                    })
+            })
+            .collect();
+        let actual = enumerate_intersections(&lines);
+
+        assert_eq!(
+            actual.iter().map(|(pair, _)| *pair).collect::<Vec<_>>(),
+            expected.iter().map(|(pair, _)| *pair).collect::<Vec<_>>()
+        );
+        assert!(matches!(actual[1].1, LineIntersection::Collinear { .. }));
+    }
+}


### PR DESCRIPTION
## Summary
- add a hidden research prototype over geo::Intersections with deterministic input-pair ordering
- retain point and collinear intersection results and cover the pairwise oracle
- add sparse-workload benchmark coverage; no production dispatch change

## Validation
- cargo test -p geo-polygonize-core
- cargo clippy -p geo-polygonize-core --all-targets -- -D warnings
- cargo bench -p geo-polygonize-core --bench polygonize_bench --no-run
- focused sparse sweep benchmark