### PR TITLE
fix(wasm): use full-page playground navigation

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   themeConfig: {
     nav: [
       { text: 'Home', link: '/' },
-      { text: 'Playground', link: '/playground/' },
+      { text: 'Playground', link: 'https://graydonpleasants.github.io/geo-polygonize/playground/' },
       { text: 'Guide', link: '/guide/getting-started' },
       { text: 'Reference', link: '/reference/' },
       { text: 'Examples', link: '/examples/' }

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,5 +14,5 @@ hero:
       link: /reference/
     - theme: alt
       text: Playground
-      link: /playground/
+      link: https://graydonpleasants.github.io/geo-polygonize/playground/
 ---

--- a/playground/src/main.tsx
+++ b/playground/src/main.tsx
@@ -591,6 +591,7 @@ function App() {
                 fullWidth
                 multiline
                 minRows={6}
+                maxRows={10}
                 label="Paste GeoJSON"
                 value={inputText}
                 onChange={(event) => setInputText(event.target.value)}


### PR DESCRIPTION
## Summary

- Make the documentation Playground links perform a full-page navigation to the standalone app.
- Cap the GeoJSON editor at ten rows so long examples scroll instead of pushing the rest of the controls down.

## Root cause

VitePress treated `/playground/` as one of its client-side routes. Clicking the link rendered VitePress's 404 page, while a hard refresh fetched the standalone Vite app correctly.

## Validation

- `npm run build --prefix playground`
- `npx vitepress build docs`
- Combined Pages artifact check for both `docs/.vitepress/dist/index.html` and `docs/.vitepress/dist/playground/index.html`
- `git diff --check`

The build still emits the existing MUI `use client` and large-chunk warnings.
