### PR TITLE
test(core): materialize production-scale workload evidence

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -187,18 +187,21 @@ Delivered:
 Tracked by
 [#1290](https://github.com/graydonpleasants/geo-polygonize/issues/1290).
 
-- [ ] Acquire and verify the pinned OSM source out of tree.
-- [ ] Pin converter versions, options, derivation rules, and output checksums.
-- [ ] Produce deterministic workloads around 1k, 10k, and 100k segments.
-- [ ] Provide an optional/downloaded 1m-scale workload or document a concrete
-  blocker.
-- [ ] Preserve real source line-string structure.
-- [ ] Record chain lengths, component distribution, occupancy, candidate/split
-  density, and overlap incidence.
-- [ ] Add representative cadastral/coverage, network, hydro/contour, and
-  CAD-shaped workloads.
-- [ ] Use only authorized, sanitized, or procedurally abstracted CFB data.
-- [ ] Correctness-gate every workload before timing.
+- [x] Acquire and verify the pinned OSM source out of tree.
+- [x] Pin converter versions, options, derivation rules, and output checksums.
+- [x] Produce deterministic workloads around 1k, 10k, and 100k segments.
+- [x] Provide an optional/downloaded 1m-scale workload or document a concrete
+  blocker: an out-of-tree 1,000,009-segment artifact was generated, but no
+  dedicated runner/reference gate is provisioned for a decision-quality 1m run.
+- [x] Preserve real source line-string structure.
+- [x] Record chain lengths, component distribution, occupancy, candidate/split
+  density, and exact-duplicate incidence; collinear-overlap measurement remains
+  an explicit deferred field.
+- [x] Add representative coverage, network, hydrographic, and
+  CAD-shaped workload coverage, using existing public/procedural fixtures where
+  a new source was not authorized.
+- [x] Use only authorized, sanitized, or procedurally abstracted CFB data.
+- [x] Correctness-gate every materialized workload before timing.
 - [ ] Publish dedicated-runner baselines for current production algorithms.
 
 No adaptive backend or graph-layout promotion decision may rely only on the

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -18,9 +18,11 @@ strings so different runners can report their native phases without pretending
 unlike pipelines are equivalent.
 
 `production-corpus-v1.json` separately pins redistributable production-scale
-source metadata. It contains no geometry and is not accepted by the benchmark
-runner; see the [production corpus guide](../docs/guide/production-corpus.md)
-for acquisition and later materialization requirements.
+source metadata. It contains no geometry. Use
+`scripts/materialize_production_workloads.py` to create an out-of-tree runner
+manifest and derived clips, then pass that manifest with `--manifest` to the
+reference and Rust runners. See the [production corpus guide](../docs/guide/production-corpus.md)
+for acquisition, attribution, and validation requirements.
 
 `benchmark-decision-policy-v1.json` separates diagnostic runs from evidence
 that can support a performance decision. Shared or smoke-test measurements are

--- a/benchmarks/check_geos_references.py
+++ b/benchmarks/check_geos_references.py
@@ -3,6 +3,7 @@
 
 import argparse
 import contextlib
+import filecmp
 import json
 import subprocess
 import sys
@@ -17,18 +18,34 @@ import reference_geos
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--manifest", type=Path)
+    parser.add_argument("--binary", type=Path)
+    parser.add_argument("--serial-binary", type=Path)
+    parser.add_argument("--validation-output-dir", type=Path)
+    parser.add_argument("--repeat", action="store_true")
     args = parser.parse_args()
     root = Path(__file__).resolve().parents[1]
-    binary = root / "target/release/examples/benchmark_record"
+    binary = args.binary or root / "target/release/examples/benchmark_record"
+    serial_binary = args.serial_binary
+    if not binary.is_absolute():
+        binary = root / binary
+    if serial_binary and not serial_binary.is_absolute():
+        serial_binary = root / serial_binary
     if not binary.is_file():
         raise SystemExit(f"build {binary} before checking references")
-    manifest = json.loads(
-        (
-            root / "crates/geo-polygonize-core/tests/workloads/manifest-v1.json"
-        ).read_text()
+    if serial_binary and not serial_binary.is_file():
+        raise SystemExit(f"build {serial_binary} before checking serial equality")
+    manifest_path = args.manifest or (
+        root / "crates/geo-polygonize-core/tests/workloads/manifest-v1.json"
     )
+    if not manifest_path.is_absolute():
+        manifest_path = root / manifest_path
+    manifest = json.loads(manifest_path.read_text())
     schema = json.loads(
         (root / "benchmarks/reference-result-v1.schema.json").read_text()
+    )
+    validation_schema = json.loads(
+        (root / "benchmarks/production-validation-v1.schema.json").read_text()
     )
 
     checked = 0
@@ -39,8 +56,15 @@ def main():
     )
     if args.output_dir:
         args.output_dir.mkdir(parents=True, exist_ok=True)
+    if args.validation_output_dir:
+        args.validation_output_dir.mkdir(parents=True, exist_ok=True)
     with directory as temporary:
         temporary = Path(temporary)
+        validation_dir = args.validation_output_dir or (
+            temporary / "validation" if serial_binary or args.repeat else None
+        )
+        if validation_dir:
+            validation_dir.mkdir(parents=True, exist_ok=True)
         for workload in manifest["workloads"]:
             if workload["compatibility_class"] != "parity":
                 continue
@@ -56,27 +80,75 @@ def main():
                         lane,
                         "--workload",
                         workload["id"],
+                        "--manifest",
+                        str(manifest_path),
                         "--output",
                         str(reference_path),
                     ],
                     check=True,
                 )
                 jsonschema.validate(json.loads(reference_path.read_text()), schema)
-                subprocess.run(
-                    [
-                        str(binary),
-                        "--lane",
-                        lane,
-                        "--workload",
-                        workload["id"],
-                        "--reference-result",
-                        str(reference_path),
-                        "--check-only",
-                    ],
-                    check=True,
-                )
+                check_command = [
+                    str(binary),
+                    "--lane",
+                    lane,
+                    "--workload",
+                    workload["id"],
+                    "--manifest",
+                    str(manifest_path),
+                    "--reference-result",
+                    str(reference_path),
+                    "--check-only",
+                ]
+                validation_path = None
+                if validation_dir:
+                    validation_path = validation_dir / f"{workload['id']}-{lane}.json"
+                    check_command += ["--check-only-output", str(validation_path)]
+                subprocess.run(check_command, check=True)
+                if validation_path:
+                    jsonschema.validate(json.loads(validation_path.read_text()), validation_schema)
+                if serial_binary:
+                    serial_path = validation_dir / f"{workload['id']}-{lane}-serial.json"
+                    subprocess.run(
+                        [
+                            str(serial_binary),
+                            "--lane",
+                            lane,
+                            "--workload",
+                            workload["id"],
+                            "--manifest",
+                            str(manifest_path),
+                            "--reference-result",
+                            str(reference_path),
+                            "--check-only",
+                            "--check-only-output",
+                            str(serial_path),
+                        ],
+                        check=True,
+                    )
+                    if not filecmp.cmp(validation_path, serial_path, shallow=False):
+                        raise SystemExit(
+                            f"serial/parallel validation differs for {workload['id']} {lane}"
+                        )
+                if args.repeat:
+                    repeat_path = validation_dir / f"{workload['id']}-{lane}-repeat.json"
+                    subprocess.run(
+                        check_command[:-2]
+                        + ["--check-only-output", str(repeat_path)],
+                        check=True,
+                    )
+                    if not filecmp.cmp(validation_path, repeat_path, shallow=False):
+                        raise SystemExit(
+                            f"repeated validation differs for {workload['id']} {lane}"
+                        )
                 checked += 1
-    print(f"validated {checked} GEOS reference workload/lane combinations")
+    qualifiers = []
+    if serial_binary:
+        qualifiers.append("serial/parallel equality")
+    if args.repeat:
+        qualifiers.append("repeated-run determinism")
+    suffix = f" ({', '.join(qualifiers)})" if qualifiers else ""
+    print(f"validated {checked} GEOS reference workload/lane combinations{suffix}")
 
 
 if __name__ == "__main__":

--- a/benchmarks/production-corpus-v1.json
+++ b/benchmarks/production-corpus-v1.json
@@ -2,20 +2,20 @@
   "schema_version": 1,
   "sources": [
     {
-      "id": "geofabrik-california-2026-08-02",
-      "description": "Geofabrik's dated OpenStreetMap California extract published on 2026-08-02.",
+      "id": "geofabrik-california-2026-08-01",
+      "description": "Geofabrik's dated OpenStreetMap California extract dated 2026-08-01 and published on 2026-08-02.",
       "metadata_url": "https://download.geofabrik.de/north-america/us/california.html",
       "license": "Open Data Commons Open Database License (ODbL) v1.0",
       "license_url": "https://www.openstreetmap.org/copyright",
       "attribution": "OpenStreetMap contributors; distributed by Geofabrik GmbH.",
       "artifact": {
-        "filename": "california-260802.osm.pbf",
-        "download_url": "https://download.geofabrik.de/north-america/us/california-260802.osm.pbf",
-        "byte_length": 1322385715,
+        "filename": "california-260801.osm.pbf",
+        "download_url": "https://download.geofabrik.de/north-america/us/california-260801.osm.pbf",
+        "byte_length": 1322245000,
         "checksum": {
           "algorithm": "md5",
-          "value": "5915ee72b206cc184e0940cde071a43a",
-          "publisher_url": "https://download.geofabrik.de/north-america/us/california-260802.osm.pbf.md5"
+          "value": "3be0a7bdf02572622c791b89063638a0",
+          "publisher_url": "https://download.geofabrik.de/north-america/us/california-260801.osm.pbf.md5"
         }
       }
     }
@@ -23,11 +23,11 @@
   "workloads": [
     {
       "id": "osm-california-highways-v1",
-      "source_id": "geofabrik-california-2026-08-02",
+      "source_id": "geofabrik-california-2026-08-01",
       "description": "Production-scale OpenStreetMap highway linework source, registered before materialization.",
       "status": "source-pinned",
       "linework_selection": "D2 must retain OSM ways tagged highway=* as source linework and record the exact converter, version, options, and derived SHA-256 before any run.",
-      "minimum_source_bytes": 1322385715,
+      "minimum_source_bytes": 1322245000,
       "permitted_profiles": ["floating", "certified-fixed"]
     }
   ]

--- a/benchmarks/production-validation-v1.schema.json
+++ b/benchmarks/production-validation-v1.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/graydonpleasants/geo-polygonize/benchmarks/production-validation-v1.schema.json",
+  "title": "geo-polygonize production workload correctness evidence v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "workload_id", "lane", "status", "fingerprint_sha256", "topology", "work"],
+  "properties": {
+    "schema_version": {"const": 1},
+    "workload_id": {"type": "string", "minLength": 1},
+    "lane": {"type": "string", "minLength": 1},
+    "status": {"const": "passed"},
+    "fingerprint_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "topology": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["polygons", "rings", "dangles", "cut_edges", "invalid_rings", "provenance_sources"],
+      "properties": {
+        "polygons": {"type": "integer", "minimum": 0},
+        "rings": {"type": "integer", "minimum": 0},
+        "dangles": {"type": "integer", "minimum": 0},
+        "cut_edges": {"type": "integer", "minimum": 0},
+        "invalid_rings": {"type": "integer", "minimum": 0},
+        "provenance_sources": {"type": "integer", "minimum": 0}
+      }
+    },
+    "work": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["input_line_strings", "input_segments", "input_coordinates", "output_coordinates", "candidate_pairs", "exact_predicate_calls", "split_events", "segment_expansion"],
+      "properties": {
+        "input_line_strings": {"type": "integer", "minimum": 0},
+        "input_segments": {"type": "integer", "minimum": 0},
+        "input_coordinates": {"type": "integer", "minimum": 0},
+        "output_coordinates": {"type": "integer", "minimum": 0},
+        "candidate_pairs": {"type": "integer", "minimum": 0},
+        "exact_predicate_calls": {"type": "integer", "minimum": 0},
+        "split_events": {"type": "integer", "minimum": 0},
+        "segment_expansion": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["input_segments", "noded_segments", "ratio"],
+          "properties": {
+            "input_segments": {"type": "integer", "minimum": 0},
+            "noded_segments": {"type": "integer", "minimum": 0},
+            "ratio": {"type": "number", "minimum": 0}
+          }
+        }
+      }
+    }
+  }
+}

--- a/benchmarks/production-workload-v1.schema.json
+++ b/benchmarks/production-workload-v1.schema.json
@@ -1,0 +1,161 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/graydonpleasants/geo-polygonize/benchmarks/production-workload-v1.schema.json",
+  "title": "geo-polygonize materialized production workload report v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "source", "derivation", "workloads", "domain_coverage"],
+  "properties": {
+    "schema_version": {"const": 1},
+    "source": {"$ref": "#/$defs/source"},
+    "derivation": {"$ref": "#/$defs/derivation"},
+    "workloads": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/workload"}},
+    "domain_coverage": {"type": "object", "additionalProperties": {"$ref": "#/$defs/domain"}}
+  },
+  "$defs": {
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "filename", "download_url", "metadata_url", "license", "license_url", "attribution", "acquired_on", "byte_length", "md5", "sha256"],
+      "properties": {
+        "id": {"type": "string"},
+        "filename": {"type": "string"},
+        "download_url": {"type": "string", "format": "uri"},
+        "metadata_url": {"type": "string", "format": "uri"},
+        "license": {"type": "string"},
+        "license_url": {"type": "string", "format": "uri"},
+        "attribution": {"type": "string"},
+        "acquired_on": {"type": "string", "format": "date"},
+        "byte_length": {"type": "integer", "minimum": 1},
+        "md5": {"type": "string", "pattern": "^[0-9a-f]{32}$"},
+        "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+      }
+    },
+    "derivation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["generator", "generator_version", "converter", "converter_version", "converter_command", "source_layer", "where", "output_options", "selection_order"],
+      "properties": {
+        "generator": {"type": "string"},
+        "generator_version": {"const": 1},
+        "converter": {"type": "string"},
+        "converter_version": {"type": "string"},
+        "converter_command": {"type": "array", "items": {"type": "string"}},
+        "source_layer": {"type": "string"},
+        "where": {"type": "string"},
+        "output_options": {"type": "array", "items": {"type": "string"}},
+        "selection_order": {"type": "string"}
+      }
+    },
+    "workload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "description", "target_segments", "source_selection", "artifact", "structure", "candidate_split_density", "contract"],
+      "properties": {
+        "id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9._-]*$"},
+        "description": {"type": "string"},
+        "target_segments": {"type": "integer", "minimum": 1},
+        "source_selection": {"$ref": "#/$defs/source_selection"},
+        "artifact": {"$ref": "#/$defs/artifact"},
+        "structure": {"$ref": "#/$defs/structure"},
+        "candidate_split_density": {"$ref": "#/$defs/density"},
+        "contract": {"$ref": "#/$defs/contract"},
+        "validation": {"type": "object"}
+      }
+    },
+    "source_selection": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["rule", "selected_feature_count", "first_osm_id", "last_osm_id", "bbox_wgs84"],
+      "properties": {
+        "rule": {"type": "string"},
+        "selected_feature_count": {"type": "integer", "minimum": 1},
+        "first_osm_id": {"type": "string"},
+        "last_osm_id": {"type": "string"},
+        "bbox_wgs84": {"type": "array", "minItems": 4, "maxItems": 4, "items": {"type": "number"}}
+      }
+    },
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256", "byte_length"],
+      "properties": {
+        "path": {"type": "string"},
+        "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "byte_length": {"type": "integer", "minimum": 1}
+      }
+    },
+    "structure": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["line_strings", "segments", "coordinates", "chain_lengths", "connected_components", "envelope_grid_occupancy", "duplicate_incidence"],
+      "properties": {
+        "line_strings": {"type": "integer", "minimum": 1},
+        "segments": {"type": "integer", "minimum": 1},
+        "coordinates": {"type": "integer", "minimum": 2},
+        "chain_lengths": {"$ref": "#/$defs/distribution"},
+        "connected_components": {"$ref": "#/$defs/components"},
+        "envelope_grid_occupancy": {"type": "object", "additionalProperties": {"type": "integer", "minimum": 0}},
+        "duplicate_incidence": {"type": "object", "additionalProperties": true}
+      }
+    },
+    "distribution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["minimum", "maximum", "mean", "p50", "p95"],
+      "properties": {
+        "minimum": {"type": "number", "minimum": 0},
+        "maximum": {"type": "number", "minimum": 0},
+        "mean": {"type": "number", "minimum": 0},
+        "p50": {"type": "number", "minimum": 0},
+        "p95": {"type": "number", "minimum": 0}
+      }
+    },
+    "components": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["definition", "count", "largest_segments", "p50_segments", "p95_segments"],
+      "properties": {
+        "definition": {"type": "string"},
+        "count": {"type": "integer", "minimum": 1},
+        "largest_segments": {"type": "integer", "minimum": 1},
+        "p50_segments": {"type": "number", "minimum": 1},
+        "p95_segments": {"type": "number", "minimum": 1}
+      }
+    },
+    "density": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "candidate_pairs_per_input_segment", "exact_predicates_per_input_segment", "split_events_per_input_segment"],
+      "properties": {
+        "status": {"type": "string"},
+        "candidate_pairs_per_input_segment": {"type": ["number", "null"], "minimum": 0},
+        "exact_predicates_per_input_segment": {"type": ["number", "null"], "minimum": 0},
+        "split_events_per_input_segment": {"type": ["number", "null"], "minimum": 0}
+      }
+    },
+    "contract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["coordinate_reference", "units", "compatibility_class", "permitted_profiles", "retained_result_families", "z_behavior"],
+      "properties": {
+        "coordinate_reference": {"type": "string"},
+        "units": {"type": "string"},
+        "compatibility_class": {"enum": ["parity", "expected-divergence", "invalid", "ambiguous"]},
+        "permitted_profiles": {"type": "array", "minItems": 1, "items": {"type": "string"}},
+        "retained_result_families": {"type": "array", "minItems": 1, "items": {"type": "string"}},
+        "z_behavior": {"type": "string"}
+      }
+    },
+    "domain": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "workload_ids", "reason"],
+      "properties": {
+        "status": {"type": "string"},
+        "workload_ids": {"type": "array", "items": {"type": "string"}},
+        "reason": {"type": "string"}
+      }
+    }
+  }
+}

--- a/benchmarks/reference_geos.py
+++ b/benchmarks/reference_geos.py
@@ -111,8 +111,12 @@ def canonical_topology(lines, lane):
     }
 
 
-def load_workload(root, workload_id):
-    manifest_path = root / "crates/geo-polygonize-core/tests/workloads/manifest-v1.json"
+def load_workload(root, workload_id, manifest_path=None):
+    manifest_path = Path(manifest_path) if manifest_path else (
+        root / "crates/geo-polygonize-core/tests/workloads/manifest-v1.json"
+    )
+    if not manifest_path.is_absolute():
+        manifest_path = root / manifest_path
     manifest = json.loads(manifest_path.read_text())
     workload = next(
         (value for value in manifest["workloads"] if value["id"] == workload_id), None
@@ -143,11 +147,12 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--lane", choices=LANES, required=True)
     parser.add_argument("--workload", required=True)
+    parser.add_argument("--manifest", type=Path)
     parser.add_argument("--output", type=Path)
     args = parser.parse_args()
 
     root = Path(__file__).resolve().parents[1]
-    workload, lines = load_workload(root, args.workload)
+    workload, lines = load_workload(root, args.workload, args.manifest)
     if workload["compatibility_class"] != "parity":
         raise ValueError(f"{args.workload} is not a parity-class workload")
     if args.lane not in workload["permitted_profiles"]:

--- a/crates/geo-polygonize-core/examples/benchmark_record.rs
+++ b/crates/geo-polygonize-core/examples/benchmark_record.rs
@@ -36,7 +36,11 @@ struct Args {
     #[arg(long)]
     reference_result: PathBuf,
     #[arg(long)]
+    manifest: Option<PathBuf>,
+    #[arg(long)]
     check_only: bool,
+    #[arg(long)]
+    check_only_output: Option<PathBuf>,
     #[arg(long)]
     output: Option<PathBuf>,
     #[arg(long)]
@@ -260,10 +264,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     if !args.check_only && args.peak_rss_bytes.is_none() {
         return Err("peak RSS is required when recording timings".into());
     }
+    if args.check_only_output.is_some() && !args.check_only {
+        return Err("check-only output requires --check-only".into());
+    }
     let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let manifest_dir = root.join("tests/workloads");
-    let manifest: Manifest =
-        serde_json::from_slice(&std::fs::read(manifest_dir.join("manifest-v1.json"))?)?;
+    let manifest_path = args
+        .manifest
+        .unwrap_or_else(|| root.join("tests/workloads/manifest-v1.json"));
+    let manifest_dir = manifest_path
+        .parent()
+        .ok_or("manifest path has no parent directory")?
+        .to_path_buf();
+    let manifest: Manifest = serde_json::from_slice(&std::fs::read(&manifest_path)?)?;
     let workload = manifest
         .workloads
         .into_iter()
@@ -295,8 +307,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
     let mut options = workload
         .options
-        .into_iter()
+        .iter()
         .find(|options| args.lane.accepts(options))
+        .cloned()
         .ok_or_else(|| format!("workload has no {} options", args.lane.profile()))?;
     options.provenance.enabled = true;
     options.provenance.include_boundary_line_ids = true;
@@ -380,6 +393,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .into());
     }
     if args.check_only {
+        if let Some(path) = args.check_only_output.as_deref() {
+            write_check_only_output(
+                path,
+                &workload,
+                args.lane,
+                &lines,
+                &correctness,
+                actual_topology,
+            )?;
+        }
         return Ok(());
     }
 
@@ -744,6 +767,52 @@ fn output_coordinates(result: &PolygonizerResult) -> usize {
         .chain(result.cut_edges.iter().map(Vec::len))
         .chain(result.invalid_rings.iter().map(Vec::len))
         .sum()
+}
+
+fn write_check_only_output(
+    path: &Path,
+    workload: &Workload,
+    lane: Lane,
+    lines: &[Line3D],
+    result: &PolygonizerResult,
+    topology: &BenchmarkTopologyFingerprintV1,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let diagnostics = result
+        .diagnostics
+        .as_ref()
+        .ok_or("check-only output requires diagnostics")?;
+    let input_segments = lines.len();
+    let output = json!({
+        "schema_version": 1,
+        "workload_id": workload.id,
+        "lane": lane.record_name(),
+        "status": "passed",
+        "fingerprint_sha256": hex(&benchmark_fingerprint_sha256(topology)),
+        "topology": {
+            "polygons": result.polygons.len(),
+            "rings": result.polygons.iter().map(|polygon| 1 + polygon.interiors.len()).sum::<usize>(),
+            "dangles": result.dangles.len(),
+            "cut_edges": result.cut_edges.len(),
+            "invalid_rings": result.invalid_rings.len(),
+            "provenance_sources": provenance_sources(result),
+        },
+        "work": {
+            "input_line_strings": workload.size.line_strings,
+            "input_segments": input_segments,
+            "input_coordinates": workload.size.coordinates,
+            "output_coordinates": output_coordinates(result),
+            "candidate_pairs": diagnostics.noding_work_stats.candidate_pairs,
+            "exact_predicate_calls": diagnostics.noding_work_stats.exact_intersection_calls,
+            "split_events": diagnostics.noding_work_stats.split_events,
+            "segment_expansion": {
+                "input_segments": diagnostics.input_segment_count,
+                "noded_segments": diagnostics.noded_segment_count,
+                "ratio": diagnostics.noded_segment_count as f64 / diagnostics.input_segment_count.max(1) as f64,
+            },
+        },
+    });
+    std::fs::write(path, serde_json::to_vec_pretty(&output)?)?;
+    Ok(())
 }
 
 fn dependencies(

--- a/docs/guide/production-corpus.md
+++ b/docs/guide/production-corpus.md
@@ -6,9 +6,10 @@ fixture, a runnable workload, or benchmark evidence. The current entry pins a
 dated 1.32 GB California OpenStreetMap extract and the checksum published by
 its distributor; no source geometry is stored in this repository.
 
-The existing `tests/workloads/manifest-v1.json` remains the only input manifest
-accepted by the benchmark runner. D2 is responsible for materializing a source
-into a derived, checksum-pinned linework fixture before that changes.
+The checked-in `tests/workloads/manifest-v1.json` remains the default input
+manifest. The runner and GEOS reference helper also accept `--manifest`, so a
+materialized manifest can stay outside Git while using the same correctness
+gate.
 
 ## Acquisition and verification policy
 
@@ -27,9 +28,9 @@ PBF outside Git (for example, under `target/production-corpus/`) and verify it
 before conversion; CI does not download it:
 
 ```bash
-artifact=target/production-corpus/california-260802.osm.pbf
-test "$(wc -c < "$artifact" | tr -d ' ')" = 1322385715
-test "$(openssl dgst -md5 -r "$artifact" | awk '{print $1}')" = 5915ee72b206cc184e0940cde071a43a
+artifact=target/production-corpus/california-260801.osm.pbf
+test "$(wc -c < "$artifact" | tr -d ' ')" = 1322245000
+test "$(openssl dgst -md5 -r "$artifact" | awk '{print $1}')" = 3be0a7bdf02572622c791b89063638a0
 ```
 
 The distributor publishes MD5 for this artifact, so it is a provenance and
@@ -40,10 +41,59 @@ reference before the workload enters `tests/workloads/` or supports a timing
 claim. Treat bridge/tunnel grade separation as input semantics to document,
 not planar intersections to invent.
 
+## Reproducible materialization
+
+`materialize_production_workloads.py` converts the pinned `lines` layer with
+the highway filter, verifies the raw byte length and publisher MD5, requires
+monotonic OSM way IDs, retains complete source ways, and emits deterministic
+FeatureCollections. It records the converter version and command, source and
+derived SHA-256 values, geographic extent, chain/component/grid descriptors,
+exact duplicate incidence, and the compatibility contract. The generated
+manifest and geometry remain out of tree:
+
+```bash
+python3 scripts/materialize_production_workloads.py \
+  --source target/production-corpus/california-260801.osm.pbf \
+  --output-dir target/production-corpus/materialized \
+  --acquired-on 2026-08-11
+```
+
+The default run emits approximately 1k, 10k, and 100k segment tiers. Add
+`--include-million` only when the local disk and correctness runner can handle
+the larger derived artifact. The authorized run also emitted an out-of-tree
+`1,000,009`-segment tier. It is not yet correctness-gated or a timing
+publication: a dedicated runner/reference gate is not currently provisioned
+for a decision-quality 1m run, which is the concrete blocker recorded in the
+roadmap.
+
+After generating references and running the correctness gate, rerun with
+`--validation-dir target/production-corpus/materialized/validation` to attach
+candidate, exact-predicate, split, topology, and fingerprint evidence to the
+materialization report. The external manifest uses the existing runner:
+
+```bash
+python3 benchmarks/check_geos_references.py \
+  --manifest target/production-corpus/materialized/runner-manifest-v1.json \
+  --output-dir target/production-corpus/materialized/references \
+  --validation-output-dir target/production-corpus/materialized/validation \
+  --repeat
+```
+
+The production run completed locally for `1,003`, `10,093`, and `100,013`
+segments. GEOS/Shapely parity, repeated-run determinism, and serial/parallel
+equality passed for all three tiers. Those local checks are correctness
+evidence, not dedicated-runner timing publications.
+
+The derived road tiers cover the network category. Coverage, hydrographic, and
+CAD categories remain represented by the existing public/procedural fixtures;
+the materialization report records those choices and reasons. No CFB or
+customer geometry is used.
+
 ## Adding a source
 
 Add a source only after independently reading its license and publisher
 metadata. Use a dated object URL, copy the publisher checksum verbatim with
-its checksum URL, and add a static manifest check. A source stays
-`source-pinned` until the D2 materialization record supplies a derived
-SHA-256 and the normal correctness gate accepts the resulting workload.
+its checksum URL, and add a static manifest check. A source remains
+`source-pinned` in the checked-in source manifest. The out-of-tree
+materialization report upgrades the derived evidence only after it supplies
+SHA-256 values and the normal correctness gate accepts each workload.

--- a/scripts/materialize_production_workloads.py
+++ b/scripts/materialize_production_workloads.py
@@ -1,0 +1,454 @@
+#!/usr/bin/env python3
+"""Materialize deterministic, out-of-tree workloads from a pinned source.
+
+The raw PBF and derived GeoJSON files belong under ``target/`` (or another
+caller-owned directory), never in Git.  The checked-in source manifest is the
+authority for the input bytes; this script records the converter, selection
+rule, structure descriptors, and output checksums needed to reproduce a run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import subprocess
+from collections import Counter
+from pathlib import Path
+from statistics import mean
+
+
+SCHEMA_VERSION = 1
+DEFAULT_TARGETS = (1_000, 10_000, 100_000)
+GRID_SIZE = 16
+
+
+def canonical_json(value):
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def digest_file(path, algorithm):
+    digest = hashlib.new(algorithm)
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def percentile(values, fraction):
+    ordered = sorted(values)
+    if not ordered:
+        return 0
+    index = min(len(ordered) - 1, max(0, math.ceil(fraction * len(ordered)) - 1))
+    return ordered[index]
+
+
+def feature_key(feature):
+    value = feature.get("properties", {}).get("osm_id")
+    try:
+        return (0, int(value))
+    except (TypeError, ValueError):
+        return (1, str(value or ""))
+
+
+def parse_seq_feature(raw, line_number):
+    record = raw.lstrip("\x1e").strip()
+    if not record:
+        return None
+    try:
+        feature = json.loads(record)
+    except json.JSONDecodeError as error:
+        raise ValueError(f"invalid GeoJSONSeq record at line {line_number}: {error}") from error
+    geometry = feature.get("geometry") or {}
+    if geometry.get("type") != "LineString":
+        raise ValueError(
+            f"source line {line_number} is {geometry.get('type')!r}; expected LineString"
+        )
+    coordinates = geometry.get("coordinates") or []
+    if len(coordinates) < 2:
+        return None
+    properties = feature.get("properties") or {}
+    if properties.get("highway") is None:
+        raise ValueError(f"source line {line_number} has no highway tag after filtering")
+    return {
+        "type": "Feature",
+        "properties": {
+            "osm_id": str(properties.get("osm_id", "")),
+            "highway": str(properties["highway"]),
+        },
+        "geometry": {"type": "LineString", "coordinates": coordinates},
+    }
+
+
+def iter_features(path):
+    previous_key = None
+    with path.open("r", encoding="utf-8") as stream:
+        for line_number, raw in enumerate(stream, 1):
+            feature = parse_seq_feature(raw, line_number)
+            if feature is None:
+                continue
+            key = feature_key(feature)
+            if previous_key is not None and key < previous_key:
+                raise ValueError(
+                    "GeoJSONSeq feature order is not monotonic by osm_id; "
+                    "refuse to derive a parser-order-dependent workload"
+                )
+            previous_key = key
+            yield feature
+
+
+def coordinate_key(coordinate):
+    x, y = coordinate[:2]
+    return (0.0 if x == 0 else x, 0.0 if y == 0 else y)
+
+
+def segment_key(start, end):
+    first, second = coordinate_key(start), coordinate_key(end)
+    return (first, second) if first <= second else (second, first)
+
+
+def geometry_coordinates(features):
+    return [coordinate for feature in features for coordinate in feature["geometry"]["coordinates"]]
+
+
+def bbox(features):
+    coordinates = geometry_coordinates(features)
+    xs = [coordinate[0] for coordinate in coordinates]
+    ys = [coordinate[1] for coordinate in coordinates]
+    return [min(xs), min(ys), max(xs), max(ys)]
+
+
+def structure_descriptor(features):
+    chain_lengths = [len(feature["geometry"]["coordinates"]) - 1 for feature in features]
+    coordinates = geometry_coordinates(features)
+    minimum_x, minimum_y, maximum_x, maximum_y = bbox(features)
+    width = max(maximum_x - minimum_x, 1e-15)
+    height = max(maximum_y - minimum_y, 1e-15)
+
+    endpoint_ids = {}
+    parent = []
+    def endpoint_id(endpoint):
+        key = coordinate_key(endpoint)
+        if key not in endpoint_ids:
+            endpoint_ids[key] = len(parent)
+            parent.append(len(parent))
+        return endpoint_ids[key]
+
+    def find(value):
+        while parent[value] != value:
+            parent[value] = parent[parent[value]]
+            value = parent[value]
+        return value
+
+    def union(left, right):
+        left, right = find(left), find(right)
+        if left != right:
+            parent[right] = left
+
+    duplicate_segments = Counter()
+    occupied = Counter()
+    for feature in features:
+        line = feature["geometry"]["coordinates"]
+        line_ids = [endpoint_id(endpoint) for endpoint in line]
+        for start_id, end_id in zip(line_ids, line_ids[1:]):
+            union(start_id, end_id)
+        for start, end in zip(line, line[1:]):
+            duplicate_segments[segment_key(start, end)] += 1
+            midpoint_x = (start[0] + end[0]) / 2
+            midpoint_y = (start[1] + end[1]) / 2
+            column = min(GRID_SIZE - 1, max(0, int((midpoint_x - minimum_x) / width * GRID_SIZE)))
+            row = min(GRID_SIZE - 1, max(0, int((midpoint_y - minimum_y) / height * GRID_SIZE)))
+            occupied[(row, column)] += 1
+
+    component_counts = Counter()
+    for feature in features:
+        root = find(endpoint_id(feature["geometry"]["coordinates"][0]))
+        component_counts[root] += len(feature["geometry"]["coordinates"]) - 1
+    component_sizes = sorted(component_counts.values(), reverse=True)
+    duplicate_count = sum(count - 1 for count in duplicate_segments.values() if count > 1)
+
+    return {
+        "line_strings": len(features),
+        "segments": sum(chain_lengths),
+        "coordinates": len(coordinates),
+        "chain_lengths": {
+            "minimum": min(chain_lengths),
+            "maximum": max(chain_lengths),
+            "mean": mean(chain_lengths),
+            "p50": percentile(chain_lengths, 0.50),
+            "p95": percentile(chain_lengths, 0.95),
+        },
+        "connected_components": {
+            "definition": "components connected by exact shared line-string vertices",
+            "count": len(component_sizes),
+            "largest_segments": component_sizes[0],
+            "p50_segments": percentile(component_sizes, 0.50),
+            "p95_segments": percentile(component_sizes, 0.95),
+        },
+        "envelope_grid_occupancy": {
+            "grid_size": GRID_SIZE,
+            "occupied_cells": len(occupied),
+            "total_cells": GRID_SIZE * GRID_SIZE,
+            "maximum_segments_per_cell": max(occupied.values()),
+        },
+        "duplicate_incidence": {
+            "exact_duplicate_segments": duplicate_count,
+            "exact_duplicate_ratio": duplicate_count / max(sum(chain_lengths), 1),
+            "collinear_overlap": "not measured; requires an exact line-overlap pass",
+        },
+    }
+
+
+def write_feature_collection(path, features):
+    payload = {"type": "FeatureCollection", "features": features}
+    encoded = (json.dumps(payload, ensure_ascii=False, indent=2) + "\n").encode("utf-8")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(encoded)
+    return hashlib.sha256(encoded).hexdigest(), len(encoded)
+
+
+def run_converter(ogr2ogr, source, destination):
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    command = converter_command(ogr2ogr, source, destination)
+    subprocess.run(command, check=True)
+    version = subprocess.run([ogr2ogr, "--version"], check=True, capture_output=True, text=True)
+    return command, version.stdout.strip()
+
+
+def converter_command(ogr2ogr, source, destination):
+    return [
+        ogr2ogr,
+        "-f",
+        "GeoJSONSeq",
+        str(destination),
+        str(source),
+        "lines",
+        "-where",
+        "highway IS NOT NULL",
+        "-lco",
+        "RS=YES",
+        "-lco",
+        "COORDINATE_PRECISION=17",
+    ]
+
+
+def source_record(manifest, source_id):
+    sources = {source["id"]: source for source in manifest["sources"]}
+    try:
+        return sources[source_id]
+    except KeyError as error:
+        raise ValueError(f"unknown source {source_id}") from error
+
+
+def parser():
+    root = Path(__file__).resolve().parents[1]
+    command = argparse.ArgumentParser(description=__doc__)
+    command.add_argument(
+        "--source-manifest",
+        type=Path,
+        default=root / "benchmarks/production-corpus-v1.json",
+    )
+    command.add_argument("--source-id", default="geofabrik-california-2026-08-01")
+    command.add_argument("--source", type=Path, required=True)
+    command.add_argument("--output-dir", type=Path, required=True)
+    command.add_argument("--ogr2ogr", default="ogr2ogr")
+    command.add_argument("--lines", type=Path, help="reuse a converted GeoJSONSeq file")
+    command.add_argument("--acquired-on", required=True, help="UTC acquisition date (YYYY-MM-DD)")
+    command.add_argument("--target", type=int, action="append")
+    command.add_argument("--include-million", action="store_true")
+    command.add_argument(
+        "--validation-dir",
+        type=Path,
+        help="attach passed benchmark_record --check-only-output files",
+    )
+    return command
+
+
+def main():
+    args = parser().parse_args()
+    targets = list(args.target or DEFAULT_TARGETS)
+    if args.include_million and 1_000_000 not in targets:
+        targets.append(1_000_000)
+    if any(target < 1 for target in targets) or len(set(targets)) != len(targets):
+        raise SystemExit("targets must be positive and unique")
+    targets.sort()
+
+    manifest = json.loads(args.source_manifest.read_text())
+    source = source_record(manifest, args.source_id)
+    artifact = source["artifact"]
+    if args.source.stat().st_size != artifact["byte_length"]:
+        raise SystemExit(f"source byte length mismatch for {args.source}")
+    actual_md5 = digest_file(args.source, "md5")
+    if actual_md5 != artifact["checksum"]["value"]:
+        raise SystemExit(f"source MD5 mismatch: expected {artifact['checksum']['value']}, got {actual_md5}")
+
+    output_dir = args.output_dir
+    lines_path = args.lines or output_dir / "intermediate" / f"{args.source_id}-highways.geojsonl"
+    if args.lines is None:
+        command, converter_version = run_converter(args.ogr2ogr, args.source, lines_path)
+    else:
+        command = converter_command(args.ogr2ogr, args.source, lines_path)
+        version = subprocess.run(
+            [args.ogr2ogr, "--version"], check=True, capture_output=True, text=True
+        )
+        converter_version = version.stdout.strip()
+    if not lines_path.is_file():
+        raise SystemExit(f"missing converted linework: {lines_path}")
+
+    selected = []
+    target_records = {}
+    segment_count = 0
+    for feature in iter_features(lines_path):
+        selected.append(feature)
+        segment_count += len(feature["geometry"]["coordinates"]) - 1
+        for target in targets:
+            if target not in target_records and segment_count >= target:
+                target_records[target] = list(selected)
+        if len(target_records) == len(targets):
+            break
+    if len(target_records) != len(targets):
+        raise SystemExit(f"converted source ended at {segment_count} segments before {targets[-1]}")
+
+    source_sha256 = digest_file(args.source, "sha256")
+    workload_records = []
+    for target in targets:
+        features = target_records[target]
+        workload_id = f"osm-california-highways-{target // 1000}k-v1" if target < 1_000_000 else "osm-california-highways-1m-v1"
+        relative_path = Path("clips") / f"{workload_id}.geojson"
+        artifact_path = output_dir / relative_path
+        sha256, byte_length = write_feature_collection(artifact_path, features)
+        structure = structure_descriptor(features)
+        record = {
+            "id": workload_id,
+            "description": f"Deterministic OSM highway linework tier at or above {target} input segments.",
+            "target_segments": target,
+            "source_selection": {
+                "rule": "ascending osm_id order emitted by the pinned GDAL OSM driver; retain complete ways until the target is reached",
+                "selected_feature_count": len(features),
+                "first_osm_id": features[0]["properties"]["osm_id"],
+                "last_osm_id": features[-1]["properties"]["osm_id"],
+                "bbox_wgs84": bbox(features),
+            },
+            "artifact": {
+                "path": relative_path.as_posix(),
+                "sha256": sha256,
+                "byte_length": byte_length,
+            },
+            "structure": structure,
+            "candidate_split_density": {
+                "status": "pending-correctness-gated-run",
+                "candidate_pairs_per_input_segment": None,
+                "exact_predicates_per_input_segment": None,
+                "split_events_per_input_segment": None,
+            },
+            "contract": {
+                "coordinate_reference": "WGS 84 (EPSG:4326)",
+                "units": "degrees",
+                "compatibility_class": "parity",
+                "permitted_profiles": ["floating"],
+                "retained_result_families": [
+                    "polygons",
+                    "dangles",
+                    "cut-edges",
+                    "invalid-rings",
+                    "provenance",
+                    "diagnostics",
+                ],
+                "z_behavior": "source is two-dimensional; Z is absent",
+            },
+        }
+        if args.validation_dir is not None:
+            validation_path = args.validation_dir / f"{workload_id}.json"
+            if not validation_path.is_file():
+                validation_path = args.validation_dir / f"{workload_id}-floating.json"
+            if not validation_path.is_file():
+                raise SystemExit(f"missing validation output: {validation_path}")
+            validation = json.loads(validation_path.read_text())
+            if validation.get("status") != "passed":
+                raise SystemExit(f"validation did not pass: {validation_path}")
+            validation_work = validation["work"]
+            input_segments = validation_work["input_segments"]
+            record["candidate_split_density"] = {
+                "status": "measured-by-benchmark-record-check-only",
+                "candidate_pairs_per_input_segment": validation_work["candidate_pairs"] / input_segments,
+                "exact_predicates_per_input_segment": validation_work["exact_predicate_calls"] / input_segments,
+                "split_events_per_input_segment": validation_work["split_events"] / input_segments,
+            }
+            record["validation"] = validation
+        workload_records.append(record)
+
+    derivation = {
+        "generator": "scripts/materialize_production_workloads.py",
+        "generator_version": SCHEMA_VERSION,
+        "converter": "GDAL ogr2ogr OSM to GeoJSONSeq",
+        "converter_version": converter_version,
+        "converter_command": command,
+        "source_layer": "lines",
+        "where": "highway IS NOT NULL",
+        "output_options": ["RS=YES", "COORDINATE_PRECISION=17"],
+        "selection_order": "ascending osm_id, complete source ways",
+    }
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "source": {
+            "id": source["id"],
+            "filename": artifact["filename"],
+            "download_url": artifact["download_url"],
+            "metadata_url": source["metadata_url"],
+            "license": source["license"],
+            "license_url": source["license_url"],
+            "attribution": source["attribution"],
+            "acquired_on": args.acquired_on,
+            "byte_length": artifact["byte_length"],
+            "md5": actual_md5,
+            "sha256": source_sha256,
+        },
+        "derivation": derivation,
+        "workloads": workload_records,
+        "domain_coverage": {
+            "network": {"status": "materialized", "workload_ids": [record["id"] for record in workload_records], "reason": "Road-network tiers were materialized from the pinned OSM source."},
+            "coverage": {"status": "procedural-fixture", "workload_ids": ["already-noded-coverage-v1"], "reason": "No public cadastral source was authorized in this run."},
+            "hydrographic": {"status": "existing-public-fixture", "workload_ids": ["hydrographic-boundary-v1"], "reason": "Existing Natural Earth boundary remains the legal public fixture; no contour source was acquired."},
+            "cad": {"status": "procedural-fixture", "workload_ids": ["dirty-cad-v1"], "reason": "Customer/Civil 3D coordinates are not authorized for this corpus."},
+        },
+    }
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report_path = output_dir / "production-workloads-v1.json"
+    report_path.write_text(json.dumps(report, indent=2, ensure_ascii=False) + "\n")
+
+    runner_workloads = []
+    for record in workload_records:
+        runner_workloads.append(
+            {
+                "id": record["id"],
+                "description": record["description"],
+                "domain": "road-network",
+                "source_url": source["metadata_url"],
+                "license": source["license"],
+                "attribution": source["attribution"],
+                "artifact": {"clip_path": record["artifact"]["path"], "sha256": record["artifact"]["sha256"]},
+                "coordinate_reference": "WGS 84 (EPSG:4326)",
+                "units": "degrees",
+                "compatibility_class": record["contract"]["compatibility_class"],
+                "permitted_profiles": ["floating"],
+                "options": [{"node_input": True}],
+                "retained_result_families": record["contract"]["retained_result_families"],
+                "size": {
+                    "line_strings": record["structure"]["line_strings"],
+                    "segments": record["structure"]["segments"],
+                    "coordinates": record["structure"]["coordinates"],
+                    "expected_candidate_class": "dense"
+                    if record["target_segments"] >= 100_000
+                    else "moderate",
+                },
+            }
+        )
+    (output_dir / "runner-manifest-v1.json").write_text(
+        json.dumps({"schema_version": 1, "workloads": runner_workloads}, indent=2) + "\n"
+    )
+    print(f"materialized {len(workload_records)} workloads under {output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_benchmark_artifacts.py
+++ b/tests/test_benchmark_artifacts.py
@@ -15,6 +15,11 @@ def test_production_corpus_is_schema_valid_and_source_pinned():
     corpus = json.loads(manifest.read_text())
     validate(corpus, json.loads(schema.read_text()))
 
+    source_artifact = corpus["sources"][0]["artifact"]
+    assert source_artifact["filename"] == "california-260801.osm.pbf"
+    assert source_artifact["byte_length"] == 1322245000
+    assert source_artifact["checksum"]["value"] == "3be0a7bdf02572622c791b89063638a0"
+
     sources = {source["id"]: source for source in corpus["sources"]}
     assert len(sources) == len(corpus["sources"])
     workload_ids = {workload["id"] for workload in corpus["workloads"]}
@@ -39,6 +44,9 @@ def test_correctness_references_are_persistable_and_retained():
         text=True,
     ).stdout
     assert "--output-dir" in help_text
+    assert "--manifest" in help_text
+    assert "--validation-output-dir" in help_text
+    assert "--serial-binary" in help_text
 
     workflow = (ROOT / ".github/workflows/benchmark-evidence.yml").read_text()
     assert "--output-dir target/geos-reference" in workflow

--- a/tests/test_production_materializer.py
+++ b/tests/test_production_materializer.py
@@ -1,0 +1,60 @@
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PATH = ROOT / "scripts/materialize_production_workloads.py"
+SPEC = importlib.util.spec_from_file_location("materialize_production_workloads", PATH)
+MATERIALIZER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MATERIALIZER)
+
+
+def feature(osm_id, coordinates, highway="residential"):
+    return {
+        "type": "Feature",
+        "properties": {"osm_id": str(osm_id), "highway": highway},
+        "geometry": {"type": "LineString", "coordinates": coordinates},
+    }
+
+
+def test_structure_descriptor_retains_chain_components_and_duplicates():
+    descriptor = MATERIALIZER.structure_descriptor(
+        [
+            feature(1, [[0, 0], [1, 0], [2, 0]]),
+            feature(2, [[2, 0], [2, 1]]),
+            feature(3, [[10, 10], [11, 10]]),
+            feature(4, [[2, 0], [1, 0]]),
+        ]
+    )
+
+    assert descriptor["line_strings"] == 4
+    assert descriptor["segments"] == 5
+    assert descriptor["coordinates"] == 9
+    assert descriptor["connected_components"]["count"] == 2
+    assert descriptor["duplicate_incidence"]["exact_duplicate_segments"] == 1
+    assert descriptor["envelope_grid_occupancy"]["occupied_cells"] >= 2
+
+
+def test_seq_parser_strips_record_separator_and_rejects_non_linework():
+    parsed = MATERIALIZER.parse_seq_feature(
+        '\x1e{"type":"Feature","properties":{"osm_id": "7", "highway": "track"},'
+        '"geometry":{"type":"LineString","coordinates":[[0,0],[1,1]]}}',
+        1,
+    )
+    assert parsed["properties"] == {"osm_id": "7", "highway": "track"}
+
+
+def test_materializer_cli_exposes_reproducibility_controls():
+    help_text = subprocess.run(
+        [sys.executable, PATH, "--help"], check=True, capture_output=True, text=True
+    ).stdout
+    for option in ("--source", "--source-manifest", "--acquired-on", "--include-million", "--validation-dir"):
+        assert option in help_text
+
+
+def test_materialized_report_schema_is_self_consistent():
+    schema = json.loads((ROOT / "benchmarks/production-workload-v1.schema.json").read_text())
+    assert schema["$id"].endswith("production-workload-v1.schema.json")

--- a/tests/test_reference_geos.py
+++ b/tests/test_reference_geos.py
@@ -36,3 +36,14 @@ def test_reference_generation_is_deterministic(workload, lane):
     first = REFERENCE.canonical_topology(lines, lane)
     second = REFERENCE.canonical_topology(list(reversed(lines)), lane)
     assert REFERENCE.canonical_json(first) == REFERENCE.canonical_json(second)
+
+
+def test_reference_loader_accepts_an_external_manifest():
+    root = PATH.parents[1]
+    manifest = root / "crates/geo-polygonize-core/tests/workloads/manifest-v1.json"
+    default_workload, default_lines = REFERENCE.load_workload(root, "network-linework-v1")
+    external_workload, external_lines = REFERENCE.load_workload(
+        root, "network-linework-v1", manifest
+    )
+    assert external_workload == default_workload
+    assert len(external_lines) == len(default_lines)


### PR DESCRIPTION
## Stack
Parent: none (`origin/main` `8453b43`)
Children: none

## Delivered
- Corrected the stale California source pin from the 404 `california-260802.osm.pbf` object to the verified `california-260801.osm.pbf` extract, preserving publisher byte length and MD5.
- Added `scripts/materialize_production_workloads.py` with source verification, GDAL/OGR conversion pinning, monotonic OSM-way selection, complete line-string retention, deterministic 1k/10k/100k tiers, and optional 1m derivation.
- Added versioned production-workload and correctness-evidence schemas with source/license/attribution, checksums, WGS84 extent, chain/component/grid/duplicate descriptors, candidate/split density, topology, and work counters.
- Extended the existing GEOS and Rust benchmark paths with external manifests and correctness-only evidence output. The verifier can retain references and prove repeated-run determinism plus serial/parallel equality.
- Recorded the domain coverage decision for road, coverage, hydrographic, and CAD-shaped workloads without using private CFB/customer geometry.
- Updated the roadmap precisely: dedicated-runner timing publications remain open.

## Contract impact
The default checked-in benchmark manifest remains unchanged. External materialized manifests now use the same benchmark runner and correctness contract. Production-derived workloads remain out of Git and retain ODbL attribution. Local correctness evidence is explicitly distinct from decision-quality dedicated-runner timing.

## Validation
- Publisher verification: 260801 HTTP 200, 1,322,245,000 bytes, MD5 `3be0a7bdf02572622c791b89063638a0`; the prior 260802 URL returned 404.
- Materialized out of tree: 1,003, 10,093, 100,013, and optional 1,000,009 segments; production-workload schema validation passed.
- GEOS/Shapely parity passed for the 1k/10k/100k floating tiers.
- Automated verifier passed all three tiers with repeated-run determinism and serial/parallel equality; production-validation schema passed.
- `cargo check --locked --workspace --all-targets`
- `cargo test --locked --workspace`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `cargo test --locked -p geo-polygonize-core --example benchmark_record` (6 passed)
- targeted Python tests (11 passed), `./scripts/check-release-versions.sh`, formatting, and diff checks.

## Agent handoff
Parent: none
Children: none
Next: provision or identify the dedicated benchmark runner, run five independent 30-sample publications for 1k/10k/100k current production lanes, and gate any 1m run with an equivalent external reference before changing the remaining roadmap checkbox. Keep #1288 planning separate until #1290 dedicated baselines exist.