### PR TITLE
refactor(core): stream broad-phase candidates

### DIFF
--- a/crates/geo-polygonize-core/src/noding/grid.rs
+++ b/crates/geo-polygonize-core/src/noding/grid.rs
@@ -683,23 +683,25 @@ impl UniformGrid {
         Ok(splits)
     }
 
-    // Broad phase: enumerate AABB-overlapping global-line pairs without calling
+    // Broad phase: visit AABB-overlapping global-line pairs without calling
     // the exact intersection predicate.
-    fn enumerate_global_candidates_for_line(
+    fn visit_global_candidates_for_line<F>(
         &self,
         g_idx: usize,
         lines: &[Line3D],
         soa: &SoALines,
         mut tracker: Option<&mut ExecutionWorkTracker<'_>>,
-    ) -> crate::Result<Vec<CandidatePair>> {
+        mut visit: F,
+    ) -> crate::Result<()>
+    where
+        F: FnMut(CandidatePair) -> crate::Result<()>,
+    {
         let global_lines = &self.global_lines;
         let query_line = lines[g_idx];
         let q_min_x = f64x4::splat(query_line.start.x.min(query_line.end.x));
         let q_max_x = f64x4::splat(query_line.start.x.max(query_line.end.x));
         let q_min_y = f64x4::splat(query_line.start.y.min(query_line.end.y));
         let q_max_y = f64x4::splat(query_line.start.y.max(query_line.end.y));
-        let mut candidates = Vec::new();
-
         for block_idx in (0..soa.len()).step_by(4) {
             let mask =
                 soa.intersects_bbox_batch_splatted(q_min_x, q_max_x, q_min_y, q_max_y, block_idx);
@@ -716,10 +718,10 @@ impl UniformGrid {
                     tracker.candidate(overlaps)?;
                 }
                 if overlaps {
-                    candidates.push(CandidatePair {
+                    visit(CandidatePair {
                         first: g_idx,
                         second: target_idx,
-                    });
+                    })?;
                 }
             }
         }
@@ -727,7 +729,7 @@ impl UniformGrid {
         if let Some(tracker) = tracker {
             tracker.check_cancelled()?;
         }
-        Ok(candidates)
+        Ok(())
     }
 
     // Exact phase: robust intersection, optional trace capture, and split accumulation.
@@ -787,15 +789,13 @@ impl UniformGrid {
     ) -> Vec<(usize, Coord3D)> {
         let global_lines = &self.global_lines;
         let process_one_global = |g_idx: usize| -> Vec<(usize, Coord3D)> {
-            let candidates = self
-                .enumerate_global_candidates_for_line(g_idx, lines, soa, None)
-                .expect("unlimited noding cannot fail");
-            candidates
-                .into_iter()
-                .flat_map(|candidate| {
-                    self.process_global_candidate(candidate, lines, snap_noder, 0, None)
-                })
-                .collect()
+            let mut events = Vec::new();
+            self.visit_global_candidates_for_line(g_idx, lines, soa, None, |candidate| {
+                events.extend(self.process_global_candidate(candidate, lines, snap_noder, 0, None));
+                Ok(())
+            })
+            .expect("unlimited noding cannot fail");
+            events
         };
 
         #[cfg(feature = "parallel")]
@@ -831,17 +831,22 @@ impl UniformGrid {
         let mut events = Vec::new();
         let soa = SoALines::new(lines);
         for &left_idx in &self.global_lines {
-            let candidates =
-                self.enumerate_global_candidates_for_line(left_idx, lines, &soa, Some(tracker))?;
-            for candidate in candidates {
-                events.extend(self.process_global_candidate(
-                    candidate,
-                    lines,
-                    snap_noder,
-                    iteration_index,
-                    trace_candidates.as_deref_mut(),
-                ));
-            }
+            self.visit_global_candidates_for_line(
+                left_idx,
+                lines,
+                &soa,
+                Some(tracker),
+                |candidate| {
+                    events.extend(self.process_global_candidate(
+                        candidate,
+                        lines,
+                        snap_noder,
+                        iteration_index,
+                        trace_candidates.as_deref_mut(),
+                    ));
+                    Ok(())
+                },
+            )?;
         }
         Ok(events)
     }
@@ -884,14 +889,17 @@ impl UniformGrid {
         }
     }
 
-    // Broad phase: enumerate AABB-overlapping pairs that share a grid cell.
-    fn enumerate_cell_candidates(
+    // Broad phase: visit AABB-overlapping pairs that share a grid cell.
+    fn visit_cell_candidates<F>(
         &self,
         cell_indices: &[u32],
         soa: &SoALines,
         mut tracker: Option<&mut ExecutionWorkTracker<'_>>,
-    ) -> crate::Result<Vec<CandidatePair>> {
-        let mut candidates = Vec::new();
+        mut visit: F,
+    ) -> crate::Result<()>
+    where
+        F: FnMut(CandidatePair) -> crate::Result<()>,
+    {
         for i in 0..cell_indices.len() {
             for j in (i + 1)..cell_indices.len() {
                 let first = cell_indices[i] as usize;
@@ -904,11 +912,11 @@ impl UniformGrid {
                     tracker.candidate(overlaps)?;
                 }
                 if overlaps {
-                    candidates.push(CandidatePair { first, second });
+                    visit(CandidatePair { first, second })?;
                 }
             }
         }
-        Ok(candidates)
+        Ok(())
     }
 
     // Exact phase: robust intersection, cell ownership, trace capture, and
@@ -1008,8 +1016,7 @@ impl UniformGrid {
             return Ok(());
         }
 
-        let candidates = self.enumerate_cell_candidates(cell_indices, soa, tracker)?;
-        for candidate in candidates {
+        self.visit_cell_candidates(cell_indices, soa, tracker, |candidate| {
             self.process_cell_candidate(
                 r,
                 c,
@@ -1020,8 +1027,8 @@ impl UniformGrid {
                 iteration_index,
                 trace_candidates.as_deref_mut(),
             );
-        }
-        Ok(())
+            Ok(())
+        })
     }
 }
 

--- a/crates/geo-polygonize-core/src/noding/snap.rs
+++ b/crates/geo-polygonize-core/src/noding/snap.rs
@@ -965,35 +965,41 @@ impl SnapNoder {
                 lines
                     .par_iter()
                     .enumerate()
-                    .flat_map(|(i, &query_line)| {
-                        let candidates = self
-                            .enumerate_candidate_pairs_simd(query_line, i, lines, &soa, None)
-                            .expect("unlimited noding cannot fail");
-                        candidates
-                            .into_iter()
-                            .flat_map(|candidate| {
-                                self.process_candidate_pair(lines, candidate, None)
-                            })
-                            .collect::<Vec<_>>()
+                    .flat_map_iter(|(i, &query_line)| {
+                        let mut events = Vec::new();
+                        self.visit_candidate_pairs_simd(
+                            query_line,
+                            i,
+                            lines,
+                            &soa,
+                            None,
+                            |candidate| {
+                                events.extend(self.process_candidate_pair(lines, candidate, None));
+                                Ok(())
+                            },
+                        )
+                        .expect("unlimited noding cannot fail");
+                        events
                     })
                     .collect()
             } else {
                 // Sequential fallback
-                lines
-                    .iter()
-                    .enumerate()
-                    .flat_map(|(i, &query_line)| {
-                        let candidates = self
-                            .enumerate_candidate_pairs_simd(query_line, i, lines, &soa, None)
-                            .expect("unlimited noding cannot fail");
-                        candidates
-                            .into_iter()
-                            .flat_map(|candidate| {
-                                self.process_candidate_pair(lines, candidate, None)
-                            })
-                            .collect::<Vec<_>>()
-                    })
-                    .collect()
+                let mut splits = Vec::new();
+                for (i, &query_line) in lines.iter().enumerate() {
+                    self.visit_candidate_pairs_simd(
+                        query_line,
+                        i,
+                        lines,
+                        &soa,
+                        None,
+                        |candidate| {
+                            splits.extend(self.process_candidate_pair(lines, candidate, None));
+                            Ok(())
+                        },
+                    )
+                    .expect("unlimited noding cannot fail");
+                }
+                splits
             }
         }
 
@@ -1001,12 +1007,11 @@ impl SnapNoder {
         {
             let mut splits = Vec::new();
             for (i, &query_line) in lines.iter().enumerate() {
-                let candidates = self
-                    .enumerate_candidate_pairs_simd(query_line, i, lines, &soa, None)
-                    .expect("unlimited noding cannot fail");
-                for candidate in candidates {
+                self.visit_candidate_pairs_simd(query_line, i, lines, &soa, None, |candidate| {
                     splits.extend(self.process_candidate_pair(lines, candidate, None));
-                }
+                    Ok(())
+                })
+                .expect("unlimited noding cannot fail");
             }
             splits
         }
@@ -1022,15 +1027,21 @@ impl SnapNoder {
         let mut splits = Vec::new();
         tracker.check_cancelled()?;
         for (i, &query_line) in lines.iter().enumerate() {
-            let candidates =
-                self.enumerate_candidate_pairs_simd(query_line, i, lines, &soa, Some(tracker))?;
-            for candidate in candidates {
-                splits.extend(self.process_candidate_pair(
-                    lines,
-                    candidate,
-                    trace_candidates.as_deref_mut(),
-                ));
-            }
+            self.visit_candidate_pairs_simd(
+                query_line,
+                i,
+                lines,
+                &soa,
+                Some(tracker),
+                |candidate| {
+                    splits.extend(self.process_candidate_pair(
+                        lines,
+                        candidate,
+                        trace_candidates.as_deref_mut(),
+                    ));
+                    Ok(())
+                },
+            )?;
         }
         tracker.check_cancelled()?;
         Ok(splits)
@@ -1055,18 +1066,21 @@ impl SnapNoder {
         }
     }
 
-    // Broad phase: enumerate AABB-overlapping pairs using the SIMD SoA.
+    // Broad phase: visit AABB-overlapping pairs using the SIMD SoA.
     #[allow(clippy::manual_div_ceil)]
     #[inline]
-    fn enumerate_candidate_pairs_simd(
+    fn visit_candidate_pairs_simd<F>(
         &self,
         query_line: Line3D,
         i: usize,
         lines: &[Line3D],
         soa: &SoALines,
         mut tracker: Option<&mut ExecutionWorkTracker<'_>>,
-    ) -> crate::Result<Vec<CandidatePair>> {
-        let mut candidates = Vec::new();
+        mut visit: F,
+    ) -> crate::Result<()>
+    where
+        F: FnMut(CandidatePair) -> crate::Result<()>,
+    {
         // Start block to avoid duplicate checks (j > i)
         // We start checking at index i+1.
         // The SoA batching index `j` steps by 4.
@@ -1098,10 +1112,10 @@ impl SnapNoder {
                 tracker.candidate(overlaps)?;
             }
             if overlaps {
-                candidates.push(CandidatePair {
+                visit(CandidatePair {
                     first: i,
                     second: j,
-                });
+                })?;
             }
         }
 
@@ -1124,14 +1138,14 @@ impl SnapNoder {
                     tracker.candidate(overlaps)?;
                 }
                 if overlaps {
-                    candidates.push(CandidatePair {
+                    visit(CandidatePair {
                         first: i,
                         second: target_idx,
-                    });
+                    })?;
                 }
             }
         }
-        Ok(candidates)
+        Ok(())
     }
 
     // Exact phase: robust intersection, trace capture, and split accumulation.
@@ -1352,7 +1366,7 @@ mod tests {
     }
 
     #[test]
-    fn simd_candidate_enumeration_is_separate_from_exact_splits() {
+    fn simd_candidate_sink_streams_in_input_order() {
         let lines = vec![
             make_line(0.0, 0.0, 2.0, 2.0),
             make_line(0.0, 2.0, 2.0, 0.0),
@@ -1360,8 +1374,12 @@ mod tests {
         ];
         let noder = SnapNoder::new(0.0);
         let soa = SoALines::new(&lines);
-        let candidates = noder
-            .enumerate_candidate_pairs_simd(lines[0], 0, &lines, &soa, None)
+        let mut candidates = Vec::new();
+        noder
+            .visit_candidate_pairs_simd(lines[0], 0, &lines, &soa, None, |candidate| {
+                candidates.push(candidate);
+                Ok(())
+            })
             .unwrap();
 
         assert_eq!(


### PR DESCRIPTION
## Stack

B1 foundation for the candidate-streaming lane. Targets `main`; B2 can build on `agent/candidate-streaming-sink` after this lands.

## Delivered

Replaced temporary `Vec<CandidatePair>` broad-phase collections with internal visitor callbacks in the SIMD, uniform-grid cell, and global-line paths. Exact intersection, split collection, tracing, and execution-work accounting remain at their existing call sites.

## Contract impact

No public API or option changes. Candidate visitation stays in existing scan order; deterministic output, cancellation polling, resource limits, and trace payloads are preserved. The new sink regression checks SIMD candidate order before exact split processing.

## Validation

- `cargo fmt --check`
- `cargo test -p geo-polygonize-core` (277 unit tests plus integration tests)
- `cargo clippy -p geo-polygonize-core --lib --tests -- -D warnings`
- `git diff --check`

## Agent handoff

Next child branch: create B2 from this branch/commit (`627238308b4bcf6487da8df09ca2f3bb04468d2d`) once the chain-model work is ready. Do not begin B2 in this PR.