### PR TITLE
test(core): close boundary execution contract

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -429,7 +429,9 @@ Tracked by
 - [x] Preserve provenance, representative IDs, Z interpolation/conflicts, and
   qualified component identity through boundary export and observation
   normalization.
-- [ ] Preserve cancellation and resource limits through boundary noding.
+- [x] Preserve cancellation and resource limits through boundary noding, with
+  fail-closed pre-mutation checks for split events, graph nodes, noded
+  segments, and cooperative cancellation.
 - [x] Export only halfedges physically present on the boundary-noded arrangement.
 - [x] Introduce collision-free atomic observation identity.
 - [x] Emit bounded trace evidence for boundary-noding counts, atomic border

--- a/crates/geo-polygonize-core/src/graph/planar_graph.rs
+++ b/crates/geo-polygonize-core/src/graph/planar_graph.rs
@@ -3130,6 +3130,46 @@ impl ComponentScratch {
 #[cfg(test)]
 mod arrangement_ring_invariant_tests {
     use super::*;
+    use crate::CancellationToken;
+
+    type BoundaryEdgeSnapshot = ([u64; 3], [u64; 3], u32, Vec<u32>, [DirEdgeId; 2]);
+    type BoundaryGraphSnapshot = (
+        Vec<[u64; 3]>,
+        Vec<BoundaryEdgeSnapshot>,
+        Vec<Vec<DirEdgeId>>,
+    );
+
+    fn boundary_graph_snapshot(graph: &PlanarGraph) -> BoundaryGraphSnapshot {
+        let nodes = graph
+            .nodes_x
+            .iter()
+            .zip(&graph.nodes_y)
+            .zip(&graph.nodes_z)
+            .map(|((x, y), z)| [x.to_bits(), y.to_bits(), z.to_bits()])
+            .collect();
+        let edges = graph
+            .edges
+            .iter()
+            .map(|edge| {
+                (
+                    [
+                        edge.line.start.x.to_bits(),
+                        edge.line.start.y.to_bits(),
+                        edge.line.start.z.to_bits(),
+                    ],
+                    [
+                        edge.line.end.x.to_bits(),
+                        edge.line.end.y.to_bits(),
+                        edge.line.end.z.to_bits(),
+                    ],
+                    edge.line.line_id,
+                    edge.sources.line_ids.to_vec(),
+                    edge.dir_edges,
+                )
+            })
+            .collect();
+        (nodes, edges, graph.nodes_outgoing.clone())
+    }
 
     fn next_links(graph: &mut PlanarGraph) -> Vec<DirEdgeId> {
         graph.compute_next_cw_edges(None).unwrap();
@@ -4005,6 +4045,7 @@ mod arrangement_ring_invariant_tests {
             max_graph_edges: Some(1),
             ..Default::default()
         };
+        let before = boundary_graph_snapshot(&graph);
         let error = graph
             .node_partition_boundaries_with_execution_policy(
                 0,
@@ -4014,7 +4055,103 @@ mod arrangement_ring_invariant_tests {
             )
             .unwrap_err();
         assert!(error.to_string().contains("graph_edges"));
-        assert_eq!(graph.edges.len(), 1);
-        assert_eq!(graph.nodes_x.len(), 2);
+        assert_eq!(boundary_graph_snapshot(&graph), before);
+    }
+
+    #[test]
+    fn partition_boundary_noding_rejects_all_planned_growth_limits_before_mutation() {
+        let assert_limit = |policy: ExecutionPolicy,
+                            expected_stage: &str,
+                            expected_limit: usize,
+                            expected_observed: usize| {
+            let mut graph = PlanarGraph::new();
+            graph.add_line(Line3D::new(
+                Coord3D::new(-1.0, 2.0, 0.0),
+                Coord3D::new(11.0, 2.0, 12.0),
+                31,
+            ));
+            let before = boundary_graph_snapshot(&graph);
+            let error = graph
+                .node_partition_boundaries_with_execution_policy(
+                    0,
+                    Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 10.0, y: 10.0 }),
+                    &policy,
+                    None,
+                )
+                .unwrap_err();
+            assert!(matches!(
+                error,
+                crate::PolygonizeError::ResourceLimitExceeded {
+                    stage,
+                    limit,
+                    observed,
+                } if stage == expected_stage
+                    && limit == expected_limit
+                    && observed == expected_observed
+            ));
+            assert_eq!(boundary_graph_snapshot(&graph), before);
+        };
+
+        assert_limit(
+            ExecutionPolicy {
+                max_split_events: Some(1),
+                ..Default::default()
+            },
+            "split_events",
+            1,
+            2,
+        );
+        assert_limit(
+            ExecutionPolicy {
+                max_graph_nodes: Some(3),
+                ..Default::default()
+            },
+            "graph_nodes",
+            3,
+            4,
+        );
+        assert_limit(
+            ExecutionPolicy {
+                max_noded_segments: Some(2),
+                ..Default::default()
+            },
+            "noded_segments",
+            2,
+            3,
+        );
+    }
+
+    #[test]
+    fn partition_boundary_noding_observes_midflight_cancellation_before_mutation() {
+        let mut graph = PlanarGraph::new();
+        for index in 0..160 {
+            let y = index as f64 + 0.25;
+            graph.add_line(Line3D::new(
+                Coord3D::new(-1.0, y, 0.0),
+                Coord3D::new(11.0, y, 12.0),
+                index as u32,
+            ));
+        }
+        let before = boundary_graph_snapshot(&graph);
+        let token = CancellationToken::new();
+        let policy = ExecutionPolicy {
+            cancellation_token: Some(token.clone()),
+            cancel_at_work_item: Some((token, 256)),
+            ..Default::default()
+        };
+
+        let error = graph
+            .node_partition_boundaries_with_execution_policy(
+                0,
+                Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 10.0, y: 200.0 }),
+                &policy,
+                None,
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::Cancelled { stage } if stage == "boundary_noding"
+        ));
+        assert_eq!(boundary_graph_snapshot(&graph), before);
     }
 }


### PR DESCRIPTION
## Stack

Parent:
- `agent/p5-boundary-preservation-contract` / #1312

This PR:
- `agent/p5-boundary-limit-cancellation`

Children:
- none

## Delivered

- Add a topology snapshot proving boundary-noding failures do not partially mutate nodes, edges, or adjacency.
- Cover fail-closed `max_split_events`, `max_graph_nodes`, and `max_noded_segments` checks with exact stage, limit, and observed counts.
- Cover deterministic mid-flight cooperative cancellation during the boundary-noding scan before mutation.
- Mark the P5.2 cancellation/resource-limit contract complete with precise evidence in `ROADMAP.md`.

## Contract impact

- Boundary noding now has explicit regression evidence for cancellation and all planned growth checks; errors remain normalized `PolygonizeError` values.
- Limits and cancellation are checked before replacement-edge mutation, preserving the no-partial-topology contract.
- Replicate-and-own tiled output, public APIs, provenance, Z behavior, and serial/parallel behavior are unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p geo-polygonize-core --lib --no-fail-fast` (313 workspace-built core tests)
- `cargo test -p geo-polygonize-core --test tiling_equivalence --no-fail-fast` (7 passed)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check --workspace --all-targets --no-default-features`
- `DYLD_LIBRARY_PATH=/Library/Frameworks/Python.framework/Versions/3.11/lib cargo test --workspace --lib --tests --no-fail-fast` (all workspace tests passed)
- Focused boundary-noding cancellation and resource-limit tests passed.
- Generated bindings were restored; no generated artifacts are included.

## Agent handoff

- Parent: #1312 `feat(core): retain partition border payload identities`.
- Children: none.
- P5.2 is now complete by evidence; P5.3 true stitching remains intentionally open and must not be inferred from these observational exports.
