### PR TITLE
feat(core): trace partition boundary evidence

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -430,6 +430,8 @@ Tracked by
   component identity, cancellation, and limits.
 - [x] Export only halfedges physically present on the boundary-noded arrangement.
 - [x] Introduce collision-free atomic observation identity.
+- [x] Emit bounded trace evidence for boundary-noding counts, atomic border
+  observations, and rejected observations.
 - [x] Run arrangement and face-walk validators after boundary noding.
 - [x] Leave replicate-and-own output unchanged.
 

--- a/crates/geo-polygonize-core/src/graph/planar_graph.rs
+++ b/crates/geo-polygonize-core/src/graph/planar_graph.rs
@@ -1,6 +1,6 @@
 use crate::diagnostics::{ComponentMemoryStats, ComponentScratchEvidence};
 use crate::options::ExecutionPolicy;
-use crate::trace::TraceCaptureBudget;
+use crate::trace::{TraceCaptureBudget, TraceRecorderV1};
 use crate::types::{Coord3D, EdgeSources, Line3D, LocalFaceRef};
 use crate::utils::parallel::{par_flat_map, par_sort_unstable, par_zip_for_each};
 use crate::utils::{
@@ -143,6 +143,13 @@ struct ComponentPartition {
 pub(crate) struct PartitionBorderExport {
     pub partition_id: usize,
     pub bbox: Rect<f64>,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct PartitionBoundaryNodingStats {
+    pub added_node_count: usize,
+    pub added_edge_count: usize,
+    pub split_event_count: usize,
 }
 
 #[derive(Default)]
@@ -813,12 +820,14 @@ impl PlanarGraph {
     /// angular order through the normal execution-policy sort path.
     pub(crate) fn node_partition_boundaries_with_execution_policy(
         &mut self,
+        partition_id: usize,
         bbox: Rect<f64>,
         execution_policy: &ExecutionPolicy,
-    ) -> crate::Result<()> {
+        mut trace: Option<&mut TraceRecorderV1>,
+    ) -> crate::Result<PartitionBoundaryNodingStats> {
         execution_policy.check_cancelled("boundary_noding")?;
         if self.edges.is_empty() {
-            return Ok(());
+            return Ok(PartitionBoundaryNodingStats::default());
         }
 
         // Bulk loading intentionally leaves this incremental map empty. Build
@@ -1004,8 +1013,14 @@ impl PlanarGraph {
             planned_edges,
         )?;
         if plans.is_empty() {
-            return Ok(());
+            return Ok(PartitionBoundaryNodingStats::default());
         }
+
+        let stats = PartitionBoundaryNodingStats {
+            added_node_count: planned_node_keys.len(),
+            added_edge_count: added_edges,
+            split_event_count: split_events,
+        };
 
         execution_policy.check_cancelled("boundary_noding_split")?;
         self.nodes_x.reserve(planned_node_keys.len());
@@ -1022,6 +1037,30 @@ impl PlanarGraph {
                 }
             })?);
         self.clear_next_links();
+
+        let mut recorded_nodes = std::collections::HashSet::new();
+        for (_, points) in &plans {
+            for point in &points[1..points.len() - 1] {
+                let node_id = self.add_node(*point);
+                if !recorded_nodes.insert(node_id) {
+                    continue;
+                }
+                if let Some(trace) = trace.as_deref_mut() {
+                    let payload = serde_json::json!({
+                        "partition_id": partition_id,
+                        "node_id": node_id,
+                        "x_bits": format!("0x{:016x}", canonical_coordinate_bits(point.x)),
+                        "y_bits": format!("0x{:016x}", canonical_coordinate_bits(point.y)),
+                        "z_bits": format!("0x{:016x}", canonical_coordinate_bits(point.z)),
+                    });
+                    trace.record(
+                        crate::trace::TraceStageV1::Graph,
+                        "partition_boundary_node",
+                        payload,
+                    );
+                }
+            }
+        }
 
         for (plan_index, (edge_idx, points)) in plans.into_iter().enumerate() {
             execution_policy.check_cancelled_every("boundary_noding_split", plan_index)?;
@@ -1060,20 +1099,49 @@ impl PlanarGraph {
             self.nodes_outgoing[first_dst].push(reverse_idx);
             self.nodes_degree[first_src] = self.nodes_outgoing[first_src].len();
             self.nodes_degree[first_dst] = self.nodes_outgoing[first_dst].len();
+            if let Some(trace) = trace.as_deref_mut() {
+                trace.record(
+                    crate::trace::TraceStageV1::Graph,
+                    "partition_boundary_split_edge",
+                    serde_json::json!({
+                        "partition_id": partition_id,
+                        "edge_id": edge_idx,
+                        "from_node_id": first_src,
+                        "to_node_id": first_dst,
+                        "representative_line_id": representative_id,
+                        "source_count": sources.line_ids.len(),
+                    }),
+                );
+            }
 
             for (piece_index, pair) in points.windows(2).enumerate().skip(1) {
                 execution_policy.check_cancelled_every("boundary_noding_split", piece_index)?;
                 if NodeKey::from(pair[0].to_coord_2d()) == NodeKey::from(pair[1].to_coord_2d()) {
                     continue;
                 }
-                self.append_edge_with_sources(
+                let edge_id = self.append_edge_with_sources(
                     Line3D::new(pair[0], pair[1], representative_id),
                     sources.clone(),
                 );
+                if let Some(trace) = trace.as_deref_mut() {
+                    trace.record(
+                        crate::trace::TraceStageV1::Graph,
+                        "partition_boundary_split_edge",
+                        serde_json::json!({
+                            "partition_id": partition_id,
+                            "edge_id": edge_id,
+                            "from_node_id": self.directed_edges[self.edges[edge_id].dir_edges[0]].src,
+                            "to_node_id": self.directed_edges[self.edges[edge_id].dir_edges[0]].dst,
+                            "representative_line_id": representative_id,
+                            "source_count": sources.line_ids.len(),
+                        }),
+                    );
+                }
             }
         }
 
-        self.sort_edges_with_execution_policy(execution_policy)
+        self.sort_edges_with_execution_policy(execution_policy)?;
+        Ok(stats)
     }
 
     /// Removes an edge by marking it as deleted by matching line ID.
@@ -3741,8 +3809,10 @@ mod arrangement_ring_invariant_tests {
 
         graph
             .node_partition_boundaries_with_execution_policy(
+                0,
                 Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 10.0, y: 10.0 }),
                 &ExecutionPolicy::default(),
+                None,
             )
             .unwrap();
 
@@ -3774,8 +3844,10 @@ mod arrangement_ring_invariant_tests {
         ));
         graph
             .node_partition_boundaries_with_execution_policy(
+                0,
                 Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 10.0, y: 10.0 }),
                 &ExecutionPolicy::default(),
+                None,
             )
             .unwrap();
 
@@ -3833,8 +3905,10 @@ mod arrangement_ring_invariant_tests {
         ));
         graph
             .node_partition_boundaries_with_execution_policy(
+                0,
                 Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 10.0, y: 1.0 }),
                 &ExecutionPolicy::default(),
+                None,
             )
             .unwrap();
 
@@ -3872,8 +3946,10 @@ mod arrangement_ring_invariant_tests {
         };
         let error = graph
             .node_partition_boundaries_with_execution_policy(
+                0,
                 Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 10.0, y: 10.0 }),
                 &policy,
+                None,
             )
             .unwrap_err();
         assert!(error.to_string().contains("graph_edges"));

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -4,7 +4,7 @@ use crate::diagnostics::{
 };
 use crate::error::{PolygonizeError, Result};
 use crate::graph::partition_border::PartitionBorderHalfEdge;
-use crate::graph::planar_graph::PartitionBorderExport;
+use crate::graph::planar_graph::{PartitionBorderExport, PartitionBoundaryNodingStats};
 use crate::graph::{ExtractedRing, PlanarGraph};
 use crate::noding::hot_pixel::HotPixelNoder;
 use crate::noding::snap::SnapNoder;
@@ -53,6 +53,7 @@ pub struct Polygonizer {
     trace: Option<TraceRecorderV1>,
     partition_border_export: Option<PartitionBorderExport>,
     partition_border_observations: Vec<PartitionBorderHalfEdge>,
+    boundary_noding_stats: PartitionBoundaryNodingStats,
 }
 
 /// Reusable allocation storage for stateless polygonization calls.
@@ -354,6 +355,7 @@ pub fn polygonize_with_workspace_and_execution_policy(
         trace: None,
         partition_border_export: None,
         partition_border_observations: Vec::new(),
+        boundary_noding_stats: PartitionBoundaryNodingStats::default(),
     };
     runner.input_line_strings = source_line_strings_for_segments(lines);
     let result = runner.polygonize_owned(lines.to_vec());
@@ -374,6 +376,7 @@ impl Polygonizer {
             trace: None,
             partition_border_export: None,
             partition_border_observations: Vec::new(),
+            boundary_noding_stats: PartitionBoundaryNodingStats::default(),
         }
     }
     /// Creates a new `Polygonizer` with specific options.
@@ -387,6 +390,7 @@ impl Polygonizer {
             trace: None,
             partition_border_export: None,
             partition_border_observations: Vec::new(),
+            boundary_noding_stats: PartitionBoundaryNodingStats::default(),
         }
     }
 
@@ -758,17 +762,22 @@ impl Polygonizer {
         self.polygonize_owned(self.input_lines.clone())
     }
 
-    pub(crate) fn polygonize_with_partition_border_export(
+    pub(crate) fn polygonize_with_partition_border_export_and_stats(
         &mut self,
         partition_id: usize,
         bbox: Rect<f64>,
-    ) -> Result<(PolygonizerResult, Vec<PartitionBorderHalfEdge>)> {
+    ) -> Result<(
+        PolygonizerResult,
+        Vec<PartitionBorderHalfEdge>,
+        PartitionBoundaryNodingStats,
+    )> {
         self.partition_border_export = Some(PartitionBorderExport { partition_id, bbox });
         self.partition_border_observations.clear();
+        self.boundary_noding_stats = PartitionBoundaryNodingStats::default();
         let result = self.polygonize();
         self.partition_border_export = None;
         let observations = std::mem::take(&mut self.partition_border_observations);
-        result.map(|result| (result, observations))
+        result.map(|result| (result, observations, self.boundary_noding_stats))
     }
 
     /// Computes polygons while recording a bounded topology trace.
@@ -832,9 +841,11 @@ impl Polygonizer {
         )?;
         let mut boundary_graph = if let Some(export) = self.partition_border_export {
             let mut graph = self.graph.clone();
-            graph.node_partition_boundaries_with_execution_policy(
+            self.boundary_noding_stats = graph.node_partition_boundaries_with_execution_policy(
+                export.partition_id,
                 export.bbox,
                 &self.execution_policy,
+                self.trace.as_mut(),
             )?;
             Some(graph)
         } else {
@@ -895,6 +906,13 @@ impl Polygonizer {
             Vec::new()
         };
         self.partition_border_observations = border_observations;
+        if let Some(trace) = self.trace.as_mut() {
+            for observation in &self.partition_border_observations {
+                if !trace.record_partition_border_observation(observation) {
+                    break;
+                }
+            }
+        }
         if let Some(trace) = self.trace.as_mut() {
             trace.record_classified_lines("dangle", &dangles)?;
             trace.record_classified_lines("cut_edge", &cut_edges)?;

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -334,6 +334,7 @@ type TileProcessResult = (
     Vec<TileOwnershipDecision>,
     Vec<PartitionBorderHalfEdge>,
     bool,
+    crate::graph::planar_graph::PartitionBoundaryNodingStats,
 );
 
 #[derive(Debug)]
@@ -920,12 +921,19 @@ impl<'a> TiledPolygonizer<'a> {
             retry_exhausted: false,
         };
         if relevant_lines == 0 {
-            return Ok((Vec::new(), report, Vec::new(), Vec::new(), false));
+            return Ok((
+                Vec::new(),
+                report,
+                Vec::new(),
+                Vec::new(),
+                false,
+                crate::graph::planar_graph::PartitionBoundaryNodingStats::default(),
+            ));
         }
 
         // Run polygonization
-        let (result, border_observations) =
-            local_poly.polygonize_with_partition_border_export(partition_id, tile_bbox)?;
+        let (result, border_observations, boundary_noding_stats) = local_poly
+            .polygonize_with_partition_border_export_and_stats(partition_id, tile_bbox)?;
         report.polygon_count = result.polygons.len();
         report.dangle_count = result.dangles.len();
         report.cut_edge_count = result.cut_edges.len();
@@ -1003,6 +1011,7 @@ impl<'a> TiledPolygonizer<'a> {
             ownership_decisions,
             border_observations,
             capture_budget.is_some_and(|budget| budget.truncated()),
+            boundary_noding_stats,
         ))
     }
 
@@ -2089,14 +2098,20 @@ impl<'a> TiledPolygonizer<'a> {
                         .records_stage(TraceStageV1::Output)
                         .then(|| trace.capture_byte_limit(TraceStageV1::Output))
                 });
-                let (polygons, report, ownership_decisions, border_observations, capture_truncated) =
-                    self.process_tile_with_retries(
-                        tile_index,
-                        tile,
-                        input_components,
-                        capture_byte_limit,
-                        &retry_attempt_counter,
-                    )?;
+                let (
+                    polygons,
+                    report,
+                    ownership_decisions,
+                    border_observations,
+                    capture_truncated,
+                    boundary_noding_stats,
+                ) = self.process_tile_with_retries(
+                    tile_index,
+                    tile,
+                    input_components,
+                    capture_byte_limit,
+                    &retry_attempt_counter,
+                )?;
                 let trace = trace.as_deref_mut().expect("tile trace exists");
                 for attempt in &report.retry_attempts {
                     if !trace.record_tile_halo_retry(tile_index, attempt) {
@@ -2148,8 +2163,13 @@ impl<'a> TiledPolygonizer<'a> {
                 if capture_truncated {
                     trace.mark_capture_truncated(TraceStageV1::Output);
                 }
+                trace.record_partition_boundary_noding(tile_index, boundary_noding_stats);
                 for observation in border_observations {
-                    partition_border_graph.insert(observation)?;
+                    trace.record_partition_border_observation(&observation);
+                    if let Err(error) = partition_border_graph.insert(observation.clone()) {
+                        trace.record_partition_border_rejection(&observation, &error.to_string());
+                        return Err(error);
+                    }
                 }
                 tile_polygons.push(polygons);
                 tile_reports.push(report);
@@ -2210,7 +2230,7 @@ impl<'a> TiledPolygonizer<'a> {
                 .collect();
 
             for result in tile_results? {
-                let (polygons, report, _, border_observations, _) = result;
+                let (polygons, report, _, border_observations, _, _) = result;
                 for observation in border_observations {
                     partition_border_graph.insert(observation)?;
                 }

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -91,12 +91,16 @@ mod tests {
                 44,
             ),
         ]);
-        let (_, observations) = polygonizer
-            .polygonize_with_partition_border_export(
+        let (_, observations, stats) = polygonizer
+            .polygonize_with_partition_border_export_and_stats(
                 7,
                 Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 10.0, y: 1.0 }),
             )
             .unwrap();
+
+        assert_eq!(stats.added_node_count, 2);
+        assert_eq!(stats.added_edge_count, 2);
+        assert_eq!(stats.split_event_count, 2);
 
         let border = observations
             .iter()
@@ -113,6 +117,65 @@ mod tests {
         assert!(border
             .iter()
             .all(|observation| observation.source_line_ids == vec![41]));
+    }
+
+    #[test]
+    fn trace_records_partition_boundary_noding_and_atomic_observations() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 2.0, y: 1.0 });
+        let geometries = [
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 0.0, y: 0.0 },
+                Coord { x: 2.0, y: 0.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 2.0, y: 0.0 },
+                Coord { x: 2.0, y: 1.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 2.0, y: 1.0 },
+                Coord { x: 0.0, y: 1.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 0.0, y: 1.0 },
+                Coord { x: 0.0, y: 0.0 },
+            ])),
+        ];
+        let mut tiled = TiledPolygonizer::new(bbox, 1.0).with_buffer(0.0);
+        for geometry in &geometries {
+            tiled.add_geometry(geometry);
+        }
+
+        let traced = tiled
+            .polygonize_with_trace(TraceLevelV1::Full, usize::MAX)
+            .unwrap();
+        let noding_events = traced
+            .trace
+            .events
+            .iter()
+            .filter(|event| event.kind == "partition_boundary_noding")
+            .collect::<Vec<_>>();
+        assert_eq!(noding_events.len(), 2);
+        assert!(noding_events.iter().all(|event| {
+            event.payload["added_node_count"].as_u64().unwrap() >= 1
+                && event.payload["added_edge_count"].as_u64().unwrap() >= 1
+                && event.payload["split_event_count"].as_u64().unwrap() >= 1
+        }));
+
+        let observations = traced
+            .trace
+            .events
+            .iter()
+            .filter(|event| event.kind == "partition_border_atomic_observation")
+            .collect::<Vec<_>>();
+        assert!(!observations.is_empty());
+        assert!(observations.iter().all(|event| {
+            event.payload["edge_key"]
+                .as_array()
+                .is_some_and(|endpoints| endpoints.len() == 2)
+                && event.payload["from_z_bits"].as_str().is_some()
+                && event.payload["to_z_bits"].as_str().is_some()
+                && event.payload["source_count"].as_u64().is_some()
+        }));
     }
 
     #[test]

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -1,6 +1,8 @@
 //! Internal bounded topology trace schema.
 
 use crate::fingerprint::{coordinate_fingerprint, float_bits};
+use crate::graph::partition_border::PartitionBorderHalfEdge;
+use crate::graph::planar_graph::PartitionBoundaryNodingStats;
 use crate::graph::{ExtractedRing, PlanarGraph};
 use crate::noding::grid::{
     UniformGridCandidateTrace, UniformGridCellTrace, UniformGridGlobalLineTrace,
@@ -582,6 +584,79 @@ impl TraceRecorderV1 {
 
     pub fn finish(self) -> TopologyTraceV1 {
         self.trace
+    }
+
+    pub(crate) fn record_partition_boundary_noding(
+        &mut self,
+        partition_id: usize,
+        stats: PartitionBoundaryNodingStats,
+    ) -> bool {
+        self.record(
+            TraceStageV1::Graph,
+            "partition_boundary_noding",
+            serde_json::json!({
+                "partition_id": partition_id,
+                "added_node_count": stats.added_node_count,
+                "added_edge_count": stats.added_edge_count,
+                "split_event_count": stats.split_event_count,
+            }),
+        )
+    }
+
+    pub(crate) fn record_partition_border_observation(
+        &mut self,
+        observation: &PartitionBorderHalfEdge,
+    ) -> bool {
+        let endpoint = |key: crate::graph::partition_border::PartitionBorderNodeKey| {
+            key.xy_bits()
+                .into_iter()
+                .map(|bits| format!("0x{bits:016x}"))
+                .collect::<Vec<_>>()
+        };
+        let (edge_start, edge_end) = observation.edge_key.endpoints();
+        self.record(
+            TraceStageV1::Graph,
+            "partition_border_atomic_observation",
+            serde_json::json!({
+                "partition_id": observation.partition_id,
+                "local_dir_edge_id": observation.local_dir_edge_id,
+                "edge_key": [endpoint(edge_start), endpoint(edge_end)],
+                "from": endpoint(observation.from),
+                "to": endpoint(observation.to),
+                "from_z_bits": format!("0x{:016x}", observation.from_z_bits),
+                "to_z_bits": format!("0x{:016x}", observation.to_z_bits),
+                "side": format!("{:?}", observation.side),
+                "face_id": observation.face_id,
+                "source_count": observation.source_line_ids.len(),
+                "first_source_line_id": observation.source_line_ids.first(),
+                "last_source_line_id": observation.source_line_ids.last(),
+            }),
+        )
+    }
+
+    pub(crate) fn record_partition_border_rejection(
+        &mut self,
+        observation: &PartitionBorderHalfEdge,
+        reason: &str,
+    ) -> bool {
+        let endpoint = |key: crate::graph::partition_border::PartitionBorderNodeKey| {
+            key.xy_bits()
+                .into_iter()
+                .map(|bits| format!("0x{bits:016x}"))
+                .collect::<Vec<_>>()
+        };
+        let (edge_start, edge_end) = observation.edge_key.endpoints();
+        self.record(
+            TraceStageV1::Graph,
+            "partition_border_observation_rejected",
+            serde_json::json!({
+                "partition_id": observation.partition_id,
+                "local_dir_edge_id": observation.local_dir_edge_id,
+                "edge_key": [endpoint(edge_start), endpoint(edge_end)],
+                "side": format!("{:?}", observation.side),
+                "reason": reason,
+            }),
+        )
     }
 
     pub(crate) fn record_diagnostics_summary(&mut self, diagnostics: &PolygonizerDiagnostics) {
@@ -1690,6 +1765,35 @@ mod tests {
         assert!(!budget.capture(&mut values, split));
         assert_eq!(values.len(), 2);
         assert!(budget.truncated());
+    }
+
+    #[test]
+    fn partition_border_rejection_trace_retains_atomic_identity() {
+        let options = PolygonizerOptions::default();
+        let mut recorder =
+            TraceRecorderV1::new(Some(TraceLevelV1::Full), usize::MAX, &options).unwrap();
+        let observation = crate::graph::partition_border::PartitionBorderHalfEdge::new(
+            3,
+            17,
+            Some(9),
+            crate::graph::partition_border::PartitionBorderSide::MinY,
+            Coord3D::new(0.0, 0.0, 1.0),
+            Coord3D::new(1.0, 0.0, 2.0),
+            [4, 8],
+        )
+        .unwrap();
+
+        assert!(recorder.record_partition_border_rejection(&observation, "conflict"));
+        let trace = recorder.finish();
+        let event = trace
+            .events
+            .iter()
+            .find(|event| event.kind == "partition_border_observation_rejected")
+            .unwrap();
+        assert_eq!(event.payload["partition_id"], 3);
+        assert_eq!(event.payload["local_dir_edge_id"], 17);
+        assert_eq!(event.payload["edge_key"].as_array().unwrap().len(), 2);
+        assert_eq!(event.payload["reason"], "conflict");
     }
 
     #[test]


### PR DESCRIPTION
## Stack

Parent:
- #1308 `agent/p5-boundary-atomic-export`
This PR:
- `agent/p5-boundary-trace-evidence`
Children:
- `agent/p5-boundary-precision-permutations` (immediate child)

## Delivered

- Adds bounded graph-trace events for partition boundary nodes, physical split edges, noding counts, atomic border observations, and rejected observations.
- Captures canonical atomic edge keys, local direction, endpoint direction, endpoint Z bits, sides, face IDs, and bounded provenance summaries.
- Threads noding statistics through private tile processing only; the public `TileReport` shape remains unchanged.
- Adds direct rejection-trace, tiled trace, multi-breakpoint, and finite-border stats regressions.
- Updates P5.2 with the completed bounded-trace evidence item.

## Contract impact

- No public API or output-selection change.
- Existing replicate-and-own output remains sourced from the original graph; the boundary-noded clone is observation-only.
- Existing execution-policy cancellation and growth checks remain before mutation, and trace capture remains bounded by the existing recorder.

## Validation

- `cargo test -p geo-polygonize-core --lib --no-fail-fast` — 309 passed.
- `cargo test -p geo-polygonize-core --test tiling_equivalence --no-fail-fast` — 7 passed.
- Focused trace regressions — passed.
- `cargo clippy -p geo-polygonize-core --lib --tests -- -D warnings` — passed.
- `cargo clippy --workspace --all-targets -- -D warnings` — passed.
- `DYLD_LIBRARY_PATH=/Library/Frameworks/Python.framework/Versions/3.11/lib cargo test --workspace --lib --tests --no-fail-fast` — passed.
- `cargo check -p geo-polygonize-core --no-default-features` and `cargo fmt --all -- --check` — passed.
- `cargo test --workspace --all-targets` passed all regular targets and benches, then stopped at optional `iai_bench` because `iai-callgrind-runner` is not installed; no source failure was observed.
- Generated bindings were restored after validation.

## Agent handoff

Parent:
- #1308 `agent/p5-boundary-atomic-export`
Children:
- `agent/p5-boundary-precision-permutations`
Remaining:
- Validate fixed-grid/certified-fixed and permutation contracts at the physical export boundary, then close the remaining P5.2 provenance/Z/cancellation/limit evidence before beginning P5.3 true stitching (#1289).
