### PR TITLE
refactor(core): unify candidate exact paths

### DIFF
--- a/crates/geo-polygonize-core/src/noding/grid.rs
+++ b/crates/geo-polygonize-core/src/noding/grid.rs
@@ -1,11 +1,11 @@
 use crate::diagnostics::ExecutionWorkTracker;
-use crate::noding::snap::{FloatingIntersectionTrace, SnapNoder};
-use crate::noding::CandidatePair;
+use crate::noding::snap::SnapNoder;
+use crate::noding::{CandidateIntersectionTrace, CandidatePair, ExactCandidate};
 use crate::options::ExecutionPolicy;
 use crate::trace::{TraceCapture, TraceCaptureBudget};
 use crate::types::{Coord3D, Line3D};
 use crate::utils::soa::SoALines;
-use geo::algorithm::line_intersection::{line_intersection, LineIntersection};
+use geo::algorithm::line_intersection::LineIntersection;
 use geo::Coord;
 use smallvec::SmallVec;
 use wide::f64x4;
@@ -240,7 +240,7 @@ pub(crate) struct UniformGridCandidateTrace {
     pub(crate) second_segment: usize,
     pub(crate) first_source_id: u32,
     pub(crate) second_source_id: u32,
-    pub(crate) witness: Option<FloatingIntersectionTrace>,
+    pub(crate) witness: Option<CandidateIntersectionTrace>,
     pub(crate) owned_by_cell: Option<bool>,
 }
 
@@ -740,19 +740,9 @@ impl UniformGrid {
         snap_noder: &SnapNoder,
         iteration_index: usize,
         trace_candidates: Option<&mut TraceCapture<'_, UniformGridCandidateTrace>>,
-    ) -> Vec<(usize, Coord3D)> {
-        let first = lines[candidate.first];
-        let second = lines[candidate.second];
-        let intersection = line_intersection(first.to_line_2d(), second.to_line_2d());
-        let witness = intersection.map(|intersection| match intersection {
-            LineIntersection::SinglePoint { intersection, .. } => {
-                FloatingIntersectionTrace::Point(Coord3D::new(intersection.x, intersection.y, 0.0))
-            }
-            LineIntersection::Collinear { intersection } => FloatingIntersectionTrace::Collinear(
-                Coord3D::new(intersection.start.x, intersection.start.y, 0.0),
-                Coord3D::new(intersection.end.x, intersection.end.y, 0.0),
-            ),
-        });
+        events: &mut Vec<(usize, Coord3D)>,
+    ) {
+        let exact = ExactCandidate::evaluate(lines, candidate);
         if let Some(trace_candidates) = trace_candidates {
             trace_candidates.push(UniformGridCandidateTrace {
                 iteration_index,
@@ -761,24 +751,13 @@ impl UniformGrid {
                 column: None,
                 first_segment: candidate.first,
                 second_segment: candidate.second,
-                first_source_id: first.line_id,
-                second_source_id: second.line_id,
-                witness,
+                first_source_id: exact.first.line_id,
+                second_source_id: exact.second.line_id,
+                witness: exact.witness(),
                 owned_by_cell: None,
             });
         }
-        let mut splits = Vec::new();
-        if let Some(intersection) = intersection {
-            snap_noder.handle_intersection(
-                intersection,
-                candidate.first,
-                candidate.second,
-                first,
-                second,
-                |idx, point| splits.push((idx, point)),
-            );
-        }
-        splits
+        snap_noder.append_exact_candidate_splits(exact, events);
     }
 
     fn process_global_lines(
@@ -791,7 +770,7 @@ impl UniformGrid {
         let process_one_global = |g_idx: usize| -> Vec<(usize, Coord3D)> {
             let mut events = Vec::new();
             self.visit_global_candidates_for_line(g_idx, lines, soa, None, |candidate| {
-                events.extend(self.process_global_candidate(candidate, lines, snap_noder, 0, None));
+                self.process_global_candidate(candidate, lines, snap_noder, 0, None, &mut events);
                 Ok(())
             })
             .expect("unlimited noding cannot fail");
@@ -837,13 +816,14 @@ impl UniformGrid {
                 &soa,
                 Some(tracker),
                 |candidate| {
-                    events.extend(self.process_global_candidate(
+                    self.process_global_candidate(
                         candidate,
                         lines,
                         snap_noder,
                         iteration_index,
                         trace_candidates.as_deref_mut(),
-                    ));
+                        &mut events,
+                    );
                     Ok(())
                 },
             )?;
@@ -863,12 +843,6 @@ impl UniformGrid {
         cell_max_y: f64,
         overlap: geo::Line<f64>,
         snap_noder: &SnapNoder,
-        res: LineIntersection<f64>,
-        idx1: usize,
-        idx2: usize,
-        l1: Line3D,
-        l2: Line3D,
-        splits: &mut Vec<(usize, Coord3D)>,
     ) -> bool {
         // Collinear is rare. Just process start/end and let HashMap dedup later.
         // SnapNoder::snap expects Coord3D. Overlap has 2D coords.
@@ -879,14 +853,7 @@ impl UniformGrid {
         // Simplified ownership: Check if p1 is in cell
         let p1_in =
             p1.x >= cell_min_x && p1.x < cell_max_x && p1.y >= cell_min_y && p1.y < cell_max_y;
-        if p1_in || (c == 0 && r == 0) {
-            snap_noder.handle_intersection(res, idx1, idx2, l1, l2, |idx, pt| {
-                splits.push((idx, pt));
-            });
-            true
-        } else {
-            false
-        }
+        p1_in || (c == 0 && r == 0)
     }
 
     // Broad phase: visit AABB-overlapping pairs that share a grid cell.
@@ -938,22 +905,9 @@ impl UniformGrid {
         let cell_min_y = self.bounds_min.y + r as f64 * self.cell_size;
         let cell_max_x = cell_min_x + self.cell_size;
         let cell_max_y = cell_min_y + self.cell_size;
-        let idx1 = candidate.first;
-        let idx2 = candidate.second;
-        let l1 = lines[idx1];
-        let l2 = lines[idx2];
-        let intersection = line_intersection(l1.to_line_2d(), l2.to_line_2d());
-        let witness = intersection.map(|intersection| match intersection {
-            LineIntersection::SinglePoint { intersection, .. } => {
-                FloatingIntersectionTrace::Point(Coord3D::new(intersection.x, intersection.y, 0.0))
-            }
-            LineIntersection::Collinear { intersection } => FloatingIntersectionTrace::Collinear(
-                Coord3D::new(intersection.start.x, intersection.start.y, 0.0),
-                Coord3D::new(intersection.end.x, intersection.end.y, 0.0),
-            ),
-        });
+        let exact = ExactCandidate::evaluate(lines, candidate);
         let mut owned_by_cell = false;
-        if let Some(res) = intersection {
+        if let Some(res) = exact.intersection {
             match res {
                 LineIntersection::SinglePoint {
                     intersection: pt, ..
@@ -966,9 +920,6 @@ impl UniformGrid {
                         && (pt.y < cell_max_y || (r == self.rows - 1 && pt.y <= cell_max_y));
                     if is_in_x && is_in_y {
                         owned_by_cell = true;
-                        snap_noder.handle_intersection(res, idx1, idx2, l1, l2, |idx, pt| {
-                            splits.push((idx, pt));
-                        });
                     }
                 }
                 LineIntersection::Collinear {
@@ -976,7 +927,6 @@ impl UniformGrid {
                 } => {
                     owned_by_cell = self.handle_collinear(
                         c, r, cell_min_x, cell_max_x, cell_min_y, cell_max_y, overlap, snap_noder,
-                        res, idx1, idx2, l1, l2, splits,
                     );
                 }
             }
@@ -987,13 +937,16 @@ impl UniformGrid {
                 scan: "cell",
                 row: Some(r),
                 column: Some(c),
-                first_segment: idx1,
-                second_segment: idx2,
-                first_source_id: l1.line_id,
-                second_source_id: l2.line_id,
-                witness,
+                first_segment: exact.pair.first,
+                second_segment: exact.pair.second,
+                first_source_id: exact.first.line_id,
+                second_source_id: exact.second.line_id,
+                witness: exact.witness(),
                 owned_by_cell: Some(owned_by_cell),
             });
+        }
+        if owned_by_cell {
+            snap_noder.append_exact_candidate_splits(exact, splits);
         }
     }
 
@@ -1110,7 +1063,7 @@ mod tests {
         assert_eq!(candidates[0].second_source_id, 2);
         assert!(matches!(
             candidates[0].witness,
-            Some(FloatingIntersectionTrace::Point(point)) if point.x == 1.0 && point.y == 1.0
+            Some(CandidateIntersectionTrace::Point(point)) if point.x == 1.0 && point.y == 1.0
         ));
     }
 

--- a/crates/geo-polygonize-core/src/noding/mod.rs
+++ b/crates/geo-polygonize-core/src/noding/mod.rs
@@ -1,7 +1,50 @@
+use crate::types::{Coord3D, Line3D};
+use geo::algorithm::line_intersection::{line_intersection, LineIntersection};
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct CandidatePair {
     pub(crate) first: usize,
     pub(crate) second: usize,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) enum CandidateIntersectionTrace {
+    Point(Coord3D),
+    Collinear(Coord3D, Coord3D),
+}
+
+/// The exact outcome shared by every floating candidate backend.
+#[derive(Clone, Copy)]
+pub(crate) struct ExactCandidate {
+    pub(crate) pair: CandidatePair,
+    pub(crate) first: Line3D,
+    pub(crate) second: Line3D,
+    pub(crate) intersection: Option<LineIntersection<f64>>,
+}
+
+impl ExactCandidate {
+    pub(crate) fn evaluate(lines: &[Line3D], pair: CandidatePair) -> Self {
+        let first = lines[pair.first];
+        let second = lines[pair.second];
+        Self {
+            pair,
+            first,
+            second,
+            intersection: line_intersection(first.to_line_2d(), second.to_line_2d()),
+        }
+    }
+
+    pub(crate) fn witness(self) -> Option<CandidateIntersectionTrace> {
+        self.intersection.map(|intersection| match intersection {
+            LineIntersection::SinglePoint { intersection, .. } => {
+                CandidateIntersectionTrace::Point(Coord3D::new(intersection.x, intersection.y, 0.0))
+            }
+            LineIntersection::Collinear { intersection } => CandidateIntersectionTrace::Collinear(
+                Coord3D::new(intersection.start.x, intersection.start.y, 0.0),
+                Coord3D::new(intersection.end.x, intersection.end.y, 0.0),
+            ),
+        })
+    }
 }
 
 pub mod grid;

--- a/crates/geo-polygonize-core/src/noding/snap.rs
+++ b/crates/geo-polygonize-core/src/noding/snap.rs
@@ -4,7 +4,7 @@ use crate::index::{IndexedEnvelope, RStarBackend};
 use crate::noding::grid::{
     UniformGrid, UniformGridCandidateTrace, UniformGridCellTrace, UniformGridGlobalLineTrace,
 };
-use crate::noding::CandidatePair;
+use crate::noding::{CandidateIntersectionTrace, CandidatePair, ExactCandidate};
 use crate::options::{ExecutionPolicy, SnapStrategy, ZPolicy};
 use crate::trace::{TraceCapture, TraceCaptureBudget};
 use crate::types::{Coord3D, Line3D};
@@ -82,19 +82,13 @@ pub enum NodingStrategy {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub(crate) enum FloatingIntersectionTrace {
-    Point(Coord3D),
-    Collinear(Coord3D, Coord3D),
-}
-
-#[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) struct FloatingCandidateTrace {
     pub(crate) iteration_index: usize,
     pub(crate) first_segment: usize,
     pub(crate) second_segment: usize,
     pub(crate) first_source_id: u32,
     pub(crate) second_source_id: u32,
-    pub(crate) witness: Option<FloatingIntersectionTrace>,
+    pub(crate) witness: Option<CandidateIntersectionTrace>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -974,7 +968,7 @@ impl SnapNoder {
                             &soa,
                             None,
                             |candidate| {
-                                events.extend(self.process_candidate_pair(lines, candidate, None));
+                                self.process_candidate_pair(lines, candidate, None, &mut events);
                                 Ok(())
                             },
                         )
@@ -993,7 +987,7 @@ impl SnapNoder {
                         &soa,
                         None,
                         |candidate| {
-                            splits.extend(self.process_candidate_pair(lines, candidate, None));
+                            self.process_candidate_pair(lines, candidate, None, &mut splits);
                             Ok(())
                         },
                     )
@@ -1008,7 +1002,7 @@ impl SnapNoder {
             let mut splits = Vec::new();
             for (i, &query_line) in lines.iter().enumerate() {
                 self.visit_candidate_pairs_simd(query_line, i, lines, &soa, None, |candidate| {
-                    splits.extend(self.process_candidate_pair(lines, candidate, None));
+                    self.process_candidate_pair(lines, candidate, None, &mut splits);
                     Ok(())
                 })
                 .expect("unlimited noding cannot fail");
@@ -1034,11 +1028,12 @@ impl SnapNoder {
                 &soa,
                 Some(tracker),
                 |candidate| {
-                    splits.extend(self.process_candidate_pair(
+                    self.process_candidate_pair(
                         lines,
                         candidate,
                         trace_candidates.as_deref_mut(),
-                    ));
+                        &mut splits,
+                    );
                     Ok(())
                 },
             )?;
@@ -1154,47 +1149,37 @@ impl SnapNoder {
         lines: &[Line3D],
         candidate: CandidatePair,
         trace_candidates: Option<&mut TraceCapture<'_, FloatingCandidateTrace>>,
-    ) -> Vec<(usize, Coord3D)> {
-        let first = lines[candidate.first];
-        let second = lines[candidate.second];
-        let intersection = line_intersection(first.to_line_2d(), second.to_line_2d());
+        events: &mut Vec<(usize, Coord3D)>,
+    ) {
+        let exact = ExactCandidate::evaluate(lines, candidate);
         if let Some(trace_candidates) = trace_candidates {
-            let witness = intersection.map(|intersection| match intersection {
-                LineIntersection::SinglePoint { intersection, .. } => {
-                    FloatingIntersectionTrace::Point(Coord3D::new(
-                        intersection.x,
-                        intersection.y,
-                        0.0,
-                    ))
-                }
-                LineIntersection::Collinear { intersection } => {
-                    FloatingIntersectionTrace::Collinear(
-                        Coord3D::new(intersection.start.x, intersection.start.y, 0.0),
-                        Coord3D::new(intersection.end.x, intersection.end.y, 0.0),
-                    )
-                }
-            });
             trace_candidates.push(FloatingCandidateTrace {
                 iteration_index: 0,
                 first_segment: candidate.first,
                 second_segment: candidate.second,
-                first_source_id: first.line_id,
-                second_source_id: second.line_id,
-                witness,
+                first_source_id: exact.first.line_id,
+                second_source_id: exact.second.line_id,
+                witness: exact.witness(),
             });
         }
-        let mut events = Vec::new();
-        if let Some(intersection) = intersection {
+        self.append_exact_candidate_splits(exact, events);
+    }
+
+    pub(crate) fn append_exact_candidate_splits(
+        &self,
+        exact: ExactCandidate,
+        events: &mut Vec<(usize, Coord3D)>,
+    ) {
+        if let Some(intersection) = exact.intersection {
             self.handle_intersection(
                 intersection,
-                candidate.first,
-                candidate.second,
-                first,
-                second,
+                exact.pair.first,
+                exact.pair.second,
+                exact.first,
+                exact.second,
                 |index, point| events.push((index, point)),
             );
         }
-        events
     }
 
     #[inline]
@@ -1389,13 +1374,48 @@ mod tests {
                 second: 1
             }]
         );
+        let mut splits = Vec::new();
+        noder.process_candidate_pair(&lines, candidates[0], None, &mut splits);
         assert_eq!(
-            noder.process_candidate_pair(&lines, candidates[0], None),
+            splits,
             vec![
                 (0, Coord3D::new(1.0, 1.0, 0.0)),
                 (1, Coord3D::new(1.0, 1.0, 0.0))
             ]
         );
+    }
+
+    #[test]
+    fn shared_exact_path_preserves_simd_grid_z_and_overlap_outcomes() {
+        let lines = vec![
+            Line3D::new(Coord3D::new(0.0, 0.0, 0.0), Coord3D::new(4.0, 4.0, 40.0), 1),
+            Line3D::new(
+                Coord3D::new(0.0, 4.0, 10.0),
+                Coord3D::new(4.0, 0.0, 30.0),
+                2,
+            ),
+            Line3D::new(Coord3D::new(0.0, 6.0, 1.0), Coord3D::new(4.0, 6.0, 5.0), 3),
+            Line3D::new(Coord3D::new(1.0, 6.0, 7.0), Coord3D::new(3.0, 6.0, 9.0), 4),
+        ];
+        let noder = SnapNoder::new(0.0);
+        let mut grid_splits = UniformGrid::new(&lines).find_splits(&lines, &noder);
+        let mut simd_splits = noder.find_splits_simd(&lines);
+        let normalize = |splits: &mut Vec<(usize, Coord3D)>| {
+            splits.sort_unstable_by(|left, right| {
+                left.0
+                    .cmp(&right.0)
+                    .then(left.1.x.total_cmp(&right.1.x))
+                    .then(left.1.y.total_cmp(&right.1.y))
+                    .then(left.1.z.total_cmp(&right.1.z))
+            });
+            splits.dedup();
+        };
+        normalize(&mut grid_splits);
+        normalize(&mut simd_splits);
+
+        assert_eq!(grid_splits, simd_splits);
+        assert!(simd_splits.contains(&(0, Coord3D::new(2.0, 2.0, 20.0))));
+        assert!(simd_splits.contains(&(1, Coord3D::new(2.0, 2.0, 20.0))));
     }
 
     #[test]

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -8,7 +8,8 @@ use crate::noding::grid::{
 use crate::noding::hot_pixel::{
     HotPixelCandidateTrace, HotPixelIntersectionTrace, HotPixelSplitTrace,
 };
-use crate::noding::snap::{FloatingCandidateTrace, FloatingIntersectionTrace, FloatingSplitTrace};
+use crate::noding::snap::{FloatingCandidateTrace, FloatingSplitTrace};
+use crate::noding::CandidateIntersectionTrace;
 use crate::types::SourceLineString;
 use crate::{
     Coord3D, CoordinateFingerprintV1, Line3D, Polygon3D, PolygonizerDiagnostics,
@@ -843,12 +844,12 @@ impl TraceRecorderV1 {
         }
         for (index, candidate) in candidates.iter().enumerate() {
             let witness = match candidate.witness {
-                Some(FloatingIntersectionTrace::Point(coordinate)) => {
+                Some(CandidateIntersectionTrace::Point(coordinate)) => {
                     Some(IntersectionWitnessTraceV1::Point {
                         coordinate: coordinate_fingerprint(coordinate)?,
                     })
                 }
-                Some(FloatingIntersectionTrace::Collinear(start, end)) => {
+                Some(CandidateIntersectionTrace::Collinear(start, end)) => {
                     Some(IntersectionWitnessTraceV1::Collinear {
                         start: coordinate_fingerprint(start)?,
                         end: coordinate_fingerprint(end)?,
@@ -925,12 +926,12 @@ impl TraceRecorderV1 {
         }
         for (index, candidate) in candidates.iter().enumerate() {
             let witness = match candidate.witness {
-                Some(FloatingIntersectionTrace::Point(coordinate)) => {
+                Some(CandidateIntersectionTrace::Point(coordinate)) => {
                     Some(IntersectionWitnessTraceV1::Point {
                         coordinate: coordinate_fingerprint(coordinate)?,
                     })
                 }
-                Some(FloatingIntersectionTrace::Collinear(start, end)) => {
+                Some(CandidateIntersectionTrace::Collinear(start, end)) => {
                     Some(IntersectionWitnessTraceV1::Collinear {
                         start: coordinate_fingerprint(start)?,
                         end: coordinate_fingerprint(end)?,


### PR DESCRIPTION
## Stack

Parent:
- #1266

This PR:
- Unify candidate exact paths for floating SIMD and uniform-grid noding.

Children:
- none

## Delivered

- Shared robust exact-candidate outcome and witness generation.
- Reused one split accumulator across floating SIMD and uniform-grid candidate processing.
- Added a focused SIMD/grid conformance regression covering crossing Z interpolation and collinear overlap.

## Contract impact

- Preserves candidate work accounting, trace order and provenance, Z-policy split values, normalization, and existing error behavior.
- Certified hot-pixel noding keeps its dedicated fixed-grid splitting semantics and existing validation gate.

## Validation

- `cargo test -p geo-polygonize-core noding:: --lib` — 52 passed
- `cargo test --quiet --locked -p geo-polygonize-core` — passed
- `cargo test --quiet --locked -p geo-polygonize-core --no-default-features --lib --tests` — passed
- `cargo fmt -- --check`; `cargo check --quiet --locked -p geo-polygonize-core --all-targets --all-features`; `cargo clippy --quiet --locked -p geo-polygonize-core --all-targets --all-features -- -D warnings` — passed

## Agent handoff

Remaining:
- B3 executable source-chain model.

Next dependency-ready branch:
- `agent/candidate-chain-model` based on `agent/candidate-common-exact-path`.