### PR TITLE
ci(github): build docs before playground pages

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -86,14 +86,14 @@ jobs:
         env:
           SKIP_SIMD: ${{ github.event_name == 'pull_request' && '1' || '0' }}
 
+      - name: Build Docs Site
+        run: npx vitepress build docs
+
       - name: Build Playground
         run: |
           cd playground
           npm ci
           npm run build
-
-      - name: Build Docs Site
-        run: npx vitepress build docs
 
       - name: Upload artifact
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'


### PR DESCRIPTION
## Summary

- Build the VitePress documentation site before the playground in the Pages workflow.
- Prevent playground setup or build steps from interfering with documentation output.

## Testing

- Not run (not requested).