### PR TITLE
feat(core): export atomic border observations

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -419,18 +419,19 @@ These prerequisites do not yet stitch topology.
 Tracked by
 [#1288](https://github.com/graydonpleasants/geo-polygonize/issues/1288).
 
-- [ ] Split local arrangement edges at exact partition-boundary intersections.
+- [x] Split local arrangement edges at exact partition-boundary intersections,
+  including breakpoints contributed by separate crossing edges.
 - [x] Define exact rectangle-side intersection events, including endpoint,
   corner, finite-side collinear, signed-zero, and reversed-edge fixtures.
-- [ ] Handle endpoints, crossings, corners, and collinear-on-border edges.
-- [ ] Rebuild adjacency, angular order, `next` links, face IDs, and unbounded
-  markers after splitting.
+- [x] Handle endpoints, crossings, corners, and collinear-on-border edges.
+- [x] Rebuild adjacency and angular order before component-local `next` links,
+  face IDs, and unbounded markers are assigned.
 - [ ] Preserve provenance, representative IDs, Z interpolation/conflicts,
   component identity, cancellation, and limits.
-- [ ] Export only halfedges physically present on the boundary-noded arrangement.
-- [ ] Introduce collision-free atomic observation identity.
-- [ ] Run arrangement and face-walk validators after boundary noding.
-- [ ] Leave replicate-and-own output unchanged.
+- [x] Export only halfedges physically present on the boundary-noded arrangement.
+- [x] Introduce collision-free atomic observation identity.
+- [x] Run arrangement and face-walk validators after boundary noding.
+- [x] Leave replicate-and-own output unchanged.
 
 ## P5.3 Stitched arrangement and equivalence
 

--- a/crates/geo-polygonize-core/src/graph/partition_border.rs
+++ b/crates/geo-polygonize-core/src/graph/partition_border.rs
@@ -461,6 +461,7 @@ impl PartitionBorderAdjacency {
 pub struct PartitionBorderObservationId {
     pub partition_id: usize,
     pub local_dir_edge_id: DirEdgeId,
+    pub edge_key: PartitionBorderEdgeKey,
 }
 
 impl PartitionBorderHalfEdge {
@@ -468,6 +469,7 @@ impl PartitionBorderHalfEdge {
         PartitionBorderObservationId {
             partition_id: self.partition_id,
             local_dir_edge_id: self.local_dir_edge_id,
+            edge_key: self.edge_key,
         }
     }
 }
@@ -517,8 +519,10 @@ impl PartitionBorderGraph {
             }
             return Err(crate::PolygonizeError::InternalInvariantViolation {
                 reason: format!(
-                    "partition border observation ({}, {}) conflicts with prior payload",
-                    observation_id.partition_id, observation_id.local_dir_edge_id
+                    "partition border observation ({}, {}, {:?}) conflicts with prior payload",
+                    observation_id.partition_id,
+                    observation_id.local_dir_edge_id,
+                    observation_id.edge_key
                 ),
             });
         }
@@ -999,11 +1003,42 @@ mod tests {
 
         let mut graph = PartitionBorderGraph::default();
         graph.insert(observation).unwrap();
-        assert_eq!(
-            graph.insert(conflict).unwrap_err().to_string(),
-            "Internal invariant violation: partition border observation (4, 7) conflicts with prior payload"
-        );
+        assert!(graph
+            .insert(conflict)
+            .unwrap_err()
+            .to_string()
+            .contains("partition border observation (4, 7, "));
         assert_eq!(graph.edge_count(), 1);
+    }
+
+    #[test]
+    fn atomic_observation_identity_allows_distinct_spans_from_one_local_edge_id() {
+        let first = PartitionBorderHalfEdge::new(
+            4,
+            7,
+            Some(3),
+            PartitionBorderSide::MinY,
+            coord(0.0, 0.0, 1.0),
+            coord(1.0, 0.0, 2.0),
+            [11],
+        )
+        .unwrap();
+        let second = PartitionBorderHalfEdge::new(
+            4,
+            7,
+            Some(3),
+            PartitionBorderSide::MinY,
+            coord(1.0, 0.0, 2.0),
+            coord(2.0, 0.0, 3.0),
+            [11],
+        )
+        .unwrap();
+        assert_ne!(first.observation_id(), second.observation_id());
+
+        let mut graph = PartitionBorderGraph::default();
+        graph.insert(first).unwrap();
+        graph.insert(second).unwrap();
+        assert_eq!(graph.edge_count(), 2);
     }
 
     #[test]
@@ -1039,10 +1074,12 @@ mod tests {
                 forward: PartitionBorderObservationId {
                     partition_id: 1,
                     local_dir_edge_id: 7,
+                    edge_key: key,
                 },
                 reverse: PartitionBorderObservationId {
                     partition_id: 2,
                     local_dir_edge_id: 9,
+                    edge_key: key,
                 },
             }]
         );
@@ -1075,6 +1112,8 @@ mod tests {
             [3],
         )
         .unwrap();
+        let low_key = low.edge_key;
+        let high_key = high.edge_key;
 
         let mut graph = PartitionBorderGraph::default();
         graph.declare_adjacency(
@@ -1103,20 +1142,24 @@ mod tests {
                     PartitionBorderObservationId {
                         partition_id: 1,
                         local_dir_edge_id: 7,
+                        edge_key: low_key,
                     },
                     PartitionBorderObservationId {
                         partition_id: 2,
                         local_dir_edge_id: 10,
+                        edge_key: low_key,
                     },
                 ),
                 (
                     PartitionBorderObservationId {
                         partition_id: 1,
                         local_dir_edge_id: 7,
+                        edge_key: high_key,
                     },
                     PartitionBorderObservationId {
                         partition_id: 2,
                         local_dir_edge_id: 9,
+                        edge_key: high_key,
                     },
                 ),
             ]

--- a/crates/geo-polygonize-core/src/graph/planar_graph.rs
+++ b/crates/geo-polygonize-core/src/graph/planar_graph.rs
@@ -286,6 +286,105 @@ fn create_edge_components(
     (u, v, de_u_v_idx, de_v_u_idx, de_u_v, de_v_u, edge)
 }
 
+const PARTITION_BOUNDARY_SIDES: [PartitionBorderSide; 4] = [
+    PartitionBorderSide::MinX,
+    PartitionBorderSide::MaxX,
+    PartitionBorderSide::MinY,
+    PartitionBorderSide::MaxY,
+];
+
+fn partition_side_index(side: PartitionBorderSide) -> usize {
+    match side {
+        PartitionBorderSide::MinX => 0,
+        PartitionBorderSide::MaxX => 1,
+        PartitionBorderSide::MinY => 2,
+        PartitionBorderSide::MaxY => 3,
+    }
+}
+
+fn partition_side_tangent(point: Coord3D, side: PartitionBorderSide) -> f64 {
+    match side {
+        PartitionBorderSide::MinX | PartitionBorderSide::MaxX => point.y,
+        PartitionBorderSide::MinY | PartitionBorderSide::MaxY => point.x,
+    }
+}
+
+fn point_lies_on_partition_side(
+    point: Coord3D,
+    bbox: Rect<f64>,
+    side: PartitionBorderSide,
+) -> bool {
+    let min = bbox.min();
+    let max = bbox.max();
+    let on_axis = |actual: f64, expected: f64| {
+        canonical_coordinate_bits(actual) == canonical_coordinate_bits(expected)
+    };
+    match side {
+        PartitionBorderSide::MinX => {
+            on_axis(point.x, min.x) && point.y >= min.y && point.y <= max.y
+        }
+        PartitionBorderSide::MaxX => {
+            on_axis(point.x, max.x) && point.y >= min.y && point.y <= max.y
+        }
+        PartitionBorderSide::MinY => {
+            on_axis(point.y, min.y) && point.x >= min.x && point.x <= max.x
+        }
+        PartitionBorderSide::MaxY => {
+            on_axis(point.y, max.y) && point.x >= min.x && point.x <= max.x
+        }
+    }
+}
+
+fn edge_is_collinear_with_partition_side(
+    start: Coord3D,
+    end: Coord3D,
+    bbox: Rect<f64>,
+    side: PartitionBorderSide,
+) -> bool {
+    let coordinate = match side {
+        PartitionBorderSide::MinX => bbox.min().x,
+        PartitionBorderSide::MaxX => bbox.max().x,
+        PartitionBorderSide::MinY => bbox.min().y,
+        PartitionBorderSide::MaxY => bbox.max().y,
+    };
+    let axis = |point: Coord3D| match side {
+        PartitionBorderSide::MinX | PartitionBorderSide::MaxX => point.x,
+        PartitionBorderSide::MinY | PartitionBorderSide::MaxY => point.y,
+    };
+    canonical_coordinate_bits(axis(start)) == canonical_coordinate_bits(coordinate)
+        && canonical_coordinate_bits(axis(end)) == canonical_coordinate_bits(coordinate)
+}
+
+fn boundary_breakpoint_parameter(
+    start: Coord3D,
+    end: Coord3D,
+    point: Coord3D,
+    side: PartitionBorderSide,
+) -> Option<f64> {
+    let start_tangent = partition_side_tangent(start, side);
+    let end_tangent = partition_side_tangent(end, side);
+    if start_tangent == end_tangent {
+        return None;
+    }
+    let t = (partition_side_tangent(point, side) - start_tangent) / (end_tangent - start_tangent);
+    (t.is_finite() && (0.0..=1.0).contains(&t)).then_some(t.clamp(0.0, 1.0))
+}
+
+fn append_partition_breakpoint(
+    breakpoints: &mut [Vec<Coord3D>; 4],
+    side: PartitionBorderSide,
+    point: Coord3D,
+) {
+    let points = &mut breakpoints[partition_side_index(side)];
+    let key = NodeKey::from(point.to_coord_2d());
+    if !points
+        .iter()
+        .any(|existing| NodeKey::from(existing.to_coord_2d()) == key)
+    {
+        points.push(point);
+    }
+}
+
 impl Default for PlanarGraph {
     fn default() -> Self {
         Self::new()
@@ -737,6 +836,65 @@ impl PlanarGraph {
             );
         }
 
+        let mut boundary_breakpoints: [Vec<Coord3D>; 4] = std::array::from_fn(|_| Vec::new());
+        for node_id in 0..self.nodes_x.len() {
+            execution_policy.check_cancelled_every("boundary_noding_intersections", node_id)?;
+            let point = Coord3D {
+                x: self.nodes_x[node_id],
+                y: self.nodes_y[node_id],
+                z: self.nodes_z[node_id],
+            };
+            for side in PARTITION_BOUNDARY_SIDES {
+                if point_lies_on_partition_side(point, bbox, side) {
+                    append_partition_breakpoint(&mut boundary_breakpoints, side, point);
+                }
+            }
+        }
+
+        // Collect all boundary events first. A crossing edge can create a
+        // breakpoint that must also split a separate collinear border edge.
+        for edge_idx in 0..self.edges.len() {
+            execution_policy.check_cancelled_every("boundary_noding_intersections", edge_idx)?;
+            let edge = &self.edges[edge_idx];
+            if edge.deleted {
+                continue;
+            }
+            let forward_idx = edge.dir_edges[0];
+            let forward = &self.directed_edges[forward_idx];
+            let start = Coord3D {
+                x: self.nodes_x[forward.src],
+                y: self.nodes_y[forward.src],
+                z: self.nodes_z[forward.src],
+            };
+            let end = Coord3D {
+                x: self.nodes_x[forward.dst],
+                y: self.nodes_y[forward.dst],
+                z: self.nodes_z[forward.dst],
+            };
+            for intersection in partition_boundary_intersections(start, end, bbox) {
+                append_partition_breakpoint(
+                    &mut boundary_breakpoints,
+                    intersection.side,
+                    intersection.point,
+                );
+            }
+        }
+        for side in PARTITION_BOUNDARY_SIDES {
+            let points = &mut boundary_breakpoints[partition_side_index(side)];
+            execution_policy
+                .check_uncancellable_sort("boundary_noding_breakpoint_sort", points.len())?;
+            points.sort_unstable_by(|left, right| {
+                partition_side_tangent(*left, side)
+                    .total_cmp(&partition_side_tangent(*right, side))
+                    .then_with(|| {
+                        canonical_coordinate_bits(left.x).cmp(&canonical_coordinate_bits(right.x))
+                    })
+                    .then_with(|| {
+                        canonical_coordinate_bits(left.y).cmp(&canonical_coordinate_bits(right.y))
+                    })
+            });
+        }
+
         let mut plans = Vec::<(EdgeId, Vec<Coord3D>)>::new();
         let mut planned_node_keys = std::collections::HashSet::new();
         let mut split_events = 0usize;
@@ -759,27 +917,47 @@ impl PlanarGraph {
                 y: self.nodes_y[forward.dst],
                 z: self.nodes_z[forward.dst],
             };
-            let start_key = NodeKey::from(start.to_coord_2d());
-            let end_key = NodeKey::from(end.to_coord_2d());
-            let mut points = Vec::with_capacity(4);
-            points.push(start);
-            let mut point_keys = std::collections::HashSet::new();
-            point_keys.insert(start_key);
-            point_keys.insert(end_key);
-            for intersection in partition_boundary_intersections(start, end, bbox) {
-                if !(intersection.t > 0.0 && intersection.t < 1.0) {
+            let mut candidates = Vec::with_capacity(8);
+            candidates.push((0.0, start));
+            candidates.push((1.0, end));
+            candidates.extend(
+                partition_boundary_intersections(start, end, bbox)
+                    .into_iter()
+                    .map(|intersection| (intersection.t, intersection.point)),
+            );
+            for side in PARTITION_BOUNDARY_SIDES {
+                if !edge_is_collinear_with_partition_side(start, end, bbox, side) {
                     continue;
                 }
-                let point_key = NodeKey::from(intersection.point.to_coord_2d());
+                for point in &boundary_breakpoints[partition_side_index(side)] {
+                    let Some(t) = boundary_breakpoint_parameter(start, end, *point, side) else {
+                        continue;
+                    };
+                    let mut point = *point;
+                    point.z = start.z + (end.z - start.z) * t;
+                    candidates.push((t, point));
+                }
+            }
+            candidates.sort_unstable_by(|left, right| {
+                left.0.total_cmp(&right.0).then_with(|| {
+                    let left_key = NodeKey::from(left.1.to_coord_2d());
+                    let right_key = NodeKey::from(right.1.to_coord_2d());
+                    left_key.cmp(&right_key)
+                })
+            });
+
+            let mut points = Vec::with_capacity(candidates.len());
+            let mut point_keys = std::collections::HashSet::new();
+            for (t, point) in candidates {
+                let point_key = NodeKey::from(point.to_coord_2d());
                 if !point_keys.insert(point_key) {
                     continue;
                 }
-                if !self.node_map.contains_key(&point_key) {
+                if !self.node_map.contains_key(&point_key) && t > 0.0 && t < 1.0 {
                     planned_node_keys.insert(point_key);
                 }
-                points.push(intersection.point);
+                points.push(point);
             }
-            points.push(end);
             if points.len() < 3 {
                 continue;
             }
@@ -3633,6 +3811,51 @@ mod arrangement_ring_invariant_tests {
         assert!(graph
             .partition_border_half_edge(0, reverse, PartitionBorderSide::MinY)
             .is_some());
+    }
+
+    #[test]
+    fn partition_boundary_noding_applies_crossing_breakpoints_to_long_border_edges() {
+        let mut graph = PlanarGraph::new();
+        graph.add_line(Line3D::new(
+            Coord3D::new(-2.0, 0.0, 0.0),
+            Coord3D::new(12.0, 0.0, 14.0),
+            51,
+        ));
+        graph.add_line(Line3D::new(
+            Coord3D::new(2.0, -1.0, 0.0),
+            Coord3D::new(2.0, 1.0, 2.0),
+            52,
+        ));
+        graph.add_line(Line3D::new(
+            Coord3D::new(6.0, -1.0, 0.0),
+            Coord3D::new(6.0, 1.0, 2.0),
+            53,
+        ));
+        graph
+            .node_partition_boundaries_with_execution_policy(
+                Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 10.0, y: 1.0 }),
+                &ExecutionPolicy::default(),
+            )
+            .unwrap();
+
+        let border_spans = graph
+            .edges
+            .iter()
+            .filter_map(|edge| {
+                let [forward, _] = edge.dir_edges;
+                let start = graph.directed_edges[forward].src;
+                let end = graph.directed_edges[forward].dst;
+                (graph.nodes_y[start] == 0.0
+                    && graph.nodes_y[end] == 0.0
+                    && graph.nodes_x[start] >= 0.0
+                    && graph.nodes_x[end] <= 10.0
+                    && graph.nodes_x[start] < graph.nodes_x[end])
+                    .then_some((graph.nodes_x[start], graph.nodes_x[end]))
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(border_spans, vec![(0.0, 2.0), (2.0, 6.0), (6.0, 10.0)]);
+        assert_eq!(graph.edges.len(), 9);
+        assert!(graph.validate_arrangement_edge_invariants().is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Stack

Parent:
- #1307 `agent/p5-boundary-physical-split`

This PR:
- Export atomic border observation identity and physically represent multi-span border segmentation.

Children:
- `agent/p5-boundary-trace-evidence` (bounded trace/resource evidence)

## Delivered

- Extends `PartitionBorderObservationId` with the canonical atomic `edge_key`.
- Allows distinct spans derived from one local directed-edge ID to coexist and still rejects same-identity conflicting payloads.
- Retains edge keys through one-to-many normalization and twin payload lookup.
- Collects exact boundary breakpoints from crossing edges and applies them to long collinear border edges.
- Adds regressions for multi-span physical border segmentation and atomic-ID collision avoidance.
- Updates ROADMAP.md only for evidence completed by this stack.

## Contract impact

- No supported API behavior change and no twin application.
- Exported observations now carry collision-free atomic span identity.
- Existing normalization remains a validator/reconciliation compatibility layer; it no longer supplies the only physical breakpoint.
- Replicate-and-own output remains unchanged.

## Validation

- `cargo test --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p geo-polygonize-core --lib --no-fail-fast` (307 passed)
- `cargo test -p geo-polygonize-core --test tiling_equivalence --no-fail-fast` (7 passed)
- `cargo test -p geo-polygonize-core graph::partition_border --lib --no-fail-fast`
- `cargo test -p geo-polygonize-core partition_boundary_noding --lib --no-fail-fast`
- `cargo check -p geo-polygonize-core --no-default-features`
- `cargo fmt --all -- --check`
- Generated bindings verified restored; `git status` clean before publish.

## Agent handoff

Parent:
- #1307 `agent/p5-boundary-physical-split`

Children:
- `agent/p5-boundary-trace-evidence`

Remaining:
- Add bounded trace evidence for added boundary nodes, split edges, atomic observations, and rejected ambiguity.
- Exercise fixed-grid/certified-fixed and permutation contracts at the export boundary.
- Preserve no-twin/no-global-face scope; #1289 remains blocked until #1288 is complete.
