### PR TITLE
feat(core): retain executable source-chain identity

### DIFF
--- a/crates/geo-polygonize-core/src/noding/mod.rs
+++ b/crates/geo-polygonize-core/src/noding/mod.rs
@@ -49,6 +49,7 @@ impl ExactCandidate {
 
 pub mod grid;
 pub mod hot_pixel;
+#[allow(dead_code)] // Research-only candidate prototype; production dispatch does not call it yet.
 pub mod monotone;
 pub mod snap;
 pub mod sweep;

--- a/crates/geo-polygonize-core/src/noding/monotone.rs
+++ b/crates/geo-polygonize-core/src/noding/monotone.rs
@@ -42,14 +42,38 @@ struct MonotoneChain {
     bounds: Bounds,
 }
 
+/// Benchmark-only compatibility entrypoint for detached source ranges.
+///
+/// The crate's hidden `noding` module keeps this compiler-public for the
+/// native benchmark; production candidate dispatch uses source-chain identity.
+#[doc(hidden)]
+pub fn enumerate_candidates(
+    lines: &[Line3D],
+    source_ranges: &[(usize, usize)],
+) -> Result<Vec<(usize, usize)>> {
+    enumerate_candidates_from_ranges(lines, source_ranges)
+}
+
 /// Enumerate deterministic segment-envelope candidates for original source chains.
 ///
 /// This is a benchmark-only prototype. It requires finite coordinates and
 /// sorted, disjoint ranges; it has no execution-policy accounting or
 /// cancellation. Candidates are envelope overlaps, not exact intersections.
-pub(crate) fn enumerate_candidates(
+pub(crate) fn enumerate_source_chain_candidates(
     lines: &[Line3D],
     source_chains: &[SourceLineString],
+) -> Result<Vec<(usize, usize)>> {
+    let source_ranges: Vec<_> = source_chains
+        .iter()
+        .filter(|chain| chain.kind == SourceChainKind::Original)
+        .map(|chain| (chain.segment_start, chain.segment_count))
+        .collect();
+    enumerate_candidates_from_ranges(lines, &source_ranges)
+}
+
+fn enumerate_candidates_from_ranges(
+    lines: &[Line3D],
+    source_ranges: &[(usize, usize)],
 ) -> Result<Vec<(usize, usize)>> {
     let segment_bounds: Vec<_> = lines
         .iter()
@@ -68,7 +92,7 @@ pub(crate) fn enumerate_candidates(
             }
         })
         .collect::<Result<Vec<_>>>()?;
-    let chains = build_chains(lines, &segment_bounds, source_chains)?;
+    let chains = build_chains(lines, &segment_bounds, source_ranges)?;
     let chain_index = RStarBackend::new(
         chains
             .iter()
@@ -112,17 +136,12 @@ pub(crate) fn enumerate_candidates(
 fn build_chains(
     lines: &[Line3D],
     segment_bounds: &[Bounds],
-    source_chains: &[SourceLineString],
+    source_ranges: &[(usize, usize)],
 ) -> Result<Vec<MonotoneChain>> {
     let mut chains = Vec::new();
     let mut previous_end = 0;
 
-    for source_chain in source_chains
-        .iter()
-        .filter(|chain| chain.kind == SourceChainKind::Original)
-    {
-        let start = source_chain.segment_start;
-        let count = source_chain.segment_count;
+    for &(start, count) in source_ranges {
         if count == 0 {
             continue;
         }
@@ -313,7 +332,7 @@ mod tests {
                 kind: SourceChainKind::Original,
             },
         ];
-        let actual = enumerate_candidates(&lines, &chains).unwrap();
+        let actual = enumerate_source_chain_candidates(&lines, &chains).unwrap();
 
         assert_eq!(actual, vec![(0, 1), (1, 2), (2, 3), (2, 4)]);
     }
@@ -322,7 +341,7 @@ mod tests {
     fn rejects_overlapping_source_ranges() {
         let lines = [line((0.0, 0.0), (1.0, 0.0)), line((1.0, 0.0), (2.0, 0.0))];
         assert!(matches!(
-            enumerate_candidates(
+            enumerate_source_chain_candidates(
                 &lines,
                 &[
                     SourceLineString {
@@ -361,6 +380,8 @@ mod tests {
             },
         ];
 
-        assert!(enumerate_candidates(&lines, &chains).unwrap().is_empty());
+        assert!(enumerate_source_chain_candidates(&lines, &chains)
+            .unwrap()
+            .is_empty());
     }
 }

--- a/crates/geo-polygonize-core/src/noding/monotone.rs
+++ b/crates/geo-polygonize-core/src/noding/monotone.rs
@@ -1,7 +1,7 @@
 //! Research-only monotone-chain candidate prototype.
 
 use crate::index::{IndexedEnvelope, RStarBackend};
-use crate::types::Line3D;
+use crate::types::{Line3D, SourceChainKind, SourceLineString};
 use crate::{PolygonizeError, Result};
 use rstar::AABB;
 
@@ -42,15 +42,14 @@ struct MonotoneChain {
     bounds: Bounds,
 }
 
-/// Enumerate deterministic segment-envelope candidates for disjoint source
-/// line-string ranges `(segment_start, segment_count)`.
+/// Enumerate deterministic segment-envelope candidates for original source chains.
 ///
 /// This is a benchmark-only prototype. It requires finite coordinates and
 /// sorted, disjoint ranges; it has no execution-policy accounting or
 /// cancellation. Candidates are envelope overlaps, not exact intersections.
-pub fn enumerate_candidates(
+pub(crate) fn enumerate_candidates(
     lines: &[Line3D],
-    source_ranges: &[(usize, usize)],
+    source_chains: &[SourceLineString],
 ) -> Result<Vec<(usize, usize)>> {
     let segment_bounds: Vec<_> = lines
         .iter()
@@ -69,7 +68,7 @@ pub fn enumerate_candidates(
             }
         })
         .collect::<Result<Vec<_>>>()?;
-    let chains = build_chains(lines, &segment_bounds, source_ranges)?;
+    let chains = build_chains(lines, &segment_bounds, source_chains)?;
     let chain_index = RStarBackend::new(
         chains
             .iter()
@@ -113,12 +112,17 @@ pub fn enumerate_candidates(
 fn build_chains(
     lines: &[Line3D],
     segment_bounds: &[Bounds],
-    source_ranges: &[(usize, usize)],
+    source_chains: &[SourceLineString],
 ) -> Result<Vec<MonotoneChain>> {
     let mut chains = Vec::new();
     let mut previous_end = 0;
 
-    for &(start, count) in source_ranges {
+    for source_chain in source_chains
+        .iter()
+        .filter(|chain| chain.kind == SourceChainKind::Original)
+    {
+        let start = source_chain.segment_start;
+        let count = source_chain.segment_count;
         if count == 0 {
             continue;
         }
@@ -276,7 +280,7 @@ fn invalid_range(start: usize, count: usize) -> PolygonizeError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::Coord3D;
+    use crate::types::{Coord3D, SourceChainKind};
 
     fn line(start: (f64, f64), end: (f64, f64)) -> Line3D {
         Line3D::new(
@@ -295,7 +299,21 @@ mod tests {
             line((3.0, 0.0), (4.0, 0.0)),
             line((2.5, -1.0), (2.5, 1.0)),
         ];
-        let actual = enumerate_candidates(&lines, &[(0, 4), (4, 1)]).unwrap();
+        let chains = [
+            SourceLineString {
+                segment_start: 0,
+                segment_count: 4,
+                source_id: Some(1),
+                kind: SourceChainKind::Original,
+            },
+            SourceLineString {
+                segment_start: 4,
+                segment_count: 1,
+                source_id: Some(2),
+                kind: SourceChainKind::Original,
+            },
+        ];
+        let actual = enumerate_candidates(&lines, &chains).unwrap();
 
         assert_eq!(actual, vec![(0, 1), (1, 2), (2, 3), (2, 4)]);
     }
@@ -304,8 +322,45 @@ mod tests {
     fn rejects_overlapping_source_ranges() {
         let lines = [line((0.0, 0.0), (1.0, 0.0)), line((1.0, 0.0), (2.0, 0.0))];
         assert!(matches!(
-            enumerate_candidates(&lines, &[(0, 2), (1, 1)]),
+            enumerate_candidates(
+                &lines,
+                &[
+                    SourceLineString {
+                        segment_start: 0,
+                        segment_count: 2,
+                        source_id: Some(1),
+                        kind: SourceChainKind::Original,
+                    },
+                    SourceLineString {
+                        segment_start: 1,
+                        segment_count: 1,
+                        source_id: Some(2),
+                        kind: SourceChainKind::Original,
+                    },
+                ],
+            ),
             Err(PolygonizeError::InvalidGeometry { .. })
         ));
+    }
+
+    #[test]
+    fn ignores_synthetic_and_unavailable_chains() {
+        let lines = [line((0.0, 0.0), (1.0, 1.0)), line((0.0, 1.0), (1.0, 0.0))];
+        let chains = [
+            SourceLineString {
+                segment_start: 0,
+                segment_count: 1,
+                source_id: Some(1),
+                kind: SourceChainKind::Synthetic,
+            },
+            SourceLineString {
+                segment_start: 1,
+                segment_count: 1,
+                source_id: None,
+                kind: SourceChainKind::Unavailable,
+            },
+        ];
+
+        assert!(enumerate_candidates(&lines, &chains).unwrap().is_empty());
     }
 }

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -14,7 +14,9 @@ use crate::trace::{
     TraceByteLimitsV1, TraceCaptureBudget, TraceLevelV1, TraceRecorderV1, TraceStageV1,
     TracedPolygonizerResultV1, ZReconciliationCandidateTraceV1, ZReconciliationTraceV1,
 };
-use crate::types::{Coord3D, Line3D, Polygon3D, RingGraphIdentity, SourceLineString};
+use crate::types::{
+    Coord3D, Line3D, Polygon3D, RingGraphIdentity, SourceChainKind, SourceLineString,
+};
 use crate::utils::simd::SimdRing;
 use crate::utils::{canonical_coordinate_bits, z_order_index};
 use float_next_after::NextAfter;
@@ -183,6 +185,8 @@ fn collect_owned_lines(
         source_line_strings.push(SourceLineString {
             segment_start: collected.len(),
             segment_count: 1,
+            source_id: Some(line.line_id),
+            kind: SourceChainKind::Synthetic,
         });
         collected.push(line);
     }
@@ -238,6 +242,8 @@ where
             source_line_strings.push(SourceLineString {
                 segment_start,
                 segment_count: 0,
+                source_id: Some(line_id),
+                kind: SourceChainKind::Original,
             });
             continue;
         };
@@ -281,6 +287,8 @@ where
         source_line_strings.push(SourceLineString {
             segment_start,
             segment_count: segments.len() - segment_start,
+            source_id: Some(line_id),
+            kind: SourceChainKind::Original,
         });
     }
     let mut polygonizer =
@@ -2439,9 +2447,11 @@ fn source_line_strings_for_segments(lines: &[Line3D]) -> Vec<SourceLineString> {
     lines
         .iter()
         .enumerate()
-        .map(|(segment_start, _)| SourceLineString {
+        .map(|(segment_start, line)| SourceLineString {
             segment_start,
             segment_count: 1,
+            source_id: Some(line.line_id),
+            kind: SourceChainKind::Synthetic,
         })
         .collect()
 }
@@ -2457,6 +2467,8 @@ fn append_line_string(
     source_line_strings.push(SourceLineString {
         segment_start,
         segment_count: out.len() - segment_start,
+        source_id: None,
+        kind: SourceChainKind::Unavailable,
     });
 }
 

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -10,7 +10,7 @@ use crate::noding::hot_pixel::{
 };
 use crate::noding::snap::{FloatingCandidateTrace, FloatingSplitTrace};
 use crate::noding::CandidateIntersectionTrace;
-use crate::types::SourceLineString;
+use crate::types::{source_segment_identity, SourceChainKind, SourceLineString};
 use crate::{
     Coord3D, CoordinateFingerprintV1, Line3D, Polygon3D, PolygonizerDiagnostics,
     PolygonizerOptions, PolygonizerResult, ZPolicy,
@@ -692,33 +692,15 @@ impl TraceRecorderV1 {
         if !self.trace.level.allows(TraceStageV1::Noding) {
             return Ok(());
         }
-        let mut chain_index = 0;
         for (index, line) in lines.iter().enumerate() {
-            while let Some(chain) = source_line_strings.and_then(|chains| chains.get(chain_index)) {
-                let chain_end = chain.segment_start.checked_add(chain.segment_count).ok_or(
-                    crate::PolygonizeError::InternalInvariantViolation {
-                        reason: "source line-string range overflow".to_string(),
-                    },
-                )?;
-                if index < chain_end {
-                    break;
-                }
-                chain_index += 1;
-            }
             let chain_metadata = source_line_strings
-                .and_then(|chains| chains.get(chain_index))
-                .and_then(|chain| {
-                    chain
-                        .segment_start
-                        .checked_add(chain.segment_count)
-                        .filter(|&chain_end| chain.segment_start <= index && index < chain_end)
-                        .map(|_| {
-                            (
-                                Some(chain_index),
-                                Some(index - chain.segment_start),
-                                Some(chain.segment_count),
-                            )
-                        })
+                .and_then(|chains| source_segment_identity(chains, index))
+                .map(|identity| {
+                    (
+                        Some(identity.chain_index),
+                        Some(identity.segment_index),
+                        Some(identity.chain_segment_count),
+                    )
                 })
                 .unwrap_or((None, None, None));
             let payload = serde_json::to_value(InputSegmentTraceV1 {
@@ -1561,6 +1543,7 @@ fn workload_descriptor(
     let coordinate_span_y = float_bits(if lines.is_empty() { 0.0 } else { max_y - min_y })?;
     let chain_segment_total = source_line_strings
         .iter()
+        .filter(|chain| chain.kind == SourceChainKind::Original)
         .try_fold(0usize, |total, chain| {
             total.checked_add(chain.segment_count).ok_or_else(|| {
                 crate::PolygonizeError::InternalInvariantViolation {
@@ -1570,14 +1553,19 @@ fn workload_descriptor(
         })?;
     let max_chain_length = source_line_strings
         .iter()
+        .filter(|chain| chain.kind == SourceChainKind::Original)
         .map(|chain| chain.segment_count)
         .max()
         .unwrap_or(0);
+    let line_string_count = source_line_strings
+        .iter()
+        .filter(|chain| chain.kind == SourceChainKind::Original)
+        .count();
 
     Ok(WorkloadDescriptorV1 {
         segment_count: lines.len(),
-        line_string_count: source_line_strings.len(),
-        average_chain_length: ratio(chain_segment_total, source_line_strings.len()),
+        line_string_count,
+        average_chain_length: ratio(chain_segment_total, line_string_count),
         max_chain_length,
         envelope_min,
         envelope_max,
@@ -2000,9 +1988,9 @@ mod tests {
         );
         let workload = &summary.payload["workload_descriptor"];
         assert_eq!(workload["segment_count"], 2);
-        assert_eq!(workload["line_string_count"], 2);
-        assert_eq!(workload["average_chain_length"], json!(1.0));
-        assert_eq!(workload["max_chain_length"], 1);
+        assert_eq!(workload["line_string_count"], 0);
+        assert_eq!(workload["average_chain_length"], json!(0.0));
+        assert_eq!(workload["max_chain_length"], 0);
         assert_eq!(workload["envelope_min"]["x"], "0x0000000000000000");
         assert_eq!(workload["envelope_max"]["x"], "0x4000000000000000");
         assert_eq!(workload["coordinate_span_x"], "0x4000000000000000");
@@ -2043,6 +2031,41 @@ mod tests {
         .trace;
         assert!(truncated.truncated);
         assert!(truncated.events.is_empty());
+    }
+
+    #[test]
+    fn workload_descriptor_uses_only_original_chain_structure() {
+        let lines = [
+            Line3D::new(Coord3D::new(0.0, 0.0, 0.0), Coord3D::new(1.0, 0.0, 0.0), 7),
+            Line3D::new(Coord3D::new(1.0, 0.0, 0.0), Coord3D::new(2.0, 0.0, 0.0), 7),
+            Line3D::new(Coord3D::new(3.0, 0.0, 0.0), Coord3D::new(4.0, 0.0, 0.0), 9),
+            Line3D::new(Coord3D::new(5.0, 0.0, 0.0), Coord3D::new(6.0, 0.0, 0.0), 0),
+        ];
+        let chains = [
+            SourceLineString {
+                segment_start: 0,
+                segment_count: 2,
+                source_id: Some(7),
+                kind: SourceChainKind::Original,
+            },
+            SourceLineString {
+                segment_start: 2,
+                segment_count: 1,
+                source_id: Some(9),
+                kind: SourceChainKind::Synthetic,
+            },
+            SourceLineString {
+                segment_start: 3,
+                segment_count: 1,
+                source_id: None,
+                kind: SourceChainKind::Unavailable,
+            },
+        ];
+
+        let descriptor = workload_descriptor(&lines, &chains, 0.0).unwrap();
+        assert_eq!(descriptor.line_string_count, 1);
+        assert_eq!(descriptor.average_chain_length, 2.0);
+        assert_eq!(descriptor.max_chain_length, 2);
     }
 
     #[test]

--- a/crates/geo-polygonize-core/src/types.rs
+++ b/crates/geo-polygonize-core/src/types.rs
@@ -52,11 +52,113 @@ pub struct Line3D {
     pub line_id: u32,
 }
 
-/// The original line-string boundary for a contiguous range of flattened segments.
+/// How much source-chain structure the noder may rely on.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum SourceChainKind {
+    /// A contiguous input line string with a stable source ID.
+    Original,
+    /// Independent owned segments; one segment is a chain only for indexing.
+    Synthetic,
+    /// Segments came from an input whose source-chain identity is unavailable.
+    Unavailable,
+}
+
+/// A source-chain boundary for a contiguous range of flattened segments.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct SourceLineString {
     pub(crate) segment_start: usize,
     pub(crate) segment_count: usize,
+    pub(crate) source_id: Option<u32>,
+    pub(crate) kind: SourceChainKind,
+}
+
+/// The source-chain identity for one flattened segment.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct SourceSegmentIdentity {
+    pub(crate) source_id: Option<u32>,
+    pub(crate) chain_index: usize,
+    pub(crate) segment_index: usize,
+    pub(crate) chain_segment_count: usize,
+    pub(crate) kind: SourceChainKind,
+}
+
+impl SourceLineString {
+    pub(crate) fn segment_identity(
+        self,
+        chain_index: usize,
+        segment: usize,
+    ) -> Option<SourceSegmentIdentity> {
+        let segment_index = segment.checked_sub(self.segment_start)?;
+        (segment_index < self.segment_count).then_some(SourceSegmentIdentity {
+            source_id: self.source_id,
+            chain_index,
+            segment_index,
+            chain_segment_count: self.segment_count,
+            kind: self.kind,
+        })
+    }
+}
+
+pub(crate) fn source_segment_identity(
+    chains: &[SourceLineString],
+    segment: usize,
+) -> Option<SourceSegmentIdentity> {
+    chains
+        .iter()
+        .enumerate()
+        .find_map(|(chain_index, chain)| chain.segment_identity(chain_index, segment))
+}
+
+#[cfg(test)]
+mod source_chain_tests {
+    use super::*;
+
+    #[test]
+    fn source_segment_identity_distinguishes_chain_origins() {
+        let chains = [
+            SourceLineString {
+                segment_start: 0,
+                segment_count: 2,
+                source_id: Some(7),
+                kind: SourceChainKind::Original,
+            },
+            SourceLineString {
+                segment_start: 2,
+                segment_count: 1,
+                source_id: Some(9),
+                kind: SourceChainKind::Synthetic,
+            },
+            SourceLineString {
+                segment_start: 3,
+                segment_count: 1,
+                source_id: None,
+                kind: SourceChainKind::Unavailable,
+            },
+        ];
+
+        assert_eq!(
+            source_segment_identity(&chains, 1),
+            Some(SourceSegmentIdentity {
+                source_id: Some(7),
+                chain_index: 0,
+                segment_index: 1,
+                chain_segment_count: 2,
+                kind: SourceChainKind::Original,
+            })
+        );
+        assert_eq!(
+            source_segment_identity(&chains, 2).map(|identity| (
+                identity.source_id,
+                identity.kind,
+                identity.segment_index
+            )),
+            Some((Some(9), SourceChainKind::Synthetic, 0))
+        );
+        assert_eq!(
+            source_segment_identity(&chains, 3).map(|identity| (identity.source_id, identity.kind)),
+            Some((None, SourceChainKind::Unavailable))
+        );
+    }
 }
 
 /// Sorted, unique input line identifiers contributing to a graph edge.


### PR DESCRIPTION
## Stack

Parent:
- #1274

This PR:
- Retain executable internal source-chain identities for candidate backends.

Children:
- none

## Delivered

- Classified source chains as original, synthetic independent segments, or unavailable.
- Retained stable source IDs and segment-within-chain identities without changing the `Line3D` hot-path layout.
- Moved the monotone research prototype from detached ranges to the internal chain model; it only admits original chains.
- Made workload chain metrics reflect only real original line strings.

## Contract impact

- No public API or backend selection changes.
- Existing provenance, Z, noding, and trace ordering behavior remain unchanged.
- Owned independent `Line3D` streams are no longer reported as natural one-segment line strings.

## Validation

- `cargo test -p geo-polygonize-core 'types::source_chain_tests::source_segment_identity_distinguishes_chain_origins' --lib` — passed
- `cargo test -p geo-polygonize-core noding::monotone:: --lib` — passed
- `cargo test -p geo-polygonize-core trace::tests:: --lib` — passed
- `cargo test --quiet --locked -p geo-polygonize-core` — passed
- `cargo test --quiet --locked -p geo-polygonize-core --no-default-features --lib --tests` — passed
- `cargo fmt -- --check`; `cargo check --quiet --locked -p geo-polygonize-core --all-targets --all-features`; `cargo clippy --quiet --locked -p geo-polygonize-core --all-targets --all-features -- -D warnings` — passed

## Agent handoff

Remaining:
- B4 baseline backend conformance.

Next dependency-ready branch:
- `agent/candidate-baseline-conformance` based on `agent/candidate-chain-model`.