### PR TITLE
test(core): retain workload artifact identity in benchmark records

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -228,6 +228,7 @@ Every decision-quality record must include:
 - peak RSS;
 - candidate pairs, exact predicates, split events, and segment expansion;
 - input/output sizes and workload descriptors;
+- selected workload artifact identity, including its manifest clip SHA-256;
 - architecture, OS, compiler, features, dependencies, and commit SHA;
 - predeclared minimum effect size and secondary regression budget.
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -13,9 +13,10 @@ both the manifest classification and a reason. Failed or unexplained runs are
 test artifacts, not timing records.
 
 Records pin the commit, compiler, operating system, architecture, implementation,
-features, and dependency versions. Phase names and throughput units are explicit
-strings so different runners can report their native phases without pretending
-unlike pipelines are equivalent.
+features, dependency versions, and the selected workload clip's manifest
+SHA-256. Phase names and throughput units are explicit strings so different
+runners can report their native phases without pretending unlike pipelines are
+equivalent.
 
 `production-corpus-v1.json` separately pins redistributable production-scale
 source metadata. It contains no geometry. Use

--- a/benchmarks/benchmark-record-v1.schema.json
+++ b/benchmarks/benchmark-record-v1.schema.json
@@ -8,6 +8,7 @@
     "schema_version",
     "record_id",
     "workload_id",
+    "artifact_sha256",
     "lane",
     "implementation",
     "correctness_gate",
@@ -20,6 +21,7 @@
     "schema_version": {"const": 1},
     "record_id": {"type": "string", "minLength": 1},
     "workload_id": {"type": "string", "minLength": 1},
+    "artifact_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
     "lane": {
       "enum": [
         "already-noded-polygonization",

--- a/benchmarks/publish_benchmark.py
+++ b/benchmarks/publish_benchmark.py
@@ -38,6 +38,7 @@ def publish(record_paths, runner_class, warmup_iterations):
         raise ValueError("record IDs must be unique")
     stable_fields = [
         "workload_id",
+        "artifact_sha256",
         "lane",
         "implementation",
         "correctness_gate",
@@ -51,7 +52,9 @@ def publish(record_paths, runner_class, warmup_iterations):
         for record in records[1:]
         for field in stable_fields
     ):
-        raise ValueError("records do not describe one commit, environment, and workload")
+        raise ValueError(
+            "records do not describe one commit, environment, workload, and artifact"
+        )
 
     p50_values = [record["measurement"]["p50_ms"] for record in records]
     median = statistics.median(p50_values)

--- a/crates/geo-polygonize-core/examples/benchmark_record.rs
+++ b/crates/geo-polygonize-core/examples/benchmark_record.rs
@@ -456,6 +456,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "schema_version": 1,
         "record_id": args.repetition.map_or(record_id.clone(), |repetition| format!("{record_id}-r{repetition}")),
         "workload_id": workload.id,
+        "artifact_sha256": workload.artifact.sha256,
         "lane": args.lane.record_name(),
         "implementation": {
             "name": "geo-polygonize-core",

--- a/crates/geo-polygonize-core/tests/benchmark_record_schema.rs
+++ b/crates/geo-polygonize-core/tests/benchmark_record_schema.rs
@@ -108,6 +108,11 @@ fn benchmark_schema_requires_measurement_work_and_environment_evidence() {
             "commit_sha",
         ]))
     );
+    assert!(required(&schema).contains("artifact_sha256"));
+    assert_eq!(
+        schema["properties"]["artifact_sha256"]["pattern"],
+        "^[0-9a-f]{64}$"
+    );
 }
 
 #[test]

--- a/tests/test_publish_benchmark.py
+++ b/tests/test_publish_benchmark.py
@@ -22,6 +22,7 @@ def record(index, p50=100.0):
         "schema_version": 1,
         "record_id": f"coverage-abcdef123456-already-noded-r{index}",
         "workload_id": "coverage",
+        "artifact_sha256": "c" * 64,
         "lane": "already-noded-polygonization",
         "implementation": {"name": "core", "version": "1", "features": []},
         "correctness_gate": {
@@ -154,6 +155,13 @@ def test_publication_enforces_decision_quality_policy(tmp_path):
     mixed[-1]["environment"]["commit_sha"] = "c" * 40
     with pytest.raises(ValueError, match="one commit"):
         PUBLISHER.publish(write_records(tmp_path / "mixed", mixed), "dedicated", 5)
+
+    mixed_artifact = [record(index) for index in range(1, 6)]
+    mixed_artifact[-1]["artifact_sha256"] = "d" * 64
+    with pytest.raises(ValueError, match="one commit, environment, workload, and artifact"):
+        PUBLISHER.publish(
+            write_records(tmp_path / "mixed-artifact", mixed_artifact), "dedicated", 5
+        )
 
     noisy = write_records(
         tmp_path / "noisy",


### PR DESCRIPTION
## Stack
Parent: #1297 (`agent/p1-dedicated-production-baselines`)
Children: none

## Delivered
- Add the selected workload clip SHA-256 to every benchmark-record-v1 timing record.
- Require the artifact identity in the record schema and keep it stable across all process repetitions before publication.
- Add schema, publisher, roadmap, and real materialized-record regression coverage.

## Contract impact
- Decision-quality publications can now prove which manifest-declared clip was measured, including out-of-tree production clips.
- The publisher fails closed when records share a workload ID but reference different artifacts.
- No topology, provenance, Z, serial/parallel, resource-limit, cancellation, or backend-selection behavior changes.

## Validation
- `cargo test --locked -p geo-polygonize-core --example benchmark_record --test benchmark_record_schema` — 7 example tests and 4 schema tests passed.
- `pytest -q tests/test_publish_benchmark.py tests/test_reference_geos.py tests/test_benchmark_artifacts.py` — 11 passed.
- Rebuilt release benchmark runner; a materialized 1k production record validated against `benchmark-record-v1.schema.json` and matched the manifest SHA-256.
- `cargo fmt -- --check` and `git diff --check` — passed.

## Agent handoff
Parent: #1297
Children: none
Next: after both PRs merge, dispatch the staged production manifest on the dedicated runner; retain the resulting five-process publications as P1.2 evidence, then start the component-layout and MCIndex decision branches from the evidence commit.