### PR TITLE
test(core): make noding evidence deterministic

### DIFF
--- a/crates/geo-polygonize-core/src/noding/monotone.rs
+++ b/crates/geo-polygonize-core/src/noding/monotone.rs
@@ -384,4 +384,35 @@ mod tests {
             .unwrap()
             .is_empty());
     }
+
+    #[test]
+    fn long_sparse_workload_matches_bruteforce_envelope_candidates() {
+        let long_segments = 2_048;
+        let mut lines = Vec::with_capacity(long_segments + long_segments / 32);
+        let mut source_ranges = vec![(0, long_segments)];
+        for index in 0..long_segments {
+            lines.push(line((index as f64, 0.0), (index as f64 + 1.0, 0.0)));
+        }
+        for index in (0..long_segments).step_by(32) {
+            let segment_index = lines.len();
+            let x = index as f64 + 0.5;
+            lines.push(line((x, -1.0), (x, 1.0)));
+            source_ranges.push((segment_index, 1));
+        }
+
+        let mut expected = Vec::new();
+        let bounds: Vec<_> = lines.iter().copied().map(Bounds::from_line).collect();
+        for first in 0..bounds.len() {
+            for second in first + 1..bounds.len() {
+                if bounds[first].overlaps(bounds[second]) {
+                    expected.push((first, second));
+                }
+            }
+        }
+
+        assert_eq!(
+            enumerate_candidates(&lines, &source_ranges).unwrap(),
+            expected
+        );
+    }
 }

--- a/crates/geo-polygonize-core/src/noding/snap.rs
+++ b/crates/geo-polygonize-core/src/noding/snap.rs
@@ -1211,7 +1211,7 @@ mod tests {
         PolygonizeError, PolygonizerOptions, ProvenanceOptions, TopologyFingerprintV1, ZOptions,
         ZPolicy,
     };
-    use rand::Rng;
+    use rand::{Rng, SeedableRng};
     use std::collections::BTreeMap;
 
     fn make_line(x1: f64, y1: f64, x2: f64, y2: f64) -> Line3D {
@@ -1293,7 +1293,7 @@ mod tests {
 
     #[test]
     fn test_grid_vs_simd_equivalence() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rngs::StdRng::seed_from_u64(0x6e6f6469_6e675f76);
         let mut lines = Vec::new();
 
         // Generate 100 random lines in a 100x100 grid


### PR DESCRIPTION
## Summary

- make the existing grid/SIMD equivalence test reproducible with a seeded RNG;
- compare the monotone-chain prototype against a brute-force envelope oracle on the long-sparse benchmark shape.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked -p geo-polygonize-core` — 278 unit tests and all core integration/doc tests passed;
- `BENCH_FAST_CI=1 cargo bench --locked -p geo-polygonize-core --bench polygonize_bench -- 'noding_workloads/crossing/sweep' --noplot` — passed.

This is evidence-only: it does not change production dispatch or promote either prototype. Criterion timings remain diagnostic until the repository's dedicated-runner policy is met.