### PR TITLE
ci(github): enforce dedicated baseline suite validation

### DIFF
--- a/.github/workflows/benchmark-baseline-suite.yml
+++ b/.github/workflows/benchmark-baseline-suite.yml
@@ -1,0 +1,56 @@
+name: Validate benchmark baseline suite
+
+on:
+  workflow_dispatch:
+    inputs:
+      publication_dir:
+        description: Absolute path to a directory of downloaded publication.json artifacts on the dedicated runner
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: [self-hosted, benchmark-dedicated, linux, x64]
+    timeout-minutes: 15
+    env:
+      PUBLICATION_DIR: ${{ inputs.publication_dir }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate staged publication directory
+        run: |
+          case "$PUBLICATION_DIR" in
+            /*) ;;
+            *) echo "publication_dir must be an absolute path on the dedicated runner" >&2; exit 1 ;;
+          esac
+          test -d "$PUBLICATION_DIR"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12.11"
+
+      - run: python -m pip install jsonschema==4.26.0
+
+      - name: Validate the complete baseline suite
+        run: |
+          mapfile -t publication_paths < <(find "$PUBLICATION_DIR" -type f -name publication.json | sort)
+          test "${#publication_paths[@]}" -gt 0
+          publication_args=()
+          for publication_path in "${publication_paths[@]}"; do
+            publication_args+=(--publication "$publication_path")
+          done
+          mkdir -p target/benchmark-baseline
+          python benchmarks/validate_baseline_suite.py \
+            --suite benchmarks/production-baseline-suite-v1.json \
+            "${publication_args[@]}" \
+            --output target/benchmark-baseline/production-baseline-evidence-v1.json
+          cat target/benchmark-baseline/production-baseline-evidence-v1.json >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Retain baseline suite evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-baseline-suite-${{ github.sha }}
+          path: target/benchmark-baseline/production-baseline-evidence-v1.json
+          retention-days: 90

--- a/.github/workflows/benchmark-evidence.yml
+++ b/.github/workflows/benchmark-evidence.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/benchmark-evidence.yml"
+      - ".github/workflows/benchmark-baseline-suite.yml"
       - "benchmarks/**"
       - "crates/geo-polygonize-core/examples/benchmark_record.rs"
       - "crates/geo-polygonize-core/tests/workloads/**"
@@ -12,6 +13,7 @@ on:
       - "tests/test_publish_benchmark.py"
       - "tests/test_benchmark_workflow_pins.py"
       - "tests/test_benchmark_artifacts.py"
+      - "tests/test_baseline_suite.py"
   push:
     branches: [main]
     paths:
@@ -22,6 +24,7 @@ on:
       - "tests/test_publish_benchmark.py"
       - "tests/test_benchmark_workflow_pins.py"
       - "tests/test_benchmark_artifacts.py"
+      - "tests/test_baseline_suite.py"
 
 permissions:
   contents: read
@@ -54,7 +57,7 @@ jobs:
 
       - run: cargo build --locked --release -p geo-polygonize-core --example benchmark_record
 
-      - run: pytest -q tests/test_reference_geos.py tests/test_publish_benchmark.py tests/test_benchmark_workflow_pins.py tests/test_benchmark_artifacts.py
+      - run: pytest -q tests/test_reference_geos.py tests/test_publish_benchmark.py tests/test_benchmark_workflow_pins.py tests/test_benchmark_artifacts.py tests/test_baseline_suite.py
 
       - run: python benchmarks/check_geos_references.py --output-dir target/geos-reference
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -119,6 +119,33 @@ The publisher rejects shared runners, too few warmups, process repetitions or
 samples, duplicate record IDs, mixed commits/environments/workloads, schema
 failures, and p50 relative median absolute deviation above 3%.
 
+`production-baseline-suite-v1.json` is the fail-closed matrix for the next
+roadmap decisions. It requires seven publications: already-noded coverage and
+nested containment, floating and certified-fixed dense crossings, and floating
+California highway tiers at approximately 1k, 10k, and 100k input segments.
+Every entry must retain `work.component_memory`, and the suite must use one
+implementation, architecture, OS, compiler, and commit. Aggregate downloaded
+`publication.json` artifacts only after each entry has passed the individual
+publication gate:
+
+```bash
+python3 benchmarks/validate_baseline_suite.py \
+  --suite benchmarks/production-baseline-suite-v1.json \
+  --publication artifacts/already-noded-coverage/publication.json \
+  --publication artifacts/component-nested-containment/publication.json \
+  --publication artifacts/floating-dense-crossings/publication.json \
+  --publication artifacts/certified-fixed-dense-crossings/publication.json \
+  --publication artifacts/production-network-1k/publication.json \
+  --publication artifacts/production-network-10k/publication.json \
+  --publication artifacts/production-network-100k/publication.json \
+  --output artifacts/production-baseline-evidence-v1.json
+```
+
+The validator emits a checksum-linked evidence summary and rejects missing,
+duplicate, mixed-environment, undersized, or incomplete publications. The
+matrix is a publication contract, not evidence by itself; the P1.2 roadmap
+gate remains open until these artifacts are produced on the dedicated runner.
+
 `benchmark-decision-v1.schema.json` defines the durable decision record for an
 experiment. Store records under `benchmarks/decisions/` when real evidence
 exists. Each record preserves the predeclared policy thresholds and links

--- a/docs/guide/production-corpus.md
+++ b/docs/guide/production-corpus.md
@@ -110,6 +110,21 @@ CAD categories remain represented by the existing public/procedural fixtures;
 the materialization report records those choices and reasons. No CFB or
 customer geometry is used.
 
+The required cross-workload baseline matrix is
+`benchmarks/production-baseline-suite-v1.json`. Repeat the dedicated publication
+workflow for each matrix entry, download each resulting `publication.json` into
+one directory on the dedicated runner, then validate the complete suite:
+
+```bash
+gh workflow run benchmark-baseline-suite.yml --ref main \
+  -f publication_dir=/mnt/geo-polygonize/publications
+```
+
+The suite workflow refuses incomplete or mixed-commit collections and retains
+only the checksum-linked `production-baseline-evidence-v1.json` summary. This
+does not close P1.2 until all seven required dedicated-runner publications
+exist; local or hosted correctness runs remain diagnostic.
+
 ## Adding a source
 
 Add a source only after independently reading its license and publisher

--- a/tests/test_benchmark_artifacts.py
+++ b/tests/test_benchmark_artifacts.py
@@ -74,3 +74,16 @@ def test_publication_requires_a_dedicated_runner_and_retains_gated_outputs():
     assert 'cat target/benchmark-publication/trends.md >> "$GITHUB_STEP_SUMMARY"' in workflow
     assert "retention-days: 90" in workflow
     assert "ubuntu-latest" not in workflow
+
+
+def test_baseline_suite_validation_is_dedicated_and_fail_closed():
+    workflow = (ROOT / ".github/workflows/benchmark-baseline-suite.yml").read_text()
+    assert "runs-on: [self-hosted, benchmark-dedicated, linux, x64]" in workflow
+    assert "publication_dir:" in workflow
+    assert 'test -d "$PUBLICATION_DIR"' in workflow
+    assert 'find "$PUBLICATION_DIR" -type f -name publication.json | sort' in workflow
+    assert "benchmarks/validate_baseline_suite.py" in workflow
+    assert "benchmarks/production-baseline-suite-v1.json" in workflow
+    assert "production-baseline-evidence-v1.json" in workflow
+    assert "retention-days: 90" in workflow
+    assert "ubuntu-latest" not in workflow


### PR DESCRIPTION
## Stack
- Parent: #1303 `agent/p1-dedicated-baseline-publication`.
- Children: none; this is the current leaf of the production-evidence stack.

## Delivered
- Added the dedicated-runner `benchmark-baseline-suite.yml` workflow to aggregate downloaded `publication.json` artifacts through the checked-in suite contract.
- Wired the baseline-suite regression tests into benchmark evidence CI.
- Documented the seven-entry matrix, artifact aggregation command, and the distinction between contract plumbing and real dedicated-runner evidence.

## Contract impact
- The suite workflow runs only on `[self-hosted, benchmark-dedicated, linux, x64]`, rejects non-absolute or missing staging directories, finds publication artifacts deterministically, and retains only checksum-linked suite evidence for 90 days.
- The individual publication workflow remains unchanged and must be run once per required entry.
- P1.2 remains open until all seven decision-quality publications exist; no algorithm or dispatch promotion is claimed.

## Validation
- `pytest -q tests/test_baseline_suite.py tests/test_benchmark_artifacts.py tests/test_publish_benchmark.py tests/test_benchmark_workflow_pins.py` (11 passed).
- YAML parse checks for both changed workflows.
- Full workspace checkpoint: `cargo fmt -- --check`; `cargo check --locked`; `cargo clippy --locked -- -D warnings`; `cargo test --locked --verbose`; `cargo test --locked -p geo-polygonize-core --no-default-features --lib --tests`; `cargo check --locked -p geo-polygonize-core --all-targets --all-features` — all passed.
- Generated TypeScript bindings were restored after the schema-test side effect.

## Agent handoff
- Parent: #1303.
- Children: none.
- Next executable branch after this stack: `agent/p1-dedicated-baseline-publication-run` for an authorized dedicated-runner publication matrix, or `agent/p2-component-memory-decision` only after the suite evidence exists.