### PR TITLE
refactor(core): make cancellation tokens single-run

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -249,7 +249,7 @@ later stages.
 Progress: Native `CancellationToken` values live in `ExecutionPolicy`, not
 semantic options. Core checkpoints cover ingest, noding, graph construction,
 ring extraction, containment, canonicalization, and output flattening; a
-cancelled workspace run is reusable after resetting its token. Python releases
+cancelled workspace run is reusable with a fresh policy and token. Python releases
 the GIL for owned Rust work and polls signals every 10 ms before cancelling the
 worker token. Wasm has cancellable GeoJSON and report calls in disposable
 browser workers; aborting terminates the worker rather than claiming that a

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -96,10 +96,12 @@ resource limits, and cancellation. Resource limits are opt-in logical work and
 output guards, not a process-memory sandbox.
 
 Cancellation is cooperative. `CancellationToken` is safe to clone and cancel
-from another thread, but cancellation is observed only at explicit polling
-points; it is not preemptive. Python computation runs on a worker without
-holding the GIL, polls Python signals, and maps an interrupt to cooperative
-cancellation. Wasm does not currently expose the native cancellation token.
+from another thread: any clone may cancel, and cancellation is monotonic for
+the token lifetime. Tokens are single-run, so each new operation needs a fresh
+token. Cancellation is observed only at explicit polling points; it is not
+preemptive. Python computation runs on a worker without holding the GIL, polls
+Python signals, and maps an interrupt to cooperative cancellation. Wasm does
+not currently expose the native cancellation token.
 
 A panic from a supported Rust entrypoint is a bug, not part of the error
 contract. Native Arrow C ABI and Python boundaries catch unwinding panics and

--- a/crates/geo-polygonize-core/src/options.rs
+++ b/crates/geo-polygonize-core/src/options.rs
@@ -14,6 +14,10 @@ pub(crate) const CANCELLATION_CHECK_INTERVAL: usize = 256;
 pub(crate) const MAX_UNCANCELLABLE_SORT_ITEMS: usize = 1_000_000;
 
 /// Cooperative native cancellation handle for an [`ExecutionPolicy`].
+///
+/// Tokens are single-run: clones share one cancellation state, so any clone
+/// may cancel the operation and cancellation remains set for the token's
+/// lifetime. Create a fresh token for each new operation.
 #[derive(Clone, Debug, Default)]
 pub struct CancellationToken(Arc<AtomicBool>);
 
@@ -24,10 +28,6 @@ impl CancellationToken {
 
     pub fn cancel(&self) {
         self.0.store(true, Ordering::Release);
-    }
-
-    pub fn reset(&self) {
-        self.0.store(false, Ordering::Release);
     }
 
     pub fn is_cancelled(&self) -> bool {
@@ -680,5 +680,16 @@ mod tests {
                 observed,
             }) if stage == "test_sort" && observed == MAX_UNCANCELLABLE_SORT_ITEMS + 1
         ));
+    }
+
+    #[test]
+    fn cancellation_is_shared_by_clones_and_monotonic() {
+        let token = CancellationToken::new();
+        let clone = token.clone();
+
+        clone.cancel();
+
+        assert!(token.is_cancelled());
+        assert!(clone.is_cancelled());
     }
 }

--- a/crates/geo-polygonize-core/tests/cancellation.rs
+++ b/crates/geo-polygonize-core/tests/cancellation.rs
@@ -14,21 +14,29 @@ fn square() -> [Line3D; 4] {
 
 #[test]
 fn cancelled_workspace_run_can_be_reused() {
-    let token = CancellationToken::new();
-    let policy = ExecutionPolicy {
-        cancellation_token: Some(token.clone()),
+    let cancelled_token = CancellationToken::new();
+    let cancelled_policy = ExecutionPolicy {
+        cancellation_token: Some(cancelled_token.clone()),
         ..Default::default()
     };
     let options = PolygonizerOptions::default();
     let mut workspace = PolygonizerWorkspace::new();
-    token.cancel();
+    cancelled_token.cancel();
 
     assert!(matches!(
-        polygonize_with_workspace_and_execution_policy(&square(), &options, &mut workspace, &policy),
+        polygonize_with_workspace_and_execution_policy(
+            &square(),
+            &options,
+            &mut workspace,
+            &cancelled_policy,
+        ),
         Err(PolygonizeError::Cancelled { stage }) if stage == "ingest"
     ));
 
-    token.reset();
+    let policy = ExecutionPolicy {
+        cancellation_token: Some(CancellationToken::new()),
+        ..Default::default()
+    };
     assert_eq!(
         polygonize_with_workspace_and_execution_policy(
             &square(),


### PR DESCRIPTION
## Stack

R3 of the release-gate stack.

- Base: `agent/release-component-scratch-growth` (R2, `58fe4db`)
- Head: `agent/release-cancellation-token-contract` (R3)

## Delivered

- Removed public `CancellationToken::reset()`.
- Require a fresh token and execution policy for a new workspace operation.
- Document that clones share cancellation state, any clone may cancel, and cancellation is monotonic for a token lifetime.
- Added a lifecycle regression for cloned cancellation handles.

## Contract impact

This is a pre-1.0 breaking API cleanup: cancelled tokens cannot be reset or reused. Construct a new `CancellationToken` for each operation. Existing cancellation polling, limits, and binding behavior are unchanged.

## Validation

- `cargo test -p geo-polygonize-core`
- `cargo doc -p geo-polygonize-core --no-deps`
- `npm run docs:build`

The documentation build completed with existing WASM dead-code, Vite module-directive/chunk-size, and npm audit warnings; generated bindings and `playground/package-lock.json` were restored before commit.

## Agent handoff

R4 may now audit the stable facade from this branch after R3 merges. Do not reintroduce resettable shared token state; a new operation receives a fresh token.