### PR TITLE
perf(core): expose component memory evidence

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -268,6 +268,9 @@ Tracked by
 - [ ] Evaluate a direct single-component fast path.
 - [ ] Evaluate deterministic sequential versus parallel component thresholds.
 - [ ] Prototype flat/CSR adjacency privately.
+- [x] Emit deterministic component distribution, adjacency-capacity, reusable
+  scratch high-water, scratch-state/worker, and merged-output evidence in
+  diagnostics and benchmark records.
 - [ ] Run arrangement and full topology conformance before timing.
 - [ ] Compare layout and execution decisions on production-scale workloads.
 - [ ] Check in explicit accept/reject decision records.
@@ -275,6 +278,10 @@ Tracked by
 
 **Promotion gate:** exact canonical equivalence plus a predeclared end-to-end or
 peak-memory win on more than one representative workload.
+
+The evidence plumbing is complete, but the measurements, fast-path/threshold
+evaluation, layout comparison, and promotion decision remain open until
+dedicated-runner publications from #1290 exist.
 
 ## P2.3 Remaining arrangement payload work
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -92,7 +92,13 @@ every GEOS-comparable parity workload using `reference-requirements.txt`.
 
 Peak RSS remains an explicit harness input because the Rust standard library
 does not expose a portable process peak. The runner measures allocations with
-the repository's existing `dhat` allocator.
+the repository's existing `dhat` allocator. Each generated record also carries
+`work.component_memory`, which reports deterministic component distribution,
+global `Vec<Vec<DirEdgeId>>` adjacency capacity, reusable scratch high-water
+capacities, scratch-state instances, configured execution workers, and merged
+output buffering.
+Those fields are element capacities rather than byte estimates; use them with
+allocation and peak-RSS measurements when evaluating a layout change.
 
 Run the benchmark in five separate processes with unique `--repetition` values,
 then gate the records before publication:

--- a/benchmarks/benchmark-record-v1.schema.json
+++ b/benchmarks/benchmark-record-v1.schema.json
@@ -205,6 +205,58 @@
             "noded_segments": {"type": "integer", "minimum": 0},
             "ratio": {"type": "number", "minimum": 0}
           }
+        },
+        "component_memory": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "component_count",
+            "active_node_count",
+            "active_edge_count",
+            "largest_component_node_count",
+            "largest_component_edge_count",
+            "partition_node_capacity",
+            "partition_edge_capacity",
+            "global_graph_node_capacity",
+            "global_graph_edge_capacity",
+            "global_graph_directed_edge_capacity",
+            "global_graph_adjacency_capacity",
+            "scratch_instance_count",
+            "execution_worker_count",
+            "max_scratch_node_capacity",
+            "max_scratch_edge_capacity",
+            "max_scratch_directed_edge_capacity",
+            "max_scratch_adjacency_capacity",
+            "max_scratch_global_node_capacity",
+            "max_scratch_local_node_capacity",
+            "max_scratch_global_dir_edge_capacity",
+            "max_merged_output_item_count",
+            "max_merged_output_coordinate_capacity"
+          ],
+          "properties": {
+            "component_count": {"type": "integer", "minimum": 0},
+            "active_node_count": {"type": "integer", "minimum": 0},
+            "active_edge_count": {"type": "integer", "minimum": 0},
+            "largest_component_node_count": {"type": "integer", "minimum": 0},
+            "largest_component_edge_count": {"type": "integer", "minimum": 0},
+            "partition_node_capacity": {"type": "integer", "minimum": 0},
+            "partition_edge_capacity": {"type": "integer", "minimum": 0},
+            "global_graph_node_capacity": {"type": "integer", "minimum": 0},
+            "global_graph_edge_capacity": {"type": "integer", "minimum": 0},
+            "global_graph_directed_edge_capacity": {"type": "integer", "minimum": 0},
+            "global_graph_adjacency_capacity": {"type": "integer", "minimum": 0},
+            "scratch_instance_count": {"type": "integer", "minimum": 0},
+            "execution_worker_count": {"type": "integer", "minimum": 0},
+            "max_scratch_node_capacity": {"type": "integer", "minimum": 0},
+            "max_scratch_edge_capacity": {"type": "integer", "minimum": 0},
+            "max_scratch_directed_edge_capacity": {"type": "integer", "minimum": 0},
+            "max_scratch_adjacency_capacity": {"type": "integer", "minimum": 0},
+            "max_scratch_global_node_capacity": {"type": "integer", "minimum": 0},
+            "max_scratch_local_node_capacity": {"type": "integer", "minimum": 0},
+            "max_scratch_global_dir_edge_capacity": {"type": "integer", "minimum": 0},
+            "max_merged_output_item_count": {"type": "integer", "minimum": 0},
+            "max_merged_output_coordinate_capacity": {"type": "integer", "minimum": 0}
+          }
         }
       }
     },

--- a/benchmarks/production-validation-v1.schema.json
+++ b/benchmarks/production-validation-v1.schema.json
@@ -45,6 +45,58 @@
             "noded_segments": {"type": "integer", "minimum": 0},
             "ratio": {"type": "number", "minimum": 0}
           }
+        },
+        "component_memory": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "component_count",
+            "active_node_count",
+            "active_edge_count",
+            "largest_component_node_count",
+            "largest_component_edge_count",
+            "partition_node_capacity",
+            "partition_edge_capacity",
+            "global_graph_node_capacity",
+            "global_graph_edge_capacity",
+            "global_graph_directed_edge_capacity",
+            "global_graph_adjacency_capacity",
+            "scratch_instance_count",
+            "execution_worker_count",
+            "max_scratch_node_capacity",
+            "max_scratch_edge_capacity",
+            "max_scratch_directed_edge_capacity",
+            "max_scratch_adjacency_capacity",
+            "max_scratch_global_node_capacity",
+            "max_scratch_local_node_capacity",
+            "max_scratch_global_dir_edge_capacity",
+            "max_merged_output_item_count",
+            "max_merged_output_coordinate_capacity"
+          ],
+          "properties": {
+            "component_count": {"type": "integer", "minimum": 0},
+            "active_node_count": {"type": "integer", "minimum": 0},
+            "active_edge_count": {"type": "integer", "minimum": 0},
+            "largest_component_node_count": {"type": "integer", "minimum": 0},
+            "largest_component_edge_count": {"type": "integer", "minimum": 0},
+            "partition_node_capacity": {"type": "integer", "minimum": 0},
+            "partition_edge_capacity": {"type": "integer", "minimum": 0},
+            "global_graph_node_capacity": {"type": "integer", "minimum": 0},
+            "global_graph_edge_capacity": {"type": "integer", "minimum": 0},
+            "global_graph_directed_edge_capacity": {"type": "integer", "minimum": 0},
+            "global_graph_adjacency_capacity": {"type": "integer", "minimum": 0},
+            "scratch_instance_count": {"type": "integer", "minimum": 0},
+            "execution_worker_count": {"type": "integer", "minimum": 0},
+            "max_scratch_node_capacity": {"type": "integer", "minimum": 0},
+            "max_scratch_edge_capacity": {"type": "integer", "minimum": 0},
+            "max_scratch_directed_edge_capacity": {"type": "integer", "minimum": 0},
+            "max_scratch_adjacency_capacity": {"type": "integer", "minimum": 0},
+            "max_scratch_global_node_capacity": {"type": "integer", "minimum": 0},
+            "max_scratch_local_node_capacity": {"type": "integer", "minimum": 0},
+            "max_scratch_global_dir_edge_capacity": {"type": "integer", "minimum": 0},
+            "max_merged_output_item_count": {"type": "integer", "minimum": 0},
+            "max_merged_output_coordinate_capacity": {"type": "integer", "minimum": 0}
+          }
         }
       }
     }

--- a/crates/geo-polygonize-core/examples/benchmark_record.rs
+++ b/crates/geo-polygonize-core/examples/benchmark_record.rs
@@ -516,6 +516,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 "noded_segments": diagnostics.noded_segment_count,
                 "ratio": diagnostics.noded_segment_count as f64 / diagnostics.input_segment_count.max(1) as f64,
             },
+            "component_memory": &diagnostics.component_memory_stats,
         },
         "environment": {
             "architecture": std::env::consts::ARCH,
@@ -838,6 +839,7 @@ fn write_check_only_output(
                 "noded_segments": diagnostics.noded_segment_count,
                 "ratio": diagnostics.noded_segment_count as f64 / diagnostics.input_segment_count.max(1) as f64,
             },
+            "component_memory": &diagnostics.component_memory_stats,
         },
     });
     std::fs::write(path, serde_json::to_vec_pretty(&output)?)?;

--- a/crates/geo-polygonize-core/src/diagnostics.rs
+++ b/crates/geo-polygonize-core/src/diagnostics.rs
@@ -74,6 +74,124 @@ impl ContainmentStats {
     }
 }
 
+/// Allocation-shape evidence for deterministic connected-component
+/// processing.
+///
+/// Capacity fields are element capacities, not byte estimates. They are
+/// intentionally recorded alongside allocator and peak-RSS measurements so
+/// layout decisions can distinguish graph shape from allocator noise.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ComponentMemoryStats {
+    pub component_count: usize,
+    pub active_node_count: usize,
+    pub active_edge_count: usize,
+    pub largest_component_node_count: usize,
+    pub largest_component_edge_count: usize,
+    pub partition_node_capacity: usize,
+    pub partition_edge_capacity: usize,
+    pub global_graph_node_capacity: usize,
+    pub global_graph_edge_capacity: usize,
+    pub global_graph_directed_edge_capacity: usize,
+    pub global_graph_adjacency_capacity: usize,
+    pub scratch_instance_count: usize,
+    pub execution_worker_count: usize,
+    pub max_scratch_node_capacity: usize,
+    pub max_scratch_edge_capacity: usize,
+    pub max_scratch_directed_edge_capacity: usize,
+    pub max_scratch_adjacency_capacity: usize,
+    pub max_scratch_global_node_capacity: usize,
+    pub max_scratch_local_node_capacity: usize,
+    pub max_scratch_global_dir_edge_capacity: usize,
+    pub max_merged_output_item_count: usize,
+    pub max_merged_output_coordinate_capacity: usize,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct ComponentScratchEvidence {
+    pub(crate) is_new_instance: bool,
+    pub(crate) node_capacity: usize,
+    pub(crate) edge_capacity: usize,
+    pub(crate) directed_edge_capacity: usize,
+    pub(crate) adjacency_capacity: usize,
+    pub(crate) global_node_capacity: usize,
+    pub(crate) local_node_capacity: usize,
+    pub(crate) global_dir_edge_capacity: usize,
+}
+
+impl ComponentMemoryStats {
+    pub(crate) fn observe_partition(
+        &mut self,
+        node_count: usize,
+        edge_count: usize,
+        node_capacity: usize,
+        edge_capacity: usize,
+    ) {
+        self.active_node_count = self.active_node_count.saturating_add(node_count);
+        self.active_edge_count = self.active_edge_count.saturating_add(edge_count);
+        self.largest_component_node_count = self.largest_component_node_count.max(node_count);
+        self.largest_component_edge_count = self.largest_component_edge_count.max(edge_count);
+        self.partition_node_capacity = self.partition_node_capacity.saturating_add(node_capacity);
+        self.partition_edge_capacity = self.partition_edge_capacity.saturating_add(edge_capacity);
+    }
+
+    pub(crate) fn observe_scratch(&mut self, evidence: ComponentScratchEvidence) {
+        if evidence.is_new_instance {
+            self.scratch_instance_count = self.scratch_instance_count.saturating_add(1);
+        }
+        self.max_scratch_node_capacity = self.max_scratch_node_capacity.max(evidence.node_capacity);
+        self.max_scratch_edge_capacity = self.max_scratch_edge_capacity.max(evidence.edge_capacity);
+        self.max_scratch_directed_edge_capacity = self
+            .max_scratch_directed_edge_capacity
+            .max(evidence.directed_edge_capacity);
+        self.max_scratch_adjacency_capacity = self
+            .max_scratch_adjacency_capacity
+            .max(evidence.adjacency_capacity);
+        self.max_scratch_global_node_capacity = self
+            .max_scratch_global_node_capacity
+            .max(evidence.global_node_capacity);
+        self.max_scratch_local_node_capacity = self
+            .max_scratch_local_node_capacity
+            .max(evidence.local_node_capacity);
+        self.max_scratch_global_dir_edge_capacity = self
+            .max_scratch_global_dir_edge_capacity
+            .max(evidence.global_dir_edge_capacity);
+    }
+
+    pub(crate) fn merge_execution(&mut self, other: &Self) {
+        self.scratch_instance_count = self
+            .scratch_instance_count
+            .saturating_add(other.scratch_instance_count);
+        self.max_scratch_node_capacity = self
+            .max_scratch_node_capacity
+            .max(other.max_scratch_node_capacity);
+        self.max_scratch_edge_capacity = self
+            .max_scratch_edge_capacity
+            .max(other.max_scratch_edge_capacity);
+        self.max_scratch_directed_edge_capacity = self
+            .max_scratch_directed_edge_capacity
+            .max(other.max_scratch_directed_edge_capacity);
+        self.max_scratch_adjacency_capacity = self
+            .max_scratch_adjacency_capacity
+            .max(other.max_scratch_adjacency_capacity);
+        self.max_scratch_global_node_capacity = self
+            .max_scratch_global_node_capacity
+            .max(other.max_scratch_global_node_capacity);
+        self.max_scratch_local_node_capacity = self
+            .max_scratch_local_node_capacity
+            .max(other.max_scratch_local_node_capacity);
+        self.max_scratch_global_dir_edge_capacity = self
+            .max_scratch_global_dir_edge_capacity
+            .max(other.max_scratch_global_dir_edge_capacity);
+    }
+
+    pub(crate) fn observe_merged_output(&mut self, item_count: usize, coordinate_capacity: usize) {
+        self.max_merged_output_item_count = self.max_merged_output_item_count.max(item_count);
+        self.max_merged_output_coordinate_capacity = self
+            .max_merged_output_coordinate_capacity
+            .max(coordinate_capacity);
+    }
+}
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct NodingWorkStats {
     pub grid_cells: usize,
@@ -198,6 +316,8 @@ pub struct PolygonizerDiagnostics {
     pub z_conflicts: ZConflictStats,
     pub containment_stats: ContainmentStats,
     pub noding_work_stats: NodingWorkStats,
+    #[serde(default)]
+    pub component_memory_stats: ComponentMemoryStats,
 }
 
 fn diagnostics_schema_version() -> u32 {
@@ -226,6 +346,7 @@ impl Default for PolygonizerDiagnostics {
             z_conflicts: ZConflictStats::default(),
             containment_stats: ContainmentStats::default(),
             noding_work_stats: NodingWorkStats::default(),
+            component_memory_stats: ComponentMemoryStats::default(),
         }
     }
 }
@@ -236,9 +357,46 @@ mod tests {
 
     #[test]
     fn diagnostics_include_a_schema_version() {
+        let value = serde_json::to_value(PolygonizerDiagnostics::default()).unwrap();
         assert_eq!(
-            serde_json::to_value(PolygonizerDiagnostics::default()).unwrap()["schema_version"],
+            value["schema_version"],
             POLYGONIZER_DIAGNOSTICS_V1_SCHEMA_VERSION
         );
+        assert!(value.get("component_memory_stats").is_some());
+    }
+
+    #[test]
+    fn component_memory_stats_track_maxima_without_overflowing() {
+        let mut stats = ComponentMemoryStats::default();
+        stats.observe_partition(3, 3, 4, 5);
+        stats.observe_partition(10, 9, 12, 16);
+        stats.observe_scratch(ComponentScratchEvidence {
+            is_new_instance: true,
+            node_capacity: 10,
+            edge_capacity: 20,
+            directed_edge_capacity: 40,
+            adjacency_capacity: 30,
+            global_node_capacity: 12,
+            local_node_capacity: 14,
+            global_dir_edge_capacity: 18,
+        });
+        stats.observe_scratch(ComponentScratchEvidence {
+            edge_capacity: 24,
+            directed_edge_capacity: 48,
+            adjacency_capacity: 32,
+            global_node_capacity: 16,
+            local_node_capacity: 18,
+            global_dir_edge_capacity: 20,
+            ..Default::default()
+        });
+        stats.observe_merged_output(7, 11);
+
+        assert_eq!(stats.active_node_count, 13);
+        assert_eq!(stats.active_edge_count, 12);
+        assert_eq!(stats.largest_component_node_count, 10);
+        assert_eq!(stats.partition_node_capacity, 16);
+        assert_eq!(stats.scratch_instance_count, 1);
+        assert_eq!(stats.max_scratch_edge_capacity, 24);
+        assert_eq!(stats.max_merged_output_item_count, 7);
     }
 }

--- a/crates/geo-polygonize-core/src/graph/planar_graph.rs
+++ b/crates/geo-polygonize-core/src/graph/planar_graph.rs
@@ -1,3 +1,4 @@
+use crate::diagnostics::{ComponentMemoryStats, ComponentScratchEvidence};
 use crate::options::ExecutionPolicy;
 use crate::trace::TraceCaptureBudget;
 use crate::types::{Coord3D, EdgeSources, Line3D, LocalFaceRef};
@@ -148,6 +149,7 @@ struct ComponentScratch {
     global_node_ids: Vec<NodeId>,
     local_node_ids: HashMap<NodeId, NodeId>,
     global_dir_edge_ids: Vec<[DirEdgeId; 2]>,
+    processed_components: usize,
 }
 
 fn append_component_output(target: &mut ComponentOutput, output: ComponentOutput) {
@@ -155,6 +157,25 @@ fn append_component_output(target: &mut ComponentOutput, output: ComponentOutput
     target.1.extend(output.1);
     target.2.extend(output.2);
     target.3.extend(output.3);
+}
+
+fn component_output_item_count(output: &ComponentOutput) -> usize {
+    output.0.len() + output.1.len() + output.2.len() + output.3.len()
+}
+
+fn component_output_coordinate_capacity(output: &ComponentOutput) -> usize {
+    output
+        .0
+        .iter()
+        .chain(&output.1)
+        .map(Vec::capacity)
+        .sum::<usize>()
+        + output
+            .2
+            .iter()
+            .chain(&output.3)
+            .map(|ring| ring.coords.capacity())
+            .sum::<usize>()
 }
 
 // Wrapper for Coord to be Hashable (since f64 is not Hash)
@@ -1933,7 +1954,7 @@ impl PlanarGraph {
     fn active_component_partitions(
         &self,
         execution_policy: &ExecutionPolicy,
-    ) -> crate::Result<Vec<ComponentPartition>> {
+    ) -> crate::Result<(Vec<ComponentPartition>, ComponentMemoryStats)> {
         let component_ids =
             self.active_component_ids_with_execution_policy(Some(execution_policy))?;
         let component_count = component_ids
@@ -1986,11 +2007,29 @@ impl PlanarGraph {
             component_edges.sort_unstable();
         }
 
-        Ok(nodes
+        let mut memory_stats = ComponentMemoryStats {
+            component_count,
+            global_graph_node_capacity: self.nodes_x.capacity(),
+            global_graph_edge_capacity: self.edges.capacity(),
+            global_graph_directed_edge_capacity: self.directed_edges.capacity(),
+            global_graph_adjacency_capacity: self.nodes_outgoing.iter().map(Vec::capacity).sum(),
+            ..Default::default()
+        };
+        let partitions = nodes
             .into_iter()
             .zip(edges)
-            .map(|(nodes, edges)| ComponentPartition { nodes, edges })
-            .collect())
+            .map(|(nodes, edges)| {
+                memory_stats.observe_partition(
+                    nodes.len(),
+                    edges.len(),
+                    nodes.capacity(),
+                    edges.capacity(),
+                );
+                ComponentPartition { nodes, edges }
+            })
+            .collect();
+
+        Ok((partitions, memory_stats))
     }
 
     fn load_component_scratch(
@@ -2070,10 +2109,16 @@ impl PlanarGraph {
         noding_postcondition_validated: bool,
         capture_byte_limit: Option<usize>,
         border_export: Option<PartitionBorderExport>,
-    ) -> crate::Result<(ComponentOutput, Vec<PartitionBorderHalfEdge>, bool)> {
-        let partitions = self.active_component_partitions(execution_policy)?;
+    ) -> crate::Result<(
+        ComponentOutput,
+        Vec<PartitionBorderHalfEdge>,
+        bool,
+        ComponentMemoryStats,
+    )> {
+        let (partitions, mut memory_stats) = self.active_component_partitions(execution_policy)?;
         let mut merged = ComponentOutput::default();
         let mut border_observations = Vec::new();
+        memory_stats.execution_worker_count = 1;
 
         let capture_truncated = if border_export.is_some() || capture_byte_limit.is_some() {
             let mut capture_budget = capture_byte_limit.map(TraceCaptureBudget::new);
@@ -2085,7 +2130,7 @@ impl PlanarGraph {
                     partition,
                     execution_policy,
                 )?;
-                let (output, observations) = scratch.process(
+                let (output, observations, scratch_stats) = scratch.process(
                     component_id,
                     include_graph_ids,
                     include_source_ids,
@@ -2094,36 +2139,44 @@ impl PlanarGraph {
                     capture_budget.as_mut(),
                     border_export,
                 )?;
+                memory_stats.merge_execution(&scratch_stats);
                 append_component_output(&mut merged, output);
+                memory_stats.observe_merged_output(
+                    component_output_item_count(&merged),
+                    component_output_coordinate_capacity(&merged),
+                );
                 border_observations.extend(observations);
             }
             capture_budget.is_some_and(|budget| budget.truncated())
         } else {
             #[cfg(all(feature = "parallel", not(target_arch = "wasm32")))]
-            let outputs: Vec<_> = partitions
-                .into_par_iter()
-                .enumerate()
-                .map_init(
-                    ComponentScratch::default,
-                    |scratch, (component_id, partition)| {
-                        self.load_component_scratch(
-                            scratch,
-                            component_id,
-                            partition,
-                            execution_policy,
-                        )?;
-                        scratch.process(
-                            component_id,
-                            include_graph_ids,
-                            include_source_ids,
-                            execution_policy,
-                            noding_postcondition_validated,
-                            None,
-                            None,
-                        )
-                    },
-                )
-                .collect();
+            let outputs: Vec<_> = {
+                memory_stats.execution_worker_count = rayon::current_num_threads();
+                partitions
+                    .into_par_iter()
+                    .enumerate()
+                    .map_init(
+                        ComponentScratch::default,
+                        |scratch, (component_id, partition)| {
+                            self.load_component_scratch(
+                                scratch,
+                                component_id,
+                                partition,
+                                execution_policy,
+                            )?;
+                            scratch.process(
+                                component_id,
+                                include_graph_ids,
+                                include_source_ids,
+                                execution_policy,
+                                noding_postcondition_validated,
+                                None,
+                                None,
+                            )
+                        },
+                    )
+                    .collect()
+            };
             #[cfg(any(not(feature = "parallel"), target_arch = "wasm32"))]
             let outputs: Vec<_> = {
                 let mut scratch = ComponentScratch::default();
@@ -2149,14 +2202,19 @@ impl PlanarGraph {
             };
 
             for output in outputs {
-                let (output, observations) = output?;
+                let (output, observations, scratch_stats) = output?;
                 debug_assert!(observations.is_empty());
+                memory_stats.merge_execution(&scratch_stats);
                 append_component_output(&mut merged, output);
+                memory_stats.observe_merged_output(
+                    component_output_item_count(&merged),
+                    component_output_coordinate_capacity(&merged),
+                );
             }
             false
         };
 
-        Ok((merged, border_observations, capture_truncated))
+        Ok((merged, border_observations, capture_truncated, memory_stats))
     }
 
     /// Validates Euler's planar relation for the active maximal-ring graph.
@@ -2441,7 +2499,12 @@ impl ComponentScratch {
         noding_postcondition_validated: bool,
         capture_budget: Option<&mut TraceCaptureBudget>,
         border_export: Option<PartitionBorderExport>,
-    ) -> crate::Result<(ComponentOutput, Vec<PartitionBorderHalfEdge>)> {
+    ) -> crate::Result<(
+        ComponentOutput,
+        Vec<PartitionBorderHalfEdge>,
+        ComponentMemoryStats,
+    )> {
+        let is_new_scratch_instance = self.processed_components == 0;
         self.graph
             .sort_edges_with_execution_policy(execution_policy)?;
         let dangles = self
@@ -2479,7 +2542,23 @@ impl ComponentScratch {
             .unwrap_or_default();
         self.remap_rings(&mut maximal, component_id, include_graph_ids)?;
         self.remap_rings(&mut minimal, component_id, include_graph_ids)?;
-        Ok(((dangles, cut_edges, maximal, minimal), observations))
+        self.processed_components = self.processed_components.saturating_add(1);
+        let mut scratch_stats = ComponentMemoryStats::default();
+        scratch_stats.observe_scratch(ComponentScratchEvidence {
+            is_new_instance: is_new_scratch_instance,
+            node_capacity: self.graph.nodes_x.capacity(),
+            edge_capacity: self.graph.edges.capacity(),
+            directed_edge_capacity: self.graph.directed_edges.capacity(),
+            adjacency_capacity: self.graph.nodes_outgoing.iter().map(Vec::capacity).sum(),
+            global_node_capacity: self.global_node_ids.capacity(),
+            local_node_capacity: self.local_node_ids.capacity(),
+            global_dir_edge_capacity: self.global_dir_edge_ids.capacity(),
+        });
+        Ok((
+            (dangles, cut_edges, maximal, minimal),
+            observations,
+            scratch_stats,
+        ))
     }
 
     fn partition_border_observations(
@@ -2754,7 +2833,7 @@ mod arrangement_ring_invariant_tests {
         assert_eq!(incremental.edges.len(), 3);
 
         let policy = ExecutionPolicy::default();
-        let mut partitions = bulk.active_component_partitions(&policy).unwrap();
+        let (mut partitions, _) = bulk.active_component_partitions(&policy).unwrap();
         assert_eq!(partitions.len(), 1);
         let mut scratch = ComponentScratch::default();
         bulk.load_component_scratch(&mut scratch, 0, partitions.remove(0), &policy)
@@ -3156,7 +3235,7 @@ mod arrangement_ring_invariant_tests {
         }
 
         let policy = ExecutionPolicy::default();
-        let mut partitions = graph.active_component_partitions(&policy).unwrap();
+        let (mut partitions, _) = graph.active_component_partitions(&policy).unwrap();
         let mut scratch = ComponentScratch::default();
         graph
             .load_component_scratch(&mut scratch, 0, partitions.remove(0), &policy)
@@ -3191,7 +3270,7 @@ mod arrangement_ring_invariant_tests {
         }
 
         let policy = ExecutionPolicy::default();
-        let partitions = graph.active_component_partitions(&policy).unwrap();
+        let (partitions, _) = graph.active_component_partitions(&policy).unwrap();
         assert_eq!(partitions.len(), 4);
         let mut scratch = ComponentScratch::default();
         for (component_id, (node_count, partition)) in
@@ -3234,7 +3313,7 @@ mod arrangement_ring_invariant_tests {
         }
 
         let policy = ExecutionPolicy::default();
-        let ((_, _, _, rings), _, _) = graph
+        let ((_, _, _, rings), _, _, _) = graph
             .process_components_with_execution_policy(true, true, &policy, true, None, None)
             .unwrap();
         let refs = rings

--- a/crates/geo-polygonize-core/src/graph/tests.rs
+++ b/crates/geo-polygonize-core/src/graph/tests.rs
@@ -695,7 +695,7 @@ mod tests {
         }
 
         let component_ids = graph.active_component_ids();
-        let ((dangles, cut_edges, maximal, rings), _, capture_truncated) = graph
+        let ((dangles, cut_edges, maximal, rings), _, capture_truncated, memory_stats) = graph
             .process_components_with_execution_policy(
                 true,
                 true,
@@ -710,6 +710,13 @@ mod tests {
         assert!(maximal.is_empty());
         assert!(!capture_truncated);
         assert_eq!(rings.len(), 4);
+        assert_eq!(memory_stats.component_count, 2);
+        assert_eq!(memory_stats.active_node_count, 6);
+        assert_eq!(memory_stats.active_edge_count, 6);
+        assert_eq!(memory_stats.largest_component_node_count, 3);
+        assert_eq!(memory_stats.largest_component_edge_count, 3);
+        assert!(memory_stats.scratch_instance_count >= 1);
+        assert!(memory_stats.max_scratch_adjacency_capacity >= 6);
 
         let mut represented_components = BTreeSet::new();
         for ring in rings {

--- a/crates/geo-polygonize-core/src/lib.rs
+++ b/crates/geo-polygonize-core/src/lib.rs
@@ -47,8 +47,8 @@ pub mod utils;
 mod polygonizer_tests;
 
 pub use diagnostics::{
-    ContainmentStats, IntersectionStats, NodingIterationStats, NodingWorkStats,
-    PolygonizerDiagnostics, PolygonizerPhaseTimes, SnapStats, ZConflictStats,
+    ComponentMemoryStats, ContainmentStats, IntersectionStats, NodingIterationStats,
+    NodingWorkStats, PolygonizerDiagnostics, PolygonizerPhaseTimes, SnapStats, ZConflictStats,
     POLYGONIZER_DIAGNOSTICS_V1_SCHEMA_VERSION,
 };
 pub use error::{NodingValidationKind, PolygonizeError, PolygonizeErrorKind, Result};

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -860,6 +860,7 @@ impl Polygonizer {
             (mut dangles, mut cut_edges, maximal, rings_with_ids),
             border_observations,
             capture_truncated,
+            component_memory_stats,
         ) = self.graph.process_components_with_execution_policy(
             self.options.node_input,
             include_source_ids,
@@ -891,6 +892,7 @@ impl Polygonizer {
             d.ring_count = rings_with_ids.len();
             d.cut_edge_count = cut_edges.len();
             d.dangle_count = dangles.len();
+            d.component_memory_stats = component_memory_stats;
         }
 
         // 4. Classify Rings (Shell vs Hole)

--- a/crates/geo-polygonize-core/src/polygonizer_tests.rs
+++ b/crates/geo-polygonize-core/src/polygonizer_tests.rs
@@ -652,6 +652,44 @@ mod tests {
     }
 
     #[test]
+    fn diagnostics_report_component_memory_evidence_without_changing_output() {
+        let mut poly = Polygonizer::new();
+        poly.options_mut().node_input = false;
+        poly.options_mut().diagnostics.enabled = true;
+        for offset in [0.0, 20.0] {
+            poly.add_geometry(
+                LineString::from(vec![
+                    (offset, 0.0),
+                    (offset + 10.0, 0.0),
+                    (offset + 10.0, 10.0),
+                    (offset, 10.0),
+                    (offset, 0.0),
+                ])
+                .into(),
+            );
+        }
+
+        let result = poly.polygonize().unwrap();
+        let diagnostics = result.diagnostics.unwrap();
+        assert_eq!(result.polygons.len(), 2);
+        assert_eq!(diagnostics.component_memory_stats.component_count, 2);
+        assert_eq!(diagnostics.component_memory_stats.active_node_count, 8);
+        assert_eq!(
+            diagnostics
+                .component_memory_stats
+                .largest_component_edge_count,
+            4
+        );
+        assert!(diagnostics.component_memory_stats.scratch_instance_count >= 1);
+        assert!(
+            diagnostics
+                .component_memory_stats
+                .max_merged_output_item_count
+                > 0
+        );
+    }
+
+    #[test]
     fn diagnostics_report_noding_iterations() {
         let mut poly = Polygonizer::new();
         poly.options_mut().node_input = true;

--- a/crates/geo-polygonize-core/tests/benchmark_record_schema.rs
+++ b/crates/geo-polygonize-core/tests/benchmark_record_schema.rs
@@ -99,6 +99,22 @@ fn benchmark_schema_requires_measurement_work_and_environment_evidence() {
         "split_events",
         "segment_expansion",
     ])));
+    let component_memory = &properties["work"]["properties"]["component_memory"];
+    assert_eq!(component_memory["additionalProperties"], false);
+    assert!(required(component_memory).is_superset(&HashSet::from([
+        "component_count",
+        "active_node_count",
+        "active_edge_count",
+        "largest_component_node_count",
+        "largest_component_edge_count",
+        "partition_node_capacity",
+        "partition_edge_capacity",
+        "global_graph_adjacency_capacity",
+        "scratch_instance_count",
+        "execution_worker_count",
+        "max_scratch_adjacency_capacity",
+        "max_merged_output_coordinate_capacity",
+    ])));
     assert!(
         required(&properties["environment"]).is_superset(&HashSet::from([
             "architecture",

--- a/release/stable-api-v1.txt
+++ b/release/stable-api-v1.txt
@@ -1,5 +1,6 @@
 # Supported non-hidden geo-polygonize-core crate-root exports for 1.x.
 # Keep compiler-public research modules and #[doc(hidden)] exports out of this list.
+diagnostics::ComponentMemoryStats
 diagnostics::ContainmentStats
 diagnostics::IntersectionStats
 diagnostics::NodingIterationStats


### PR DESCRIPTION
## Stack

- Parent: none; root branch `agent/p2-component-memory-layout-evidence` starts from `origin/main` at `0550a10`.
- Children: PR #1301, `test(core): guard component memory serial parity`.
- Native stack: #1302.
- Roadmap target: P2.2 / issue #1291.
- This is an evidence-foundation PR only; it does not promote a layout, backend, fast path, or threshold.

## Delivered

- Added additive `ComponentMemoryStats` diagnostics for component distribution, active sizes, partition capacities, global graph capacities, adjacency capacity, reusable scratch high-water capacities, scratch-state instances, configured execution workers, and merged-output buffering.
- Recorded the evidence in both benchmark-record and production-validation V1 records, with schema coverage and documentation.
- Added graph, polygonizer, diagnostics, and record-schema regression/contract tests.
- Added `diagnostics::ComponentMemoryStats` to `release/stable-api-v1.txt` so the new public export is covered by the release contract.
- Updated `ROADMAP.md` precisely: the evidence-plumbing item is complete; measurements, layout comparison, and promotion remain open pending #1290 dedicated publications.

## Contract impact

- `PolygonizerDiagnostics` gains an additive serde-defaulted `component_memory_stats` field; polygon topology, canonical ordering, provenance, Z behavior, serial/parallel equality, resource limits, and cancellation behavior are unchanged.
- The public `ComponentMemoryStats` re-export is now explicitly included in the stable 1.x API allowlist.
- Existing V1 benchmark records remain valid because `work.component_memory` is optional; newly generated records include it.
- Capacity values are element capacities, not byte estimates. `scratch_instance_count` counts initialized reusable scratch states, while `execution_worker_count` reports the configured Rayon worker pool for the parallel path.
- No public execution-policy or adjacency-layout behavior is changed.

## Validation

- `cargo fmt -- --check`
- `cargo check --locked -p geo-polygonize-core --all-targets --all-features`
- `cargo check --locked -p geo-polygonize-core --no-default-features --all-targets`
- `cargo clippy --locked -p geo-polygonize-core --all-targets --all-features -- -D warnings`
- Focused core graph tests: 44 passed; core library tests: 297 passed; benchmark schema tests: 4 passed.
- Full `cargo test --locked` workspace checkpoint passed.
- Release guards passed: core robustness plus NaN regression (4 tests) and Arrow FFI errors (1 test).
- `./scripts/check-release-versions.sh` now passes, including the stable API allowlist.
- Both JSON schemas parse and validate with Draft 2020-12.
- Materialized `osm-california-highways-1k-v1` check-only evidence validates: 74 components, 1,003 active edges, 74 scratch states, 10 configured workers.
- Generated bindings were restored; final staged diff passed `git diff --check`. Dedicated-runner baselines were not claimed or fabricated.

## Agent handoff

- Parent: none.
- Children: PR #1301.
- Remaining dependency: #1290 must publish dedicated correctness-gated workload baselines before any layout/fast-path/threshold decision is promoted.
- Exact next branch: `agent/p2-component-layout-decision` after those publications; parallel independent work may use `agent/p3-mcindex-production-experiment`.
- Remaining risks: these are shape/evidence measurements, not allocator byte or peak-RSS measurements; no flat/CSR comparison or production dispatch decision has been made.