### PR TITLE
test(core): validate precision boundary export permutations

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -432,6 +432,7 @@ Tracked by
 - [x] Introduce collision-free atomic observation identity.
 - [x] Emit bounded trace evidence for boundary-noding counts, atomic border
   observations, and rejected observations.
+- [x] Exercise fixed-grid and certified-fixed export under input permutation.
 - [x] Run arrangement and face-walk validators after boundary noding.
 - [x] Leave replicate-and-own output unchanged.
 

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -179,6 +179,128 @@ mod tests {
     }
 
     #[test]
+    fn fixed_and_certified_boundary_export_survives_input_permutation() {
+        let bbox = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 2.0, y: 1.0 });
+        let geometries = [
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: -1.0, y: 0.0 },
+                Coord { x: 3.0, y: 0.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 3.0, y: 0.0 },
+                Coord { x: 3.0, y: 1.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: 3.0, y: 1.0 },
+                Coord { x: -1.0, y: 1.0 },
+            ])),
+            Geometry::LineString(LineString::new(vec![
+                Coord { x: -1.0, y: 1.0 },
+                Coord { x: -1.0, y: 0.0 },
+            ])),
+        ];
+        let options = [
+            PolygonizerOptions {
+                node_input: true,
+                precision_model: PrecisionModel::FixedGrid { grid_size: 1.0 },
+                ..Default::default()
+            },
+            PolygonizerOptions {
+                node_input: true,
+                precision_model: PrecisionModel::FixedGrid { grid_size: 1.0 },
+                noding: NodingOptions {
+                    guarantee: NodingGuarantee::CertifiedFixedPrecision,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ];
+
+        let atomic_signature = |trace: &crate::trace::TopologyTraceV1| {
+            let mut signature = trace
+                .events
+                .iter()
+                .filter(|event| event.kind == "partition_border_atomic_observation")
+                .map(|event| {
+                    serde_json::to_string(&serde_json::json!({
+                        "partition_id": event.payload["partition_id"],
+                        "edge_key": event.payload["edge_key"],
+                        "from": event.payload["from"],
+                        "to": event.payload["to"],
+                        "from_z_bits": event.payload["from_z_bits"],
+                        "to_z_bits": event.payload["to_z_bits"],
+                        "side": event.payload["side"],
+                        "source_count": event.payload["source_count"],
+                    }))
+                    .unwrap()
+                })
+                .collect::<Vec<_>>();
+            signature.sort_unstable();
+            signature
+        };
+        let noding_signature = |trace: &crate::trace::TopologyTraceV1| {
+            let mut signature = trace
+                .events
+                .iter()
+                .filter(|event| event.kind == "partition_boundary_noding")
+                .map(|event| {
+                    (
+                        event.payload["partition_id"].as_u64().unwrap(),
+                        event.payload["added_node_count"].as_u64().unwrap(),
+                        event.payload["added_edge_count"].as_u64().unwrap(),
+                        event.payload["split_event_count"].as_u64().unwrap(),
+                    )
+                })
+                .collect::<Vec<_>>();
+            signature.sort_unstable();
+            signature
+        };
+
+        let mut precision_signatures = Vec::new();
+        for option in options {
+            let mut forward = TiledPolygonizer::new(bbox, 1.0)
+                .with_buffer(0.0)
+                .with_options(option.clone());
+            for geometry in &geometries {
+                forward.add_geometry(geometry);
+            }
+            let forward = forward
+                .polygonize_with_trace(TraceLevelV1::Full, usize::MAX)
+                .unwrap();
+            let forward_atomic = atomic_signature(&forward.trace);
+            let forward_noding = noding_signature(&forward.trace);
+            assert_eq!(forward_noding.len(), 2);
+            assert!(forward_noding
+                .iter()
+                .all(|(_, nodes, edges, splits)| { *nodes > 0 && *edges > 0 && *splits > 0 }));
+            assert!(!forward_atomic.is_empty());
+
+            let mut reversed = TiledPolygonizer::new(bbox, 1.0)
+                .with_buffer(0.0)
+                .with_options(option);
+            for geometry in geometries.iter().rev() {
+                reversed.add_geometry(geometry);
+            }
+            let reversed = reversed
+                .polygonize_with_trace(TraceLevelV1::Full, usize::MAX)
+                .unwrap();
+            assert_eq!(forward_atomic, atomic_signature(&reversed.trace));
+            assert_eq!(forward_noding, noding_signature(&reversed.trace));
+            assert_eq!(
+                forward.result.partition_border_graph.edge_count(),
+                reversed.result.partition_border_graph.edge_count()
+            );
+            assert_eq!(
+                forward.result.partition_border_graph.node_count(),
+                reversed.result.partition_border_graph.node_count()
+            );
+
+            precision_signatures.push(forward_atomic);
+        }
+        assert_eq!(precision_signatures[0], precision_signatures[1]);
+    }
+
+    #[test]
     fn test_tiled_polygonization_grid() {
         // Create a 2x2 grid of squares
         // 0,0 - 10,0 - 20,0


### PR DESCRIPTION
## Stack

Parent:
- #1309 `agent/p5-boundary-trace-evidence`
This PR:
- `agent/p5-boundary-precision-permutations`
Children:
- none

## Delivered

- Adds fixed-grid and certified-fixed physical boundary-export coverage.
- Verifies canonical noding counts, physical atomic edge keys, direction, endpoint Z bits, side, and source summaries under reversed input order.
- Verifies physical border graph node and edge counts are stable across the same permutation.
- Confirms the two precision profiles produce the same canonical border evidence for this exact-grid fixture.
- Updates P5.2 with the completed precision/permutation evidence item.

## Contract impact

- Tests and roadmap only; no runtime behavior or public API changes.
- This is evidence for observation export, not twin application, global component merging, or stitched output.

## Validation

- `cargo test -p geo-polygonize-core tiling::tests::tests::fixed_and_certified_boundary_export_survives_input_permutation --lib --no-fail-fast` — passed.
- `DYLD_LIBRARY_PATH=/Library/Frameworks/Python.framework/Versions/3.11/lib cargo test --workspace --lib --tests --no-fail-fast` — passed, including 310 core tests and all workspace adapter tests.
- `cargo clippy --workspace --all-targets -- -D warnings` — passed.
- `cargo check -p geo-polygonize-core --no-default-features` — passed.
- `cargo fmt --all -- --check` — passed.
- Generated bindings were restored after validation.

## Agent handoff

Parent:
- #1309 `agent/p5-boundary-trace-evidence`
Children:
- none
Remaining:
- P5.2 still needs explicit provenance/Z/cancellation/limit evidence as a complete contract item; after that, begin P5.3 true stitching on #1289 with declared-border twins only.
