### PR TITLE
docs(core): add production-scale corpus manifest

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -17,6 +17,11 @@ features, and dependency versions. Phase names and throughput units are explicit
 strings so different runners can report their native phases without pretending
 unlike pipelines are equivalent.
 
+`production-corpus-v1.json` separately pins redistributable production-scale
+source metadata. It contains no geometry and is not accepted by the benchmark
+runner; see the [production corpus guide](../docs/guide/production-corpus.md)
+for acquisition and later materialization requirements.
+
 `benchmark-decision-policy-v1.json` separates diagnostic runs from evidence
 that can support a performance decision. Shared or smoke-test measurements are
 diagnostic and nonpublishable. Decision-quality measurements require a

--- a/benchmarks/production-corpus-v1.json
+++ b/benchmarks/production-corpus-v1.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "sources": [
+    {
+      "id": "geofabrik-california-2026-08-02",
+      "description": "Geofabrik's dated OpenStreetMap California extract published on 2026-08-02.",
+      "metadata_url": "https://download.geofabrik.de/north-america/us/california.html",
+      "license": "Open Data Commons Open Database License (ODbL) v1.0",
+      "license_url": "https://www.openstreetmap.org/copyright",
+      "attribution": "OpenStreetMap contributors; distributed by Geofabrik GmbH.",
+      "artifact": {
+        "filename": "california-260802.osm.pbf",
+        "download_url": "https://download.geofabrik.de/north-america/us/california-260802.osm.pbf",
+        "byte_length": 1322385715,
+        "checksum": {
+          "algorithm": "md5",
+          "value": "5915ee72b206cc184e0940cde071a43a",
+          "publisher_url": "https://download.geofabrik.de/north-america/us/california-260802.osm.pbf.md5"
+        }
+      }
+    }
+  ],
+  "workloads": [
+    {
+      "id": "osm-california-highways-v1",
+      "source_id": "geofabrik-california-2026-08-02",
+      "description": "Production-scale OpenStreetMap highway linework source, registered before materialization.",
+      "status": "source-pinned",
+      "linework_selection": "D2 must retain OSM ways tagged highway=* as source linework and record the exact converter, version, options, and derived SHA-256 before any run.",
+      "minimum_source_bytes": 1322385715,
+      "permitted_profiles": ["floating", "certified-fixed"]
+    }
+  ]
+}

--- a/benchmarks/production-corpus-v1.schema.json
+++ b/benchmarks/production-corpus-v1.schema.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/graydonpleasants/geo-polygonize/benchmarks/production-corpus-v1.schema.json",
+  "title": "geo-polygonize production corpus source manifest v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "sources", "workloads"],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "sources": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/source" }
+    },
+    "workloads": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/workload" }
+    }
+  },
+  "$defs": {
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._-]*$"
+    },
+    "checksum": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["algorithm", "value", "publisher_url"],
+      "properties": {
+        "algorithm": { "const": "md5" },
+        "value": { "type": "string", "pattern": "^[0-9a-f]{32}$" },
+        "publisher_url": { "type": "string", "format": "uri" }
+      }
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id", "description", "metadata_url", "license", "license_url",
+        "attribution", "artifact"
+      ],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "description": { "type": "string", "minLength": 1 },
+        "metadata_url": { "type": "string", "format": "uri" },
+        "license": { "type": "string", "minLength": 1 },
+        "license_url": { "type": "string", "format": "uri" },
+        "attribution": { "type": "string", "minLength": 1 },
+        "artifact": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["filename", "download_url", "byte_length", "checksum"],
+          "properties": {
+            "filename": { "type": "string", "minLength": 1 },
+            "download_url": { "type": "string", "format": "uri" },
+            "byte_length": { "type": "integer", "minimum": 1 },
+            "checksum": { "$ref": "#/$defs/checksum" }
+          }
+        }
+      }
+    },
+    "workload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id", "source_id", "description", "status", "linework_selection",
+        "minimum_source_bytes", "permitted_profiles"
+      ],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "source_id": { "$ref": "#/$defs/id" },
+        "description": { "type": "string", "minLength": 1 },
+        "status": { "const": "source-pinned" },
+        "linework_selection": { "type": "string", "minLength": 1 },
+        "minimum_source_bytes": { "type": "integer", "minimum": 1073741824 },
+        "permitted_profiles": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "enum": ["floating", "certified-fixed"] }
+        }
+      }
+    }
+  }
+}

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
           { text: 'WASM Integration', link: '/guide/wasm' },
           { text: 'Python Integration', link: '/guide/python' },
           { text: 'Benchmark methodology', link: '/guide/benchmark-methodology' },
+          { text: 'Production-scale corpus', link: '/guide/production-corpus' },
         ]
       },
       {

--- a/docs/guide/production-corpus.md
+++ b/docs/guide/production-corpus.md
@@ -1,0 +1,49 @@
+# Production-scale corpus
+
+`benchmarks/production-corpus-v1.json` registers redistributable source
+artifacts for production-scale benchmark work. It is not a checked-in geometry
+fixture, a runnable workload, or benchmark evidence. The current entry pins a
+dated 1.32 GB California OpenStreetMap extract and the checksum published by
+its distributor; no source geometry is stored in this repository.
+
+The existing `tests/workloads/manifest-v1.json` remains the only input manifest
+accepted by the benchmark runner. D2 is responsible for materializing a source
+into a derived, checksum-pinned linework fixture before that changes.
+
+## Acquisition and verification policy
+
+Only a public artifact with an explicit redistribution license, attribution,
+immutable download URL, publisher checksum URL, and byte length belongs in the
+manifest. Do not register private data, `latest` URLs, or an artifact whose
+checksum was calculated from an unreviewed local copy.
+
+The registered California artifact is OpenStreetMap data under ODbL. Preserve
+the stated attribution and comply with ODbL terms when sharing a derived
+database. A derived benchmark input must retain its source ID and license
+notice even when the raw PBF is not distributed.
+
+Download only when a dedicated D2 materialization run is authorized. Keep the
+PBF outside Git (for example, under `target/production-corpus/`) and verify it
+before conversion; CI does not download it:
+
+```bash
+artifact=target/production-corpus/california-260802.osm.pbf
+test "$(wc -c < "$artifact" | tr -d ' ')" = 1322385715
+test "$(openssl dgst -md5 -r "$artifact" | awk '{print $1}')" = 5915ee72b206cc184e0940cde071a43a
+```
+
+The distributor publishes MD5 for this artifact, so it is a provenance and
+corruption check rather than a substitute for a content-addressed source. D2
+must record a SHA-256 for every derived linework artifact, the converter and
+its exact version, its selection options, line/segment counts, and a topology
+reference before the workload enters `tests/workloads/` or supports a timing
+claim. Treat bridge/tunnel grade separation as input semantics to document,
+not planar intersections to invent.
+
+## Adding a source
+
+Add a source only after independently reading its license and publisher
+metadata. Use a dated object URL, copy the publisher checksum verbatim with
+its checksum URL, and add a static manifest check. A source stays
+`source-pinned` until the D2 materialization record supplies a derived
+SHA-256 and the normal correctness gate accepts the resulting workload.

--- a/tests/test_benchmark_artifacts.py
+++ b/tests/test_benchmark_artifacts.py
@@ -1,9 +1,34 @@
+import json
 import subprocess
 import sys
 from pathlib import Path
 
+from jsonschema import validate
+
 
 ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_production_corpus_is_schema_valid_and_source_pinned():
+    manifest = ROOT / "benchmarks" / "production-corpus-v1.json"
+    schema = ROOT / "benchmarks" / "production-corpus-v1.schema.json"
+    corpus = json.loads(manifest.read_text())
+    validate(corpus, json.loads(schema.read_text()))
+
+    sources = {source["id"]: source for source in corpus["sources"]}
+    assert len(sources) == len(corpus["sources"])
+    workload_ids = {workload["id"] for workload in corpus["workloads"]}
+    assert len(workload_ids) == len(corpus["workloads"])
+    for workload in corpus["workloads"]:
+        source = sources[workload["source_id"]]
+        assert workload["minimum_source_bytes"] <= source["artifact"]["byte_length"]
+    for source in sources.values():
+        artifact = source["artifact"]
+        assert artifact["byte_length"] >= 1 << 30
+        assert "latest" not in artifact["filename"]
+        assert "latest" not in artifact["download_url"]
+        assert artifact["download_url"].startswith("https://")
+        assert artifact["checksum"]["publisher_url"].startswith("https://")
 
 
 def test_correctness_references_are_persistable_and_retained():


### PR DESCRIPTION
## Stack

D1 of the production-scale corpus evidence lane; standalone on `main`.

## Delivered

- Versioned source manifest and JSON Schema for redistributable production inputs.
- A dated 1.32 GB California OpenStreetMap source with publisher URL, byte length, ODbL attribution, and publisher MD5.
- Acquisition/verification policy and sidebar entry.
- Static schema and source-pinning check.

## Contract impact

No public API, checked-in workload fixture, benchmark-runner input, or performance claim changes. The new entry is explicitly `source-pinned` and unmaterialized; CI does not download the PBF.

## Validation

- `python3 -m pytest -q tests/test_benchmark_artifacts.py`
- `npm run docs:gen`
- `node_modules/.bin/vitepress build docs`
- `git diff --check`

## Agent handoff

D2 should perform one authorized out-of-tree materialization: verify the source byte length and publisher MD5, record converter/version/options plus derived SHA-256 and line/segment counts, then add only a correctness-gated derived workload. Do not fetch or commit the raw PBF in this PR.