### PR TITLE
feat(core): plan global face boundaries

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -461,6 +461,9 @@ Blocked by #1288.
   qualified border faces, including explicit singleton faces and linked twin
   edges with fail-closed limit and cancellation behavior; do not mutate local
   or tiled topology.
+- [x] Retain qualified local face-walk successor and unbounded-face evidence
+  in a deterministic global face-boundary plan, reporting missing successors
+  without mutating local `next`, face IDs, or tiled output.
 - [ ] Apply unambiguous twins only across declared adjacent borders.
 - [ ] Reconcile canonical border nodes, source sets, representative IDs, and
   selected Z-policy decisions.

--- a/crates/geo-polygonize-core/src/graph/partition_border.rs
+++ b/crates/geo-polygonize-core/src/graph/partition_border.rs
@@ -308,6 +308,12 @@ pub struct PartitionBorderHalfEdge {
     /// Component-local face ID retained for existing debug consumers.
     pub face_id: Option<FaceId>,
     pub(crate) face_ref: Option<PartitionFaceRef>,
+    /// Face-walk successor from the local arrangement, when a qualified face
+    /// was assigned. This is evidence for a future global face plan, not a
+    /// global `next` link.
+    pub(crate) local_face_successor: Option<DirEdgeId>,
+    /// Whether the local face containing this directed edge is unbounded.
+    pub(crate) local_face_is_unbounded: bool,
     pub source_line_ids: Vec<u32>,
     /// The deterministic representative source ID carried by the local edge.
     /// This is the first ID in the sorted source set, or `None` for synthetic
@@ -370,6 +376,8 @@ impl PartitionBorderHalfEdge {
             local_dir_edge_id,
             face_id: face_ref.map(|face_ref| face_ref.face_id),
             face_ref,
+            local_face_successor: None,
+            local_face_is_unbounded: false,
             source_line_ids,
             representative_line_id,
         })
@@ -579,6 +587,40 @@ pub(crate) struct PartitionBorderGlobalComponentReconciliationStats {
     pub(crate) twin_link_count: usize,
 }
 
+/// One qualified local border half-edge prepared for a future global face
+/// walk. The successor remains in the local directed-edge identity space;
+/// this record does not rewrite it into a global arrangement.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(crate) struct PartitionBorderFaceBoundaryCandidate {
+    pub(crate) observation_id: PartitionBorderObservationId,
+    pub(crate) edge_key: PartitionBorderEdgeKey,
+    pub(crate) face_ref: PartitionFaceRef,
+    pub(crate) local_dir_edge_id: DirEdgeId,
+    pub(crate) local_face_successor: DirEdgeId,
+    pub(crate) local_face_is_unbounded: bool,
+}
+
+/// Deterministic boundary evidence grouped by qualified local face identity.
+/// Cross-partition twin edges are retained separately so a later stitcher can
+/// validate transitions before assigning global `next` links or face IDs.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct PartitionBorderGlobalFacePlan {
+    pub(crate) face_ref: PartitionFaceRef,
+    pub(crate) candidates: Vec<PartitionBorderFaceBoundaryCandidate>,
+    pub(crate) twin_edge_keys: Vec<PartitionBorderEdgeKey>,
+    pub(crate) local_face_is_unbounded: bool,
+}
+
+/// Counts from the retained global face-boundary plan.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct PartitionBorderGlobalFacePlanStats {
+    pub(crate) face_count: usize,
+    pub(crate) candidate_count: usize,
+    pub(crate) missing_successor_count: usize,
+    pub(crate) unbounded_face_count: usize,
+    pub(crate) linked_face_count: usize,
+}
+
 /// Deterministic evidence for the declared-adjacency twin boundary.
 ///
 /// Only observations covered by a declared partition adjacency contribute to
@@ -606,6 +648,7 @@ pub struct PartitionBorderGraph {
     applied_face_twins: Vec<PartitionBorderFaceTwin>,
     reconciled_nodes: Vec<PartitionBorderNodePayload>,
     global_components: Vec<PartitionBorderGlobalComponent>,
+    global_face_plans: Vec<PartitionBorderGlobalFacePlan>,
 }
 
 impl PartitionBorderGraph {
@@ -642,6 +685,7 @@ impl PartitionBorderGraph {
         self.applied_face_twins.clear();
         self.reconciled_nodes.clear();
         self.global_components.clear();
+        self.global_face_plans.clear();
         Ok(())
     }
 
@@ -650,6 +694,7 @@ impl PartitionBorderGraph {
         self.applied_face_twins.clear();
         self.reconciled_nodes.clear();
         self.global_components.clear();
+        self.global_face_plans.clear();
     }
 
     pub fn node_count(&self) -> usize {
@@ -899,6 +944,7 @@ impl PartitionBorderGraph {
         stats.applied_twin_count = applied_face_twins.len();
         self.applied_face_twins = applied_face_twins;
         self.global_components.clear();
+        self.global_face_plans.clear();
         Ok(stats)
     }
 
@@ -1038,6 +1084,7 @@ impl PartitionBorderGraph {
         }
         self.reconciled_nodes = reconciled_nodes;
         self.global_components.clear();
+        self.global_face_plans.clear();
         Ok(stats)
     }
 
@@ -1180,11 +1227,120 @@ impl PartitionBorderGraph {
             twin_link_count: self.applied_face_twins.len(),
         };
         self.global_components = global_components;
+        self.global_face_plans.clear();
         Ok(stats)
     }
 
     pub(crate) fn global_components(&self) -> &[PartitionBorderGlobalComponent] {
         &self.global_components
+    }
+
+    /// Builds deterministic face-boundary evidence from qualified local
+    /// observations and their local face-walk successors. Missing successors
+    /// are reported and excluded from the plan; no local `next`, face ID, or
+    /// tiled output is mutated.
+    pub(crate) fn reconcile_global_face_plans(
+        &mut self,
+        execution_policy: &ExecutionPolicy,
+    ) -> crate::Result<PartitionBorderGlobalFacePlanStats> {
+        execution_policy.check_cancelled("partition_border_global_face_plan")?;
+
+        let mut candidates = Vec::new();
+        let mut missing_successor_count = 0;
+        for (observation_index, observation) in self.observations.values().enumerate() {
+            execution_policy
+                .check_cancelled_every("partition_border_global_face_plan", observation_index)?;
+            let Some(face_ref) = observation.face_ref else {
+                continue;
+            };
+            let Some(local_face_successor) = observation.local_face_successor else {
+                missing_successor_count += 1;
+                continue;
+            };
+            candidates.push(PartitionBorderFaceBoundaryCandidate {
+                observation_id: observation.observation_id(),
+                edge_key: observation.edge_key,
+                face_ref,
+                local_dir_edge_id: observation.local_dir_edge_id,
+                local_face_successor,
+                local_face_is_unbounded: observation.local_face_is_unbounded,
+            });
+        }
+        execution_policy.check(
+            "partition_border_global_face_candidates",
+            execution_policy.max_graph_edges,
+            candidates.len(),
+        )?;
+
+        let mut face_groups = BTreeMap::<
+            PartitionFaceRef,
+            (
+                BTreeSet<PartitionBorderFaceBoundaryCandidate>,
+                BTreeSet<PartitionBorderEdgeKey>,
+                bool,
+            ),
+        >::new();
+        for candidate in candidates {
+            execution_policy
+                .check_cancelled_every("partition_border_global_face_plan", face_groups.len())?;
+            let group = face_groups.entry(candidate.face_ref).or_default();
+            group.0.insert(candidate);
+            group.2 |= candidate.local_face_is_unbounded;
+        }
+
+        for (twin_index, twin) in self.applied_face_twins.iter().enumerate() {
+            execution_policy
+                .check_cancelled_every("partition_border_global_face_plan", twin_index)?;
+            face_groups
+                .entry(twin.forward_face_ref)
+                .or_default()
+                .1
+                .insert(twin.twin.edge_key);
+            face_groups
+                .entry(twin.reverse_face_ref)
+                .or_default()
+                .1
+                .insert(twin.twin.edge_key);
+        }
+
+        execution_policy.check(
+            "partition_border_global_faces",
+            execution_policy.max_graph_nodes,
+            face_groups.len(),
+        )?;
+        let mut global_face_plans = Vec::with_capacity(face_groups.len());
+        let mut unbounded_face_count = 0;
+        let mut linked_face_count = 0;
+        for (face_ref, (candidates, twin_edge_keys, local_face_is_unbounded)) in face_groups {
+            if local_face_is_unbounded {
+                unbounded_face_count += 1;
+            }
+            if !twin_edge_keys.is_empty() {
+                linked_face_count += 1;
+            }
+            global_face_plans.push(PartitionBorderGlobalFacePlan {
+                face_ref,
+                candidates: candidates.into_iter().collect(),
+                twin_edge_keys: twin_edge_keys.into_iter().collect(),
+                local_face_is_unbounded,
+            });
+        }
+        let stats = PartitionBorderGlobalFacePlanStats {
+            face_count: global_face_plans.len(),
+            candidate_count: global_face_plans
+                .iter()
+                .map(|plan| plan.candidates.len())
+                .sum(),
+            missing_successor_count,
+            unbounded_face_count,
+            linked_face_count,
+        };
+        self.global_face_plans = global_face_plans;
+        Ok(stats)
+    }
+
+    pub(crate) fn global_face_plans(&self) -> &[PartitionBorderGlobalFacePlan] {
+        &self.global_face_plans
     }
 
     /// Merges source IDs and retains every distinct Z candidate for each
@@ -1375,6 +1531,15 @@ mod tests {
         );
         graph.insert(reverse).unwrap();
         graph.insert(forward).unwrap();
+        graph
+    }
+
+    fn exact_face_twin_graph_with_successors() -> PartitionBorderGraph {
+        let mut graph = exact_face_twin_graph();
+        for observation in graph.observations.values_mut() {
+            observation.local_face_successor = Some(observation.local_dir_edge_id + 100);
+            observation.local_face_is_unbounded = false;
+        }
         graph
     }
 
@@ -2254,6 +2419,104 @@ mod tests {
             error,
             crate::PolygonizeError::Cancelled { ref stage }
                 if stage == "partition_border_global_components"
+        ));
+        assert_eq!(cancelled, before);
+    }
+
+    #[test]
+    fn global_face_plan_retains_local_successors_and_twin_edges_deterministically() {
+        let mut graph = exact_face_twin_graph_with_successors();
+        graph
+            .apply_unambiguous_face_twins(&ExecutionPolicy::default())
+            .unwrap();
+        let stats = graph
+            .reconcile_global_face_plans(&ExecutionPolicy::default())
+            .unwrap();
+
+        assert_eq!(
+            stats,
+            PartitionBorderGlobalFacePlanStats {
+                face_count: 2,
+                candidate_count: 2,
+                missing_successor_count: 0,
+                unbounded_face_count: 0,
+                linked_face_count: 2,
+            }
+        );
+        assert_eq!(graph.global_face_plans().len(), 2);
+        assert!(graph.global_face_plans().iter().all(|plan| {
+            plan.candidates.len() == 1
+                && plan.twin_edge_keys.len() == 1
+                && plan.candidates[0].local_face_successor >= 100
+                && !plan.local_face_is_unbounded
+        }));
+
+        let mut reordered = PartitionBorderGraph::default();
+        for adjacency in graph.adjacencies.iter().copied() {
+            reordered.declare_adjacency(adjacency);
+        }
+        for observation in graph.observations.values().rev().cloned() {
+            reordered.insert(observation).unwrap();
+        }
+        reordered
+            .apply_unambiguous_face_twins(&ExecutionPolicy::default())
+            .unwrap();
+        reordered
+            .reconcile_global_face_plans(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(reordered.global_face_plans(), graph.global_face_plans());
+    }
+
+    #[test]
+    fn global_face_plan_reports_missing_successors_and_fails_closed_on_limits() {
+        let mut missing = exact_face_twin_graph();
+        missing
+            .apply_unambiguous_face_twins(&ExecutionPolicy::default())
+            .unwrap();
+        let stats = missing
+            .reconcile_global_face_plans(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(stats.face_count, 2);
+        assert_eq!(stats.candidate_count, 0);
+        assert_eq!(stats.missing_successor_count, 2);
+        assert_eq!(stats.linked_face_count, 2);
+        assert!(missing
+            .global_face_plans()
+            .iter()
+            .all(|plan| plan.candidates.is_empty()));
+
+        let mut limited = exact_face_twin_graph_with_successors();
+        let before = limited.clone();
+        let error = limited
+            .reconcile_global_face_plans(&ExecutionPolicy {
+                max_graph_nodes: Some(1),
+                ..Default::default()
+            })
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::ResourceLimitExceeded {
+                ref stage,
+                limit: 1,
+                observed: 2,
+            } if stage == "partition_border_global_faces"
+        ));
+        assert_eq!(limited, before);
+
+        let token = CancellationToken::new();
+        token.cancel();
+        let mut cancelled = exact_face_twin_graph_with_successors();
+        let before = cancelled.clone();
+        let error = cancelled
+            .reconcile_global_face_plans(&ExecutionPolicy {
+                cancellation_token: Some(token),
+                ..Default::default()
+            })
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::Cancelled { ref stage }
+                if stage == "partition_border_global_face_plan"
         ));
         assert_eq!(cancelled, before);
     }

--- a/crates/geo-polygonize-core/src/graph/planar_graph.rs
+++ b/crates/geo-polygonize-core/src/graph/planar_graph.rs
@@ -466,6 +466,13 @@ impl PlanarGraph {
             end,
             edge.sources.line_ids.iter().copied(),
         )?;
+        observation.local_face_successor = directed
+            .face_id
+            .and_then(|_| self.directed_edges.get(directed.sym_idx))
+            .and_then(|symmetric| symmetric.next_idx);
+        observation.local_face_is_unbounded = directed
+            .face_id
+            .is_some_and(|face_id| self.unbounded_face_ids.contains(&face_id));
         observation.component_id = component_id;
         Some(observation)
     }
@@ -3033,10 +3040,7 @@ impl ComponentScratch {
         (0..self.graph.directed_edges.len())
             .filter_map(|local_dir_edge_id| {
                 let side = self.border_side(local_dir_edge_id, export.bbox)?;
-                let local_edge_id = self.graph.directed_edges[local_dir_edge_id].edge_idx;
-                let local_dir_edges = self.graph.edges[local_edge_id].dir_edges;
-                let direction = usize::from(local_dir_edges[1] == local_dir_edge_id);
-                let global_dir_edge_id = self.global_dir_edge_ids.get(local_edge_id)?[direction];
+                let global_dir_edge_id = self.global_dir_edge_id(local_dir_edge_id)?;
                 let mut observation = self.graph.partition_border_half_edge_for_component(
                     export.partition_id,
                     component_id,
@@ -3044,9 +3048,22 @@ impl ComponentScratch {
                     side,
                 )?;
                 observation.local_dir_edge_id = global_dir_edge_id;
+                observation.local_face_successor = observation
+                    .local_face_successor
+                    .and_then(|successor| self.global_dir_edge_id(successor));
                 Some(observation)
             })
             .collect()
+    }
+
+    fn global_dir_edge_id(&self, local_dir_edge_id: DirEdgeId) -> Option<DirEdgeId> {
+        let local_edge_id = self.graph.directed_edges.get(local_dir_edge_id)?.edge_idx;
+        let local_dir_edges = self.graph.edges.get(local_edge_id)?.dir_edges;
+        let direction = usize::from(local_dir_edges[1] == local_dir_edge_id);
+        self.global_dir_edge_ids
+            .get(local_edge_id)?
+            .get(direction)
+            .copied()
     }
 
     fn border_side(&self, dir_edge_id: DirEdgeId, bbox: Rect<f64>) -> Option<PartitionBorderSide> {
@@ -3892,6 +3909,10 @@ mod arrangement_ring_invariant_tests {
                 .representative_line_id
                 .is_some_and(|representative| observation.source_line_ids.contains(&representative))
         }));
+        assert!(observations
+            .iter()
+            .filter(|observation| observation.face_ref.is_some())
+            .all(|observation| observation.local_face_successor.is_some()));
     }
 
     #[test]

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -266,6 +266,16 @@ pub struct StitchingReport {
     pub partition_border_global_face_count: usize,
     /// Face references participating in at least one retained twin link.
     pub partition_border_global_linked_face_count: usize,
+    /// Qualified local faces retained in the deterministic face-walk plan.
+    pub partition_border_global_face_plan_count: usize,
+    /// Local border half-edges retained as face-walk candidates.
+    pub partition_border_global_face_candidate_count: usize,
+    /// Qualified observations that lacked a local face-walk successor.
+    pub partition_border_global_face_missing_successor_count: usize,
+    /// Local faces marked unbounded by their source arrangement.
+    pub partition_border_global_unbounded_face_count: usize,
+    /// Planned faces that participate in at least one retained twin edge.
+    pub partition_border_global_face_linked_count: usize,
     /// Exact twin pairs whose observations also carried valid qualified local
     /// face references and were retained as face-level links.
     pub partition_border_face_twin_count: usize,
@@ -2290,6 +2300,13 @@ impl<'a> TiledPolygonizer<'a> {
             global_component_count,
             partition_border_global_component_reconciliation.component_count
         );
+        let partition_border_global_face_plan =
+            partition_border_graph.reconcile_global_face_plans(&self.execution_policy)?;
+        let global_face_plan_count = partition_border_graph.global_face_plans().len();
+        debug_assert_eq!(
+            global_face_plan_count,
+            partition_border_global_face_plan.face_count
+        );
         if let Some(trace) = trace.as_deref_mut() {
             trace.record_partition_border_reconciliation(partition_border_reconciliation);
             trace.record_partition_border_twin_application(partition_border_twin_application);
@@ -2300,6 +2317,7 @@ impl<'a> TiledPolygonizer<'a> {
             trace.record_partition_border_global_component_reconciliation(
                 partition_border_global_component_reconciliation,
             );
+            trace.record_partition_border_global_face_plan(partition_border_global_face_plan);
         }
         let unresolved = tile_reports.iter().any(Self::report_is_unresolved);
         let component_fallback_attempted = self.component_fallback && unresolved;
@@ -2536,6 +2554,15 @@ impl<'a> TiledPolygonizer<'a> {
                     partition_border_global_component_reconciliation.face_count,
                 partition_border_global_linked_face_count:
                     partition_border_global_component_reconciliation.linked_face_count,
+                partition_border_global_face_plan_count: global_face_plan_count,
+                partition_border_global_face_candidate_count: partition_border_global_face_plan
+                    .candidate_count,
+                partition_border_global_face_missing_successor_count:
+                    partition_border_global_face_plan.missing_successor_count,
+                partition_border_global_unbounded_face_count: partition_border_global_face_plan
+                    .unbounded_face_count,
+                partition_border_global_face_linked_count: partition_border_global_face_plan
+                    .linked_face_count,
                 partition_border_face_twin_count: applied_face_twin_count,
                 partition_border_face_twin_missing_face_count: partition_border_twin_application
                     .missing_face_ref_count,

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -140,6 +140,45 @@ mod tests {
                 .map(|component| component.face_refs.len())
                 .sum::<usize>()
         );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_plan_count,
+            result.partition_border_graph.global_face_plans().len()
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_candidate_count,
+            result
+                .partition_border_graph
+                .global_face_plans()
+                .iter()
+                .map(|plan| plan.candidates.len())
+                .sum::<usize>()
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_unbounded_face_count,
+            result
+                .partition_border_graph
+                .global_face_plans()
+                .iter()
+                .filter(|plan| plan.local_face_is_unbounded)
+                .count()
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_linked_count,
+            result
+                .partition_border_graph
+                .global_face_plans()
+                .iter()
+                .filter(|plan| !plan.twin_edge_keys.is_empty())
+                .count()
+        );
         assert_eq!(result.polygons.len(), 2);
     }
 
@@ -360,6 +399,57 @@ mod tests {
                     .result
                     .stitching_report
                     .partition_border_global_linked_face_count as u64
+            )
+        );
+        let global_face_plan = traced
+            .trace
+            .events
+            .iter()
+            .find(|event| event.kind == "partition_border_global_face_plan")
+            .expect("global face plan evidence");
+        assert_eq!(
+            global_face_plan.payload["face_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_plan_count as u64
+            )
+        );
+        assert_eq!(
+            global_face_plan.payload["candidate_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_candidate_count as u64
+            )
+        );
+        assert_eq!(
+            global_face_plan.payload["missing_successor_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_missing_successor_count as u64
+            )
+        );
+        assert_eq!(
+            global_face_plan.payload["unbounded_face_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_unbounded_face_count as u64
+            )
+        );
+        assert_eq!(
+            global_face_plan.payload["linked_face_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_linked_count as u64
             )
         );
     }

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -2,9 +2,9 @@
 
 use crate::fingerprint::{coordinate_fingerprint, float_bits};
 use crate::graph::partition_border::{
-    PartitionBorderGlobalComponentReconciliationStats, PartitionBorderHalfEdge,
-    PartitionBorderNodeReconciliationStats, PartitionBorderReconciliationStats,
-    PartitionBorderTwinApplicationStats,
+    PartitionBorderGlobalComponentReconciliationStats, PartitionBorderGlobalFacePlanStats,
+    PartitionBorderHalfEdge, PartitionBorderNodeReconciliationStats,
+    PartitionBorderReconciliationStats, PartitionBorderTwinApplicationStats,
 };
 use crate::graph::planar_graph::PartitionBoundaryNodingStats;
 use crate::graph::{ExtractedRing, PlanarGraph};
@@ -672,6 +672,23 @@ impl TraceRecorderV1 {
         )
     }
 
+    pub(crate) fn record_partition_border_global_face_plan(
+        &mut self,
+        stats: PartitionBorderGlobalFacePlanStats,
+    ) -> bool {
+        self.record(
+            TraceStageV1::Graph,
+            "partition_border_global_face_plan",
+            serde_json::json!({
+                "face_count": stats.face_count,
+                "candidate_count": stats.candidate_count,
+                "missing_successor_count": stats.missing_successor_count,
+                "unbounded_face_count": stats.unbounded_face_count,
+                "linked_face_count": stats.linked_face_count,
+            }),
+        )
+    }
+
     pub(crate) fn record_partition_border_observation(
         &mut self,
         observation: &PartitionBorderHalfEdge,
@@ -697,6 +714,8 @@ impl TraceRecorderV1 {
                 "side": format!("{:?}", observation.side),
                 "face_id": observation.face_id,
                 "component_id": observation.component_id,
+                "local_face_successor": observation.local_face_successor,
+                "local_face_is_unbounded": observation.local_face_is_unbounded,
                 "source_count": observation.source_line_ids.len(),
                 "first_source_line_id": observation.source_line_ids.first(),
                 "last_source_line_id": observation.source_line_ids.last(),
@@ -726,6 +745,8 @@ impl TraceRecorderV1 {
                 "edge_key": [endpoint(edge_start), endpoint(edge_end)],
                 "side": format!("{:?}", observation.side),
                 "component_id": observation.component_id,
+                "local_face_successor": observation.local_face_successor,
+                "local_face_is_unbounded": observation.local_face_is_unbounded,
                 "representative_line_id": observation.representative_line_id,
                 "reason": reason,
             }),


### PR DESCRIPTION
## Stack
- Parent: `main` at `65cf5a0`
- This PR: `agent/p5-global-next-face-plan` (`5a98154`)
- Children: #1321 (`agent/p5-global-face-validation`, `e6c4830`)

## Delivered
- Retains the local face-walk successor and unbounded-face marker when exporting qualified partition-border observations.
- Remaps successor identities into the component export identity space without changing local arrangement links.
- Builds a deterministic per-face global boundary evidence plan with candidate edges, local successors, twin edge keys, and unbounded markers.
- Reports missing successors and fails closed for graph-node, graph-edge, and cancellation limits without committing partial plans.
- Extends bounded trace evidence and regression coverage for deterministic insertion order, missing metadata, tiled report/trace consistency, and arrangement export.
- Updates ROADMAP.md only for this evidence-level face-boundary plan.

## Contract impact
- This PR does not mutate local `next_idx`, local face IDs, unbounded-face assignments, tiled polygons, or global topology.
- Existing canonical ordering, provenance, representative IDs, Z behavior, serial/parallel equality, cancellation, and resource limits remain unchanged.
- Missing local successors are reported and excluded from the plan; they do not authorize speculative global links.
- Actual global `next` construction, global face IDs, unbounded-face proof, validation, extraction, and untiled equivalence remain open.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p geo-polygonize-core partition_border --lib` — 29 passed
- Planar export regression — 1 passed
- Tiled report and trace regressions — 1 passed each
- `DYLD_LIBRARY_PATH=/Library/Frameworks/Python.framework/Versions/3.11/lib cargo test --workspace --lib --tests --no-fail-fast` — 324 core unit tests and all workspace integration targets passed
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check --workspace --all-targets --no-default-features`
- `git diff --cached --check`; generated bindings restored and no unintended files remain

## Agent handoff
- Parent: `main` at `65cf5a0`
- Children: #1321 (`agent/p5-global-face-validation`, `e6c4830`)
- Exact next branch after #1321: `agent/p5-global-arrangement-mutation-gate`
- Remaining risk: P5.3 still needs actual global twin application, global `next`/face construction, exactly-one-unbounded-face proof, cycle/source/Euler/face-walk validation, extraction, equivalence, differential fuzzing, and promotion evidence.