### PR TITLE
test(core): close the 1.0 stable facade gate

### DIFF
--- a/crates/geo-polygonize-core/src/options.rs
+++ b/crates/geo-polygonize-core/src/options.rs
@@ -18,6 +18,23 @@ pub(crate) const MAX_UNCANCELLABLE_SORT_ITEMS: usize = 1_000_000;
 /// Tokens are single-run: clones share one cancellation state, so any clone
 /// may cancel the operation and cancellation remains set for the token's
 /// lifetime. Create a fresh token for each new operation.
+///
+/// # Examples
+///
+/// ```
+/// use geo_polygonize_core::{CancellationToken, ExecutionPolicy};
+///
+/// let token = CancellationToken::new();
+/// let worker_token = token.clone();
+/// worker_token.cancel();
+/// assert!(token.is_cancelled());
+///
+/// let next_run = ExecutionPolicy {
+///     cancellation_token: Some(CancellationToken::new()),
+///     ..Default::default()
+/// };
+/// assert!(!next_run.cancellation_token.unwrap().is_cancelled());
+/// ```
 #[derive(Clone, Debug, Default)]
 pub struct CancellationToken(Arc<AtomicBool>);
 


### PR DESCRIPTION
## Stack

R4 of the release-gate stack.

- Base: `agent/release-cancellation-token-contract` (R3, `9144ee0`)
- Head: `agent/release-stable-facade-audit` (R4)

## Delivered

- Audited the supported Rust facade defined by `SUPPORT.md`: research modules and re-exports remain `#[doc(hidden)]`.
- Confirmed the existing release-contract script synchronizes Rust, npm, and Python versions.
- Added a compiling public-rustdoc example that demonstrates clone cancellation and a fresh token for the next operation.

## Validation

- `cargo test --locked -p geo-polygonize-core --no-default-features --lib --tests`
- `cargo test --locked -p geo-polygonize-core`
- `cargo check --locked -p geo-polygonize-core --all-targets --all-features`
- `cargo test --locked -p geo-polygonize-core --doc`
- `cargo doc --locked -p geo-polygonize-core --no-deps`
- `cargo test --release --locked -p geo-polygonize-core --test robustness --test regression_nan_panic`
- `cargo test --locked -p geo-polygonize-arrow --test arrow_integration --test test_ffi_errors`
- `maturin build --locked --release` plus abi3 wheel import/call probe on CPython 3.11
- `./scripts/build_wasm.sh --variant scalar|simd|threads --no-bundle`
- `./scripts/build_wasm.sh --bundle-only && npm test` (54 tests)
- `./scripts/check-release-versions.sh`

Generated bindings were restored before commit. Local Wasm builds emitted existing dead-code warnings; the threaded build also reports an existing nightly deprecation warning.

## Matrix boundary

This macOS/aarch64 checkout cannot replace CI's Linux x86_64 gate or CPython 3.8 import run. The wheel was built with `abi3-py38` and successfully imported on CPython 3.11.

## Release recommendation

No stable-facade blocker remains in R4. The draft release PR #1002 is safe to merge after the R1-R4 stack lands and its normal required CI passes; this audit does not certify unrelated roadmap research work.

## Agent handoff

Keep this PR draft and do not modify release PR #1002 from this branch.