### PR TITLE
feat(core): report declared partition twins

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -446,6 +446,9 @@ Tracked by
 [#1289](https://github.com/graydonpleasants/geo-polygonize/issues/1289).
 Blocked by #1288.
 
+- [x] Emit deterministic declared-adjacency twin/payload reconciliation
+  evidence while leaving ambiguous, unrelated, and replicate-and-own output
+  cases untouched.
 - [ ] Apply unambiguous twins only across declared adjacent borders.
 - [ ] Reconcile canonical border nodes, source sets, representative IDs, and
   selected Z-policy decisions.

--- a/crates/geo-polygonize-core/src/graph/partition_border.rs
+++ b/crates/geo-polygonize-core/src/graph/partition_border.rs
@@ -512,6 +512,19 @@ pub struct PartitionBorderTwinPayload {
     pub end_z_bits: Vec<u64>,
 }
 
+/// Deterministic evidence for the declared-adjacency twin boundary.
+///
+/// Only observations covered by a declared partition adjacency contribute to
+/// normalized or matched counts. Unrelated coincident observations therefore
+/// cannot become twins by geometry alone.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct PartitionBorderReconciliationStats {
+    pub declared_adjacency_count: usize,
+    pub normalized_edge_count: usize,
+    pub matched_twin_count: usize,
+    pub unmatched_edge_count: usize,
+}
+
 /// Deterministic partition-border observations ready for twin reconciliation.
 ///
 /// The graph stores canonical undirected edge buckets while retaining each
@@ -684,6 +697,19 @@ impl PartitionBorderGraph {
     /// unrelated-partition buckets remain unmatched for later reconciliation.
     pub fn twin_pairs(&self) -> Vec<PartitionBorderTwin> {
         self.twin_pairs_from_edges(&self.normalized_edges())
+    }
+
+    /// Reports the conservative declared-adjacency reconciliation boundary
+    /// without mutating observations or choosing a Z/provenance policy.
+    pub fn reconciliation_stats(&self) -> PartitionBorderReconciliationStats {
+        let edges = self.normalized_edges();
+        let matched_twin_count = self.twin_pairs_from_edges(&edges).len();
+        PartitionBorderReconciliationStats {
+            declared_adjacency_count: self.adjacencies.len(),
+            normalized_edge_count: edges.len(),
+            matched_twin_count,
+            unmatched_edge_count: edges.len().saturating_sub(matched_twin_count),
+        }
     }
 
     /// Merges source IDs and retains every distinct Z candidate for each
@@ -1236,6 +1262,15 @@ mod tests {
         graph.insert(forward).unwrap();
 
         assert!(graph.twin_pairs().is_empty());
+        assert_eq!(
+            graph.reconciliation_stats(),
+            PartitionBorderReconciliationStats {
+                declared_adjacency_count: 1,
+                normalized_edge_count: 0,
+                matched_twin_count: 0,
+                unmatched_edge_count: 0,
+            }
+        );
     }
 
     #[test]
@@ -1279,6 +1314,16 @@ mod tests {
         );
         graph.insert(reverse).unwrap();
         graph.insert(forward).unwrap();
+
+        assert_eq!(
+            graph.reconciliation_stats(),
+            PartitionBorderReconciliationStats {
+                declared_adjacency_count: 1,
+                normalized_edge_count: 1,
+                matched_twin_count: 1,
+                unmatched_edge_count: 0,
+            }
+        );
 
         assert_eq!(
             graph.reconcile_twin_payloads(),

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -247,6 +247,14 @@ pub struct StitchingReport {
     pub retried_tile_count: usize,
     pub retry_attempt_count: usize,
     pub retry_exhausted_tile_count: usize,
+    /// Number of declared geometric adjacencies used for border matching.
+    pub partition_border_adjacency_count: usize,
+    /// Number of normalized border edge buckets covered by those adjacencies.
+    pub partition_border_normalized_edge_count: usize,
+    /// Number of unambiguous opposite-direction border pairs.
+    pub partition_border_twin_count: usize,
+    /// Normalized border buckets conservatively left unmatched.
+    pub partition_border_unmatched_edge_count: usize,
     /// Whether indexed components were recovered by component or region fallback.
     /// This is operational metadata; strict validation uses `coverage_resolution`.
     pub component_fallback_used: bool,
@@ -2239,6 +2247,10 @@ impl<'a> TiledPolygonizer<'a> {
             }
         }
         self.declare_partition_adjacencies(&mut partition_border_graph, &tile_reports)?;
+        let partition_border_reconciliation = partition_border_graph.reconciliation_stats();
+        if let Some(trace) = trace.as_deref_mut() {
+            trace.record_partition_border_reconciliation(partition_border_reconciliation);
+        }
         let unresolved = tile_reports.iter().any(Self::report_is_unresolved);
         let component_fallback_attempted = self.component_fallback && unresolved;
         let (component_fallback, component_fallback_decline_reason) =
@@ -2459,6 +2471,13 @@ impl<'a> TiledPolygonizer<'a> {
                 retried_tile_count,
                 retry_attempt_count,
                 retry_exhausted_tile_count,
+                partition_border_adjacency_count: partition_border_reconciliation
+                    .declared_adjacency_count,
+                partition_border_normalized_edge_count: partition_border_reconciliation
+                    .normalized_edge_count,
+                partition_border_twin_count: partition_border_reconciliation.matched_twin_count,
+                partition_border_unmatched_edge_count: partition_border_reconciliation
+                    .unmatched_edge_count,
                 component_fallback_used,
                 untiled_fallback_attempted,
                 untiled_fallback_authoritative,

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -63,6 +63,22 @@ mod tests {
         assert!(observations
             .iter()
             .all(|observation| observation.face_ref.is_some()));
+        let reconciliation = result.partition_border_graph.reconciliation_stats();
+        assert_eq!(reconciliation.declared_adjacency_count, 1);
+        assert_eq!(
+            result.stitching_report.partition_border_adjacency_count,
+            reconciliation.declared_adjacency_count
+        );
+        assert_eq!(
+            result.stitching_report.partition_border_twin_count,
+            reconciliation.matched_twin_count
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_unmatched_edge_count,
+            reconciliation.unmatched_edge_count
+        );
         assert_eq!(result.polygons.len(), 2);
     }
 
@@ -184,6 +200,24 @@ mod tests {
                 && event.payload["representative_line_id"].as_u64().is_some()
                 && event.payload["component_id"].as_u64().is_some()
         }));
+        let reconciliation = traced
+            .trace
+            .events
+            .iter()
+            .find(|event| event.kind == "partition_border_twin_reconciliation")
+            .expect("twin reconciliation evidence");
+        assert_eq!(reconciliation.payload["declared_adjacency_count"], 1);
+        assert_eq!(
+            reconciliation.payload["matched_twin_count"]
+                .as_u64()
+                .unwrap()
+                + reconciliation.payload["unmatched_edge_count"]
+                    .as_u64()
+                    .unwrap(),
+            reconciliation.payload["normalized_edge_count"]
+                .as_u64()
+                .unwrap()
+        );
     }
 
     #[test]

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -1,7 +1,7 @@
 //! Internal bounded topology trace schema.
 
 use crate::fingerprint::{coordinate_fingerprint, float_bits};
-use crate::graph::partition_border::PartitionBorderHalfEdge;
+use crate::graph::partition_border::{PartitionBorderHalfEdge, PartitionBorderReconciliationStats};
 use crate::graph::planar_graph::PartitionBoundaryNodingStats;
 use crate::graph::{ExtractedRing, PlanarGraph};
 use crate::noding::grid::{
@@ -599,6 +599,22 @@ impl TraceRecorderV1 {
                 "added_node_count": stats.added_node_count,
                 "added_edge_count": stats.added_edge_count,
                 "split_event_count": stats.split_event_count,
+            }),
+        )
+    }
+
+    pub(crate) fn record_partition_border_reconciliation(
+        &mut self,
+        stats: PartitionBorderReconciliationStats,
+    ) -> bool {
+        self.record(
+            TraceStageV1::Graph,
+            "partition_border_twin_reconciliation",
+            serde_json::json!({
+                "declared_adjacency_count": stats.declared_adjacency_count,
+                "normalized_edge_count": stats.normalized_edge_count,
+                "matched_twin_count": stats.matched_twin_count,
+                "unmatched_edge_count": stats.unmatched_edge_count,
             }),
         )
     }


### PR DESCRIPTION
## Stack

Parent:
- `agent/p5-boundary-limit-cancellation` / #1313

This PR:
- `agent/p5-declared-twin-reconciliation`

Children:
- none

## Delivered

- Add deterministic declared-adjacency reconciliation statistics for normalized border buckets, unambiguous twins, and conservatively unmatched buckets.
- Integrate those statistics into the experimental tiled stitching report without changing polygon output.
- Emit one bounded `partition_border_twin_reconciliation` trace event per tiled call.
- Add direct and tiled regressions proving exact declared opposite pairs reconcile, while unrelated coincident observations remain outside the normalized set.
- Record this evidence boundary in `ROADMAP.md` while leaving actual twin application and global graph mutation open.

## Contract impact

- Tiled output remains replicate-and-own; no border observations are merged into polygon topology.
- Only declared complementary partition adjacencies contribute to normalized border buckets or matched twins.
- Ambiguous buckets remain unmatched, and no representative or Z policy is selected by this PR.
- New report and trace fields are observational research metadata; stable facade behavior is unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p geo-polygonize-core --lib --no-fail-fast` (313 passed)
- `cargo test -p geo-polygonize-core --test tiling_equivalence --no-fail-fast` (7 passed)
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings`
- `DYLD_LIBRARY_PATH=/Library/Frameworks/Python.framework/Versions/3.11/lib cargo test --workspace --lib --tests --no-fail-fast` (all workspace tests passed)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check --workspace --all-targets --no-default-features`
- Generated bindings were restored; no generated artifacts are included.

## Agent handoff

- Parent: #1313 `test(core): close boundary execution contract`.
- Children: none.
- Remaining P5.3 work: apply only unambiguous twins, reconcile payload policy, build one validated global arrangement/unbounded face, and prove untiled equivalence for a documented class.
- Do not describe this report/trace evidence as graph stitching.
