### PR TITLE
feat(github): verify cross-registry release publication

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,7 +16,24 @@ permissions:
 name: release-please
 
 jobs:
+  release-publication-gate:
+    name: Verify previous release publication
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Require a complete previous release report
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: python3 scripts/verify_release.py --check-previous --repository "${{ github.repository }}" --github-token "$GH_TOKEN"
+
   release-please:
+    needs: release-publication-gate
     runs-on: ubuntu-latest
     steps:
       - name: Run release-please on push

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -1,0 +1,80 @@
+name: Verify release publication
+
+on:
+  push:
+    tags:
+      - "v*"
+      - "geo-polygonize-v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Published version to verify"
+        required: true
+        type: string
+      tag:
+        description: "Release tag carrying the publication"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  verify:
+    name: Verify public registries and install smoke tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Verify registries and install exact artifacts
+        id: verify
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version="${{ inputs.version }}"
+          tag="${{ inputs.tag }}"
+          if [ -z "$version" ]; then
+            version="${GITHUB_REF_NAME#geo-polygonize-v}"
+            version="${version#v}"
+          fi
+          if [ -z "$tag" ]; then
+            tag="$GITHUB_REF_NAME"
+          fi
+          python3 scripts/verify_release.py \
+            --version "$version" \
+            --tag "$tag" \
+            --repository "$GITHUB_REPOSITORY" \
+            --github-token "$GH_TOKEN" \
+            --report release-publication-report.json
+
+      - name: Upload machine-readable report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-publication-report-${{ github.ref_name }}
+          path: release-publication-report.json
+          if-no-files-found: error
+
+      - name: Attach complete report to the GitHub release
+        if: steps.verify.outcome == 'success' && github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "$GITHUB_REF_NAME" release-publication-report.json --clobber
+
+      - name: Fail the release when the report is incomplete
+        if: steps.verify.outcome != 'success'
+        run: exit 1

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,17 +1,19 @@
 # Release Process
 
-This document outlines the steps for releasing a new version of `geo-polygonize`.
+Release publication is deliberately split across crates.io, npm, and PyPI.
+The tag-triggered publish workflows are not atomic, so a release is not
+complete until the post-publication verifier has installed the exact public
+artifacts and attached a complete report to the GitHub release.
 
 ## Checklist
 
-1.  **Update Changelog**:
+1.  **Open the release PR**:
+    - Let `release-please` update all synchronized package versions.
+    - Keep the PR draft until the previous release publication gate passes.
+
+2.  **Update Changelog**:
     - Update `CHANGELOG.md` with all notable changes.
     - Change `[Unreleased]` to the new version number and date.
-
-2.  **Bump Version**:
-    - Update version in `Cargo.toml`.
-    - Update version in `package.json`.
-    - Run `cargo check` to ensure `Cargo.lock` is updated.
 
 3.  **Run Tests**:
     - Run `cargo test` to verify Rust tests.
@@ -24,12 +26,37 @@ This document outlines the steps for releasing a new version of `geo-polygonize`
     - Create a git tag: `git tag vX.Y.Z`.
     - Push changes and tag: `git push origin main --tags`.
 
-6.  **Publish to Crates.io**:
-    - `cargo publish`.
+6.  **Wait for publication verification**:
+    - `Publish to crates.io`, `Publish to npm`, and `Publish Python Package` run
+      from the tag.
+    - `Verify release publication` polls all registries with bounded retries,
+      runs the Rust, npm standard/slim, and Python install-smoke fixtures, and
+      uploads `release-publication-report.json`.
+    - A complete report is attached to the GitHub release as
+      `publication-report.json`.
 
-7.  **Publish to NPM**:
-    - `npm publish`.
+## Repair and rerun procedure
 
-## Automation
+If verification fails, use the report artifact to identify the registry,
+package, platform, or smoke fixture. Repair only the failed publication using
+the registry's supported rerun procedure; never force-move the release tag or
+overwrite a different version. Then manually dispatch **Verify release
+publication** with the exact version and tag. A later release remains gated
+until the prior tag has a complete report.
 
-Currently, releases are manual. Future improvements may include GitHub Actions for automated publishing on tag push.
+For a local audit against public artifacts, use bounded retries explicitly:
+
+```bash
+GH_TOKEN="$(gh auth token)" python3 scripts/verify_release.py \
+  --version 1.0.0 \
+  --tag geo-polygonize-v1.0.0 \
+  --repository graydonpleasants/geo-polygonize \
+  --github-token "$GH_TOKEN" \
+  --attempts 1 \
+  --delay-seconds 0 \
+  --report target/release-publication-report.json
+```
+
+The report is evidence, not a replacement for the registry-specific publish
+workflows. A failed or missing report must be repaired before starting another
+release.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -123,16 +123,16 @@ completion externally verifiable and the 1.x support contract precise.
 Tracked by
 [#1285](https://github.com/graydonpleasants/geo-polygonize/issues/1285).
 
-- [ ] Verify the actual `1.0.0` state on crates.io, npm, and PyPI.
-- [ ] Repair any missing or failed publication before publishing another version.
-- [ ] Install exact released artifacts from each public registry.
-- [ ] Run canonical success and normalized-error smoke tests against those
+- [x] Verify the actual `1.0.0` state on crates.io, npm, and PyPI.
+- [x] Repair any missing or failed publication before publishing another version.
+- [x] Install exact released artifacts from each public registry.
+- [x] Run canonical success and normalized-error smoke tests against those
   registry artifacts.
-- [ ] Add a bounded tag-triggered post-publication verifier.
-- [ ] Emit a machine-readable publication report by package, registry, version,
+- [x] Add a bounded tag-triggered post-publication verifier.
+- [x] Emit a machine-readable publication report by package, registry, version,
   platform, and result.
-- [ ] Document publication repair and rerun procedures.
-- [ ] Prevent a later release from being treated as complete while the previous
+- [x] Document publication repair and rerun procedures.
+- [x] Prevent a later release from being treated as complete while the previous
   release report is incomplete.
 
 Draft release PR

--- a/release/publication-report-v1.schema.json
+++ b/release/publication-report-v1.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/graydonpleasants/geo-polygonize/release/publication-report-v1.schema.json",
+  "title": "geo-polygonize cross-registry publication report v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "release_version",
+    "tag",
+    "verified_at",
+    "repository",
+    "registries",
+    "workflows",
+    "smoke",
+    "complete"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "release_version": { "type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$" },
+    "tag": { "type": "string", "pattern": "^(?:v|geo-polygonize-v)[0-9]+\\.[0-9]+\\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$" },
+    "verified_at": { "type": "string", "format": "date-time" },
+    "repository": { "type": "string", "pattern": "^[^/]+/[^/]+$" },
+    "registries": {
+      "type": "array",
+      "minItems": 6,
+      "items": { "type": "object" }
+    },
+    "workflows": {
+      "type": "array",
+      "minItems": 3,
+      "items": { "type": "object" }
+    },
+    "smoke": {
+      "type": "object",
+      "required": ["rust", "npm", "python"],
+      "properties": {
+        "rust": { "type": "object" },
+        "npm": { "type": "object" },
+        "python": { "type": "object" }
+      },
+      "additionalProperties": false
+    },
+    "complete": { "type": "boolean" },
+    "error": { "type": "string" }
+  }
+}

--- a/release/reports/geo-polygonize-v1.0.0.json
+++ b/release/reports/geo-polygonize-v1.0.0.json
@@ -1,0 +1,207 @@
+{
+  "schema_version": 1,
+  "release_version": "1.0.0",
+  "tag": "geo-polygonize-v1.0.0",
+  "verified_at": "2026-08-11T14:59:56Z",
+  "repository": "graydonpleasants/geo-polygonize",
+  "registries": [
+    {
+      "registry": "crates.io",
+      "package": "geo-polygonize-core",
+      "version": "1.0.0",
+      "status": "available",
+      "published_at": "2026-08-03T20:36:46.147755Z",
+      "artifact": {
+        "download_url": "https://crates.io/api/v1/crates/geo-polygonize-core/1.0.0/download",
+        "sha256": "5b2a404236c96004f419e036c2934579e79bed14884d3fcf6ee2b55d7f3c8811",
+        "size_bytes": 237447
+      },
+      "platforms": [
+        "source"
+      ]
+    },
+    {
+      "registry": "crates.io",
+      "package": "geo-polygonize-arrow",
+      "version": "1.0.0",
+      "status": "available",
+      "published_at": "2026-08-03T20:37:23.277083Z",
+      "artifact": {
+        "download_url": "https://crates.io/api/v1/crates/geo-polygonize-arrow/1.0.0/download",
+        "sha256": "8e25b9e80d90369f10592672fe772acc602701d6b8e2af62006b1638bc651d90",
+        "size_bytes": 35054
+      },
+      "platforms": [
+        "source"
+      ]
+    },
+    {
+      "registry": "crates.io",
+      "package": "geo-polygonize-flatgeobuf",
+      "version": "1.0.0",
+      "status": "available",
+      "published_at": "2026-08-03T20:37:34.270055Z",
+      "artifact": {
+        "download_url": "https://crates.io/api/v1/crates/geo-polygonize-flatgeobuf/1.0.0/download",
+        "sha256": "84b12c4d6702f1f05edb579d4717498b7fb9abe734c1fe417f35934a83f49749",
+        "size_bytes": 16602
+      },
+      "platforms": [
+        "source"
+      ]
+    },
+    {
+      "registry": "crates.io",
+      "package": "geo-polygonize-wasm",
+      "version": "1.0.0",
+      "status": "available",
+      "published_at": "2026-08-03T20:38:11.470284Z",
+      "artifact": {
+        "download_url": "https://crates.io/api/v1/crates/geo-polygonize-wasm/1.0.0/download",
+        "sha256": "d96ffcf45f39667e41740981f6db0ef8a3551382c506f8f136340bb156b0a93c",
+        "size_bytes": 32108
+      },
+      "platforms": [
+        "source"
+      ]
+    },
+    {
+      "registry": "npm",
+      "package": "geo-polygonize",
+      "version": "1.0.0",
+      "status": "available",
+      "published_at": "2026-08-03T20:45:56.622Z",
+      "artifact": {
+        "tarball": "https://registry.npmjs.org/geo-polygonize/-/geo-polygonize-1.0.0.tgz",
+        "shasum": "e08d6279cf0289a0b09d507280e49ece53ecbd72",
+        "integrity": "sha512-ljyfQ+Nh21yrIv+OZbmlm9tKh8zNfJk2EPpwEpprtEgC/hy6ib4F7bZSBQkXC+Cr34rkGTISV3v7ngofYMppfQ=="
+      },
+      "platforms": [
+        "node",
+        "wasm-scalar",
+        "wasm-slim"
+      ]
+    },
+    {
+      "registry": "pypi",
+      "package": "geo-polygonize-py",
+      "version": "1.0.0",
+      "status": "available",
+      "published_at": "2026-08-03T20:39:23",
+      "artifact": {
+        "files": [
+          {
+            "filename": "geo_polygonize_py-1.0.0-cp38-abi3-macosx_11_0_arm64.whl",
+            "packagetype": "bdist_wheel",
+            "python_version": "cp38",
+            "digests": {
+              "blake2b_256": "3035317b766710dd67787baa962cb22fa6ac0c1815aa2d658e0eed1140d77356",
+              "md5": "34a53350ee9190f5aff8425973b902b6",
+              "sha256": "f8cf41c53ed7975a29e75fb78742d03885f2a053a45ccc021aa398b5aba86f6f"
+            }
+          },
+          {
+            "filename": "geo_polygonize_py-1.0.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+            "packagetype": "bdist_wheel",
+            "python_version": "cp38",
+            "digests": {
+              "blake2b_256": "9ae68da86d5d3d8fe6e8ccf4b281d0ce2be6acae1852757903bb5ace690ed0a0",
+              "md5": "521966ff6427f1ebc7c5f17ec8e6bbaa",
+              "sha256": "49719daa939eaed4bb7cafdc0957a4c757b5620430e47e7f5ea3b68dcc06c257"
+            }
+          },
+          {
+            "filename": "geo_polygonize_py-1.0.0-cp38-abi3-manylinux_2_35_x86_64.whl",
+            "packagetype": "bdist_wheel",
+            "python_version": "cp38",
+            "digests": {
+              "blake2b_256": "02f70532fbc13f68e637d9a3395089010a881c9c94dfb224831d67740de4ec08",
+              "md5": "4a0eec44beabd65e1e6efdc994269879",
+              "sha256": "250215a0706fbb6053f36a1d0ec8cce02d0d72ed46e348c08eb85a5116720343"
+            }
+          },
+          {
+            "filename": "geo_polygonize_py-1.0.0-cp38-abi3-win_amd64.whl",
+            "packagetype": "bdist_wheel",
+            "python_version": "cp38",
+            "digests": {
+              "blake2b_256": "28cc204c1347d2f8c2cada0dd038b11ccac9006c331e9bef1dfd8daba470aba5",
+              "md5": "fc0d2ea876aee6eaf6c8506fd32d904c",
+              "sha256": "b2b8cbba371e6059dfa6c6ea33769157327c6fc4b5a69e48a0ab0fdaae3fec6c"
+            }
+          },
+          {
+            "filename": "geo_polygonize_py-1.0.0.tar.gz",
+            "packagetype": "sdist",
+            "python_version": "source",
+            "digests": {
+              "blake2b_256": "2cb3f8df34d3056a4f3e1b2d95203fd5ab1d1d311521f2d5050d416999883c6c",
+              "md5": "fd0511686ddd8d195177b669235194f8",
+              "sha256": "dae946d7f1ec363d3a2255ddecfd9f22ebc4f0d1e6841367c5b89eb652ec3318"
+            }
+          }
+        ]
+      },
+      "platforms": [
+        "1.0.0.tar.gz",
+        "macosx_11_0_arm64.whl",
+        "manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+        "manylinux_2_35_x86_64.whl",
+        "win_amd64.whl"
+      ]
+    }
+  ],
+  "workflows": [
+    {
+      "workflow": "Publish Python Package",
+      "run_id": 30850949126,
+      "status": "completed",
+      "conclusion": "success",
+      "head_sha": "d60fba054066bed348b4d4f594dbbb7bb3989c79",
+      "created_at": "2026-08-03T20:36:15Z",
+      "updated_at": "2026-08-03T20:39:43Z",
+      "url": "https://github.com/graydonpleasants/geo-polygonize/actions/runs/30850949126"
+    },
+    {
+      "workflow": "Publish to crates.io",
+      "run_id": 30850949037,
+      "status": "completed",
+      "conclusion": "success",
+      "head_sha": "d60fba054066bed348b4d4f594dbbb7bb3989c79",
+      "created_at": "2026-08-03T20:36:15Z",
+      "updated_at": "2026-08-03T20:38:18Z",
+      "url": "https://github.com/graydonpleasants/geo-polygonize/actions/runs/30850949037"
+    },
+    {
+      "workflow": "Publish to npm",
+      "run_id": 30850951383,
+      "status": "completed",
+      "conclusion": "success",
+      "head_sha": "d60fba054066bed348b4d4f594dbbb7bb3989c79",
+      "created_at": "2026-08-03T20:36:17Z",
+      "updated_at": "2026-08-03T20:46:11Z",
+      "url": "https://github.com/graydonpleasants/geo-polygonize/actions/runs/30850951383"
+    }
+  ],
+  "smoke": {
+    "rust": {
+      "status": "passed",
+      "package": "geo-polygonize-core",
+      "version": "1.0.0",
+      "platform": "native-registry-consumer"
+    },
+    "npm": {
+      "status": "passed",
+      "package": "geo-polygonize",
+      "version": "1.0.0",
+      "platform": "node-standard-slim-wasm"
+    },
+    "python": {
+      "status": "passed",
+      "package": "geo-polygonize-py",
+      "version": "1.0.0",
+      "platform": "cp-abi3-registry-wheel"
+    }
+  },
+  "complete": true
+}

--- a/scripts/verify_release.py
+++ b/scripts/verify_release.py
@@ -1,0 +1,561 @@
+#!/usr/bin/env python3
+"""Verify published release artifacts and smoke-test public registry installs.
+
+The publish workflows are intentionally independent.  This verifier is the
+post-publication contract: it checks the public registries, records the tag
+workflow runs, installs exact released artifacts outside the repository, and
+emits one machine-readable report suitable for a release asset.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+
+REPOSITORY = "graydonpleasants/geo-polygonize"
+REPORT_SCHEMA_VERSION = 1
+USER_AGENT = "geo-polygonize-release-verifier/1.0 (+https://github.com/graydonpleasants/geo-polygonize)"
+CRATE_PACKAGES = (
+    "geo-polygonize-core",
+    "geo-polygonize-arrow",
+    "geo-polygonize-flatgeobuf",
+    "geo-polygonize-wasm",
+)
+PUBLISH_WORKFLOWS = {
+    "publish.yml": "Publish to crates.io",
+    "publish-npm.yml": "Publish to npm",
+    "publish-python.yml": "Publish Python Package",
+}
+VERSION_RE = re.compile(r"^(?:geo-polygonize-v|v)(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)$")
+
+
+class VerificationError(RuntimeError):
+    """A bounded verification failure with a user-actionable message."""
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def version_from_tag(tag: str) -> str:
+    match = VERSION_RE.fullmatch(tag)
+    if not match:
+        raise VerificationError(f"tag {tag!r} is not a supported geo-polygonize release tag")
+    return match.group(1)
+
+
+def tag_for_version(version: str) -> str:
+    return f"geo-polygonize-v{version}"
+
+
+def request_json(url: str, token: str | None = None) -> object:
+    headers = {"Accept": "application/json", "User-Agent": USER_AGENT}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.load(response)
+    except urllib.error.HTTPError as error:
+        body = error.read().decode("utf-8", errors="replace")
+        raise VerificationError(f"GET {url} returned HTTP {error.code}: {body[:400]}") from error
+    except urllib.error.URLError as error:
+        raise VerificationError(f"GET {url} failed: {error.reason}") from error
+
+
+def request_json_with_retries(url: str, attempts: int, delay_seconds: float) -> object:
+    last_error: VerificationError | None = None
+    for attempt in range(1, attempts + 1):
+        try:
+            return request_json(url)
+        except VerificationError as error:
+            last_error = error
+            if attempt < attempts:
+                time.sleep(delay_seconds)
+    assert last_error is not None
+    raise last_error
+
+
+def run(command: list[str], cwd: Path, env: dict[str, str] | None = None) -> str:
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        env=env,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=900,
+    )
+    if result.returncode:
+        output = result.stdout.strip()
+        raise VerificationError(
+            f"command {' '.join(command)} failed with exit {result.returncode}: {output[-4000:]}"
+        )
+    return result.stdout
+
+
+def run_stdout(command: list[str], cwd: Path, env: dict[str, str] | None = None) -> str:
+    """Run a command while keeping machine-readable stdout free of cargo logs."""
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        env=env,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=900,
+    )
+    if result.returncode:
+        output = (result.stdout + result.stderr).strip()
+        raise VerificationError(
+            f"command {' '.join(command)} failed with exit {result.returncode}: {output[-4000:]}"
+        )
+    return result.stdout
+
+
+def registry_record(registry: str, package: str, version: str, attempts: int, delay_seconds: float) -> dict:
+    if registry == "crates.io":
+        encoded = urllib.parse.quote(package, safe="")
+        data = request_json_with_retries(
+            f"https://crates.io/api/v1/crates/{encoded}/{version}", attempts, delay_seconds
+        )
+        published = data.get("version", {})
+        if published.get("num") != version or published.get("yanked"):
+            raise VerificationError(f"crates.io has no non-yanked {package} {version}")
+        return {
+            "registry": registry,
+            "package": package,
+            "version": version,
+            "status": "available",
+            "published_at": published.get("created_at"),
+            "artifact": {
+                "download_url": f"https://crates.io{published['dl_path']}",
+                "sha256": published.get("checksum"),
+                "size_bytes": published.get("crate_size"),
+            },
+            "platforms": ["source"],
+        }
+
+    if registry == "npm":
+        encoded = urllib.parse.quote(package, safe="")
+        data = request_json_with_retries(
+            f"https://registry.npmjs.org/{encoded}", attempts, delay_seconds
+        )
+        published = data.get("versions", {}).get(version)
+        if not published:
+            raise VerificationError(f"npm has no {package} {version}")
+        dist = published.get("dist", {})
+        return {
+            "registry": registry,
+            "package": package,
+            "version": version,
+            "status": "available",
+            "published_at": data.get("time", {}).get(version),
+            "artifact": {
+                "tarball": dist.get("tarball"),
+                "shasum": dist.get("shasum"),
+                "integrity": dist.get("integrity"),
+            },
+            "platforms": ["node", "wasm-scalar", "wasm-slim"],
+        }
+
+    if registry == "pypi":
+        encoded = urllib.parse.quote(package, safe="")
+        data = request_json_with_retries(
+            f"https://pypi.org/pypi/{encoded}/{version}/json", attempts, delay_seconds
+        )
+        files = data.get("urls", [])
+        if not files:
+            raise VerificationError(f"PyPI has no files for {package} {version}")
+        return {
+            "registry": registry,
+            "package": package,
+            "version": version,
+            "status": "available",
+            "published_at": min(file.get("upload_time_iso", file.get("upload_time")) for file in files),
+            "artifact": {
+                "files": [
+                    {
+                        "filename": file.get("filename"),
+                        "packagetype": file.get("packagetype"),
+                        "python_version": file.get("python_version"),
+                        "digests": file.get("digests", {}),
+                    }
+                    for file in files
+                ]
+            },
+            "platforms": sorted({file.get("filename", "").split("-")[-1] for file in files}),
+        }
+
+    raise VerificationError(f"unsupported registry {registry}")
+
+
+def verify_registries(version: str, attempts: int, delay_seconds: float) -> list[dict]:
+    records: list[dict] = []
+    for package in CRATE_PACKAGES:
+        try:
+            records.append(registry_record("crates.io", package, version, attempts, delay_seconds))
+        except VerificationError as error:
+            records.append(
+                {"registry": "crates.io", "package": package, "version": version, "status": "missing", "error": str(error)}
+            )
+    for registry, package in (("npm", "geo-polygonize"), ("pypi", "geo-polygonize-py")):
+        try:
+            records.append(registry_record(registry, package, version, attempts, delay_seconds))
+        except VerificationError as error:
+            records.append(
+                {"registry": registry, "package": package, "version": version, "status": "missing", "error": str(error)}
+            )
+    return records
+
+
+def github_runs(repository: str, token: str, tag: str) -> list[dict]:
+    data = request_json(
+        f"https://api.github.com/repos/{repository}/actions/runs?event=push&per_page=100", token
+    )
+    runs = []
+    for run_info in data.get("workflow_runs", []):
+        if run_info.get("head_branch") != tag:
+            continue
+        workflow_name = run_info.get("name")
+        if workflow_name not in PUBLISH_WORKFLOWS.values():
+            continue
+        runs.append(
+            {
+                "workflow": workflow_name,
+                "run_id": run_info.get("id"),
+                "status": run_info.get("status"),
+                "conclusion": run_info.get("conclusion"),
+                "head_sha": run_info.get("head_sha"),
+                "created_at": run_info.get("created_at"),
+                "updated_at": run_info.get("updated_at"),
+                "url": run_info.get("html_url"),
+            }
+        )
+    return sorted(runs, key=lambda value: (value["workflow"], value["created_at"] or ""))
+
+
+def smoke_rust(version: str) -> dict:
+    with tempfile.TemporaryDirectory(prefix="geo-polygonize-release-rust-") as directory:
+        root = Path(directory)
+        (root / "src").mkdir()
+        (root / "Cargo.toml").write_text(
+            f'''[package]\nname = "registry-smoke"\nversion = "0.0.0"\nedition = "2021"\n\n[dependencies]\ngeo-polygonize-core = "={version}"\n'''
+        )
+        (root / "src/main.rs").write_text(
+            '''use geo_polygonize_core::{normalize_polygonize_error, polygonize, Coord3D, Line3D, PolygonizerOptions};
+
+fn line(start: (f64, f64), end: (f64, f64), id: u32) -> Line3D {
+    Line3D::new(Coord3D::new(start.0, start.1, 0.0), Coord3D::new(end.0, end.1, 0.0), id)
+}
+
+fn main() {
+    let square = [
+        line((0.0, 0.0), (1.0, 0.0), 1),
+        line((1.0, 0.0), (1.0, 1.0), 2),
+        line((1.0, 1.0), (0.0, 1.0), 3),
+        line((0.0, 1.0), (0.0, 0.0), 4),
+    ];
+    let result = polygonize(square, &PolygonizerOptions::default()).expect("canonical square");
+    assert_eq!(result.polygons.len(), 1);
+
+    let invalid = PolygonizerOptions { pre_snap_tolerance: 1.0, ..Default::default() };
+    let error = polygonize([line((0.0, 0.0), (1.0, 0.0), 1)], &invalid).expect_err("invalid options");
+    let normalized = normalize_polygonize_error(&error);
+    assert_eq!(normalized.family, "invalid_argument");
+    assert_eq!(normalized.code, "unsupported_option_combination");
+    println!("version={}", env!("CARGO_PKG_VERSION"));
+    println!("polygons={}", result.polygons.len());
+    println!("error={}", normalized.code);
+}
+'''
+        )
+        cargo_home = root / "cargo-home"
+        env = os.environ.copy()
+        env["CARGO_HOME"] = str(cargo_home)
+        env.pop("RUSTFLAGS", None)
+        # The temporary consumer has no lockfile on its first invocation. The
+        # first check resolves the exact dependency, after which every command
+        # is locked and the metadata check rejects path/workspace resolution.
+        run(["cargo", "check"], root, env)
+        metadata = json.loads(run_stdout(["cargo", "metadata", "--format-version", "1", "--locked"], root, env))
+        packages = [
+            package
+            for package in metadata["packages"]
+            if package["name"] == "geo-polygonize-core" and package["version"] == version
+        ]
+        if len(packages) != 1 or not packages[0].get("source", "").startswith("registry+"):
+            raise VerificationError("Rust smoke dependency did not resolve to the public registry")
+        output = run(["cargo", "run", "--locked", "--quiet"], root, env)
+        if "polygons=1" not in output or "error=unsupported_option_combination" not in output:
+            raise VerificationError(f"Rust smoke output did not contain the canonical contract: {output[-1000:]}")
+    return {"status": "passed", "package": "geo-polygonize-core", "version": version, "platform": "native-registry-consumer"}
+
+
+def smoke_npm(version: str) -> dict:
+    with tempfile.TemporaryDirectory(prefix="geo-polygonize-release-npm-") as directory:
+        root = Path(directory)
+        run(["npm", "init", "-y"], root)
+        run(
+            [
+                "npm",
+                "install",
+                "--ignore-scripts",
+                "--no-package-lock",
+                "--no-save",
+                "--no-audit",
+                "--no-fund",
+                f"geo-polygonize@{version}",
+            ],
+            root,
+        )
+        (root / "smoke.mjs").write_text(
+            '''import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import * as standard from "geo-polygonize";
+import * as slim from "geo-polygonize/slim";
+
+const square = JSON.stringify({ type: "LineString", coordinates: [[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]] });
+const invalidOptions = { node_input: false, pre_snap_tolerance: 1 };
+const packageJson = JSON.parse(await readFile(join(process.cwd(), "node_modules/geo-polygonize/package.json"), "utf8"));
+if (packageJson.version !== process.env.EXPECTED_VERSION) throw new Error(`package version ${packageJson.version}`);
+
+async function check(name, module) {
+  const report = JSON.parse(module.polygonizeReportWithOptions(square, {}));
+  if (report.schema_version !== 1 || report.polygons.length !== 1) throw new Error(`${name} canonical result failed`);
+  try {
+    module.polygonizeReportWithOptions(square, invalidOptions);
+    throw new Error(`${name} accepted invalid options`);
+  } catch (error) {
+    if (error.normalized?.family !== "invalid_argument" || error.normalized?.code !== "unsupported_option_combination") throw error;
+  }
+}
+
+await standard.default();
+await check("standard", standard);
+const wasm = await readFile(join(process.cwd(), "node_modules/geo-polygonize/dist/geo_polygonize.wasm"));
+const slimExports = await slim.initBest({ module: wasm });
+await check("slim", slimExports);
+console.log(`version=${packageJson.version}`);
+console.log("standard=passed");
+console.log("slim=passed");
+'''
+        )
+        env = os.environ.copy()
+        env["EXPECTED_VERSION"] = version
+        run(["node", "smoke.mjs"], root, env)
+    return {"status": "passed", "package": "geo-polygonize", "version": version, "platform": "node-standard-slim-wasm"}
+
+
+def smoke_python(version: str) -> dict:
+    with tempfile.TemporaryDirectory(prefix="geo-polygonize-release-python-") as directory:
+        root = Path(directory)
+        venv = root / "venv"
+        run([sys.executable, "-m", "venv", str(venv)], root)
+        python = venv / "bin/python"
+        run(
+            [
+                str(python),
+                "-m",
+                "pip",
+                "install",
+                "--disable-pip-version-check",
+                "--no-cache-dir",
+                "--only-binary=:all:",
+                f"geo-polygonize-py=={version}",
+            ],
+            root,
+        )
+        (root / "smoke.py").write_text(
+            '''import importlib.metadata
+import json
+import numpy as np
+import geo_polygonize
+
+version = importlib.metadata.version("geo-polygonize-py")
+assert version == __import__("os").environ["EXPECTED_VERSION"], version
+coords = np.asarray([0, 0, 1, 0, 1, 1, 0, 1, 0, 0], dtype=np.float64)
+offsets = np.asarray([0], dtype=np.uint32)
+result = geo_polygonize.polygonize_with_options(coords=coords, offsets=offsets, options={})
+assert len(result["polygons"]) == 1
+try:
+    geo_polygonize.polygonize_with_options(
+        coords=coords,
+        offsets=offsets,
+        options={"node_input": False, "pre_snap_tolerance": 1.0},
+    )
+    raise AssertionError("invalid options were accepted")
+except Exception as error:
+    normalized = json.loads(error.normalized)
+    assert normalized["family"] == "invalid_argument", normalized
+    assert normalized["code"] == "unsupported_option_combination", normalized
+print(f"version={version}")
+print("polygons=1")
+print("error=unsupported_option_combination")
+'''
+        )
+        env = os.environ.copy()
+        env["EXPECTED_VERSION"] = version
+        env.pop("PYTHONPATH", None)
+        run([str(python), "smoke.py"], root, env)
+    return {"status": "passed", "package": "geo-polygonize-py", "version": version, "platform": "cp-abi3-registry-wheel"}
+
+
+def smoke_registry_installs(version: str) -> dict:
+    results = {}
+    for name, function in (("rust", smoke_rust), ("npm", smoke_npm), ("python", smoke_python)):
+        try:
+            results[name] = function(version)
+        except (OSError, VerificationError, subprocess.SubprocessError) as error:
+            results[name] = {"status": "failed", "error": str(error)}
+    return results
+
+
+def report_complete(report: dict) -> bool:
+    registries = report.get("registries", [])
+    expected = len(CRATE_PACKAGES) + 2
+    return (
+        len(registries) == expected
+        and all(record.get("status") == "available" for record in registries)
+        and all(record.get("conclusion") == "success" for record in report.get("workflows", []))
+        and len(report.get("workflows", [])) == len(PUBLISH_WORKFLOWS)
+        and all(result.get("status") == "passed" for result in report.get("smoke", {}).values())
+    )
+
+
+def release_report(
+    version: str,
+    tag: str,
+    repository: str,
+    token: str,
+    attempts: int,
+    delay_seconds: float,
+) -> dict:
+    report = {
+        "schema_version": REPORT_SCHEMA_VERSION,
+        "release_version": version,
+        "tag": tag,
+        "verified_at": utc_now(),
+        "repository": repository,
+        "registries": verify_registries(version, attempts, delay_seconds),
+        "workflows": github_runs(repository, token, tag),
+        "smoke": smoke_registry_installs(version),
+        "complete": False,
+    }
+    report["complete"] = report_complete(report)
+    return report
+
+
+def github_release(repository: str, token: str, tag: str) -> dict:
+    encoded = urllib.parse.quote(tag, safe="")
+    return request_json(f"https://api.github.com/repos/{repository}/releases/tags/{encoded}", token)
+
+
+def semver_key(tag: str) -> tuple[int, int, int, str] | None:
+    match = VERSION_RE.fullmatch(tag)
+    if not match:
+        return None
+    version = match.group(1).split("+", 1)[0]
+    core, _, prerelease = version.partition("-")
+    major, minor, patch = (int(part) for part in core.split("."))
+    return major, minor, patch, prerelease
+
+
+def latest_release_tag(repository: str, token: str) -> str:
+    tags = request_json(f"https://api.github.com/repos/{repository}/tags?per_page=100", token)
+    candidates = [tag["name"] for tag in tags if semver_key(tag["name"]) is not None]
+    if not candidates:
+        raise VerificationError(f"no geo-polygonize release tags found in {repository}")
+    return max(candidates, key=lambda tag: semver_key(tag))
+
+
+def check_previous_report(repository: str, token: str, root: Path) -> None:
+    tag = latest_release_tag(repository, token)
+    version = version_from_tag(tag)
+    report: dict | None = None
+    try:
+        release = github_release(repository, token, tag)
+        asset = next((asset for asset in release.get("assets", []) if asset.get("name") == "publication-report.json"), None)
+        if asset:
+            report = request_json(asset["browser_download_url"], token)
+    except VerificationError:
+        report = None
+    if report is None:
+        path = root / "release" / "reports" / f"{tag}.json"
+        if path.is_file():
+            report = json.loads(path.read_text())
+    if not report or report.get("release_version") != version or report.get("tag") != tag or not report.get("complete"):
+        raise VerificationError(
+            f"previous release {tag} has no complete publication report; repair/verify it before publishing another version"
+        )
+    print(f"previous release gate passed: {tag}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--version")
+    parser.add_argument("--tag")
+    parser.add_argument("--repository", default=os.environ.get("GITHUB_REPOSITORY", REPOSITORY))
+    parser.add_argument("--github-token", default=os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN"))
+    parser.add_argument("--report", type=Path)
+    parser.add_argument("--attempts", type=int, default=6)
+    parser.add_argument("--delay-seconds", type=float, default=30.0)
+    parser.add_argument("--check-previous", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        if args.check_previous:
+            if not args.github_token:
+                raise VerificationError("--check-previous requires --github-token or GH_TOKEN")
+            check_previous_report(args.repository, args.github_token, Path.cwd())
+            return 0
+        if args.attempts < 1 or args.delay_seconds < 0:
+            raise VerificationError("attempts must be positive and delay-seconds must be non-negative")
+        version = args.version or (version_from_tag(args.tag) if args.tag else None)
+        if not version:
+            raise VerificationError("provide --version or --tag")
+        tag = args.tag or tag_for_version(version)
+        if version_from_tag(tag) != version:
+            raise VerificationError(f"version {version} does not match tag {tag}")
+        if not args.github_token:
+            raise VerificationError("release verification requires --github-token or GH_TOKEN")
+        report = release_report(version, tag, args.repository, args.github_token, args.attempts, args.delay_seconds)
+        if args.report:
+            args.report.parent.mkdir(parents=True, exist_ok=True)
+            args.report.write_text(json.dumps(report, indent=2) + "\n")
+        print(json.dumps(report, indent=2))
+        return 0 if report["complete"] else 1
+    except (VerificationError, OSError, ValueError, json.JSONDecodeError) as error:
+        if args.report:
+            failure = {
+                "schema_version": REPORT_SCHEMA_VERSION,
+                "release_version": args.version,
+                "tag": args.tag,
+                "verified_at": utc_now(),
+                "repository": args.repository,
+                "complete": False,
+                "error": str(error),
+            }
+            args.report.parent.mkdir(parents=True, exist_ok=True)
+            args.report.write_text(json.dumps(failure, indent=2) + "\n")
+        print(f"release verification failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_release_verifier.py
+++ b/tests/test_release_verifier.py
@@ -1,0 +1,99 @@
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "verify_release", ROOT / "scripts/verify_release.py"
+)
+VERIFY = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(VERIFY)
+
+
+def test_release_report_is_complete_and_versioned():
+    report = json.loads(
+        (ROOT / "release/reports/geo-polygonize-v1.0.0.json").read_text()
+    )
+    assert report["schema_version"] == 1
+    assert report["complete"] is True
+    assert VERIFY.report_complete(report)
+
+    report["smoke"]["npm"]["status"] = "failed"
+    assert not VERIFY.report_complete(report)
+
+
+@pytest.mark.parametrize(
+    ("tag", "version"),
+    [
+        ("geo-polygonize-v1.0.0", "1.0.0"),
+        ("v2.3.4", "2.3.4"),
+        ("geo-polygonize-v1.2.3-rc.1", "1.2.3-rc.1"),
+    ],
+)
+def test_release_tag_parsing(tag, version):
+    assert VERIFY.version_from_tag(tag) == version
+
+
+def test_release_tag_parsing_rejects_non_release_tag():
+    with pytest.raises(VERIFY.VerificationError):
+        VERIFY.version_from_tag("main")
+
+
+def test_registry_records_capture_public_artifact_metadata(monkeypatch):
+    payloads = {
+        "crates.io": {
+            "version": {
+                "num": "1.0.0",
+                "yanked": False,
+                "created_at": "2026-08-03T20:36:46Z",
+                "dl_path": "/api/v1/crates/example/1.0.0/download",
+                "checksum": "a" * 64,
+                "crate_size": 12,
+            }
+        },
+        "npm": {
+            "time": {"1.0.0": "2026-08-03T20:45:56Z"},
+            "versions": {
+                "1.0.0": {
+                    "dist": {
+                        "tarball": "https://registry.npmjs.org/example.tgz",
+                        "shasum": "b" * 40,
+                    }
+                }
+            },
+        },
+        "pypi": {
+            "urls": [
+                {
+                    "filename": "example-1.0.0-py3-none-any.whl",
+                    "packagetype": "bdist_wheel",
+                    "python_version": "py3",
+                    "upload_time_iso": "2026-08-03T20:39:23Z",
+                    "digests": {"sha256": "c" * 64},
+                }
+            ]
+        },
+    }
+
+    def fake_request(url, attempts, delay):
+        if "crates.io" in url:
+            return payloads["crates.io"]
+        if "npmjs.org" in url:
+            return payloads["npm"]
+        return payloads["pypi"]
+
+    monkeypatch.setattr(VERIFY, "request_json_with_retries", fake_request)
+    assert VERIFY.registry_record("crates.io", "example", "1.0.0", 1, 0)["status"] == "available"
+    assert VERIFY.registry_record("npm", "example", "1.0.0", 1, 0)["artifact"]["shasum"] == "b" * 40
+    assert VERIFY.registry_record("pypi", "example", "1.0.0", 1, 0)["artifact"]["files"][0]["filename"].endswith(".whl")
+
+
+def test_report_requires_all_publish_workflows():
+    report = json.loads(
+        (ROOT / "release/reports/geo-polygonize-v1.0.0.json").read_text()
+    )
+    report["workflows"] = report["workflows"][:2]
+    assert not VERIFY.report_complete(report)


### PR DESCRIPTION
## Stack
Parent: none (`origin/main` `8453b43`)
Children: #1294 (`agent/p0-post1-support`)

## Delivered
- Audited the actual 1.0.0 crates.io, npm, and PyPI publication records and recorded checksums, timestamps, artifacts, and supported platforms.
- Added a bounded cross-registry verifier with exact Rust, npm standard/slim Wasm, and Python abi3 smoke calls.
- Added a versioned publication-report schema and checked-in historical 1.0.0 evidence.
- Added a tag/manual verification workflow, release-please pre-publication gate, and release-report repair instructions.

## Contract impact
Future releases are blocked before release-please publication when the previous release lacks complete cross-registry evidence. Tag verification fails closed on missing or mismatched artifacts. Existing 1.0.0 behavior is documented; no runtime API changed.

## Validation
- Live 1.0.0 registry and GitHub Actions audit completed.
- `python3 scripts/verify_release.py --check-previous ...` passed using the checked-in historical fallback because the existing GitHub release has no attached report asset.
- `pytest -q tests/test_release_verifier.py` (7 passed).
- Report schema, workflow YAML, and `git diff --check` passed.

## Agent handoff
Parent: none
Children: #1294 (`agent/p0-post1-support`)
Next: child #1294 closes #1286; #1290 remains an independent root from `origin/main`.