### PR TITLE
test(core): guard component memory serial parity

### DIFF
--- a/crates/geo-polygonize-core/src/polygonizer_tests.rs
+++ b/crates/geo-polygonize-core/src/polygonizer_tests.rs
@@ -690,6 +690,54 @@ mod tests {
     }
 
     #[test]
+    fn component_memory_shape_contract_is_shared_by_feature_builds() {
+        // This test intentionally runs in both the default (parallel) and
+        // --no-default-features (serial) builds. Shape/capacity evidence must
+        // remain stable; worker and scratch-state cardinality are execution
+        // details and are checked only as bounded values.
+        let mut poly = Polygonizer::new();
+        poly.options_mut().diagnostics.enabled = true;
+        for offset in [0.0, 20.0] {
+            poly.add_geometry(
+                LineString::from(vec![
+                    (offset, 0.0),
+                    (offset + 10.0, 0.0),
+                    (offset + 10.0, 10.0),
+                    (offset, 10.0),
+                    (offset, 0.0),
+                ])
+                .into(),
+            );
+        }
+
+        let result = poly.polygonize().unwrap();
+        let stats = result.diagnostics.unwrap().component_memory_stats;
+        assert_eq!(result.polygons.len(), 2);
+        assert_eq!(stats.component_count, 2);
+        assert_eq!(stats.active_node_count, 8);
+        assert_eq!(stats.active_edge_count, 8);
+        assert_eq!(stats.largest_component_node_count, 4);
+        assert_eq!(stats.largest_component_edge_count, 4);
+        assert_eq!(stats.partition_node_capacity, 8);
+        assert_eq!(stats.partition_edge_capacity, 8);
+        assert_eq!(stats.global_graph_node_capacity, 8);
+        assert_eq!(stats.global_graph_edge_capacity, 8);
+        assert_eq!(stats.global_graph_directed_edge_capacity, 16);
+        assert_eq!(stats.global_graph_adjacency_capacity, 32);
+        assert_eq!(stats.max_scratch_node_capacity, 4);
+        assert_eq!(stats.max_scratch_edge_capacity, 4);
+        assert_eq!(stats.max_scratch_directed_edge_capacity, 8);
+        assert_eq!(stats.max_scratch_adjacency_capacity, 16);
+        assert_eq!(stats.max_scratch_global_node_capacity, 4);
+        assert_eq!(stats.max_scratch_local_node_capacity, 7);
+        assert_eq!(stats.max_scratch_global_dir_edge_capacity, 4);
+        assert_eq!(stats.max_merged_output_item_count, 4);
+        assert_eq!(stats.max_merged_output_coordinate_capacity, 20);
+        assert!(stats.scratch_instance_count >= 1);
+        assert!(stats.execution_worker_count >= 1);
+    }
+
+    #[test]
     fn diagnostics_report_noding_iterations() {
         let mut poly = Polygonizer::new();
         poly.options_mut().node_input = true;


### PR DESCRIPTION
## Stack

- Parent: PR #1300, `perf(core): expose component memory evidence`.
- Children: none.
- Base branch: `agent/p2-component-memory-layout-evidence`; this child is not based directly on `main`.
- Roadmap target: P2.2 / issue #1291.

## Delivered

- Added a shared contract test that runs in both the default parallel build and the `--no-default-features` serial build.
- Locked exact component distribution, graph/partition/adjacency capacities, reusable scratch high-water capacities, and merged-output buffering for two disconnected components.
- Kept worker-pool and scratch-state counts explicitly execution-dependent, requiring only bounded nonzero values.
- This is a regression/contract slice only; it does not change production behavior or promote a layout.

## Contract impact

- No runtime, public API, topology, canonical ordering, provenance, Z, resource-limit, or cancellation changes.
- The test makes the serial/parallel evidence boundary explicit: shape/capacity fields must match, while `execution_worker_count` and `scratch_instance_count` describe execution strategy and are not asserted equal.
- The parent’s additive diagnostics and benchmark-record contract remain the only production changes.

## Validation

- `cargo fmt -- --check`
- `cargo clippy --locked -p geo-polygonize-core --all-targets --all-features -- -D warnings`
- New shape contract: 1 passed in default parallel build and 1 passed in `--no-default-features` serial build.
- Existing serial/parallel conformance snapshot: 1 passed in each feature build.
- Staged diff passed `git diff --cached --check`; generated artifacts unchanged.
- Parent PR #1300 carries the full workspace checkpoint, release guards, schema validation, and materialized workload evidence.

## Agent handoff

- Parent: PR #1300.
- Children: none.
- Exact next branch: `agent/p2-component-layout-decision` only after #1290 publishes dedicated correctness-gated baselines.
- Remaining risks: this test covers a representative disconnected-component shape, not dedicated-runner allocator/RSS measurements or a flat/CSR comparison; no production layout or dispatch decision is made.