### PR TITLE
ci(github): publish baselines from external workload manifests

### DIFF
--- a/.github/workflows/benchmark-publication.yml
+++ b/.github/workflows/benchmark-publication.yml
@@ -15,6 +15,10 @@ on:
           - already-noded
           - floating
           - certified-fixed
+      manifest_path:
+        description: Absolute path to an out-of-tree runner-manifest-v1.json staged on the dedicated runner
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -25,8 +29,18 @@ jobs:
     timeout-minutes: 60
     env:
       MAVEN_IMAGE: maven:3.9.11-eclipse-temurin-21@sha256:6fdc855a6ed81d288ca7ca37ac6ff5e9308b612485c0801d70b25a858c83d237
+      MANIFEST_PATH: ${{ inputs.manifest_path }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Validate staged workload manifest
+        if: inputs.manifest_path != ''
+        run: |
+          case "$MANIFEST_PATH" in
+            /*) ;;
+            *) echo "manifest_path must be an absolute path on the dedicated runner" >&2; exit 1 ;;
+          esac
+          test -f "$MANIFEST_PATH"
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -42,17 +56,30 @@ jobs:
       - name: Generate external correctness reference
         run: |
           mkdir -p target/benchmark-publication
+          manifest_args=()
+          if [ -n "$MANIFEST_PATH" ]; then
+            manifest_args+=(--manifest "$MANIFEST_PATH")
+          fi
           if [ "${{ inputs.lane }}" = certified-fixed ]; then
-            docker run --rm -v "$PWD:/workspace" -w /workspace "$MAVEN_IMAGE" \
+            jts_mount_args=(-v "$PWD:/workspace")
+            jts_manifest_args=()
+            if [ -n "$MANIFEST_PATH" ]; then
+              manifest_directory=$(dirname "$MANIFEST_PATH")
+              manifest_name=$(basename "$MANIFEST_PATH")
+              jts_mount_args+=(-v "$manifest_directory:/external-manifest:ro")
+              jts_manifest_args+=(--manifest "/external-manifest/$manifest_name")
+            fi
+            docker run --rm "${jts_mount_args[@]}" -w /workspace "$MAVEN_IMAGE" \
               mvn -q -f benchmarks/jts-reference/pom.xml package
-            docker run --rm -v "$PWD:/workspace" -w /workspace "$MAVEN_IMAGE" \
+            docker run --rm "${jts_mount_args[@]}" -w /workspace "$MAVEN_IMAGE" \
               java -jar benchmarks/jts-reference/target/geo-polygonize-jts-reference-1.0.0.jar \
-              --root /workspace --workload "${{ inputs.workload }}" \
+              --root /workspace --workload "${{ inputs.workload }}" "${jts_manifest_args[@]}" \
               --output /workspace/target/benchmark-publication/reference.json
           else
             python benchmarks/reference_geos.py \
               --lane "${{ inputs.lane }}" \
               --workload "${{ inputs.workload }}" \
+              "${manifest_args[@]}" \
               --output target/benchmark-publication/reference.json
           fi
 
@@ -60,14 +87,20 @@ jobs:
         run: |
           binary=target/release/examples/benchmark_record
           reference=target/benchmark-publication/reference.json
+          manifest_args=()
+          if [ -n "$MANIFEST_PATH" ]; then
+            manifest_args+=(--manifest "$MANIFEST_PATH")
+          fi
           /usr/bin/time -f '%M' -o target/benchmark-publication/peak-rss-kib.txt \
             "$binary" --lane "${{ inputs.lane }}" --workload "${{ inputs.workload }}" \
+            "${manifest_args[@]}" \
             --reference-result "$reference" --check-only
           peak_kib=$(tr -d '[:space:]' < target/benchmark-publication/peak-rss-kib.txt)
           case "$peak_kib" in *[!0-9]*|'') exit 1 ;; esac
           peak_bytes=$((peak_kib * 1024))
           for repetition in 1 2 3 4 5; do
             "$binary" --lane "${{ inputs.lane }}" --workload "${{ inputs.workload }}" \
+              "${manifest_args[@]}" \
               --samples 30 --warmup-iterations 5 --repetition "$repetition" \
               --peak-rss-bytes "$peak_bytes" --reference-result "$reference" \
               --output "target/benchmark-publication/record-${repetition}.json"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -208,6 +208,12 @@ Tracked by
 - [x] Correctness-gate every materialized workload before timing.
 - [ ] Publish dedicated-runner baselines for current production algorithms.
 
+The publication workflow now accepts an operator-staged out-of-tree
+`runner-manifest-v1.json` and verifies each selected clip SHA-256 in the GEOS,
+Rust, and JTS reference paths. This evidence plumbing is complete, but the
+checkbox remains open until decision-quality dedicated-runner publications
+exist for the current production algorithms.
+
 No adaptive backend or graph-layout promotion decision may rely only on the
 tiny correctness corpus.
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -24,6 +24,24 @@ manifest and derived clips, then pass that manifest with `--manifest` to the
 reference and Rust runners. See the [production corpus guide](../docs/guide/production-corpus.md)
 for acquisition, attribution, and validation requirements.
 
+The dedicated publication workflow accepts the same operator-staged manifest
+without copying the source or derived clips into Git. Dispatch it with an
+absolute manifest path that exists on the `benchmark-dedicated` runner:
+
+```bash
+gh workflow run benchmark-publication.yml --ref main \
+  -f workload=osm-california-highways-10k-v1 \
+  -f lane=floating \
+  -f manifest_path=/mnt/geo-polygonize/runner-manifest-v1.json
+```
+
+The selected clip path is resolved relative to that manifest and its declared
+SHA-256 is verified by the GEOS reference, Rust benchmark runner, and JTS
+reference before any correctness or timing work. Certified-fixed dispatches
+mount the manifest parent into the JTS container; a manifest must explicitly
+permit that lane. The workflow publishes only the resulting gated records and
+does not download or retain the source material.
+
 `benchmark-decision-policy-v1.json` separates diagnostic runs from evidence
 that can support a performance decision. Shared or smoke-test measurements are
 diagnostic and nonpublishable. Decision-quality measurements require a

--- a/benchmarks/jts-reference/src/main/java/io/github/graydonpleasants/JtsReference.java
+++ b/benchmarks/jts-reference/src/main/java/io/github/graydonpleasants/JtsReference.java
@@ -36,12 +36,20 @@ public final class JtsReference {
         Path root = Path.of(args.getOrDefault("--root", ".")).toAbsolutePath();
         String workloadId = required(args, "--workload");
         Path output = Path.of(required(args, "--output"));
-        Path workloads = root.resolve("crates/geo-polygonize-core/tests/workloads");
+        Path manifestPath = args.containsKey("--manifest")
+                ? Path.of(args.get("--manifest")).toAbsolutePath()
+                : root.resolve("crates/geo-polygonize-core/tests/workloads/manifest-v1.json");
+        Path manifestDirectory = manifestPath.getParent();
+        if (manifestDirectory == null) {
+            throw new IllegalArgumentException("manifest path has no parent directory");
+        }
         JsonNode workload = workload(
-                JSON.readTree(workloads.resolve("manifest-v1.json").toFile()), workloadId);
+                JSON.readTree(manifestPath.toFile()), workloadId);
         double gridSize = certifiedGridSize(workload);
+        Path clipPath = manifestDirectory.resolve(workload.at("/artifact/clip_path").asText());
+        verifyArtifactSha256(clipPath, workload.at("/artifact/sha256").asText());
         List<LineString> input = inputSegments(
-                JSON.readTree(workloads.resolve(workload.at("/artifact/clip_path").asText()).toFile()),
+                JSON.readTree(clipPath.toFile()),
                 new GeometryFactory());
 
         PrecisionModel precision = new PrecisionModel(1.0 / gridSize);
@@ -114,6 +122,26 @@ public final class JtsReference {
             }
         }
         return false;
+    }
+
+    private static void verifyArtifactSha256(Path path, String expected) throws Exception {
+        if (!expected.matches("[0-9a-f]{64}")) {
+            throw new IllegalArgumentException("workload artifact SHA-256 must use lowercase hex");
+        }
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        try (var input = Files.newInputStream(path)) {
+            byte[] buffer = new byte[64 * 1024];
+            int read;
+            while ((read = input.read(buffer)) != -1) {
+                digest.update(buffer, 0, read);
+            }
+        }
+        String observed = HexFormat.of().formatHex(digest.digest());
+        if (!observed.equals(expected)) {
+            throw new IllegalArgumentException(
+                    "workload artifact checksum mismatch for " + path
+                            + ": expected " + expected + ", observed " + observed);
+        }
     }
 
     private static double certifiedGridSize(JsonNode workload) {

--- a/benchmarks/reference_geos.py
+++ b/benchmarks/reference_geos.py
@@ -78,6 +78,14 @@ def canonical_json(value):
     return json.dumps(value, separators=(",", ":"), sort_keys=False)
 
 
+def sha256_file(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
 def geometries(collection):
     return list(collection.geoms)
 
@@ -124,6 +132,19 @@ def load_workload(root, workload_id, manifest_path=None):
     if workload is None:
         raise ValueError(f"unknown workload {workload_id}")
     clip = manifest_path.parent / workload["artifact"]["clip_path"]
+    expected = workload["artifact"]["sha256"]
+    if (
+        not isinstance(expected, str)
+        or len(expected) != 64
+        or any(character not in "0123456789abcdef" for character in expected)
+    ):
+        raise ValueError("workload artifact SHA-256 must use lowercase hex")
+    observed = sha256_file(clip)
+    if observed != expected:
+        raise ValueError(
+            f"workload artifact checksum mismatch for {workload_id}: "
+            f"expected {expected}, observed {observed}"
+        )
     collection = json.loads(clip.read_text())
     lines = []
     for feature in collection["features"]:

--- a/crates/geo-polygonize-core/examples/benchmark_record.rs
+++ b/crates/geo-polygonize-core/examples/benchmark_record.rs
@@ -12,8 +12,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
-use std::fs::OpenOptions;
-use std::io::Write;
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{Duration, Instant};
@@ -114,6 +114,7 @@ struct Workload {
 #[derive(Deserialize)]
 struct Artifact {
     clip_path: String,
+    sha256: String,
 }
 
 #[derive(Deserialize)]
@@ -295,7 +296,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .into());
     }
 
-    let lines = load_lines(&manifest_dir.join(&workload.artifact.clip_path))?;
+    let clip_path = manifest_dir.join(&workload.artifact.clip_path);
+    verify_artifact_sha256(&clip_path, &workload.artifact.sha256)?;
+    let lines = load_lines(&clip_path)?;
     if lines.len() != workload.size.segments {
         return Err(format!(
             "{} declares {} segments but contains {}",
@@ -565,6 +568,31 @@ fn load_lines(path: &Path) -> Result<Vec<Line3D>, Box<dyn std::error::Error>> {
     Ok(segments)
 }
 
+fn verify_artifact_sha256(path: &Path, expected: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let expected = parse_sha256(expected)?;
+    let mut input = File::open(path)?;
+    let mut digest = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let read = input.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        digest.update(&buffer[..read]);
+    }
+    let observed: [u8; 32] = digest.finalize().into();
+    if observed != expected {
+        return Err(format!(
+            "workload artifact checksum mismatch for {}: expected {}, observed {}",
+            path.display(),
+            hex(&expected),
+            hex(&observed),
+        )
+        .into());
+    }
+    Ok(())
+}
+
 fn coordinate(position: &[f64]) -> Result<Coord3D, Box<dyn std::error::Error>> {
     if position.len() < 2 {
         return Err("GeoJSON position must contain x and y".into());
@@ -721,14 +749,14 @@ fn benchmark_fingerprint_sha256(topology: &BenchmarkTopologyFingerprintV1) -> [u
 
 fn parse_sha256(value: &str) -> Result<[u8; 32], Box<dyn std::error::Error>> {
     if value.len() != 64 {
-        return Err("expected fingerprint SHA-256 must contain 64 lowercase hex digits".into());
+        return Err("SHA-256 must contain 64 lowercase hex digits".into());
     }
     let mut result = [0; 32];
     for (index, byte) in result.iter_mut().enumerate() {
         *byte = u8::from_str_radix(&value[index * 2..index * 2 + 2], 16)?;
     }
     if hex(&result) != value {
-        return Err("expected fingerprint SHA-256 must use lowercase hex".into());
+        return Err("SHA-256 must use lowercase hex".into());
     }
     Ok(result)
 }
@@ -907,6 +935,19 @@ mod tests {
         let hash = "00".repeat(32);
         assert_eq!(parse_sha256(&hash).unwrap(), [0; 32]);
         assert!(parse_sha256(&"AA".repeat(32)).is_err());
+    }
+
+    #[test]
+    fn workload_artifact_sha256_is_verified() {
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let clip = root.join("tests/workloads/clips/network-linework.geojson");
+        let expected = "93d10a61d937c2fd2ff4cdc2a584589050de946b4f53a29b136a8a18ff9515fb";
+        assert!(verify_artifact_sha256(&clip, expected).is_ok());
+
+        let error = verify_artifact_sha256(&clip, &"00".repeat(32)).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("workload artifact checksum mismatch"));
     }
 
     #[test]

--- a/docs/guide/production-corpus.md
+++ b/docs/guide/production-corpus.md
@@ -84,6 +84,27 @@ segments. GEOS/Shapely parity, repeated-run determinism, and serial/parallel
 equality passed for all three tiers. Those local checks are correctness
 evidence, not dedicated-runner timing publications.
 
+## Dedicated baseline publication
+
+Stage the generated `runner-manifest-v1.json` and its relative clip directory
+on the dedicated runner, then dispatch the publication workflow with its
+absolute manifest path:
+
+```bash
+gh workflow run benchmark-publication.yml --ref main \
+  -f workload=osm-california-highways-10k-v1 \
+  -f lane=floating \
+  -f manifest_path=/mnt/geo-polygonize/runner-manifest-v1.json
+```
+
+The workflow keeps the staged bundle out of Git, resolves clips relative to the
+manifest, and verifies each declared SHA-256 before generating a reference or
+running the Rust correctness gate. The five independent timing processes then
+publish only through the existing dedicated-runner policy. A certified-fixed
+manifest follows the same path through the pinned JTS container and must
+explicitly declare the certified-fixed profile; the materializer's current OSM
+manifest intentionally permits only the floating profile.
+
 The derived road tiers cover the network category. Coverage, hydrographic, and
 CAD categories remain represented by the existing public/procedural fixtures;
 the materialization report records those choices and reasons. No CFB or

--- a/tests/test_benchmark_artifacts.py
+++ b/tests/test_benchmark_artifacts.py
@@ -58,6 +58,12 @@ def test_correctness_references_are_persistable_and_retained():
 def test_publication_requires_a_dedicated_runner_and_retains_gated_outputs():
     workflow = (ROOT / ".github/workflows/benchmark-publication.yml").read_text()
     assert "runs-on: [self-hosted, benchmark-dedicated, linux, x64]" in workflow
+    assert "manifest_path:" in workflow
+    assert "MANIFEST_PATH: ${{ inputs.manifest_path }}" in workflow
+    assert 'test -f "$MANIFEST_PATH"' in workflow
+    assert 'manifest_args+=(--manifest "$MANIFEST_PATH")' in workflow
+    assert 'jts_mount_args+=(-v "$manifest_directory:/external-manifest:ro")' in workflow
+    assert 'jts_manifest_args+=(--manifest "/external-manifest/$manifest_name")' in workflow
     assert workflow.count("--repetition") == 1
     assert "for repetition in 1 2 3 4 5" in workflow
     assert "--runner-class dedicated" in workflow

--- a/tests/test_reference_geos.py
+++ b/tests/test_reference_geos.py
@@ -1,4 +1,5 @@
 import importlib.util
+import json
 from pathlib import Path
 
 import pytest
@@ -47,3 +48,21 @@ def test_reference_loader_accepts_an_external_manifest():
     )
     assert external_workload == default_workload
     assert len(external_lines) == len(default_lines)
+
+
+def test_reference_loader_rejects_a_modified_external_artifact(tmp_path):
+    root = PATH.parents[1]
+    source_manifest = root / "crates/geo-polygonize-core/tests/workloads/manifest-v1.json"
+    manifest = json.loads(source_manifest.read_text())
+    workload = next(
+        value for value in manifest["workloads"] if value["id"] == "network-linework-v1"
+    )
+    source_clip = source_manifest.parent / workload["artifact"]["clip_path"]
+    clip = tmp_path / "network-linework.geojson"
+    clip.write_bytes(source_clip.read_bytes() + b"\n")
+    workload["artifact"]["clip_path"] = clip.name
+    external_manifest = tmp_path / "runner-manifest-v1.json"
+    external_manifest.write_text(json.dumps(manifest))
+
+    with pytest.raises(ValueError, match="workload artifact checksum mismatch"):
+        REFERENCE.load_workload(root, "network-linework-v1", external_manifest)


### PR DESCRIPTION
## Stack
Parent: none (`origin/main` at `4b8cac5`)
Children: #1298 (`agent/p1-record-artifact-identity`)

## Delivered
- Added an optional `manifest_path` dispatch input for the dedicated publication workflow, with absolute-path preflight and safe propagation to GEOS, Rust, and certified-fixed JTS reference paths.
- Added streamed SHA-256 verification for selected workload clips in the GEOS helper, Rust benchmark runner, and JTS reference before correctness or timing work.
- Added regression and workflow contract tests, operator documentation, and a precise P1.2 roadmap note.

## Contract impact
- Existing checked-in manifests and default publication behavior are unchanged.
- Out-of-tree runner manifests now resolve clips relative to the manifest and fail closed on missing, malformed, or mismatched artifact checksums.
- Certified-fixed remains opt-in through the manifest's explicit permitted profile; no baseline or backend promotion is claimed by this PR.

## Validation
- `pytest -q tests/test_reference_geos.py tests/test_benchmark_artifacts.py` — 8 passed.
- `pytest -q tests/test_reference_geos.py tests/test_publish_benchmark.py tests/test_benchmark_workflow_pins.py tests/test_benchmark_artifacts.py tests/test_production_materializer.py` — 16 passed.
- `actionlint .github/workflows/benchmark-publication.yml` — passed.
- `cargo fmt -- --check`, `cargo check --locked`, `cargo clippy --locked -- -D warnings`, full `cargo test --locked --verbose`, no-default core tests, all-targets/all-features check, and release robustness/FFI tests — passed.
- Pinned Docker Maven package and JTS external-manifest smoke test — passed.
- Rebuilt release benchmark runner and ran the out-of-tree 1k production manifest through GEOS reference plus Rust `--check-only` — passed.

## Agent handoff
Parent: none
Children: #1298
Next: after the stack merges, stage the materialized runner bundle on the dedicated runner and publish decision-quality current-production baselines; then use those artifacts to start the dependent component-layout and MCIndex experiment branches. P1.2 remains unchecked until those publications exist.