### PR TITLE
ci(github): define dedicated baseline suite contract

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -206,13 +206,18 @@ Tracked by
   a new source was not authorized.
 - [x] Use only authorized, sanitized, or procedurally abstracted CFB data.
 - [x] Correctness-gate every materialized workload before timing.
+- [x] Define a fail-closed production baseline suite covering the current
+  already-noded, floating, certified-fixed, component-local, and 1k/10k/100k
+  production-network paths.
 - [ ] Publish dedicated-runner baselines for current production algorithms.
 
 The publication workflow now accepts an operator-staged out-of-tree
 `runner-manifest-v1.json` and verifies each selected clip SHA-256 in the GEOS,
 Rust, and JTS reference paths. This evidence plumbing is complete, but the
-checkbox remains open until decision-quality dedicated-runner publications
-exist for the current production algorithms.
+suite contract now fails closed on missing, duplicate, mixed-environment, or
+under-sized publications, and requires component-memory evidence. The checkbox
+remains open until decision-quality dedicated-runner publications exist for
+every required suite entry.
 
 No adaptive backend or graph-layout promotion decision may rely only on the
 tiny correctness corpus.

--- a/benchmarks/production-baseline-evidence-v1.schema.json
+++ b/benchmarks/production-baseline-evidence-v1.schema.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/graydonpleasants/geo-polygonize/benchmarks/production-baseline-evidence-v1.schema.json",
+  "title": "geo-polygonize production baseline evidence V1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "suite_id",
+    "policy_id",
+    "measurement_class",
+    "runner_class",
+    "publication_count",
+    "environment",
+    "publications"
+  ],
+  "properties": {
+    "schema_version": {"const": 1},
+    "suite_id": {"const": "production-baseline-suite-v1"},
+    "policy_id": {"const": "benchmark-decision-v1"},
+    "measurement_class": {"const": "decision-quality"},
+    "runner_class": {"const": "dedicated"},
+    "publication_count": {"type": "integer", "minimum": 1},
+    "environment": {"$ref": "#/$defs/environment"},
+    "publications": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/publication"}
+    }
+  },
+  "$defs": {
+    "environment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["architecture", "os", "compiler", "commit_sha"],
+      "properties": {
+        "architecture": {"type": "string", "minLength": 1},
+        "os": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["name", "version"],
+          "properties": {
+            "name": {"type": "string", "minLength": 1},
+            "version": {"type": "string", "minLength": 1}
+          }
+        },
+        "compiler": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["name", "version"],
+          "properties": {
+            "name": {"type": "string", "minLength": 1},
+            "version": {"type": "string", "minLength": 1}
+          }
+        },
+        "commit_sha": {"type": "string", "pattern": "^[0-9a-f]{40}$"}
+      }
+    },
+    "publication": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "entry_id",
+        "workload_id",
+        "lane",
+        "publication_id",
+        "publication_sha256",
+        "artifact_sha256",
+        "record_count",
+        "input_segments",
+        "median_p50_ms",
+        "median_p95_ms",
+        "median_throughput",
+        "median_allocated_bytes",
+        "median_peak_rss_bytes"
+      ],
+      "properties": {
+        "entry_id": {"type": "string", "minLength": 1},
+        "workload_id": {"type": "string", "minLength": 1},
+        "lane": {
+          "enum": [
+            "already-noded-polygonization",
+            "floating-noding-plus-polygonization",
+            "certified-fixed-precision-noding-plus-polygonization"
+          ]
+        },
+        "publication_id": {"type": "string", "minLength": 1},
+        "publication_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "artifact_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "record_count": {"type": "integer", "minimum": 5},
+        "input_segments": {"type": "integer", "minimum": 1},
+        "median_p50_ms": {"type": "number", "exclusiveMinimum": 0},
+        "median_p95_ms": {"type": "number", "exclusiveMinimum": 0},
+        "median_throughput": {"type": "number", "exclusiveMinimum": 0},
+        "median_allocated_bytes": {"type": "number", "minimum": 0},
+        "median_peak_rss_bytes": {"type": "number", "minimum": 0}
+      }
+    }
+  }
+}

--- a/benchmarks/production-baseline-suite-v1.json
+++ b/benchmarks/production-baseline-suite-v1.json
@@ -1,0 +1,64 @@
+{
+  "schema_version": 1,
+  "suite_id": "production-baseline-suite-v1",
+  "policy_id": "benchmark-decision-v1",
+  "description": "Decision-quality baselines for current polygonization, noding, component, and production-scale paths.",
+  "required_publications": [
+    {
+      "entry_id": "already-noded-coverage",
+      "workload_id": "already-noded-coverage-v1",
+      "lane": "already-noded-polygonization",
+      "coverage": ["already-noded-polygonization", "component-local-graph"],
+      "minimum_input_segments": 12,
+      "required_work_fields": ["component_memory"]
+    },
+    {
+      "entry_id": "component-nested-containment",
+      "workload_id": "disconnected-nested-rings-v1",
+      "lane": "already-noded-polygonization",
+      "coverage": ["already-noded-polygonization", "component-local-graph", "nested-containment"],
+      "minimum_input_segments": 12,
+      "required_work_fields": ["component_memory"]
+    },
+    {
+      "entry_id": "floating-dense-crossings",
+      "workload_id": "dense-crossings-v1",
+      "lane": "floating-noding-plus-polygonization",
+      "coverage": ["floating-noding-plus-polygonization", "component-local-graph"],
+      "minimum_input_segments": 8,
+      "required_work_fields": ["component_memory"]
+    },
+    {
+      "entry_id": "certified-fixed-dense-crossings",
+      "workload_id": "dense-crossings-v1",
+      "lane": "certified-fixed-precision-noding-plus-polygonization",
+      "coverage": ["certified-fixed-precision-noding-plus-polygonization", "component-local-graph"],
+      "minimum_input_segments": 8,
+      "required_work_fields": ["component_memory"]
+    },
+    {
+      "entry_id": "production-network-1k",
+      "workload_id": "osm-california-highways-1k-v1",
+      "lane": "floating-noding-plus-polygonization",
+      "coverage": ["floating-noding-plus-polygonization", "production-scale-network", "component-local-graph"],
+      "minimum_input_segments": 1000,
+      "required_work_fields": ["component_memory"]
+    },
+    {
+      "entry_id": "production-network-10k",
+      "workload_id": "osm-california-highways-10k-v1",
+      "lane": "floating-noding-plus-polygonization",
+      "coverage": ["floating-noding-plus-polygonization", "production-scale-network", "component-local-graph"],
+      "minimum_input_segments": 10000,
+      "required_work_fields": ["component_memory"]
+    },
+    {
+      "entry_id": "production-network-100k",
+      "workload_id": "osm-california-highways-100k-v1",
+      "lane": "floating-noding-plus-polygonization",
+      "coverage": ["floating-noding-plus-polygonization", "production-scale-network", "component-local-graph"],
+      "minimum_input_segments": 100000,
+      "required_work_fields": ["component_memory"]
+    }
+  ]
+}

--- a/benchmarks/production-baseline-suite-v1.schema.json
+++ b/benchmarks/production-baseline-suite-v1.schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/graydonpleasants/geo-polygonize/benchmarks/production-baseline-suite-v1.schema.json",
+  "title": "geo-polygonize production baseline suite V1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "suite_id", "policy_id", "description", "required_publications"],
+  "properties": {
+    "schema_version": {"const": 1},
+    "suite_id": {"const": "production-baseline-suite-v1"},
+    "policy_id": {"const": "benchmark-decision-v1"},
+    "description": {"type": "string", "minLength": 1},
+    "required_publications": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/publication"}
+    }
+  },
+  "$defs": {
+    "publication": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "entry_id",
+        "workload_id",
+        "lane",
+        "coverage",
+        "minimum_input_segments",
+        "required_work_fields"
+      ],
+      "properties": {
+        "entry_id": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9-]*$"
+        },
+        "workload_id": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9._-]*$"
+        },
+        "lane": {
+          "enum": [
+            "already-noded-polygonization",
+            "floating-noding-plus-polygonization",
+            "certified-fixed-precision-noding-plus-polygonization"
+          ]
+        },
+        "coverage": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "already-noded-polygonization",
+              "floating-noding-plus-polygonization",
+              "certified-fixed-precision-noding-plus-polygonization",
+              "component-local-graph",
+              "nested-containment",
+              "production-scale-network"
+            ]
+          }
+        },
+        "minimum_input_segments": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "required_work_fields": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"enum": ["component_memory"]}
+        }
+      }
+    }
+  }
+}

--- a/benchmarks/validate_baseline_suite.py
+++ b/benchmarks/validate_baseline_suite.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Fail closed unless a complete dedicated baseline suite is present."""
+
+import argparse
+import hashlib
+import json
+import statistics
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+from referencing import Registry, Resource
+
+
+ROOT = Path(__file__).resolve().parent
+RECORD_SCHEMA_NAME = "benchmark-record-v1.schema.json"
+PUBLICATION_SCHEMA_NAME = "benchmark-publication-v1.schema.json"
+SUITE_SCHEMA_NAME = "production-baseline-suite-v1.schema.json"
+EVIDENCE_SCHEMA_NAME = "production-baseline-evidence-v1.schema.json"
+QUALITY = {
+    "runner_class": "dedicated",
+    "measurement_class": "decision-quality",
+    "minimum_samples_per_process": 30,
+    "minimum_process_repetitions": 5,
+    "minimum_warmup_iterations": 5,
+    "maximum_relative_mad_percent": 3.0,
+}
+STABLE_RECORD_FIELDS = (
+    "workload_id",
+    "artifact_sha256",
+    "lane",
+    "implementation",
+    "correctness_gate",
+    "topology",
+    "work",
+    "environment",
+)
+ENVIRONMENT_FIELDS = ("architecture", "os", "compiler", "commit_sha")
+
+
+def load_json(path):
+    return json.loads(Path(path).read_text())
+
+
+def load_schema(name):
+    return load_json(ROOT / name)
+
+
+def validate_document(document, schema, name, registry=None):
+    validator = (
+        Draft202012Validator(schema)
+        if registry is None
+        else Draft202012Validator(schema, registry=registry)
+    )
+    errors = sorted(validator.iter_errors(document), key=lambda error: list(error.path))
+    if errors:
+        error = errors[0]
+        location = ".".join(str(part) for part in error.path) or "document"
+        raise ValueError(f"{name} schema validation failed at {location}: {error.message}")
+
+
+def validate_suite_document(path):
+    suite = load_json(path)
+    schema = load_schema(SUITE_SCHEMA_NAME)
+    validate_document(suite, schema, "baseline suite")
+    entries = suite["required_publications"]
+    entry_ids = [entry["entry_id"] for entry in entries]
+    if len(set(entry_ids)) != len(entry_ids):
+        raise ValueError("baseline suite entry IDs must be unique")
+    if any(entry["lane"] not in entry["coverage"] for entry in entries):
+        raise ValueError("baseline suite coverage must include each publication lane")
+    keys = [(entry["workload_id"], entry["lane"]) for entry in entries]
+    if len(set(keys)) != len(keys):
+        raise ValueError("baseline suite workload/lane pairs must be unique")
+    return suite
+
+
+def _publication_validator():
+    record_schema = load_schema(RECORD_SCHEMA_NAME)
+    publication_schema = load_schema(PUBLICATION_SCHEMA_NAME)
+    registry = Registry().with_resource(
+        record_schema["$id"], Resource.from_contents(record_schema)
+    )
+    return publication_schema, registry
+
+
+def _environment_identity(environment):
+    return tuple(
+        json.dumps(environment[field], sort_keys=True) if isinstance(environment[field], dict)
+        else environment[field]
+        for field in ENVIRONMENT_FIELDS
+    )
+
+
+def _validate_record_set(publication, path):
+    records = publication["records"]
+    if publication["process_repetitions"] != len(records):
+        raise ValueError(f"{path}: process_repetitions does not match records")
+    if len({record["record_id"] for record in records}) != len(records):
+        raise ValueError(f"{path}: record IDs must be unique")
+
+    baseline = records[0]
+    for record in records[1:]:
+        if any(record[field] != baseline[field] for field in STABLE_RECORD_FIELDS):
+            raise ValueError(f"{path}: records do not describe one stable workload and environment")
+
+    for record in records:
+        gate = record["correctness_gate"]
+        if gate["status"] != "passed" or gate["validation"]["result"] != "passed":
+            raise ValueError(f"{path}: every record must pass the correctness gate")
+        if gate["compatibility"]["observed"] != "equal":
+            raise ValueError(f"{path}: every baseline record must have equal reference topology")
+        if gate["fingerprint"]["outcome"] != "equal":
+            raise ValueError(f"{path}: every baseline record must have an equal fingerprint")
+
+        measurement = record["measurement"]
+        if measurement["samples"] < QUALITY["minimum_samples_per_process"]:
+            raise ValueError(f"{path}: insufficient samples per process")
+        if measurement["p50_ms"] <= 0 or measurement["p95_ms"] < measurement["p50_ms"]:
+            raise ValueError(f"{path}: invalid timing percentiles")
+        if measurement["throughput"]["value"] <= 0:
+            raise ValueError(f"{path}: throughput must be positive")
+        if measurement["throughput"]["unit"] != "input-segments/second":
+            raise ValueError(f"{path}: unsupported throughput unit")
+
+    if publication["p50_relative_mad_percent"] > QUALITY["maximum_relative_mad_percent"]:
+        raise ValueError(f"{path}: p50 dispersion exceeds the decision-quality limit")
+    return baseline, records
+
+
+def _load_publication(path):
+    path = Path(path)
+    publication = load_json(path)
+    publication_schema, registry = _publication_validator()
+    validate_document(publication, publication_schema, str(path), registry)
+    if publication["policy_id"] != "benchmark-decision-v1":
+        raise ValueError(f"{path}: unexpected policy")
+    if publication["measurement_class"] != QUALITY["measurement_class"]:
+        raise ValueError(f"{path}: publication is not decision-quality")
+    if publication["runner_class"] != QUALITY["runner_class"]:
+        raise ValueError(f"{path}: publication is not from a dedicated runner")
+    if publication["warmup_iterations"] < QUALITY["minimum_warmup_iterations"]:
+        raise ValueError(f"{path}: insufficient warmup iterations")
+    if publication["process_repetitions"] < QUALITY["minimum_process_repetitions"]:
+        raise ValueError(f"{path}: insufficient process repetitions")
+
+    baseline, records = _validate_record_set(publication, path)
+    return {
+        "path": path,
+        "publication": publication,
+        "baseline": baseline,
+        "records": records,
+        "publication_sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+    }
+
+
+def _median(records, field):
+    return statistics.median(record["measurement"][field] for record in records)
+
+
+def validate_baseline_suite(suite_path, publication_paths):
+    suite = validate_suite_document(suite_path)
+    expected = {
+        (entry["workload_id"], entry["lane"]): entry
+        for entry in suite["required_publications"]
+    }
+    if len(publication_paths) != len(expected):
+        raise ValueError(
+            f"baseline suite requires {len(expected)} publications, got {len(publication_paths)}"
+        )
+
+    contexts = [_load_publication(path) for path in publication_paths]
+    seen = set()
+    for context in contexts:
+        baseline = context["baseline"]
+        key = (baseline["workload_id"], baseline["lane"])
+        if key not in expected:
+            raise ValueError(f"unexpected publication for {key[0]} / {key[1]}")
+        if key in seen:
+            raise ValueError(f"duplicate publication for {key[0]} / {key[1]}")
+        seen.add(key)
+
+        entry = expected[key]
+        if baseline["work"]["input_segments"] < entry["minimum_input_segments"]:
+            raise ValueError(
+                f"{entry['entry_id']}: input has fewer than {entry['minimum_input_segments']} segments"
+            )
+        for field in entry["required_work_fields"]:
+            if field not in baseline["work"]:
+                raise ValueError(f"{entry['entry_id']}: work.{field} is required")
+
+    missing = set(expected) - seen
+    if missing:
+        formatted = ", ".join(f"{workload} / {lane}" for workload, lane in sorted(missing))
+        raise ValueError(f"missing baseline publications: {formatted}")
+
+    first = contexts[0]["baseline"]
+    suite_environment = _environment_identity(first["environment"])
+    implementation = first["implementation"]
+    for context in contexts[1:]:
+        baseline = context["baseline"]
+        if _environment_identity(baseline["environment"]) != suite_environment:
+            raise ValueError("baseline publications must use one architecture, OS, compiler, and commit")
+        if baseline["implementation"] != implementation:
+            raise ValueError("baseline publications must use one implementation")
+
+    summaries = []
+    for context in contexts:
+        baseline = context["baseline"]
+        records = context["records"]
+        entry = expected[(baseline["workload_id"], baseline["lane"])]
+        summaries.append(
+            {
+                "entry_id": entry["entry_id"],
+                "workload_id": baseline["workload_id"],
+                "lane": baseline["lane"],
+                "publication_id": context["publication"]["publication_id"],
+                "publication_sha256": context["publication_sha256"],
+                "artifact_sha256": baseline["artifact_sha256"],
+                "record_count": len(records),
+                "input_segments": baseline["work"]["input_segments"],
+                "median_p50_ms": _median(records, "p50_ms"),
+                "median_p95_ms": _median(records, "p95_ms"),
+                "median_throughput": statistics.median(
+                    record["measurement"]["throughput"]["value"] for record in records
+                ),
+                "median_allocated_bytes": statistics.median(
+                    record["measurement"]["allocations"]["bytes"] for record in records
+                ),
+                "median_peak_rss_bytes": statistics.median(
+                    record["measurement"]["peak_rss_bytes"] for record in records
+                ),
+            }
+        )
+    summaries.sort(key=lambda summary: summary["entry_id"])
+
+    evidence = {
+        "schema_version": 1,
+        "suite_id": suite["suite_id"],
+        "policy_id": suite["policy_id"],
+        "measurement_class": QUALITY["measurement_class"],
+        "runner_class": QUALITY["runner_class"],
+        "publication_count": len(summaries),
+        "environment": {
+            field: first["environment"][field] for field in ENVIRONMENT_FIELDS
+        },
+        "publications": summaries,
+    }
+    validate_document(evidence, load_schema(EVIDENCE_SCHEMA_NAME), "baseline evidence")
+    return evidence
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--suite", type=Path, default=ROOT / "production-baseline-suite-v1.json")
+    parser.add_argument("--publication", type=Path, action="append", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    evidence = validate_baseline_suite(args.suite, args.publication)
+    args.output.write_text(json.dumps(evidence, indent=2, allow_nan=False) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_baseline_suite.py
+++ b/tests/test_baseline_suite.py
@@ -1,0 +1,204 @@
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import validate
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_module(name, relative_path):
+    path = ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+PUBLISHER = load_module("publish_benchmark", "benchmarks/publish_benchmark.py")
+SUITE = load_module("validate_baseline_suite", "benchmarks/validate_baseline_suite.py")
+
+COMPONENT_MEMORY_FIELDS = (
+    "component_count",
+    "active_node_count",
+    "active_edge_count",
+    "largest_component_node_count",
+    "largest_component_edge_count",
+    "partition_node_capacity",
+    "partition_edge_capacity",
+    "global_graph_node_capacity",
+    "global_graph_edge_capacity",
+    "global_graph_directed_edge_capacity",
+    "global_graph_adjacency_capacity",
+    "scratch_instance_count",
+    "execution_worker_count",
+    "max_scratch_node_capacity",
+    "max_scratch_edge_capacity",
+    "max_scratch_directed_edge_capacity",
+    "max_scratch_adjacency_capacity",
+    "max_scratch_global_node_capacity",
+    "max_scratch_local_node_capacity",
+    "max_scratch_global_dir_edge_capacity",
+    "max_merged_output_item_count",
+    "max_merged_output_coordinate_capacity",
+)
+
+
+def record(workload_id, lane, index, input_segments, commit="b" * 40):
+    return {
+        "schema_version": 1,
+        "record_id": f"{workload_id}-{lane}-r{index}",
+        "workload_id": workload_id,
+        "artifact_sha256": (workload_id.encode().hex() + "a" * 64)[:64],
+        "lane": lane,
+        "implementation": {"name": "core", "version": "1", "features": ["parallel"]},
+        "correctness_gate": {
+            "status": "passed",
+            "validation": {"promised": True, "result": "passed"},
+            "compatibility": {"expected": "parity", "observed": "equal"},
+            "fingerprint": {
+                "outcome": "equal",
+                "actual_sha256": "a" * 64,
+                "reference_sha256": "a" * 64,
+            },
+        },
+        "topology": {
+            "polygons": 1,
+            "rings": 1,
+            "dangles": 0,
+            "cut_edges": 0,
+            "invalid_rings": 0,
+            "provenance_sources": 1,
+        },
+        "measurement": {
+            "p50_ms": 100 + index / 10,
+            "p95_ms": 110 + index / 10,
+            "throughput": {"value": input_segments / 100, "unit": "input-segments/second"},
+            "samples": 30,
+            "phase_times_ms": {"polygonize": 100},
+            "allocations": {"count": 10, "bytes": 1000},
+            "peak_rss_bytes": 2000,
+        },
+        "work": {
+            "input_line_strings": 1,
+            "input_segments": input_segments,
+            "input_coordinates": input_segments + 1,
+            "output_polygons": 1,
+            "output_coordinates": 5,
+            "candidate_pairs": 1,
+            "exact_predicate_calls": 1,
+            "split_events": 1,
+            "segment_expansion": {
+                "input_segments": input_segments,
+                "noded_segments": input_segments,
+                "ratio": 1,
+            },
+            "component_memory": {field: 1 for field in COMPONENT_MEMORY_FIELDS},
+        },
+        "environment": {
+            "architecture": "x86_64",
+            "os": {"name": "Linux", "version": "test"},
+            "compiler": {"name": "rustc", "version": "test"},
+            "dependencies": {"core": "1"},
+            "commit_sha": commit,
+        },
+    }
+
+
+def write_publication(tmp_path, entry, input_segments=None):
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    if input_segments is None:
+        input_segments = entry["minimum_input_segments"]
+    records = []
+    for index in range(1, 6):
+        value = record(
+            entry["workload_id"],
+            entry["lane"],
+            index,
+            input_segments,
+        )
+        path = tmp_path / f"{entry['entry_id']}-record-{index}.json"
+        path.write_text(json.dumps(value))
+        records.append(path)
+    publication = PUBLISHER.publish(records, "dedicated", 5)
+    path = tmp_path / f"{entry['entry_id']}-publication.json"
+    path.write_text(json.dumps(publication, indent=2) + "\n")
+    return path
+
+
+def entries():
+    return json.loads(
+        (ROOT / "benchmarks/production-baseline-suite-v1.json").read_text()
+    )["required_publications"]
+
+
+def test_production_baseline_suite_manifest_is_schema_valid():
+    manifest = json.loads(
+        (ROOT / "benchmarks/production-baseline-suite-v1.json").read_text()
+    )
+    schema = json.loads(
+        (ROOT / "benchmarks/production-baseline-suite-v1.schema.json").read_text()
+    )
+    validate(manifest, schema)
+    SUITE.validate_suite_document(ROOT / "benchmarks/production-baseline-suite-v1.json")
+    assert len(manifest["required_publications"]) == 7
+    assert {entry["minimum_input_segments"] for entry in manifest["required_publications"]} >= {
+        1000,
+        10000,
+        100000,
+    }
+
+
+def test_complete_suite_emits_deterministic_evidence(tmp_path):
+    publication_paths = [write_publication(tmp_path, entry) for entry in entries()]
+    evidence = SUITE.validate_baseline_suite(
+        ROOT / "benchmarks/production-baseline-suite-v1.json", publication_paths[::-1]
+    )
+
+    assert evidence["publication_count"] == 7
+    assert evidence["runner_class"] == "dedicated"
+    assert evidence["environment"]["commit_sha"] == "b" * 40
+    assert [item["entry_id"] for item in evidence["publications"]] == sorted(
+        item["entry_id"] for item in evidence["publications"]
+    )
+    assert all(item["record_count"] == 5 for item in evidence["publications"])
+
+    output = tmp_path / "evidence.json"
+    output.write_text(json.dumps(evidence, indent=2) + "\n")
+    validate(
+        evidence,
+        json.loads(
+            (ROOT / "benchmarks/production-baseline-evidence-v1.schema.json").read_text()
+        ),
+    )
+
+
+def test_suite_rejects_missing_duplicate_mixed_and_under_sized_publications(tmp_path):
+    publication_paths = [write_publication(tmp_path, entry) for entry in entries()]
+    suite_path = ROOT / "benchmarks/production-baseline-suite-v1.json"
+
+    with pytest.raises(ValueError, match="requires 7 publications"):
+        SUITE.validate_baseline_suite(suite_path, publication_paths[:-1])
+
+    with pytest.raises(ValueError, match="duplicate publication"):
+        SUITE.validate_baseline_suite(suite_path, publication_paths[:-1] + [publication_paths[0]])
+
+    mixed_path = publication_paths[-1]
+    mixed = json.loads(mixed_path.read_text())
+    for value in mixed["records"]:
+        value["environment"]["commit_sha"] = "c" * 40
+    mixed_path.write_text(json.dumps(mixed))
+    with pytest.raises(ValueError, match="one architecture, OS, compiler, and commit"):
+        SUITE.validate_baseline_suite(suite_path, publication_paths)
+
+    undersized_paths = [write_publication(tmp_path / "undersized", entry) for entry in entries()]
+    undersized = entries()[-1]
+    undersized_path = tmp_path / "undersized" / f"{undersized['entry_id']}-publication.json"
+    value = json.loads(undersized_path.read_text())
+    for record_value in value["records"]:
+        record_value["work"]["input_segments"] = 999
+    undersized_path.write_text(json.dumps(value))
+    with pytest.raises(ValueError, match="fewer than 100000 segments"):
+        SUITE.validate_baseline_suite(suite_path, undersized_paths)


### PR DESCRIPTION
## Stack
- Parent: none; this is the root of the production-evidence stack.
- Children: `agent/p1-dedicated-baseline-publication-ci` (next exact child branch).

## Delivered
- Added the checked-in `production-baseline-suite-v1` matrix for already-noded, floating, certified-fixed, component-local, nested-containment, and 1k/10k/100k production-network coverage.
- Added schemas for the suite contract and emitted baseline evidence.
- Added a fail-closed validator that aggregates individual decision-quality publications only when they are complete, dedicated-runner, correctness-gated, stable, sufficiently sized, and component-memory-bearing.
- Updated ROADMAP.md without marking the actual dedicated-runner publication gate complete.

## Contract impact
- Individual publication artifacts remain unchanged.
- A suite now requires exactly one publication per declared workload/lane, one architecture/OS/compiler/commit/implementation, minimum workload sizes, component-memory evidence, and valid timing/correctness contracts.
- No performance claim is added: the required dedicated publications still do not exist.

## Validation
- `pytest -q tests/test_baseline_suite.py` (3 passed).
- JSON Schema checks for the suite and evidence schemas.
- `git diff --check`.

## Agent handoff
- Parent: none.
- Exact child: `agent/p1-dedicated-baseline-publication-ci`.
- Child should wire the validator into benchmark CI/operator workflow and document artifact aggregation; it must preserve the open publication checkbox until real dedicated-runner evidence is supplied.