### PR TITLE
feat(core): apply qualified partition twin links

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -449,6 +449,10 @@ Blocked by #1288.
 - [x] Emit deterministic declared-adjacency twin/payload reconciliation
   evidence while leaving ambiguous, unrelated, and replicate-and-own output
   cases untouched.
+- [x] Build and retain a deterministic face-qualified twin-link plan for exact
+  declared-adjacency pairs with valid partition-matching local face identity;
+  report and trace missing or malformed face lineage without mutating local
+  adjacency or tiled output.
 - [ ] Apply unambiguous twins only across declared adjacent borders.
 - [ ] Reconcile canonical border nodes, source sets, representative IDs, and
   selected Z-policy decisions.

--- a/crates/geo-polygonize-core/src/graph/partition_border.rs
+++ b/crates/geo-polygonize-core/src/graph/partition_border.rs
@@ -1,5 +1,6 @@
 use crate::types::{Coord3D, PartitionFaceRef};
 use crate::utils::canonical_coordinate_bits;
+use crate::ExecutionPolicy;
 use geo_types::Rect;
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -512,6 +513,27 @@ pub struct PartitionBorderTwinPayload {
     pub end_z_bits: Vec<u64>,
 }
 
+/// One face-qualified twin link that is safe to carry into a future global
+/// arrangement. The local observations and their payload remain immutable;
+/// this relation does not rewrite either partition's local adjacency.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct PartitionBorderFaceTwin {
+    pub(crate) twin: PartitionBorderTwin,
+    pub(crate) forward_face_ref: PartitionFaceRef,
+    pub(crate) reverse_face_ref: PartitionFaceRef,
+    pub(crate) payload: PartitionBorderTwinPayload,
+}
+
+/// Evidence from attempting to apply exact declared-adjacency twins to
+/// qualified local faces.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct PartitionBorderTwinApplicationStats {
+    pub(crate) candidate_twin_count: usize,
+    pub(crate) applied_twin_count: usize,
+    pub(crate) missing_face_ref_count: usize,
+    pub(crate) invalid_face_ref_count: usize,
+}
+
 /// Deterministic evidence for the declared-adjacency twin boundary.
 ///
 /// Only observations covered by a declared partition adjacency contribute to
@@ -536,6 +558,7 @@ pub struct PartitionBorderGraph {
     observations: BTreeMap<PartitionBorderObservationId, PartitionBorderHalfEdge>,
     adjacencies: BTreeSet<PartitionBorderAdjacency>,
     edges: BTreeMap<PartitionBorderEdgeKey, BTreeSet<PartitionBorderHalfEdge>>,
+    applied_face_twins: Vec<PartitionBorderFaceTwin>,
 }
 
 impl PartitionBorderGraph {
@@ -569,11 +592,13 @@ impl PartitionBorderGraph {
             .or_default()
             .insert(half_edge.clone());
         self.observations.insert(observation_id, half_edge);
+        self.applied_face_twins.clear();
         Ok(())
     }
 
     pub fn declare_adjacency(&mut self, adjacency: PartitionBorderAdjacency) {
         self.adjacencies.insert(adjacency);
+        self.applied_face_twins.clear();
     }
 
     pub fn node_count(&self) -> usize {
@@ -712,46 +737,130 @@ impl PartitionBorderGraph {
         }
     }
 
+    fn twin_payload_from_edges(
+        &self,
+        edges: &BTreeMap<PartitionBorderEdgeKey, BTreeSet<PartitionBorderHalfEdge>>,
+        twin: PartitionBorderTwin,
+    ) -> Option<PartitionBorderTwinPayload> {
+        let observations = edges.get(&twin.edge_key)?;
+        let forward = observations
+            .iter()
+            .find(|observation| observation.observation_id() == twin.forward)?;
+        let reverse = observations
+            .iter()
+            .find(|observation| observation.observation_id() == twin.reverse)?;
+
+        let mut source_line_ids = forward
+            .source_line_ids
+            .iter()
+            .chain(&reverse.source_line_ids)
+            .copied()
+            .collect::<Vec<_>>();
+        source_line_ids.sort_unstable();
+        source_line_ids.dedup();
+
+        let mut start_z_bits = vec![forward.from_z_bits, reverse.to_z_bits];
+        start_z_bits.sort_unstable();
+        start_z_bits.dedup();
+        let mut end_z_bits = vec![forward.to_z_bits, reverse.from_z_bits];
+        end_z_bits.sort_unstable();
+        end_z_bits.dedup();
+
+        Some(PartitionBorderTwinPayload {
+            twin,
+            source_line_ids,
+            forward_representative_line_id: forward.representative_line_id,
+            reverse_representative_line_id: reverse.representative_line_id,
+            start_z_bits,
+            end_z_bits,
+        })
+    }
+
+    /// Applies only exact declared-adjacency twins whose two observations
+    /// carry qualified, partition-matching local face references. The
+    /// resulting links are retained on this exported graph for later global
+    /// arrangement work; no local adjacency, output polygon, or Z policy is
+    /// mutated here.
+    pub(crate) fn apply_unambiguous_face_twins(
+        &mut self,
+        execution_policy: &ExecutionPolicy,
+    ) -> crate::Result<PartitionBorderTwinApplicationStats> {
+        execution_policy.check_cancelled("partition_border_twin_application")?;
+        let edges = self.normalized_edges();
+        let twins = self.twin_pairs_from_edges(&edges);
+        execution_policy.check(
+            "partition_border_twin_applications",
+            execution_policy.max_graph_edges,
+            twins.len(),
+        )?;
+        let mut stats = PartitionBorderTwinApplicationStats {
+            candidate_twin_count: twins.len(),
+            ..Default::default()
+        };
+        let mut applied_face_twins = Vec::new();
+
+        for (twin_index, twin) in twins.into_iter().enumerate() {
+            execution_policy
+                .check_cancelled_every("partition_border_twin_application", twin_index)?;
+            let Some(observations) = edges.get(&twin.edge_key) else {
+                stats.invalid_face_ref_count += 1;
+                continue;
+            };
+            let Some(forward) = observations
+                .iter()
+                .find(|observation| observation.observation_id() == twin.forward)
+            else {
+                stats.invalid_face_ref_count += 1;
+                continue;
+            };
+            let Some(reverse) = observations
+                .iter()
+                .find(|observation| observation.observation_id() == twin.reverse)
+            else {
+                stats.invalid_face_ref_count += 1;
+                continue;
+            };
+
+            let (Some(forward_face_ref), Some(reverse_face_ref)) =
+                (forward.face_ref, reverse.face_ref)
+            else {
+                stats.missing_face_ref_count += 1;
+                continue;
+            };
+            if forward_face_ref.partition_id != forward.partition_id
+                || reverse_face_ref.partition_id != reverse.partition_id
+                || forward_face_ref.partition_id == reverse_face_ref.partition_id
+            {
+                stats.invalid_face_ref_count += 1;
+                continue;
+            }
+            let Some(payload) = self.twin_payload_from_edges(&edges, twin) else {
+                stats.invalid_face_ref_count += 1;
+                continue;
+            };
+            applied_face_twins.push(PartitionBorderFaceTwin {
+                twin,
+                forward_face_ref,
+                reverse_face_ref,
+                payload,
+            });
+        }
+        stats.applied_twin_count = applied_face_twins.len();
+        self.applied_face_twins = applied_face_twins;
+        Ok(stats)
+    }
+
+    pub(crate) fn applied_face_twins(&self) -> &[PartitionBorderFaceTwin] {
+        &self.applied_face_twins
+    }
+
     /// Merges source IDs and retains every distinct Z candidate for each
     /// canonical endpoint. No Z conflict policy is applied here.
     pub fn reconcile_twin_payloads(&self) -> Vec<PartitionBorderTwinPayload> {
         let edges = self.normalized_edges();
         self.twin_pairs_from_edges(&edges)
             .into_iter()
-            .filter_map(|twin| {
-                let observations = edges.get(&twin.edge_key)?;
-                let forward = observations
-                    .iter()
-                    .find(|observation| observation.observation_id() == twin.forward)?;
-                let reverse = observations
-                    .iter()
-                    .find(|observation| observation.observation_id() == twin.reverse)?;
-
-                let mut source_line_ids = forward
-                    .source_line_ids
-                    .iter()
-                    .chain(&reverse.source_line_ids)
-                    .copied()
-                    .collect::<Vec<_>>();
-                source_line_ids.sort_unstable();
-                source_line_ids.dedup();
-
-                let mut start_z_bits = vec![forward.from_z_bits, reverse.to_z_bits];
-                start_z_bits.sort_unstable();
-                start_z_bits.dedup();
-                let mut end_z_bits = vec![forward.to_z_bits, reverse.from_z_bits];
-                end_z_bits.sort_unstable();
-                end_z_bits.dedup();
-
-                Some(PartitionBorderTwinPayload {
-                    twin,
-                    source_line_ids,
-                    forward_representative_line_id: forward.representative_line_id,
-                    reverse_representative_line_id: reverse.representative_line_id,
-                    start_z_bits,
-                    end_z_bits,
-                })
-            })
+            .filter_map(|twin| self.twin_payload_from_edges(&edges, twin))
             .collect()
     }
 
@@ -772,6 +881,7 @@ mod tests {
     use super::*;
     use crate::graph::PlanarGraph;
     use crate::types::Line3D;
+    use crate::CancellationToken;
 
     fn coord(x: f64, y: f64, z: f64) -> Coord3D {
         Coord3D::new(x, y, z)
@@ -896,6 +1006,43 @@ mod tests {
             component_id,
             face_id,
         }
+    }
+
+    fn exact_face_twin_graph() -> PartitionBorderGraph {
+        let forward = PartitionBorderHalfEdge::new_with_face_ref(
+            1,
+            7,
+            Some(face(1, 4, 9)),
+            PartitionBorderSide::MinY,
+            coord(0.0, 0.0, 1.0),
+            coord(2.0, 0.0, 2.0),
+            [8],
+        )
+        .unwrap();
+        let reverse = PartitionBorderHalfEdge::new_with_face_ref(
+            2,
+            9,
+            Some(face(2, 6, 11)),
+            PartitionBorderSide::MaxY,
+            coord(2.0, 0.0, 20.0),
+            coord(0.0, 0.0, 10.0),
+            [7],
+        )
+        .unwrap();
+        let mut graph = PartitionBorderGraph::default();
+        graph.declare_adjacency(
+            PartitionBorderAdjacency::new(
+                1,
+                PartitionBorderSide::MinY,
+                2,
+                PartitionBorderSide::MaxY,
+                0.0,
+            )
+            .unwrap(),
+        );
+        graph.insert(reverse).unwrap();
+        graph.insert(forward).unwrap();
+        graph
     }
 
     #[test]
@@ -1336,6 +1483,213 @@ mod tests {
                 end_z_bits: vec![2.0f64.to_bits()],
             }]
         );
+    }
+
+    #[test]
+    fn face_twin_application_retains_qualified_faces_and_payload_lineage() {
+        let forward = PartitionBorderHalfEdge::new_with_face_ref(
+            1,
+            7,
+            Some(face(1, 4, 9)),
+            PartitionBorderSide::MinY,
+            coord(0.0, 0.0, 1.0),
+            coord(2.0, 0.0, 2.0),
+            [8, 3],
+        )
+        .unwrap();
+        let reverse = PartitionBorderHalfEdge::new_with_face_ref(
+            2,
+            9,
+            Some(face(2, 6, 11)),
+            PartitionBorderSide::MaxY,
+            coord(2.0, 0.0, 20.0),
+            coord(0.0, 0.0, 10.0),
+            [7, 3],
+        )
+        .unwrap();
+        let twin = PartitionBorderTwin {
+            edge_key: forward.edge_key,
+            forward: forward.observation_id(),
+            reverse: reverse.observation_id(),
+        };
+
+        let mut graph = PartitionBorderGraph::default();
+        graph.declare_adjacency(
+            PartitionBorderAdjacency::new(
+                1,
+                PartitionBorderSide::MinY,
+                2,
+                PartitionBorderSide::MaxY,
+                0.0,
+            )
+            .unwrap(),
+        );
+        graph.insert(reverse).unwrap();
+        graph.insert(forward).unwrap();
+
+        let stats = graph
+            .apply_unambiguous_face_twins(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(
+            stats,
+            PartitionBorderTwinApplicationStats {
+                candidate_twin_count: 1,
+                applied_twin_count: 1,
+                missing_face_ref_count: 0,
+                invalid_face_ref_count: 0,
+            }
+        );
+        assert_eq!(graph.applied_face_twins().len(), 1);
+        let application = &graph.applied_face_twins()[0];
+        assert_eq!(application.twin, twin);
+        assert_eq!(application.forward_face_ref, face(1, 4, 9));
+        assert_eq!(application.reverse_face_ref, face(2, 6, 11));
+        assert_eq!(application.payload.source_line_ids, vec![3, 7, 8]);
+        assert_eq!(application.payload.forward_representative_line_id, Some(3));
+        assert_eq!(application.payload.reverse_representative_line_id, Some(3));
+        assert_eq!(
+            application.payload.start_z_bits,
+            vec![1.0f64.to_bits(), 10.0f64.to_bits()]
+        );
+        assert_eq!(
+            application.payload.end_z_bits,
+            vec![2.0f64.to_bits(), 20.0f64.to_bits()]
+        );
+    }
+
+    #[test]
+    fn face_twin_application_declines_missing_face_identity_without_mutating_observations() {
+        let forward = PartitionBorderHalfEdge::new_with_face_ref(
+            1,
+            7,
+            None,
+            PartitionBorderSide::MinY,
+            coord(0.0, 0.0, 1.0),
+            coord(2.0, 0.0, 2.0),
+            [8],
+        )
+        .unwrap();
+        let reverse = PartitionBorderHalfEdge::new_with_face_ref(
+            2,
+            9,
+            Some(face(2, 6, 11)),
+            PartitionBorderSide::MaxY,
+            coord(2.0, 0.0, 20.0),
+            coord(0.0, 0.0, 10.0),
+            [7],
+        )
+        .unwrap();
+
+        let mut graph = PartitionBorderGraph::default();
+        graph.declare_adjacency(
+            PartitionBorderAdjacency::new(
+                1,
+                PartitionBorderSide::MinY,
+                2,
+                PartitionBorderSide::MaxY,
+                0.0,
+            )
+            .unwrap(),
+        );
+        graph.insert(forward).unwrap();
+        graph.insert(reverse).unwrap();
+        let before = graph.clone();
+
+        let stats = graph
+            .apply_unambiguous_face_twins(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(stats.candidate_twin_count, 1);
+        assert_eq!(stats.applied_twin_count, 0);
+        assert_eq!(stats.missing_face_ref_count, 1);
+        assert_eq!(stats.invalid_face_ref_count, 0);
+        assert!(graph.applied_face_twins().is_empty());
+        assert_eq!(graph.observations, before.observations);
+        assert_eq!(graph.edges, before.edges);
+    }
+
+    #[test]
+    fn face_twin_application_declines_malformed_face_partition_identity() {
+        let forward = PartitionBorderHalfEdge::new_with_face_ref(
+            1,
+            7,
+            Some(face(99, 4, 9)),
+            PartitionBorderSide::MinY,
+            coord(0.0, 0.0, 1.0),
+            coord(2.0, 0.0, 2.0),
+            [8],
+        )
+        .unwrap();
+        let reverse = PartitionBorderHalfEdge::new_with_face_ref(
+            2,
+            9,
+            Some(face(2, 6, 11)),
+            PartitionBorderSide::MaxY,
+            coord(2.0, 0.0, 20.0),
+            coord(0.0, 0.0, 10.0),
+            [7],
+        )
+        .unwrap();
+
+        let mut graph = PartitionBorderGraph::default();
+        graph.declare_adjacency(
+            PartitionBorderAdjacency::new(
+                1,
+                PartitionBorderSide::MinY,
+                2,
+                PartitionBorderSide::MaxY,
+                0.0,
+            )
+            .unwrap(),
+        );
+        graph.insert(reverse).unwrap();
+        graph.insert(forward).unwrap();
+
+        let stats = graph
+            .apply_unambiguous_face_twins(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(stats.candidate_twin_count, 1);
+        assert_eq!(stats.applied_twin_count, 0);
+        assert_eq!(stats.missing_face_ref_count, 0);
+        assert_eq!(stats.invalid_face_ref_count, 1);
+        assert!(graph.applied_face_twins().is_empty());
+    }
+
+    #[test]
+    fn face_twin_application_is_bounded_and_cancellable_before_mutation() {
+        let mut limited = exact_face_twin_graph();
+        let before = limited.clone();
+        let error = limited
+            .apply_unambiguous_face_twins(&ExecutionPolicy {
+                max_graph_edges: Some(0),
+                ..Default::default()
+            })
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::ResourceLimitExceeded {
+                ref stage,
+                limit: 0,
+                observed: 1,
+            } if stage == "partition_border_twin_applications"
+        ));
+        assert_eq!(limited, before);
+
+        let token = CancellationToken::new();
+        token.cancel();
+        let mut cancelled = exact_face_twin_graph();
+        let before = cancelled.clone();
+        let error = cancelled
+            .apply_unambiguous_face_twins(&ExecutionPolicy {
+                cancellation_token: Some(token),
+                ..Default::default()
+            })
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::Cancelled { ref stage }
+                if stage == "partition_border_twin_application"
+        ));
+        assert_eq!(cancelled, before);
     }
 
     #[test]

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -255,6 +255,15 @@ pub struct StitchingReport {
     pub partition_border_twin_count: usize,
     /// Normalized border buckets conservatively left unmatched.
     pub partition_border_unmatched_edge_count: usize,
+    /// Exact twin pairs whose observations also carried valid qualified local
+    /// face references and were retained as face-level links.
+    pub partition_border_face_twin_count: usize,
+    /// Exact twin pairs declined because at least one observation had no face
+    /// reference.
+    pub partition_border_face_twin_missing_face_count: usize,
+    /// Exact twin pairs declined because a face reference was malformed or
+    /// did not match its observation's partition.
+    pub partition_border_face_twin_invalid_face_count: usize,
     /// Whether indexed components were recovered by component or region fallback.
     /// This is operational metadata; strict validation uses `coverage_resolution`.
     pub component_fallback_used: bool,
@@ -275,9 +284,10 @@ pub struct TiledPolygonizeResult {
     pub polygons: Vec<Polygon3D>,
     pub tile_reports: Vec<TileReport>,
     pub stitching_report: StitchingReport,
-    /// Canonical observations captured from physical tile arrangements.
-    ///
-    /// These are exported only; tiled output does not stitch or reconcile them.
+    /// Canonical observations captured from physical tile arrangements. A
+    /// conservative face-qualified twin-link plan may be retained on this
+    /// graph, but tiled output does not build a global arrangement or replace
+    /// replicate-and-own polygons with stitched output.
     #[doc(hidden)]
     pub partition_border_graph: PartitionBorderGraph,
 }
@@ -2248,8 +2258,16 @@ impl<'a> TiledPolygonizer<'a> {
         }
         self.declare_partition_adjacencies(&mut partition_border_graph, &tile_reports)?;
         let partition_border_reconciliation = partition_border_graph.reconciliation_stats();
+        let partition_border_twin_application =
+            partition_border_graph.apply_unambiguous_face_twins(&self.execution_policy)?;
+        let applied_face_twin_count = partition_border_graph.applied_face_twins().len();
+        debug_assert_eq!(
+            applied_face_twin_count,
+            partition_border_twin_application.applied_twin_count
+        );
         if let Some(trace) = trace.as_deref_mut() {
             trace.record_partition_border_reconciliation(partition_border_reconciliation);
+            trace.record_partition_border_twin_application(partition_border_twin_application);
         }
         let unresolved = tile_reports.iter().any(Self::report_is_unresolved);
         let component_fallback_attempted = self.component_fallback && unresolved;
@@ -2478,6 +2496,11 @@ impl<'a> TiledPolygonizer<'a> {
                 partition_border_twin_count: partition_border_reconciliation.matched_twin_count,
                 partition_border_unmatched_edge_count: partition_border_reconciliation
                     .unmatched_edge_count,
+                partition_border_face_twin_count: applied_face_twin_count,
+                partition_border_face_twin_missing_face_count: partition_border_twin_application
+                    .missing_face_ref_count,
+                partition_border_face_twin_invalid_face_count: partition_border_twin_application
+                    .invalid_face_ref_count,
                 component_fallback_used,
                 untiled_fallback_attempted,
                 untiled_fallback_authoritative,

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -79,6 +79,20 @@ mod tests {
                 .partition_border_unmatched_edge_count,
             reconciliation.unmatched_edge_count
         );
+        assert_eq!(
+            result.stitching_report.partition_border_face_twin_count,
+            result.partition_border_graph.applied_face_twins().len()
+        );
+        assert_eq!(
+            result.stitching_report.partition_border_face_twin_count
+                + result
+                    .stitching_report
+                    .partition_border_face_twin_missing_face_count
+                + result
+                    .stitching_report
+                    .partition_border_face_twin_invalid_face_count,
+            reconciliation.matched_twin_count
+        );
         assert_eq!(result.polygons.len(), 2);
     }
 
@@ -215,6 +229,28 @@ mod tests {
                     .as_u64()
                     .unwrap(),
             reconciliation.payload["normalized_edge_count"]
+                .as_u64()
+                .unwrap()
+        );
+        let application = traced
+            .trace
+            .events
+            .iter()
+            .find(|event| event.kind == "partition_border_twin_application")
+            .expect("twin application evidence");
+        assert_eq!(
+            application.payload["candidate_twin_count"],
+            reconciliation.payload["matched_twin_count"]
+        );
+        assert_eq!(
+            application.payload["applied_twin_count"].as_u64().unwrap()
+                + application.payload["missing_face_ref_count"]
+                    .as_u64()
+                    .unwrap()
+                + application.payload["invalid_face_ref_count"]
+                    .as_u64()
+                    .unwrap(),
+            application.payload["candidate_twin_count"]
                 .as_u64()
                 .unwrap()
         );

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -1,7 +1,10 @@
 //! Internal bounded topology trace schema.
 
 use crate::fingerprint::{coordinate_fingerprint, float_bits};
-use crate::graph::partition_border::{PartitionBorderHalfEdge, PartitionBorderReconciliationStats};
+use crate::graph::partition_border::{
+    PartitionBorderHalfEdge, PartitionBorderReconciliationStats,
+    PartitionBorderTwinApplicationStats,
+};
 use crate::graph::planar_graph::PartitionBoundaryNodingStats;
 use crate::graph::{ExtractedRing, PlanarGraph};
 use crate::noding::grid::{
@@ -615,6 +618,22 @@ impl TraceRecorderV1 {
                 "normalized_edge_count": stats.normalized_edge_count,
                 "matched_twin_count": stats.matched_twin_count,
                 "unmatched_edge_count": stats.unmatched_edge_count,
+            }),
+        )
+    }
+
+    pub(crate) fn record_partition_border_twin_application(
+        &mut self,
+        stats: PartitionBorderTwinApplicationStats,
+    ) -> bool {
+        self.record(
+            TraceStageV1::Graph,
+            "partition_border_twin_application",
+            serde_json::json!({
+                "candidate_twin_count": stats.candidate_twin_count,
+                "applied_twin_count": stats.applied_twin_count,
+                "missing_face_ref_count": stats.missing_face_ref_count,
+                "invalid_face_ref_count": stats.invalid_face_ref_count,
             }),
         )
     }


### PR DESCRIPTION
## Stack

- Parent: `main` at `85dc102`
- This PR: `agent/p5-face-twin-application`
- Children: none

## Delivered

- Adds a deterministic face-qualified twin-link record for each exact, declared-adjacency, opposite-direction border pair whose local face references are present and partition-consistent.
- Retains the merged source set, both representative source IDs, endpoint Z candidates, and qualified partition/component/face lineage on each retained link.
- Stores the links on the exported border graph and reports applied, missing-face, and malformed-face counts.
- Emits bounded trace evidence for the application attempt.
- Adds regressions for qualified lineage, missing and malformed face identity, ambiguity preservation, cancellation, resource limits, and tiled trace/report consistency.
- Updates P5.3 with the checked plan-level evidence while leaving global graph stitching and equivalence gates open.

## Contract impact

- The experimental tiled API still returns replicate-and-own polygons; this PR does not rewrite local adjacency, choose a Z policy, merge global nodes/components, build global next links, or extract stitched output.
- Ambiguous, undeclared, same-partition, missing-face, and malformed observations remain unlinked and explicitly counted.
- The application pass is fail-closed: cancellation and the existing graph-edge budget are checked before retained-link mutation, and partial plans are not committed.

## Validation

- `cargo test -p geo-polygonize-core partition_border --lib` — 22 passed.
- Focused tiled export/trace tests — 2 passed.
- `cargo fmt --all -- --check`
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings`
- `DYLD_LIBRARY_PATH=/Library/Frameworks/Python.framework/Versions/3.11/lib cargo test --workspace --lib --tests --no-fail-fast` — all workspace tests passed, including 317 core unit tests.
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check --workspace --all-targets --no-default-features`
- `git diff --check`

## Agent handoff

- Parent: `main`
- Children: none
- Exact next branch: `agent/p5-border-node-reconciliation`
- Remaining risk: this is a retained face-level link plan, not global node/component/face stitching; full untiled equivalence remains unclaimed.
