### PR TITLE
refactor(core): qualify partition face identity

### DIFF
--- a/crates/geo-polygonize-core/src/containment.rs
+++ b/crates/geo-polygonize-core/src/containment.rs
@@ -24,7 +24,7 @@ fn graph_identities_with_faces<'a>(
     ring: Option<&'a RingGraphIdentity>,
 ) -> Option<(&'a RingGraphIdentity, &'a RingGraphIdentity)> {
     match (shell, ring) {
-        (Some(shell), Some(ring)) if shell.face_id.is_some() && ring.face_id.is_some() => {
+        (Some(shell), Some(ring)) if shell.face_ref.is_some() && ring.face_ref.is_some() => {
             Some((shell, ring))
         }
         _ => None,
@@ -515,8 +515,22 @@ mod tests {
     #[test]
     fn graph_identity_distinguishes_point_and_edge_touch() {
         let polygon = Polygon3D::new(vec![], vec![], vec![], vec![]);
-        let shell_ids = RingGraphIdentity::new(Some(0), vec![(0, 1)], vec![0, 1]);
-        let ring_ids = RingGraphIdentity::new(Some(1), vec![(1, 2)], vec![1, 2]);
+        let shell_ids = RingGraphIdentity::new(
+            Some(crate::types::LocalFaceRef {
+                component_id: 0,
+                face_id: 0,
+            }),
+            vec![(0, 1)],
+            vec![0, 1],
+        );
+        let ring_ids = RingGraphIdentity::new(
+            Some(crate::types::LocalFaceRef {
+                component_id: 0,
+                face_id: 1,
+            }),
+            vec![(1, 2)],
+            vec![1, 2],
+        );
         let mut stats = ContainmentStats::default();
 
         assert!(touch_allowed(

--- a/crates/geo-polygonize-core/src/graph/partition_border.rs
+++ b/crates/geo-polygonize-core/src/graph/partition_border.rs
@@ -1,4 +1,4 @@
-use crate::types::Coord3D;
+use crate::types::{Coord3D, PartitionFaceRef};
 use crate::utils::canonical_coordinate_bits;
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -76,7 +76,9 @@ pub struct PartitionBorderHalfEdge {
     pub side: PartitionBorderSide,
     pub partition_id: usize,
     pub local_dir_edge_id: DirEdgeId,
+    /// Component-local face ID retained for existing debug consumers.
     pub face_id: Option<FaceId>,
+    pub(crate) face_ref: Option<PartitionFaceRef>,
     pub source_line_ids: Vec<u32>,
 }
 
@@ -86,6 +88,31 @@ impl PartitionBorderHalfEdge {
         partition_id: usize,
         local_dir_edge_id: DirEdgeId,
         face_id: Option<FaceId>,
+        side: PartitionBorderSide,
+        start: Coord3D,
+        end: Coord3D,
+        source_line_ids: impl IntoIterator<Item = u32>,
+    ) -> Option<Self> {
+        Self::new_with_face_ref(
+            partition_id,
+            local_dir_edge_id,
+            face_id.map(|face_id| PartitionFaceRef {
+                partition_id,
+                component_id: 0,
+                face_id,
+            }),
+            side,
+            start,
+            end,
+            source_line_ids,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new_with_face_ref(
+        partition_id: usize,
+        local_dir_edge_id: DirEdgeId,
+        face_ref: Option<PartitionFaceRef>,
         side: PartitionBorderSide,
         start: Coord3D,
         end: Coord3D,
@@ -106,7 +133,8 @@ impl PartitionBorderHalfEdge {
             side,
             partition_id,
             local_dir_edge_id,
-            face_id,
+            face_id: face_ref.map(|face_ref| face_ref.face_id),
+            face_ref,
             source_line_ids,
         })
     }
@@ -287,6 +315,14 @@ mod tests {
         Coord3D::new(x, y, z)
     }
 
+    fn face(partition_id: usize, component_id: usize, face_id: usize) -> PartitionFaceRef {
+        PartitionFaceRef {
+            partition_id,
+            component_id,
+            face_id,
+        }
+    }
+
     #[test]
     fn node_keys_normalize_signed_zero_but_preserve_z_outside_identity() {
         assert_eq!(
@@ -389,6 +425,33 @@ mod tests {
         assert!(planar
             .partition_border_half_edge(4, 0, PartitionBorderSide::MinY)
             .is_none());
+    }
+
+    #[test]
+    fn face_refs_distinguish_components_with_the_same_local_face_id() {
+        let first = PartitionBorderHalfEdge::new_with_face_ref(
+            4,
+            0,
+            Some(face(4, 0, 0)),
+            PartitionBorderSide::MinY,
+            coord(0.0, 0.0, 0.0),
+            coord(1.0, 0.0, 0.0),
+            [],
+        )
+        .unwrap();
+        let second = PartitionBorderHalfEdge::new_with_face_ref(
+            4,
+            1,
+            Some(face(4, 1, 0)),
+            PartitionBorderSide::MinY,
+            coord(2.0, 0.0, 0.0),
+            coord(3.0, 0.0, 0.0),
+            [],
+        )
+        .unwrap();
+
+        assert_eq!(first.face_id, second.face_id);
+        assert_ne!(first.face_ref, second.face_ref);
     }
 
     #[test]

--- a/crates/geo-polygonize-core/src/graph/planar_graph.rs
+++ b/crates/geo-polygonize-core/src/graph/planar_graph.rs
@@ -1,6 +1,6 @@
 use crate::options::ExecutionPolicy;
 use crate::trace::TraceCaptureBudget;
-use crate::types::{Coord3D, EdgeSources, Line3D};
+use crate::types::{Coord3D, EdgeSources, Line3D, LocalFaceRef};
 use crate::utils::parallel::{par_flat_map, par_sort_unstable, par_zip_for_each};
 use crate::utils::{
     canonical_coordinate_bits, compare_angular, minimum_rotation_index, z_order_index,
@@ -30,6 +30,8 @@ pub(crate) struct ExtractedRing {
     /// Component-local deterministic face identity for final ring extraction.
     /// Maximal trace rings are captured before face identities are assigned.
     pub face_id: Option<FaceId>,
+    /// Qualified identity once the component-local result is merged.
+    pub(crate) face_ref: Option<LocalFaceRef>,
     pub edge_keys: Vec<(NodeId, NodeId)>,
     pub node_ids: Vec<NodeId>,
 }
@@ -288,6 +290,16 @@ impl PlanarGraph {
         dir_edge_id: DirEdgeId,
         side: PartitionBorderSide,
     ) -> Option<PartitionBorderHalfEdge> {
+        self.partition_border_half_edge_for_component(partition_id, 0, dir_edge_id, side)
+    }
+
+    pub(crate) fn partition_border_half_edge_for_component(
+        &self,
+        partition_id: usize,
+        component_id: usize,
+        dir_edge_id: DirEdgeId,
+        side: PartitionBorderSide,
+    ) -> Option<PartitionBorderHalfEdge> {
         let directed = self.directed_edges.get(dir_edge_id)?;
         let edge = self.edges.get(directed.edge_idx)?;
         if edge.deleted {
@@ -303,10 +315,16 @@ impl PlanarGraph {
             y: *self.nodes_y.get(directed.dst)?,
             z: *self.nodes_z.get(directed.dst)?,
         };
-        PartitionBorderHalfEdge::new(
+        PartitionBorderHalfEdge::new_with_face_ref(
             partition_id,
             dir_edge_id,
-            directed.face_id,
+            directed.face_id.map(|face_id| {
+                LocalFaceRef {
+                    component_id,
+                    face_id,
+                }
+                .in_partition(partition_id)
+            }),
             side,
             start,
             end,
@@ -1579,6 +1597,10 @@ impl PlanarGraph {
             line_ids: ids,
             source_line_ids: source_ids,
             face_id,
+            face_ref: face_id.map(|face_id| LocalFaceRef {
+                component_id: 0,
+                face_id,
+            }),
             edge_keys,
             node_ids,
         })
@@ -2049,6 +2071,7 @@ impl PlanarGraph {
                 append_component_output(
                     &mut merged,
                     scratch.process(
+                        component_id,
                         include_graph_ids,
                         include_source_ids,
                         execution_policy,
@@ -2073,6 +2096,7 @@ impl PlanarGraph {
                             execution_policy,
                         )?;
                         scratch.process(
+                            component_id,
                             include_graph_ids,
                             include_source_ids,
                             execution_policy,
@@ -2094,6 +2118,7 @@ impl PlanarGraph {
                         execution_policy,
                     )?;
                     outputs.push(scratch.process(
+                        component_id,
                         include_graph_ids,
                         include_source_ids,
                         execution_policy,
@@ -2387,6 +2412,7 @@ impl PlanarGraph {
 impl ComponentScratch {
     fn process(
         &mut self,
+        component_id: usize,
         include_graph_ids: bool,
         include_source_ids: bool,
         execution_policy: &ExecutionPolicy,
@@ -2425,20 +2451,25 @@ impl ComponentScratch {
                     )?,
             )
         };
-        self.remap_rings(&mut maximal, include_graph_ids)?;
-        self.remap_rings(&mut minimal, include_graph_ids)?;
+        self.remap_rings(&mut maximal, component_id, include_graph_ids)?;
+        self.remap_rings(&mut minimal, component_id, include_graph_ids)?;
         Ok((dangles, cut_edges, maximal, minimal))
     }
 
     fn remap_rings(
         &self,
         rings: &mut [ExtractedRing],
+        component_id: usize,
         include_graph_ids: bool,
     ) -> crate::Result<()> {
-        if !include_graph_ids {
-            return Ok(());
-        }
         for ring in rings {
+            ring.face_ref = ring.face_ref.map(|face_ref| LocalFaceRef {
+                component_id,
+                ..face_ref
+            });
+            if !include_graph_ids {
+                continue;
+            }
             for (start, end) in &mut ring.edge_keys {
                 *start = *self.global_node_ids.get(*start).ok_or_else(|| {
                     crate::PolygonizeError::InternalInvariantViolation {
@@ -3042,7 +3073,9 @@ mod arrangement_ring_invariant_tests {
             .unwrap();
         let node_capacity = scratch.graph.nodes_x.capacity();
         let edge_capacity = scratch.graph.edges.capacity();
-        scratch.process(false, false, &policy, true, None).unwrap();
+        scratch
+            .process(0, false, false, &policy, true, None)
+            .unwrap();
         graph
             .load_component_scratch(&mut scratch, 1, partitions.remove(0), &policy)
             .unwrap();
@@ -3081,5 +3114,51 @@ mod arrangement_ring_invariant_tests {
             assert!(scratch.global_node_ids.capacity() >= node_count);
             assert!(scratch.local_node_ids.capacity() >= node_count);
         }
+    }
+
+    #[test]
+    fn component_extraction_qualifies_reused_local_face_ids() {
+        let mut graph = PlanarGraph::new();
+        for (offset, points) in [
+            [
+                Coord3D::new(0.0, 0.0, 0.0),
+                Coord3D::new(2.0, 0.0, 0.0),
+                Coord3D::new(1.0, 1.0, 0.0),
+            ],
+            [
+                Coord3D::new(10.0, 0.0, 0.0),
+                Coord3D::new(12.0, 0.0, 0.0),
+                Coord3D::new(11.0, 1.0, 0.0),
+            ],
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            for edge in 0..3 {
+                graph.add_line(Line3D::new(
+                    points[edge],
+                    points[(edge + 1) % 3],
+                    (offset * 10 + edge) as u32,
+                ));
+            }
+        }
+
+        let policy = ExecutionPolicy::default();
+        let ((_, _, _, rings), _) = graph
+            .process_components_with_execution_policy(true, true, &policy, true, None)
+            .unwrap();
+        let refs = rings
+            .iter()
+            .map(|ring| ring.face_ref.unwrap())
+            .collect::<std::collections::BTreeSet<_>>();
+
+        assert!(refs.contains(&LocalFaceRef {
+            component_id: 0,
+            face_id: 0,
+        }));
+        assert!(refs.contains(&LocalFaceRef {
+            component_id: 1,
+            face_id: 0,
+        }));
     }
 }

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -1320,7 +1320,7 @@ pub(crate) fn extract_and_classify_rings(
         let ring = (
             poly3d,
             include_graph_ids
-                .then(|| RingGraphIdentity::new(ring.face_id, ring.edge_keys, ring.node_ids)),
+                .then(|| RingGraphIdentity::new(ring.face_ref, ring.edge_keys, ring.node_ids)),
         );
         if area > 0.0 {
             shells.push(ring);

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -272,6 +272,8 @@ pub struct ClassifiedLineTraceV1 {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct RingTraceV1 {
     pub index: usize,
+    pub component_id: Option<usize>,
+    pub face_id: Option<usize>,
     pub coordinates: Vec<CoordinateFingerprintV1>,
     pub edge_ids: Vec<String>,
     pub source_ids: Vec<String>,
@@ -1088,6 +1090,8 @@ impl TraceRecorderV1 {
                 kind,
                 RingTraceV1 {
                     index,
+                    component_id: ring.face_ref.map(|face_ref| face_ref.component_id),
+                    face_id: ring.face_ref.map(|face_ref| face_ref.face_id),
                     coordinates: exact_coordinates(&ring.coords)?,
                     edge_ids: ring
                         .line_ids
@@ -1116,6 +1120,8 @@ impl TraceRecorderV1 {
     ) -> crate::Result<()> {
         let payload = RingTraceV1 {
             index,
+            component_id: None,
+            face_id: None,
             coordinates: exact_coordinates(&ring.exterior)?,
             edge_ids: ring
                 .exterior_ids
@@ -1141,6 +1147,8 @@ impl TraceRecorderV1 {
     ) -> crate::Result<()> {
         let payload = RingTraceV1 {
             index,
+            component_id: None,
+            face_id: None,
             coordinates: exact_coordinates(&ring.exterior)?,
             edge_ids: ring
                 .exterior_ids

--- a/crates/geo-polygonize-core/src/types.rs
+++ b/crates/geo-polygonize-core/src/types.rs
@@ -226,17 +226,45 @@ pub struct PolygonProvenance {
     pub input_profile_id: Option<String>,
 }
 
+/// Identity of a face produced by one component-local arrangement.
+///
+/// Local face IDs restart for every component, so they are only meaningful
+/// together with the component that assigned them.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub(crate) struct LocalFaceRef {
+    pub(crate) component_id: usize,
+    pub(crate) face_id: usize,
+}
+
+/// Identity of a face observed at one partition border.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub(crate) struct PartitionFaceRef {
+    pub(crate) partition_id: usize,
+    pub(crate) component_id: usize,
+    pub(crate) face_id: usize,
+}
+
+impl LocalFaceRef {
+    pub(crate) fn in_partition(self, partition_id: usize) -> PartitionFaceRef {
+        PartitionFaceRef {
+            partition_id,
+            component_id: self.component_id,
+            face_id: self.face_id,
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub(crate) struct RingGraphIdentity {
-    /// Component-local deterministic face identity.
-    pub face_id: Option<usize>,
+    /// Qualified deterministic identity from component-local extraction.
+    pub face_ref: Option<LocalFaceRef>,
     pub edge_keys: std::sync::Arc<[(usize, usize)]>,
     pub node_ids: std::sync::Arc<[usize]>,
 }
 
 impl RingGraphIdentity {
     pub(crate) fn new(
-        face_id: Option<usize>,
+        face_ref: Option<LocalFaceRef>,
         mut edge_keys: Vec<(usize, usize)>,
         mut node_ids: Vec<usize>,
     ) -> Self {
@@ -245,7 +273,7 @@ impl RingGraphIdentity {
         node_ids.sort_unstable();
         node_ids.dedup();
         Self {
-            face_id,
+            face_ref,
             edge_keys: edge_keys.into(),
             node_ids: node_ids.into(),
         }


### PR DESCRIPTION
## Stack

Parent:
- main

This PR:
- Qualify component-local arrangement face IDs before they are merged or recorded as partition-border observations.

Children:
- none

## Delivered

- Added private local and partition face references carrying component identity.
- Qualify extracted-ring and ring-graph identities during component scratch merging.
- Preserve existing border helpers while recording qualified internal face observations and trace fields.
- Added collision regressions for two components sharing local face ID `0`.

## Contract impact

- No supported public API or polygonization behavior changes.
- Experimental ring traces now include optional component and face IDs for extracted rings.
- Partition-border internals no longer treat a local face ID as unique within a partition.

## Validation

- `cargo fmt --check` - passed
- `cargo test -p geo-polygonize-core --lib --no-fail-fast` - passed (279 tests)
- `cargo clippy -p geo-polygonize-core --lib --tests -- -D warnings` - passed
- `cargo check -p geo-polygonize-core --no-default-features` - passed

## Agent handoff

Remaining:
- C2: reject duplicate border-observation identities with conflicting payloads.

Next dependency-ready branch:
- `agent/border-observation-identity`
