### PR TITLE
feat(core): reconcile global border components

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -457,6 +457,10 @@ Blocked by #1288.
   sets, representative IDs, face lineage, and endpoint-Z candidates under
   the selected Z policy, with fail-closed conflict, limit, and cancellation
   behavior; do not mutate local or tiled topology.
+- [x] Build and retain deterministic connected-component evidence for
+  qualified border faces, including explicit singleton faces and linked twin
+  edges with fail-closed limit and cancellation behavior; do not mutate local
+  or tiled topology.
 - [ ] Apply unambiguous twins only across declared adjacent borders.
 - [ ] Reconcile canonical border nodes, source sets, representative IDs, and
   selected Z-policy decisions.

--- a/crates/geo-polygonize-core/src/graph/partition_border.rs
+++ b/crates/geo-polygonize-core/src/graph/partition_border.rs
@@ -559,6 +559,26 @@ pub(crate) struct PartitionBorderNodeReconciliationStats {
     pub(crate) z_conflict_count: usize,
 }
 
+/// One deterministic connected component of qualified partition-border face
+/// evidence. This is retained for a future global arrangement; it does not
+/// rewrite local face IDs, adjacency, or tiled output.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct PartitionBorderGlobalComponent {
+    pub(crate) component_index: usize,
+    pub(crate) face_refs: Vec<PartitionFaceRef>,
+    pub(crate) border_node_keys: Vec<PartitionBorderNodeKey>,
+    pub(crate) twin_edge_keys: Vec<PartitionBorderEdgeKey>,
+}
+
+/// Counts from deterministic global component reconciliation evidence.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct PartitionBorderGlobalComponentReconciliationStats {
+    pub(crate) component_count: usize,
+    pub(crate) face_count: usize,
+    pub(crate) linked_face_count: usize,
+    pub(crate) twin_link_count: usize,
+}
+
 /// Deterministic evidence for the declared-adjacency twin boundary.
 ///
 /// Only observations covered by a declared partition adjacency contribute to
@@ -585,6 +605,7 @@ pub struct PartitionBorderGraph {
     edges: BTreeMap<PartitionBorderEdgeKey, BTreeSet<PartitionBorderHalfEdge>>,
     applied_face_twins: Vec<PartitionBorderFaceTwin>,
     reconciled_nodes: Vec<PartitionBorderNodePayload>,
+    global_components: Vec<PartitionBorderGlobalComponent>,
 }
 
 impl PartitionBorderGraph {
@@ -620,6 +641,7 @@ impl PartitionBorderGraph {
         self.observations.insert(observation_id, half_edge);
         self.applied_face_twins.clear();
         self.reconciled_nodes.clear();
+        self.global_components.clear();
         Ok(())
     }
 
@@ -627,6 +649,7 @@ impl PartitionBorderGraph {
         self.adjacencies.insert(adjacency);
         self.applied_face_twins.clear();
         self.reconciled_nodes.clear();
+        self.global_components.clear();
     }
 
     pub fn node_count(&self) -> usize {
@@ -875,6 +898,7 @@ impl PartitionBorderGraph {
         }
         stats.applied_twin_count = applied_face_twins.len();
         self.applied_face_twins = applied_face_twins;
+        self.global_components.clear();
         Ok(stats)
     }
 
@@ -884,11 +908,10 @@ impl PartitionBorderGraph {
 
     /// Reconciles every exact border node without mutating observations or
     /// local topology. All source, representative, face, and Z evidence is
-    /// retained. Non-ignored policies choose the first canonical Z candidate,
-    /// matching the existing deterministic graph-construction rule; conflict
-    /// detection remains explicit and `ErrorOnConflict` fails before the plan
-    /// is committed. Non-ignored selection follows the existing source-ID
-    /// ordering used by untiled graph construction.
+    /// retained. Non-ignored policies choose the first candidate under the
+    /// existing representative/source ordering used by untiled graph
+    /// construction; conflict detection remains explicit and
+    /// `ErrorOnConflict` fails before the plan is committed.
     pub(crate) fn reconcile_border_nodes(
         &mut self,
         z_options: ZOptions,
@@ -1014,11 +1037,154 @@ impl PartitionBorderGraph {
             });
         }
         self.reconciled_nodes = reconciled_nodes;
+        self.global_components.clear();
         Ok(stats)
     }
 
     pub(crate) fn reconciled_border_nodes(&self) -> &[PartitionBorderNodePayload] {
         &self.reconciled_nodes
+    }
+
+    /// Reconciles qualified face references into deterministic connected
+    /// components using only retained exact twin links. Every face observed
+    /// at a reconciled border node is included, so unlinked faces remain
+    /// explicit singleton components instead of being silently dropped.
+    /// Components are retained as evidence only; no local or tiled topology
+    /// is mutated.
+    pub(crate) fn reconcile_global_components(
+        &mut self,
+        execution_policy: &ExecutionPolicy,
+    ) -> crate::Result<PartitionBorderGlobalComponentReconciliationStats> {
+        execution_policy.check_cancelled("partition_border_global_components")?;
+        let mut face_set = BTreeSet::new();
+        for (node_index, node) in self.reconciled_nodes.iter().enumerate() {
+            execution_policy
+                .check_cancelled_every("partition_border_global_components", node_index)?;
+            face_set.extend(node.face_refs.iter().copied());
+        }
+        face_set.extend(
+            self.applied_face_twins
+                .iter()
+                .flat_map(|twin| [twin.forward_face_ref, twin.reverse_face_ref]),
+        );
+        execution_policy.check(
+            "partition_border_global_faces",
+            execution_policy.max_graph_nodes,
+            face_set.len(),
+        )?;
+        execution_policy.check(
+            "partition_border_global_links",
+            execution_policy.max_graph_edges,
+            self.applied_face_twins.len(),
+        )?;
+
+        let faces = face_set.into_iter().collect::<Vec<_>>();
+        let face_indices = faces
+            .iter()
+            .enumerate()
+            .map(|(index, face_ref)| (*face_ref, index))
+            .collect::<BTreeMap<_, _>>();
+        let mut parents = (0..faces.len()).collect::<Vec<_>>();
+        fn find(parents: &mut [usize], mut index: usize) -> usize {
+            while parents[index] != index {
+                parents[index] = parents[parents[index]];
+                index = parents[index];
+            }
+            index
+        }
+        let mut linked_faces = BTreeSet::new();
+        for (twin_index, twin) in self.applied_face_twins.iter().enumerate() {
+            execution_policy
+                .check_cancelled_every("partition_border_global_components", twin_index)?;
+            let Some(&forward_index) = face_indices.get(&twin.forward_face_ref) else {
+                continue;
+            };
+            let Some(&reverse_index) = face_indices.get(&twin.reverse_face_ref) else {
+                continue;
+            };
+            linked_faces.insert(twin.forward_face_ref);
+            linked_faces.insert(twin.reverse_face_ref);
+            let forward_root = find(&mut parents, forward_index);
+            let reverse_root = find(&mut parents, reverse_index);
+            if forward_root != reverse_root {
+                let (root, child) = if forward_root < reverse_root {
+                    (forward_root, reverse_root)
+                } else {
+                    (reverse_root, forward_root)
+                };
+                parents[child] = root;
+            }
+        }
+
+        let mut groups = BTreeMap::<
+            usize,
+            (
+                BTreeSet<PartitionFaceRef>,
+                BTreeSet<PartitionBorderNodeKey>,
+                BTreeSet<PartitionBorderEdgeKey>,
+            ),
+        >::new();
+        for (face_index, face_ref) in faces.iter().copied().enumerate() {
+            execution_policy
+                .check_cancelled_every("partition_border_global_components", face_index)?;
+            groups
+                .entry(find(&mut parents, face_index))
+                .or_default()
+                .0
+                .insert(face_ref);
+        }
+        for (node_index, node) in self.reconciled_nodes.iter().enumerate() {
+            execution_policy
+                .check_cancelled_every("partition_border_global_components", node_index)?;
+            let mut roots = BTreeSet::new();
+            for face_ref in &node.face_refs {
+                if let Some(&face_index) = face_indices.get(face_ref) {
+                    roots.insert(find(&mut parents, face_index));
+                }
+            }
+            for root in roots {
+                groups.entry(root).or_default().1.insert(node.key);
+            }
+        }
+        for (twin_index, twin) in self.applied_face_twins.iter().enumerate() {
+            execution_policy
+                .check_cancelled_every("partition_border_global_components", twin_index)?;
+            let Some(&face_index) = face_indices.get(&twin.forward_face_ref) else {
+                continue;
+            };
+            groups
+                .entry(find(&mut parents, face_index))
+                .or_default()
+                .2
+                .insert(twin.twin.edge_key);
+        }
+
+        let global_components = groups
+            .into_iter()
+            .enumerate()
+            .map(
+                |(component_index, (_root, (face_refs, border_node_keys, twin_edge_keys)))| {
+                    PartitionBorderGlobalComponent {
+                        component_index,
+                        face_refs: face_refs.into_iter().collect(),
+                        border_node_keys: border_node_keys.into_iter().collect(),
+                        twin_edge_keys: twin_edge_keys.into_iter().collect(),
+                    }
+                },
+            )
+            .collect::<Vec<_>>();
+        let stats = PartitionBorderGlobalComponentReconciliationStats {
+            component_count: global_components.len(),
+            face_count: faces.len(),
+            linked_face_count: linked_faces.len(),
+            twin_link_count: self.applied_face_twins.len(),
+        };
+        self.global_components = global_components;
+        Ok(stats)
+    }
+
+    pub(crate) fn global_components(&self) -> &[PartitionBorderGlobalComponent] {
+        &self.global_components
     }
 
     /// Merges source IDs and retains every distinct Z candidate for each
@@ -1975,6 +2141,119 @@ mod tests {
             error,
             crate::PolygonizeError::Cancelled { ref stage }
                 if stage == "partition_border_node_reconciliation"
+        ));
+        assert_eq!(cancelled, before);
+    }
+
+    #[test]
+    fn global_component_reconciliation_unions_qualified_faces_deterministically() {
+        let mut graph = exact_face_twin_graph();
+        graph
+            .apply_unambiguous_face_twins(&ExecutionPolicy::default())
+            .unwrap();
+        graph
+            .reconcile_border_nodes(ZOptions::default(), &ExecutionPolicy::default())
+            .unwrap();
+        let stats = graph
+            .reconcile_global_components(&ExecutionPolicy::default())
+            .unwrap();
+
+        assert_eq!(
+            stats,
+            PartitionBorderGlobalComponentReconciliationStats {
+                component_count: 1,
+                face_count: 2,
+                linked_face_count: 2,
+                twin_link_count: 1,
+            }
+        );
+        assert_eq!(graph.global_components().len(), 1);
+        let component = &graph.global_components()[0];
+        assert_eq!(component.component_index, 0);
+        assert_eq!(component.face_refs, vec![face(1, 4, 9), face(2, 6, 11)]);
+        assert_eq!(component.border_node_keys.len(), 2);
+        assert_eq!(
+            component.twin_edge_keys,
+            vec![PartitionBorderEdgeKey::new(
+                PartitionBorderNodeKey::from_coord(coord(0.0, 0.0, 0.0)),
+                PartitionBorderNodeKey::from_coord(coord(2.0, 0.0, 0.0)),
+            )
+            .unwrap(),]
+        );
+
+        let mut reordered = PartitionBorderGraph::default();
+        for adjacency in graph.adjacencies.iter().copied() {
+            reordered.declare_adjacency(adjacency);
+        }
+        for observation in graph.observations.values().rev().cloned() {
+            reordered.insert(observation).unwrap();
+        }
+        reordered
+            .apply_unambiguous_face_twins(&ExecutionPolicy::default())
+            .unwrap();
+        reordered
+            .reconcile_border_nodes(ZOptions::default(), &ExecutionPolicy::default())
+            .unwrap();
+        reordered
+            .reconcile_global_components(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(reordered.global_components(), graph.global_components());
+
+        let mut singletons = exact_face_twin_graph();
+        singletons
+            .reconcile_border_nodes(ZOptions::default(), &ExecutionPolicy::default())
+            .unwrap();
+        let singleton_stats = singletons
+            .reconcile_global_components(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(singleton_stats.component_count, 2);
+        assert_eq!(singleton_stats.linked_face_count, 0);
+        assert!(singletons
+            .global_components()
+            .iter()
+            .all(|component| component.twin_edge_keys.is_empty()));
+    }
+
+    #[test]
+    fn global_component_reconciliation_is_bounded_and_cancellable_before_mutation() {
+        let mut limited = exact_face_twin_graph();
+        limited
+            .apply_unambiguous_face_twins(&ExecutionPolicy::default())
+            .unwrap();
+        limited
+            .reconcile_border_nodes(ZOptions::default(), &ExecutionPolicy::default())
+            .unwrap();
+        let before = limited.clone();
+        let error = limited
+            .reconcile_global_components(&ExecutionPolicy {
+                max_graph_nodes: Some(1),
+                ..Default::default()
+            })
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::ResourceLimitExceeded {
+                ref stage,
+                limit: 1,
+                observed: 2,
+            } if stage == "partition_border_global_faces"
+        ));
+        assert_eq!(limited, before);
+
+        let token = CancellationToken::new();
+        token.cancel();
+        let mut cancelled = exact_face_twin_graph();
+        let before = cancelled.clone();
+        let error = cancelled
+            .reconcile_global_components(&ExecutionPolicy {
+                cancellation_token: Some(token),
+                ..Default::default()
+            })
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::Cancelled { ref stage }
+                if stage == "partition_border_global_components"
         ));
         assert_eq!(cancelled, before);
     }

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -260,6 +260,12 @@ pub struct StitchingReport {
     /// Reconciled border nodes whose Z candidates exceed the configured
     /// conflict tolerance.
     pub partition_border_node_z_conflict_count: usize,
+    /// Deterministic connected components of qualified border-face evidence.
+    pub partition_border_global_component_count: usize,
+    /// Qualified face references included in the retained global plan.
+    pub partition_border_global_face_count: usize,
+    /// Face references participating in at least one retained twin link.
+    pub partition_border_global_linked_face_count: usize,
     /// Exact twin pairs whose observations also carried valid qualified local
     /// face references and were retained as face-level links.
     pub partition_border_face_twin_count: usize,
@@ -2277,12 +2283,22 @@ impl<'a> TiledPolygonizer<'a> {
             reconciled_border_node_count,
             partition_border_node_reconciliation.node_count
         );
+        let partition_border_global_component_reconciliation =
+            partition_border_graph.reconcile_global_components(&self.execution_policy)?;
+        let global_component_count = partition_border_graph.global_components().len();
+        debug_assert_eq!(
+            global_component_count,
+            partition_border_global_component_reconciliation.component_count
+        );
         if let Some(trace) = trace.as_deref_mut() {
             trace.record_partition_border_reconciliation(partition_border_reconciliation);
             trace.record_partition_border_twin_application(partition_border_twin_application);
             trace.record_partition_border_node_reconciliation(
                 partition_border_node_reconciliation,
                 self.options.z,
+            );
+            trace.record_partition_border_global_component_reconciliation(
+                partition_border_global_component_reconciliation,
             );
         }
         let unresolved = tile_reports.iter().any(Self::report_is_unresolved);
@@ -2515,6 +2531,11 @@ impl<'a> TiledPolygonizer<'a> {
                 partition_border_reconciled_node_count: reconciled_border_node_count,
                 partition_border_node_z_conflict_count: partition_border_node_reconciliation
                     .z_conflict_count,
+                partition_border_global_component_count: global_component_count,
+                partition_border_global_face_count:
+                    partition_border_global_component_reconciliation.face_count,
+                partition_border_global_linked_face_count:
+                    partition_border_global_component_reconciliation.linked_face_count,
                 partition_border_face_twin_count: applied_face_twin_count,
                 partition_border_face_twin_missing_face_count: partition_border_twin_application
                     .missing_face_ref_count,

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -113,6 +113,33 @@ mod tests {
                 .filter(|node| node.z_conflict)
                 .count()
         );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_component_count,
+            result.partition_border_graph.global_components().len()
+        );
+        assert_eq!(
+            result.stitching_report.partition_border_global_face_count,
+            result
+                .partition_border_graph
+                .global_components()
+                .iter()
+                .map(|component| component.face_refs.len())
+                .sum::<usize>()
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_linked_face_count,
+            result
+                .partition_border_graph
+                .global_components()
+                .iter()
+                .filter(|component| !component.twin_edge_keys.is_empty())
+                .map(|component| component.face_refs.len())
+                .sum::<usize>()
+        );
         assert_eq!(result.polygons.len(), 2);
     }
 
@@ -301,6 +328,39 @@ mod tests {
         assert_eq!(
             node_reconciliation.payload["conflict_tolerance"],
             "0x0000000000000000"
+        );
+        let global_components = traced
+            .trace
+            .events
+            .iter()
+            .find(|event| event.kind == "partition_border_global_component_reconciliation")
+            .expect("global component reconciliation evidence");
+        assert_eq!(
+            global_components.payload["component_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_component_count as u64
+            )
+        );
+        assert_eq!(
+            global_components.payload["face_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_count as u64
+            )
+        );
+        assert_eq!(
+            global_components.payload["linked_face_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_linked_face_count as u64
+            )
         );
     }
 

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -2,8 +2,9 @@
 
 use crate::fingerprint::{coordinate_fingerprint, float_bits};
 use crate::graph::partition_border::{
-    PartitionBorderHalfEdge, PartitionBorderNodeReconciliationStats,
-    PartitionBorderReconciliationStats, PartitionBorderTwinApplicationStats,
+    PartitionBorderGlobalComponentReconciliationStats, PartitionBorderHalfEdge,
+    PartitionBorderNodeReconciliationStats, PartitionBorderReconciliationStats,
+    PartitionBorderTwinApplicationStats,
 };
 use crate::graph::planar_graph::PartitionBoundaryNodingStats;
 use crate::graph::{ExtractedRing, PlanarGraph};
@@ -651,6 +652,22 @@ impl TraceRecorderV1 {
                 "z_conflict_count": stats.z_conflict_count,
                 "z_policy": format!("{:?}", z_options.policy),
                 "conflict_tolerance": format!("0x{:016x}", z_options.conflict_tolerance.to_bits()),
+            }),
+        )
+    }
+
+    pub(crate) fn record_partition_border_global_component_reconciliation(
+        &mut self,
+        stats: PartitionBorderGlobalComponentReconciliationStats,
+    ) -> bool {
+        self.record(
+            TraceStageV1::Graph,
+            "partition_border_global_component_reconciliation",
+            serde_json::json!({
+                "component_count": stats.component_count,
+                "face_count": stats.face_count,
+                "linked_face_count": stats.linked_face_count,
+                "twin_link_count": stats.twin_link_count,
             }),
         )
     }


### PR DESCRIPTION
## Stack
- Parent: #1317 (`agent/p5-border-node-reconciliation`, `df2609d`)
- This PR: `agent/p5-global-component-reconciliation` (`1b40513`)
- Children: none

## Delivered
- Builds and retains deterministic connected-component evidence for qualified partition-border face references.
- Unions only retained exact face-qualified twin links; faces without links remain explicit singleton components.
- Retains qualified face references, canonical border-node keys, and linked twin edge keys for each component.
- Adds stable input-order regression coverage plus fail-closed graph-node, graph-edge, and cancellation checks.
- Reports and traces component, face, linked-face, and twin-link counts.
- Updates ROADMAP.md only for the completed global-component evidence slice.

## Contract impact
- This is an evidence plan only: it does not mutate local adjacency, face IDs, tiled output, or the global arrangement.
- Existing replicate-and-own output, canonical ordering, provenance, representative IDs, Z behavior, cancellation, and resource-limit contracts remain unchanged.
- Ambiguous, missing, malformed, and unrelated border observations do not become global links.
- Global `next`/face construction, unbounded-face selection, validation, extraction, and untiled equivalence remain open.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p geo-polygonize-core partition_border --lib` — 27 passed
- Focused tiled report and trace regressions — 1 passed each
- `cargo test --workspace --lib --tests --no-fail-fast` with the workspace Python library path — 322 core unit tests and all workspace integration targets passed
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check --workspace --all-targets --no-default-features`
- `git diff --cached --check`; generated bindings restored and no unintended files remain

## Agent handoff
- Parent: #1317 / `agent/p5-border-node-reconciliation`
- Children: none
- Exact next branch: `agent/p5-global-next-face-plan`, based on this PR after publication
- Remaining risk: P5.3 still needs actual global twin application, `next`/face construction, unbounded-face and invariant validation, extraction, untiled equivalence, differential fuzzing, and promotion-gate evidence.