### PR TITLE
feat(core): retain partition border payload identities

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -426,8 +426,10 @@ Tracked by
 - [x] Handle endpoints, crossings, corners, and collinear-on-border edges.
 - [x] Rebuild adjacency and angular order before component-local `next` links,
   face IDs, and unbounded markers are assigned.
-- [ ] Preserve provenance, representative IDs, Z interpolation/conflicts,
-  component identity, cancellation, and limits.
+- [x] Preserve provenance, representative IDs, Z interpolation/conflicts, and
+  qualified component identity through boundary export and observation
+  normalization.
+- [ ] Preserve cancellation and resource limits through boundary noding.
 - [x] Export only halfedges physically present on the boundary-noded arrangement.
 - [x] Introduce collision-free atomic observation identity.
 - [x] Emit bounded trace evidence for boundary-noding counts, atomic border

--- a/crates/geo-polygonize-core/src/graph/partition_border.rs
+++ b/crates/geo-polygonize-core/src/graph/partition_border.rs
@@ -300,11 +300,18 @@ pub struct PartitionBorderHalfEdge {
     pub to_z_bits: u64,
     pub side: PartitionBorderSide,
     pub partition_id: usize,
+    /// Component identity remains available even when this directed edge is
+    /// on the unbounded side and has no local face ID.
+    pub component_id: usize,
     pub local_dir_edge_id: DirEdgeId,
     /// Component-local face ID retained for existing debug consumers.
     pub face_id: Option<FaceId>,
     pub(crate) face_ref: Option<PartitionFaceRef>,
     pub source_line_ids: Vec<u32>,
+    /// The deterministic representative source ID carried by the local edge.
+    /// This is the first ID in the sorted source set, or `None` for synthetic
+    /// observations without source provenance.
+    pub representative_line_id: Option<u32>,
 }
 
 impl PartitionBorderHalfEdge {
@@ -349,6 +356,7 @@ impl PartitionBorderHalfEdge {
         let mut source_line_ids = source_line_ids.into_iter().collect::<Vec<_>>();
         source_line_ids.sort_unstable();
         source_line_ids.dedup();
+        let representative_line_id = source_line_ids.first().copied();
         Some(Self {
             edge_key,
             from,
@@ -357,10 +365,12 @@ impl PartitionBorderHalfEdge {
             to_z_bits: canonical_coordinate_bits(end.z),
             side,
             partition_id,
+            component_id: face_ref.map_or(0, |face_ref| face_ref.component_id),
             local_dir_edge_id,
             face_id: face_ref.map(|face_ref| face_ref.face_id),
             face_ref,
             source_line_ids,
+            representative_line_id,
         })
     }
 
@@ -489,6 +499,11 @@ pub struct PartitionBorderTwin {
 pub struct PartitionBorderTwinPayload {
     pub twin: PartitionBorderTwin,
     pub source_line_ids: Vec<u32>,
+    /// Representative IDs retained separately for the two local observations.
+    /// A future stitcher may reconcile them only after applying its explicit
+    /// representative policy.
+    pub forward_representative_line_id: Option<u32>,
+    pub reverse_representative_line_id: Option<u32>,
     /// Distinct Z candidates at `twin.edge_key.endpoints().0`, in bit order.
     /// A length greater than one is an explicit conflict, not a hidden choice.
     pub start_z_bits: Vec<u64>,
@@ -705,6 +720,8 @@ impl PartitionBorderGraph {
                 Some(PartitionBorderTwinPayload {
                     twin,
                     source_line_ids,
+                    forward_representative_line_id: forward.representative_line_id,
+                    reverse_representative_line_id: reverse.representative_line_id,
                     start_z_bits,
                     end_z_bits,
                 })
@@ -921,6 +938,10 @@ mod tests {
         assert_eq!(
             observations.iter().next().unwrap().source_line_ids,
             vec![2, 4]
+        );
+        assert_eq!(
+            observations.iter().next().unwrap().representative_line_id,
+            Some(2)
         );
     }
 
@@ -1264,6 +1285,8 @@ mod tests {
             vec![PartitionBorderTwinPayload {
                 twin,
                 source_line_ids: vec![2, 4, 8],
+                forward_representative_line_id: Some(2),
+                reverse_representative_line_id: Some(4),
                 start_z_bits: vec![0, 1.0f64.to_bits()],
                 end_z_bits: vec![2.0f64.to_bits()],
             }]

--- a/crates/geo-polygonize-core/src/graph/planar_graph.rs
+++ b/crates/geo-polygonize-core/src/graph/planar_graph.rs
@@ -451,7 +451,7 @@ impl PlanarGraph {
             y: *self.nodes_y.get(directed.dst)?,
             z: *self.nodes_z.get(directed.dst)?,
         };
-        PartitionBorderHalfEdge::new_with_face_ref(
+        let mut observation = PartitionBorderHalfEdge::new_with_face_ref(
             partition_id,
             dir_edge_id,
             directed.face_id.map(|face_id| {
@@ -465,7 +465,9 @@ impl PlanarGraph {
             start,
             end,
             edge.sources.line_ids.iter().copied(),
-        )
+        )?;
+        observation.component_id = component_id;
+        Some(observation)
     }
 
     pub(crate) fn clear(&mut self) {
@@ -3790,6 +3792,65 @@ mod arrangement_ring_invariant_tests {
         assert!(refs.contains(&LocalFaceRef {
             component_id: 1,
             face_id: 0,
+        }));
+    }
+
+    #[test]
+    fn partition_border_export_qualifies_components_and_representatives() {
+        let mut graph = PlanarGraph::new();
+        add_square(
+            &mut graph,
+            [
+                Coord3D::new(0.0, 0.0, 1.0),
+                Coord3D::new(1.0, 0.0, 2.0),
+                Coord3D::new(1.0, 1.0, 3.0),
+                Coord3D::new(0.0, 1.0, 4.0),
+            ],
+            10,
+        );
+        add_square(
+            &mut graph,
+            [
+                Coord3D::new(2.0, 0.0, 5.0),
+                Coord3D::new(3.0, 0.0, 6.0),
+                Coord3D::new(3.0, 1.0, 7.0),
+                Coord3D::new(2.0, 1.0, 8.0),
+            ],
+            20,
+        );
+
+        let (_, observations, _, _) = graph
+            .process_components_with_execution_policy(
+                true,
+                true,
+                &ExecutionPolicy::default(),
+                true,
+                None,
+                Some(PartitionBorderExport {
+                    partition_id: 9,
+                    bbox: Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 3.0, y: 1.0 }),
+                }),
+            )
+            .unwrap();
+
+        let component_ids = observations
+            .iter()
+            .map(|observation| observation.component_id)
+            .collect::<std::collections::BTreeSet<_>>();
+        assert_eq!(component_ids, std::collections::BTreeSet::from([0, 1]));
+
+        let representative_ids = observations
+            .iter()
+            .filter_map(|observation| observation.representative_line_id)
+            .collect::<std::collections::BTreeSet<_>>();
+        assert_eq!(
+            representative_ids,
+            std::collections::BTreeSet::from([10, 12, 13, 20, 21, 22])
+        );
+        assert!(observations.iter().all(|observation| {
+            observation
+                .representative_line_id
+                .is_some_and(|representative| observation.source_line_ids.contains(&representative))
         }));
     }
 

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -117,6 +117,12 @@ mod tests {
         assert!(border
             .iter()
             .all(|observation| observation.source_line_ids == vec![41]));
+        assert!(border.iter().all(|observation| {
+            let z_bits = [observation.from_z_bits, observation.to_z_bits];
+            observation.representative_line_id == Some(41)
+                && (z_bits == [3.0f64.to_bits(), 13.0f64.to_bits()]
+                    || z_bits == [13.0f64.to_bits(), 3.0f64.to_bits()])
+        }));
     }
 
     #[test]
@@ -175,6 +181,8 @@ mod tests {
                 && event.payload["from_z_bits"].as_str().is_some()
                 && event.payload["to_z_bits"].as_str().is_some()
                 && event.payload["source_count"].as_u64().is_some()
+                && event.payload["representative_line_id"].as_u64().is_some()
+                && event.payload["component_id"].as_u64().is_some()
         }));
     }
 

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -627,9 +627,11 @@ impl TraceRecorderV1 {
                 "to_z_bits": format!("0x{:016x}", observation.to_z_bits),
                 "side": format!("{:?}", observation.side),
                 "face_id": observation.face_id,
+                "component_id": observation.component_id,
                 "source_count": observation.source_line_ids.len(),
                 "first_source_line_id": observation.source_line_ids.first(),
                 "last_source_line_id": observation.source_line_ids.last(),
+                "representative_line_id": observation.representative_line_id,
             }),
         )
     }
@@ -654,6 +656,8 @@ impl TraceRecorderV1 {
                 "local_dir_edge_id": observation.local_dir_edge_id,
                 "edge_key": [endpoint(edge_start), endpoint(edge_end)],
                 "side": format!("{:?}", observation.side),
+                "component_id": observation.component_id,
+                "representative_line_id": observation.representative_line_id,
                 "reason": reason,
             }),
         )


### PR DESCRIPTION
## Stack

Parent:
- `main` at `9262ba3`

This PR:
- `agent/p5-boundary-preservation-contract`

Children:
- `agent/p5-boundary-limit-cancellation` (immediate child)

## Delivered

- Retain the deterministic representative source ID on every partition-border halfedge.
- Carry both local representative IDs through normalized twin payloads without applying a future stitch policy.
- Preserve component identity independently of optional local face identity, including unbounded-side observations.
- Extend bounded atomic-observation and rejection trace evidence with component and representative identities.
- Add component-local export, provenance, representative-ID, interpolated-Z, conflict, and trace regressions.
- Split the P5.2 roadmap contract so execution-policy evidence remains explicitly open for the child.

## Contract impact

- Tiled polygon output and replicate-and-own behavior are unchanged; boundary export remains an observational research surface.
- Source sets, representative IDs, endpoint Z bits, qualified face identity when available, and component identity are now explicit in exported observations.
- Twin reconciliation retains both local representatives and all Z candidates; it still does not choose a global representative or Z policy.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p geo-polygonize-core --lib --no-fail-fast` (311 passed)
- `cargo test -p geo-polygonize-core --test tiling_equivalence --no-fail-fast` (7 passed)
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings`
- Focused partition-border, trace, physical-span, and component-export tests passed.
- Generated bindings were restored; no generated artifacts are included.

## Agent handoff

- Immediate child: `agent/p5-boundary-limit-cancellation`, based on this PR.
- The child will add cancellation and resource-limit regressions and close the remaining P5.2 checkbox only after proving fail-closed, pre-mutation behavior.
- Do not claim P5.3 stitching or untiled equivalence from this stack.
