### PR TITLE
feat(core): export tile border observations

### DIFF
--- a/crates/geo-polygonize-core/src/graph/planar_graph.rs
+++ b/crates/geo-polygonize-core/src/graph/planar_graph.rs
@@ -5,7 +5,7 @@ use crate::utils::parallel::{par_flat_map, par_sort_unstable, par_zip_for_each};
 use crate::utils::{
     canonical_coordinate_bits, compare_angular, minimum_rotation_index, z_order_index,
 };
-use geo_types::{Coord, LineString};
+use geo_types::{Coord, LineString, Rect};
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 use std::cmp::Ordering;
@@ -136,11 +136,18 @@ struct ComponentPartition {
     edges: Vec<EdgeId>,
 }
 
+#[derive(Clone, Copy)]
+pub(crate) struct PartitionBorderExport {
+    pub partition_id: usize,
+    pub bbox: Rect<f64>,
+}
+
 #[derive(Default)]
 struct ComponentScratch {
     graph: PlanarGraph,
     global_node_ids: Vec<NodeId>,
     local_node_ids: HashMap<NodeId, NodeId>,
+    global_dir_edge_ids: Vec<[DirEdgeId; 2]>,
 }
 
 fn append_component_output(target: &mut ComponentOutput, output: ComponentOutput) {
@@ -1997,9 +2004,12 @@ impl PlanarGraph {
         scratch.graph.clear();
         scratch.global_node_ids.clear();
         scratch.local_node_ids.clear();
+        scratch.global_dir_edge_ids.clear();
         scratch.global_node_ids.reserve(partition.nodes.len());
         scratch.local_node_ids.reserve(partition.nodes.len());
+        scratch.global_dir_edge_ids.reserve(partition.edges.len());
         let global_node_capacity = scratch.global_node_ids.capacity();
+        let global_dir_edge_capacity = scratch.global_dir_edge_ids.capacity();
         for (node_offset, global_node_id) in partition.nodes.into_iter().enumerate() {
             execution_policy.check_cancelled_every("graph_components", node_offset)?;
             let local_node_id = scratch.graph.add_node(Coord3D {
@@ -2043,7 +2053,12 @@ impl PlanarGraph {
                 scratch.graph.directed_edges[scratch.graph.edges[local_edge_id].dir_edges[0]].dst,
                 local_dst
             );
+            scratch.global_dir_edge_ids.push(edge.dir_edges);
         }
+        debug_assert_eq!(
+            scratch.global_dir_edge_ids.capacity(),
+            global_dir_edge_capacity
+        );
         Ok(())
     }
 
@@ -2054,12 +2069,14 @@ impl PlanarGraph {
         execution_policy: &ExecutionPolicy,
         noding_postcondition_validated: bool,
         capture_byte_limit: Option<usize>,
-    ) -> crate::Result<(ComponentOutput, bool)> {
+        border_export: Option<PartitionBorderExport>,
+    ) -> crate::Result<(ComponentOutput, Vec<PartitionBorderHalfEdge>, bool)> {
         let partitions = self.active_component_partitions(execution_policy)?;
         let mut merged = ComponentOutput::default();
+        let mut border_observations = Vec::new();
 
-        let capture_truncated = if let Some(capture_byte_limit) = capture_byte_limit {
-            let mut capture_budget = TraceCaptureBudget::new(capture_byte_limit);
+        let capture_truncated = if border_export.is_some() || capture_byte_limit.is_some() {
+            let mut capture_budget = capture_byte_limit.map(TraceCaptureBudget::new);
             let mut scratch = ComponentScratch::default();
             for (component_id, partition) in partitions.into_iter().enumerate() {
                 self.load_component_scratch(
@@ -2068,19 +2085,19 @@ impl PlanarGraph {
                     partition,
                     execution_policy,
                 )?;
-                append_component_output(
-                    &mut merged,
-                    scratch.process(
-                        component_id,
-                        include_graph_ids,
-                        include_source_ids,
-                        execution_policy,
-                        noding_postcondition_validated,
-                        Some(&mut capture_budget),
-                    )?,
-                );
+                let (output, observations) = scratch.process(
+                    component_id,
+                    include_graph_ids,
+                    include_source_ids,
+                    execution_policy,
+                    noding_postcondition_validated,
+                    capture_budget.as_mut(),
+                    border_export,
+                )?;
+                append_component_output(&mut merged, output);
+                border_observations.extend(observations);
             }
-            capture_budget.truncated()
+            capture_budget.is_some_and(|budget| budget.truncated())
         } else {
             #[cfg(all(feature = "parallel", not(target_arch = "wasm32")))]
             let outputs: Vec<_> = partitions
@@ -2101,6 +2118,7 @@ impl PlanarGraph {
                             include_source_ids,
                             execution_policy,
                             noding_postcondition_validated,
+                            None,
                             None,
                         )
                     },
@@ -2124,18 +2142,21 @@ impl PlanarGraph {
                         execution_policy,
                         noding_postcondition_validated,
                         None,
+                        None,
                     ));
                 }
                 outputs
             };
 
             for output in outputs {
-                append_component_output(&mut merged, output?);
+                let (output, observations) = output?;
+                debug_assert!(observations.is_empty());
+                append_component_output(&mut merged, output);
             }
             false
         };
 
-        Ok((merged, capture_truncated))
+        Ok((merged, border_observations, capture_truncated))
     }
 
     /// Validates Euler's planar relation for the active maximal-ring graph.
@@ -2410,6 +2431,7 @@ impl PlanarGraph {
 }
 
 impl ComponentScratch {
+    #[allow(clippy::too_many_arguments)]
     fn process(
         &mut self,
         component_id: usize,
@@ -2418,7 +2440,8 @@ impl ComponentScratch {
         execution_policy: &ExecutionPolicy,
         noding_postcondition_validated: bool,
         capture_budget: Option<&mut TraceCaptureBudget>,
-    ) -> crate::Result<ComponentOutput> {
+        border_export: Option<PartitionBorderExport>,
+    ) -> crate::Result<(ComponentOutput, Vec<PartitionBorderHalfEdge>)> {
         self.graph
             .sort_edges_with_execution_policy(execution_policy)?;
         let dangles = self
@@ -2451,9 +2474,76 @@ impl ComponentScratch {
                     )?,
             )
         };
+        let observations = border_export
+            .map(|export| self.partition_border_observations(component_id, export))
+            .unwrap_or_default();
         self.remap_rings(&mut maximal, component_id, include_graph_ids)?;
         self.remap_rings(&mut minimal, component_id, include_graph_ids)?;
-        Ok((dangles, cut_edges, maximal, minimal))
+        Ok(((dangles, cut_edges, maximal, minimal), observations))
+    }
+
+    fn partition_border_observations(
+        &self,
+        component_id: usize,
+        export: PartitionBorderExport,
+    ) -> Vec<PartitionBorderHalfEdge> {
+        (0..self.graph.directed_edges.len())
+            .filter_map(|local_dir_edge_id| {
+                let side = self.border_side(local_dir_edge_id, export.bbox)?;
+                let local_edge_id = self.graph.directed_edges[local_dir_edge_id].edge_idx;
+                let local_dir_edges = self.graph.edges[local_edge_id].dir_edges;
+                let direction = usize::from(local_dir_edges[1] == local_dir_edge_id);
+                let global_dir_edge_id = self.global_dir_edge_ids.get(local_edge_id)?[direction];
+                let mut observation = self.graph.partition_border_half_edge_for_component(
+                    export.partition_id,
+                    component_id,
+                    local_dir_edge_id,
+                    side,
+                )?;
+                observation.local_dir_edge_id = global_dir_edge_id;
+                Some(observation)
+            })
+            .collect()
+    }
+
+    fn border_side(&self, dir_edge_id: DirEdgeId, bbox: Rect<f64>) -> Option<PartitionBorderSide> {
+        let directed = self.graph.directed_edges.get(dir_edge_id)?;
+        let start = Coord {
+            x: *self.graph.nodes_x.get(directed.src)?,
+            y: *self.graph.nodes_y.get(directed.src)?,
+        };
+        let end = Coord {
+            x: *self.graph.nodes_x.get(directed.dst)?,
+            y: *self.graph.nodes_y.get(directed.dst)?,
+        };
+        let on_axis = |start: f64, end: f64, value: f64| {
+            canonical_coordinate_bits(start) == canonical_coordinate_bits(value)
+                && canonical_coordinate_bits(end) == canonical_coordinate_bits(value)
+        };
+        let within = |value: f64, min: f64, max: f64| value >= min && value <= max;
+        if on_axis(start.x, end.x, bbox.min().x)
+            && within(start.y, bbox.min().y, bbox.max().y)
+            && within(end.y, bbox.min().y, bbox.max().y)
+        {
+            Some(PartitionBorderSide::MinX)
+        } else if on_axis(start.x, end.x, bbox.max().x)
+            && within(start.y, bbox.min().y, bbox.max().y)
+            && within(end.y, bbox.min().y, bbox.max().y)
+        {
+            Some(PartitionBorderSide::MaxX)
+        } else if on_axis(start.y, end.y, bbox.min().y)
+            && within(start.x, bbox.min().x, bbox.max().x)
+            && within(end.x, bbox.min().x, bbox.max().x)
+        {
+            Some(PartitionBorderSide::MinY)
+        } else if on_axis(start.y, end.y, bbox.max().y)
+            && within(start.x, bbox.min().x, bbox.max().x)
+            && within(end.x, bbox.min().x, bbox.max().x)
+        {
+            Some(PartitionBorderSide::MaxY)
+        } else {
+            None
+        }
     }
 
     fn remap_rings(
@@ -3074,7 +3164,7 @@ mod arrangement_ring_invariant_tests {
         let node_capacity = scratch.graph.nodes_x.capacity();
         let edge_capacity = scratch.graph.edges.capacity();
         scratch
-            .process(0, false, false, &policy, true, None)
+            .process(0, false, false, &policy, true, None, None)
             .unwrap();
         graph
             .load_component_scratch(&mut scratch, 1, partitions.remove(0), &policy)
@@ -3144,8 +3234,8 @@ mod arrangement_ring_invariant_tests {
         }
 
         let policy = ExecutionPolicy::default();
-        let ((_, _, _, rings), _) = graph
-            .process_components_with_execution_policy(true, true, &policy, true, None)
+        let ((_, _, _, rings), _, _) = graph
+            .process_components_with_execution_policy(true, true, &policy, true, None, None)
             .unwrap();
         let refs = rings
             .iter()

--- a/crates/geo-polygonize-core/src/graph/tests.rs
+++ b/crates/geo-polygonize-core/src/graph/tests.rs
@@ -695,12 +695,13 @@ mod tests {
         }
 
         let component_ids = graph.active_component_ids();
-        let ((dangles, cut_edges, maximal, rings), capture_truncated) = graph
+        let ((dangles, cut_edges, maximal, rings), _, capture_truncated) = graph
             .process_components_with_execution_policy(
                 true,
                 true,
                 &ExecutionPolicy::default(),
                 true,
+                None,
                 None,
             )
             .unwrap();

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -3,6 +3,8 @@ use crate::diagnostics::{
     ContainmentStats, NodingIterationStats, PolygonizerDiagnostics, ZConflictStats,
 };
 use crate::error::{PolygonizeError, Result};
+use crate::graph::partition_border::PartitionBorderHalfEdge;
+use crate::graph::planar_graph::PartitionBorderExport;
 use crate::graph::{ExtractedRing, PlanarGraph};
 use crate::noding::hot_pixel::HotPixelNoder;
 use crate::noding::snap::SnapNoder;
@@ -22,7 +24,7 @@ use crate::utils::{canonical_coordinate_bits, z_order_index};
 use float_next_after::NextAfter;
 use geo::Contains;
 use geo_traits::{CoordTrait, LineStringTrait};
-use geo_types::{Coord, Geometry, LineString, MultiPolygon, Polygon};
+use geo_types::{Coord, Geometry, LineString, MultiPolygon, Polygon, Rect};
 use std::collections::HashMap;
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -49,6 +51,8 @@ pub struct Polygonizer {
     input_lines: Vec<Line3D>,
     input_line_strings: Vec<SourceLineString>,
     trace: Option<TraceRecorderV1>,
+    partition_border_export: Option<PartitionBorderExport>,
+    partition_border_observations: Vec<PartitionBorderHalfEdge>,
 }
 
 /// Reusable allocation storage for stateless polygonization calls.
@@ -348,6 +352,8 @@ pub fn polygonize_with_workspace_and_execution_policy(
         input_lines: Vec::new(),
         input_line_strings: Vec::new(),
         trace: None,
+        partition_border_export: None,
+        partition_border_observations: Vec::new(),
     };
     runner.input_line_strings = source_line_strings_for_segments(lines);
     let result = runner.polygonize_owned(lines.to_vec());
@@ -366,6 +372,8 @@ impl Polygonizer {
             input_lines: Vec::new(),
             input_line_strings: Vec::new(),
             trace: None,
+            partition_border_export: None,
+            partition_border_observations: Vec::new(),
         }
     }
     /// Creates a new `Polygonizer` with specific options.
@@ -377,6 +385,8 @@ impl Polygonizer {
             input_lines: Vec::new(),
             input_line_strings: Vec::new(),
             trace: None,
+            partition_border_export: None,
+            partition_border_observations: Vec::new(),
         }
     }
 
@@ -748,6 +758,19 @@ impl Polygonizer {
         self.polygonize_owned(self.input_lines.clone())
     }
 
+    pub(crate) fn polygonize_with_partition_border_export(
+        &mut self,
+        partition_id: usize,
+        bbox: Rect<f64>,
+    ) -> Result<(PolygonizerResult, Vec<PartitionBorderHalfEdge>)> {
+        self.partition_border_export = Some(PartitionBorderExport { partition_id, bbox });
+        self.partition_border_observations.clear();
+        let result = self.polygonize();
+        self.partition_border_export = None;
+        let observations = std::mem::take(&mut self.partition_border_observations);
+        result.map(|result| (result, observations))
+    }
+
     /// Computes polygons while recording a bounded topology trace.
     #[doc(hidden)]
     pub fn polygonize_with_trace(
@@ -833,14 +856,19 @@ impl Polygonizer {
                 .map(|trace| trace.capture_byte_limit(TraceStageV1::Rings))
                 .unwrap_or(0)
         });
-        let ((mut dangles, mut cut_edges, maximal, rings_with_ids), capture_truncated) =
-            self.graph.process_components_with_execution_policy(
-                self.options.node_input,
-                include_source_ids,
-                &self.execution_policy,
-                noding_postcondition_validated,
-                capture_byte_limit,
-            )?;
+        let (
+            (mut dangles, mut cut_edges, maximal, rings_with_ids),
+            border_observations,
+            capture_truncated,
+        ) = self.graph.process_components_with_execution_policy(
+            self.options.node_input,
+            include_source_ids,
+            &self.execution_policy,
+            noding_postcondition_validated,
+            capture_byte_limit,
+            self.partition_border_export,
+        )?;
+        self.partition_border_observations = border_observations;
         if let Some(trace) = self.trace.as_mut() {
             trace.record_classified_lines("dangle", &dangles)?;
             trace.record_classified_lines("cut_edge", &cut_edges)?;

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -1,4 +1,7 @@
 use crate::diagnostics::ExecutionWorkTracker;
+use crate::graph::partition_border::{
+    PartitionBorderAdjacency, PartitionBorderGraph, PartitionBorderHalfEdge, PartitionBorderSide,
+};
 use crate::index::{IndexedEnvelope, RStarBackend};
 use crate::noding::hot_pixel::HotPixelNoder;
 use crate::noding::snap::SnapNoder;
@@ -264,6 +267,11 @@ pub struct TiledPolygonizeResult {
     pub polygons: Vec<Polygon3D>,
     pub tile_reports: Vec<TileReport>,
     pub stitching_report: StitchingReport,
+    /// Canonical observations captured from physical tile arrangements.
+    ///
+    /// These are exported only; tiled output does not stitch or reconcile them.
+    #[doc(hidden)]
+    pub partition_border_graph: PartitionBorderGraph,
 }
 
 /// Coverage contract requested for experimental tiled polygonization.
@@ -320,7 +328,13 @@ pub struct TracedTiledPolygonizeResultV1 {
 }
 
 type TileOwnershipDecision = (usize, Option<Coord3D>, bool);
-type TileProcessResult = (Vec<Polygon3D>, TileReport, Vec<TileOwnershipDecision>, bool);
+type TileProcessResult = (
+    Vec<Polygon3D>,
+    TileReport,
+    Vec<TileOwnershipDecision>,
+    Vec<PartitionBorderHalfEdge>,
+    bool,
+);
 
 #[derive(Debug)]
 struct InputComponent {
@@ -821,6 +835,7 @@ impl<'a> TiledPolygonizer<'a> {
 
     fn process_tile(
         &self,
+        partition_id: usize,
         tile_bbox: Rect<f64>,
         input_components: &[InputComponent],
         buffer: f64,
@@ -905,11 +920,12 @@ impl<'a> TiledPolygonizer<'a> {
             retry_exhausted: false,
         };
         if relevant_lines == 0 {
-            return Ok((Vec::new(), report, Vec::new(), false));
+            return Ok((Vec::new(), report, Vec::new(), Vec::new(), false));
         }
 
         // Run polygonization
-        let result = local_poly.polygonize()?;
+        let (result, border_observations) =
+            local_poly.polygonize_with_partition_border_export(partition_id, tile_bbox)?;
         report.polygon_count = result.polygons.len();
         report.dangle_count = result.dangles.len();
         report.cut_edge_count = result.cut_edges.len();
@@ -985,6 +1001,7 @@ impl<'a> TiledPolygonizer<'a> {
             valid_polys,
             report,
             ownership_decisions,
+            border_observations,
             capture_budget.is_some_and(|budget| budget.truncated()),
         ))
     }
@@ -1409,19 +1426,25 @@ impl<'a> TiledPolygonizer<'a> {
 
     fn process_tile_with_retries(
         &self,
+        partition_id: usize,
         tile_bbox: Rect<f64>,
         input_components: &[InputComponent],
         capture_byte_limit: Option<usize>,
         retry_attempt_counter: &AtomicUsize,
     ) -> Result<TileProcessResult> {
         let mut buffer = self.buffer;
-        let mut result =
-            self.process_tile(tile_bbox, input_components, buffer, capture_byte_limit)?;
+        let mut result = self.process_tile(
+            partition_id,
+            tile_bbox,
+            input_components,
+            buffer,
+            capture_byte_limit,
+        )?;
         let Some(policy) = self.retry_policy else {
             return Ok(result);
         };
         let mut retry_attempts = Vec::new();
-        let mut capture_truncated = result.3;
+        let mut capture_truncated = result.4;
         for attempt in 1..=policy.max_attempts {
             if !Self::report_has_retry_evidence(&result.1) || buffer >= policy.max_buffer {
                 break;
@@ -1448,8 +1471,14 @@ impl<'a> TiledPolygonizer<'a> {
                 observed_attempts,
             )?;
             buffer = (buffer + policy.buffer_increment).min(policy.max_buffer);
-            result = self.process_tile(tile_bbox, input_components, buffer, capture_byte_limit)?;
-            capture_truncated |= result.3;
+            result = self.process_tile(
+                partition_id,
+                tile_bbox,
+                input_components,
+                buffer,
+                capture_byte_limit,
+            )?;
+            capture_truncated |= result.4;
             let resolved = !Self::report_is_unresolved(&result.1);
             retry_attempts.push(TileRetryAttempt {
                 attempt,
@@ -1463,7 +1492,7 @@ impl<'a> TiledPolygonizer<'a> {
         }
         result.1.retry_exhausted = Self::report_has_retry_evidence(&result.1);
         result.1.retry_attempts = retry_attempts;
-        result.3 = capture_truncated;
+        result.4 = capture_truncated;
         Ok(result)
     }
 
@@ -1549,6 +1578,64 @@ impl<'a> TiledPolygonizer<'a> {
             unresolved_sides.push(TileBoundarySide::MaxY);
         }
         unresolved_sides
+    }
+
+    fn declare_partition_adjacencies(
+        &self,
+        graph: &mut PartitionBorderGraph,
+        reports: &[TileReport],
+    ) -> Result<()> {
+        for (first_partition_id, first) in reports.iter().enumerate() {
+            for (second_partition_id, second) in
+                reports.iter().enumerate().skip(first_partition_id + 1)
+            {
+                let first_bbox = first.tile_bbox;
+                let second_bbox = second.tile_bbox;
+                let y_overlap = first_bbox.min().y < second_bbox.max().y
+                    && second_bbox.min().y < first_bbox.max().y;
+                let x_overlap = first_bbox.min().x < second_bbox.max().x
+                    && second_bbox.min().x < first_bbox.max().x;
+                let adjacency = if y_overlap && first_bbox.max().x == second_bbox.min().x {
+                    Some(PartitionBorderAdjacency::new(
+                        first_partition_id,
+                        PartitionBorderSide::MaxX,
+                        second_partition_id,
+                        PartitionBorderSide::MinX,
+                        first_bbox.max().x,
+                    )?)
+                } else if y_overlap && second_bbox.max().x == first_bbox.min().x {
+                    Some(PartitionBorderAdjacency::new(
+                        first_partition_id,
+                        PartitionBorderSide::MinX,
+                        second_partition_id,
+                        PartitionBorderSide::MaxX,
+                        first_bbox.min().x,
+                    )?)
+                } else if x_overlap && first_bbox.max().y == second_bbox.min().y {
+                    Some(PartitionBorderAdjacency::new(
+                        first_partition_id,
+                        PartitionBorderSide::MaxY,
+                        second_partition_id,
+                        PartitionBorderSide::MinY,
+                        first_bbox.max().y,
+                    )?)
+                } else if x_overlap && second_bbox.max().y == first_bbox.min().y {
+                    Some(PartitionBorderAdjacency::new(
+                        first_partition_id,
+                        PartitionBorderSide::MinY,
+                        second_partition_id,
+                        PartitionBorderSide::MaxY,
+                        first_bbox.min().y,
+                    )?)
+                } else {
+                    None
+                };
+                if let Some(adjacency) = adjacency {
+                    graph.declare_adjacency(adjacency);
+                }
+            }
+        }
+        Ok(())
     }
 
     fn generate_tiles(&self) -> Result<Vec<Rect<f64>>> {
@@ -1994,6 +2081,7 @@ impl<'a> TiledPolygonizer<'a> {
 
         let mut tile_polygons = Vec::with_capacity(tiles.len());
         let mut tile_reports = Vec::with_capacity(tiles.len());
+        let mut partition_border_graph = PartitionBorderGraph::default();
         if trace_ownership {
             for (tile_index, tile) in tiles.into_iter().enumerate() {
                 let capture_byte_limit = trace.as_ref().and_then(|trace| {
@@ -2001,8 +2089,9 @@ impl<'a> TiledPolygonizer<'a> {
                         .records_stage(TraceStageV1::Output)
                         .then(|| trace.capture_byte_limit(TraceStageV1::Output))
                 });
-                let (polygons, report, ownership_decisions, capture_truncated) = self
-                    .process_tile_with_retries(
+                let (polygons, report, ownership_decisions, border_observations, capture_truncated) =
+                    self.process_tile_with_retries(
+                        tile_index,
                         tile,
                         input_components,
                         capture_byte_limit,
@@ -2059,6 +2148,9 @@ impl<'a> TiledPolygonizer<'a> {
                 if capture_truncated {
                     trace.mark_capture_truncated(TraceStageV1::Output);
                 }
+                for observation in border_observations {
+                    partition_border_graph.insert(observation)?;
+                }
                 tile_polygons.push(polygons);
                 tile_reports.push(report);
             }
@@ -2075,8 +2167,10 @@ impl<'a> TiledPolygonizer<'a> {
                     pool.install(|| {
                         tiles
                             .into_par_iter()
-                            .map(|tile| {
+                            .enumerate()
+                            .map(|(tile_index, tile)| {
                                 self.process_tile_with_retries(
+                                    tile_index,
                                     tile,
                                     input_components,
                                     None,
@@ -2088,8 +2182,10 @@ impl<'a> TiledPolygonizer<'a> {
                 } else {
                     tiles
                         .into_par_iter()
-                        .map(|tile| {
+                        .enumerate()
+                        .map(|(tile_index, tile)| {
                             self.process_tile_with_retries(
+                                tile_index,
                                 tile,
                                 input_components,
                                 None,
@@ -2101,8 +2197,10 @@ impl<'a> TiledPolygonizer<'a> {
             #[cfg(not(feature = "parallel"))]
             let tile_results: Result<Vec<_>> = tiles
                 .into_iter()
-                .map(|tile| {
+                .enumerate()
+                .map(|(tile_index, tile)| {
                     self.process_tile_with_retries(
+                        tile_index,
                         tile,
                         input_components,
                         None,
@@ -2112,11 +2210,15 @@ impl<'a> TiledPolygonizer<'a> {
                 .collect();
 
             for result in tile_results? {
-                let (polygons, report, _, _) = result;
+                let (polygons, report, _, border_observations, _) = result;
+                for observation in border_observations {
+                    partition_border_graph.insert(observation)?;
+                }
                 tile_polygons.push(polygons);
                 tile_reports.push(report);
             }
         }
+        self.declare_partition_adjacencies(&mut partition_border_graph, &tile_reports)?;
         let unresolved = tile_reports.iter().any(Self::report_is_unresolved);
         let component_fallback_attempted = self.component_fallback && unresolved;
         let (component_fallback, component_fallback_decline_reason) =
@@ -2315,6 +2417,7 @@ impl<'a> TiledPolygonizer<'a> {
         let result = TiledPolygonizeResult {
             polygons,
             tile_reports,
+            partition_border_graph,
             stitching_report: StitchingReport {
                 merged_polygon_count,
                 duplicate_polygon_count: merged_polygon_count - output_polygon_count,

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -15,6 +15,58 @@ mod tests {
     use geo::{Contains, Coord, Geometry, LineString, MultiLineString, Rect};
 
     #[test]
+    fn exports_physical_tile_border_observations_before_scratch_is_released() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 2.0, y: 1.0 });
+        let geometries = [
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 0.0, y: 0.0 },
+                Coord { x: 1.0, y: 0.0 },
+                Coord { x: 2.0, y: 0.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 0.0, y: 1.0 },
+                Coord { x: 1.0, y: 1.0 },
+                Coord { x: 2.0, y: 1.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 0.0, y: 0.0 },
+                Coord { x: 0.0, y: 1.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 1.0, y: 0.0 },
+                Coord { x: 1.0, y: 1.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 2.0, y: 0.0 },
+                Coord { x: 2.0, y: 1.0 },
+            ])),
+        ];
+        let mut tiled = TiledPolygonizer::new(bbox, 1.0).with_buffer(0.0);
+        for geometry in &geometries {
+            tiled.add_geometry(geometry);
+        }
+
+        let result = tiled.polygonize().unwrap();
+        let start = crate::graph::partition_border::PartitionBorderNodeKey::from_coord(
+            Coord3D::new(1.0, 0.0, 0.0),
+        );
+        let end = crate::graph::partition_border::PartitionBorderNodeKey::from_coord(Coord3D::new(
+            1.0, 1.0, 0.0,
+        ));
+        let key = crate::graph::partition_border::PartitionBorderEdgeKey::new(start, end).unwrap();
+        let observations = result
+            .partition_border_graph
+            .edge_observations(key)
+            .unwrap();
+
+        assert_eq!(observations.len(), 4);
+        assert!(observations
+            .iter()
+            .all(|observation| observation.face_ref.is_some()));
+        assert_eq!(result.polygons.len(), 2);
+    }
+
+    #[test]
     fn test_tiled_polygonization_grid() {
         // Create a 2x2 grid of squares
         // 0,0 - 10,0 - 20,0
@@ -1786,7 +1838,7 @@ mod tests {
         });
 
         assert!(matches!(
-            tiled.process_tile(bbox, &[], 0.0, None),
+            tiled.process_tile(0, bbox, &[], 0.0, None),
             Err(PolygonizeError::Cancelled { stage }) if stage == "tile_processing"
         ));
     }
@@ -1814,7 +1866,7 @@ mod tests {
         }
 
         assert!(matches!(
-            tiled.process_tile(bbox, &[], 0.0, None),
+            tiled.process_tile(0, bbox, &[], 0.0, None),
             Err(PolygonizeError::Cancelled { stage }) if stage == "tile_processing"
         ));
     }
@@ -1841,7 +1893,7 @@ mod tests {
         };
 
         assert!(matches!(
-            tiled.process_tile(bbox, &[component], 0.0, None),
+            tiled.process_tile(0, bbox, &[component], 0.0, None),
             Err(PolygonizeError::Cancelled { stage }) if stage == "tile_processing"
         ));
     }


### PR DESCRIPTION
## Stack

- Base: `agent/border-segmentation-normalization` (C4)
- This PR: C5 — export physical tile-pass partition-border observations
- Next child: C6 — apply validated twins during tiled reconstruction

## What changed

Captures canonical directed border observations from each tile's arrangement after face assignment and before component scratch state is released. The tiled result carries the exported partition-border graph and declared tile adjacencies.

## Why

Later tiled stitching must use physical arrangement state, not geometry inferred from final polygon envelopes.

## Validation

- `cargo test -p geo-polygonize-core --lib --no-fail-fast`
- `cargo clippy -p geo-polygonize-core --lib -- -D warnings`
- `cargo check -p geo-polygonize-core --no-default-features`
- `cargo fmt --check`

No twin application or output stitching behavior changes are included.