### PR TITLE
feat(core): gate global face transitions

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -467,6 +467,9 @@ Blocked by #1288.
 - [x] Validate retained face-boundary plan identity, successor lineage, twin
   coverage, deterministic grouping, limits, and cancellation without mutating
   local or global topology.
+- [x] Retain deterministic local face-boundary successor identities and report
+  closed-cycle mutation readiness without assigning global `next` links, face
+  IDs, or tiled output.
 - [ ] Apply unambiguous twins only across declared adjacent borders.
 - [ ] Reconcile canonical border nodes, source sets, representative IDs, and
   selected Z-policy decisions.

--- a/crates/geo-polygonize-core/src/graph/partition_border.rs
+++ b/crates/geo-polygonize-core/src/graph/partition_border.rs
@@ -314,6 +314,9 @@ pub struct PartitionBorderHalfEdge {
     pub(crate) local_face_successor: Option<DirEdgeId>,
     /// Whether the local face containing this directed edge is unbounded.
     pub(crate) local_face_is_unbounded: bool,
+    /// The first retained border half-edge reached by following this local
+    /// face cycle, when the boundary continuation can be resolved.
+    pub(crate) local_face_boundary_successor: Option<PartitionBorderObservationId>,
     pub source_line_ids: Vec<u32>,
     /// The deterministic representative source ID carried by the local edge.
     /// This is the first ID in the sorted source set, or `None` for synthetic
@@ -378,6 +381,7 @@ impl PartitionBorderHalfEdge {
             face_ref,
             local_face_successor: None,
             local_face_is_unbounded: false,
+            local_face_boundary_successor: None,
             source_line_ids,
             representative_line_id,
         })
@@ -598,6 +602,7 @@ pub(crate) struct PartitionBorderFaceBoundaryCandidate {
     pub(crate) local_dir_edge_id: DirEdgeId,
     pub(crate) local_face_successor: DirEdgeId,
     pub(crate) local_face_is_unbounded: bool,
+    pub(crate) local_face_boundary_successor: Option<PartitionBorderObservationId>,
 }
 
 /// Deterministic boundary evidence grouped by qualified local face identity.
@@ -619,6 +624,7 @@ pub(crate) struct PartitionBorderGlobalFacePlanStats {
     pub(crate) missing_successor_count: usize,
     pub(crate) unbounded_face_count: usize,
     pub(crate) linked_face_count: usize,
+    pub(crate) missing_boundary_successor_count: usize,
 }
 
 /// Counts from validating the retained global face-boundary plan.
@@ -628,6 +634,16 @@ pub(crate) struct PartitionBorderGlobalFacePlanValidationStats {
     pub(crate) candidate_count: usize,
     pub(crate) twin_link_count: usize,
     pub(crate) unbounded_face_count: usize,
+}
+
+/// Counts from the mutation gate for local face-boundary transitions.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct PartitionBorderGlobalFaceMutationGateStats {
+    pub(crate) face_count: usize,
+    pub(crate) candidate_count: usize,
+    pub(crate) boundary_transition_count: usize,
+    pub(crate) missing_boundary_successor_count: usize,
+    pub(crate) mutation_ready_face_count: usize,
 }
 
 /// Deterministic evidence for the declared-adjacency twin boundary.
@@ -1256,6 +1272,7 @@ impl PartitionBorderGraph {
 
         let mut candidates = Vec::new();
         let mut missing_successor_count = 0;
+        let mut missing_boundary_successor_count = 0;
         let mut face_unbounded = BTreeMap::<PartitionFaceRef, bool>::new();
         for (observation_index, observation) in self.observations.values().enumerate() {
             execution_policy
@@ -1271,6 +1288,9 @@ impl PartitionBorderGraph {
                 missing_successor_count += 1;
                 continue;
             };
+            if observation.local_face_boundary_successor.is_none() {
+                missing_boundary_successor_count += 1;
+            }
             candidates.push(PartitionBorderFaceBoundaryCandidate {
                 observation_id: observation.observation_id(),
                 edge_key: observation.edge_key,
@@ -1278,6 +1298,7 @@ impl PartitionBorderGraph {
                 local_dir_edge_id: observation.local_dir_edge_id,
                 local_face_successor,
                 local_face_is_unbounded: observation.local_face_is_unbounded,
+                local_face_boundary_successor: observation.local_face_boundary_successor,
             });
         }
         execution_policy.check(
@@ -1352,6 +1373,7 @@ impl PartitionBorderGraph {
             missing_successor_count,
             unbounded_face_count,
             linked_face_count,
+            missing_boundary_successor_count,
         };
         self.global_face_plans = global_face_plans;
         Ok(stats)
@@ -1485,6 +1507,8 @@ impl PartitionBorderGraph {
                     || observation.local_dir_edge_id != candidate.local_dir_edge_id
                     || observation.local_face_successor != Some(candidate.local_face_successor)
                     || observation.local_face_is_unbounded != candidate.local_face_is_unbounded
+                    || observation.local_face_boundary_successor
+                        != candidate.local_face_boundary_successor
                 {
                     return Err(crate::PolygonizeError::InternalInvariantViolation {
                         reason: format!(
@@ -1624,6 +1648,112 @@ impl PartitionBorderGraph {
             candidate_count,
             twin_link_count: twin_faces.len(),
             unbounded_face_count,
+        })
+    }
+
+    /// Checks whether each retained local face can be reduced to one closed
+    /// boundary-transition cycle. This is a mutation gate only: it retains no
+    /// global `next` links and does not alter local topology or tiled output.
+    /// Incomplete local evidence is reported as not ready; contradictory
+    /// identity or face lineage fails closed.
+    pub(crate) fn validate_global_face_mutation_gate(
+        &self,
+        execution_policy: &ExecutionPolicy,
+    ) -> crate::Result<PartitionBorderGlobalFaceMutationGateStats> {
+        let validation = self.validate_global_face_plans(execution_policy)?;
+        execution_policy.check_cancelled("partition_border_global_face_mutation_gate")?;
+
+        let mut candidate_faces = BTreeMap::<PartitionBorderObservationId, PartitionFaceRef>::new();
+        for plan in &self.global_face_plans {
+            for candidate in &plan.candidates {
+                candidate_faces.insert(candidate.observation_id, plan.face_ref);
+            }
+        }
+
+        let mut boundary_transition_count = 0;
+        let mut missing_boundary_successor_count = 0;
+        let mut mutation_ready_face_count = 0;
+        for (plan_index, plan) in self.global_face_plans.iter().enumerate() {
+            execution_policy
+                .check_cancelled_every("partition_border_global_face_mutation_gate", plan_index)?;
+            let mut transitions =
+                BTreeMap::<PartitionBorderObservationId, PartitionBorderObservationId>::new();
+            let mut complete = !plan.candidates.is_empty();
+            for (candidate_index, candidate) in plan.candidates.iter().enumerate() {
+                execution_policy.check_cancelled_every(
+                    "partition_border_global_face_mutation_gate_candidates",
+                    candidate_index,
+                )?;
+                let Some(boundary_successor) = candidate.local_face_boundary_successor else {
+                    missing_boundary_successor_count += 1;
+                    complete = false;
+                    continue;
+                };
+                let Some(successor_observation) = self.observations.get(&boundary_successor) else {
+                    return Err(crate::PolygonizeError::InternalInvariantViolation {
+                        reason: format!(
+                            "global face boundary successor {:?} is missing",
+                            boundary_successor
+                        ),
+                    });
+                };
+                if successor_observation.face_ref != Some(plan.face_ref) {
+                    return Err(crate::PolygonizeError::InternalInvariantViolation {
+                        reason: format!(
+                            "global face boundary successor {:?} crosses face {:?}",
+                            boundary_successor, plan.face_ref
+                        ),
+                    });
+                }
+                match candidate_faces.get(&boundary_successor) {
+                    Some(&successor_face_ref) if successor_face_ref == plan.face_ref => {
+                        transitions.insert(candidate.observation_id, boundary_successor);
+                        boundary_transition_count += 1;
+                    }
+                    Some(&successor_face_ref) => {
+                        return Err(crate::PolygonizeError::InternalInvariantViolation {
+                            reason: format!(
+                                "global face boundary successor {:?} is assigned to face {:?}",
+                                boundary_successor, successor_face_ref
+                            ),
+                        });
+                    }
+                    None => {
+                        missing_boundary_successor_count += 1;
+                        complete = false;
+                    }
+                }
+            }
+            if !complete || transitions.len() != plan.candidates.len() {
+                continue;
+            }
+
+            let start = plan.candidates[0].observation_id;
+            let mut visited = BTreeSet::new();
+            let mut current = start;
+            loop {
+                if !visited.insert(current) {
+                    if current == start && visited.len() == plan.candidates.len() {
+                        mutation_ready_face_count += 1;
+                    }
+                    break;
+                }
+                let Some(&next) = transitions.get(&current) else {
+                    break;
+                };
+                current = next;
+                if visited.len() > plan.candidates.len() {
+                    break;
+                }
+            }
+        }
+
+        Ok(PartitionBorderGlobalFaceMutationGateStats {
+            face_count: validation.face_count,
+            candidate_count: validation.candidate_count,
+            boundary_transition_count,
+            missing_boundary_successor_count,
+            mutation_ready_face_count,
         })
     }
 
@@ -2725,6 +2855,7 @@ mod tests {
                 missing_successor_count: 0,
                 unbounded_face_count: 0,
                 linked_face_count: 2,
+                missing_boundary_successor_count: 2,
             }
         );
         assert_eq!(graph.global_face_plans().len(), 2);
@@ -2764,6 +2895,7 @@ mod tests {
         assert_eq!(stats.candidate_count, 0);
         assert_eq!(stats.missing_successor_count, 2);
         assert_eq!(stats.linked_face_count, 2);
+        assert_eq!(stats.missing_boundary_successor_count, 0);
         assert!(missing
             .global_face_plans()
             .iter()
@@ -2847,6 +2979,77 @@ mod tests {
             stats
         );
         assert_eq!(graph, before);
+    }
+
+    #[test]
+    fn global_face_mutation_gate_reports_incomplete_and_closed_boundary_cycles() {
+        let mut incomplete = exact_face_twin_graph_with_successors();
+        incomplete
+            .apply_unambiguous_face_twins(&ExecutionPolicy::default())
+            .unwrap();
+        incomplete
+            .reconcile_global_face_plans(&ExecutionPolicy::default())
+            .unwrap();
+        let before = incomplete.clone();
+        assert_eq!(
+            incomplete
+                .validate_global_face_mutation_gate(&ExecutionPolicy::default())
+                .unwrap(),
+            PartitionBorderGlobalFaceMutationGateStats {
+                face_count: 2,
+                candidate_count: 2,
+                boundary_transition_count: 0,
+                missing_boundary_successor_count: 2,
+                mutation_ready_face_count: 0,
+            }
+        );
+        assert_eq!(incomplete, before);
+
+        let mut complete = exact_face_twin_graph_with_successors();
+        let observation_ids = complete.observations.keys().copied().collect::<Vec<_>>();
+        for observation_id in observation_ids {
+            complete
+                .observations
+                .get_mut(&observation_id)
+                .expect("observation identity")
+                .local_face_boundary_successor = Some(observation_id);
+        }
+        complete
+            .apply_unambiguous_face_twins(&ExecutionPolicy::default())
+            .unwrap();
+        complete
+            .reconcile_global_face_plans(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(
+            complete
+                .validate_global_face_mutation_gate(&ExecutionPolicy::default())
+                .unwrap(),
+            PartitionBorderGlobalFaceMutationGateStats {
+                face_count: 2,
+                candidate_count: 2,
+                boundary_transition_count: 2,
+                missing_boundary_successor_count: 0,
+                mutation_ready_face_count: 2,
+            }
+        );
+        let first_id = complete.observations.keys().next().copied().unwrap();
+        let second_id = complete.observations.keys().nth(1).copied().unwrap();
+        complete
+            .observations
+            .get_mut(&first_id)
+            .unwrap()
+            .local_face_boundary_successor = Some(second_id);
+        complete
+            .reconcile_global_face_plans(&ExecutionPolicy::default())
+            .unwrap();
+        let error = complete
+            .validate_global_face_mutation_gate(&ExecutionPolicy::default())
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::InternalInvariantViolation { ref reason }
+                if reason.contains("crosses face")
+        ));
     }
 
     #[test]

--- a/crates/geo-polygonize-core/src/graph/planar_graph.rs
+++ b/crates/geo-polygonize-core/src/graph/planar_graph.rs
@@ -13,7 +13,8 @@ use std::cmp::Ordering;
 use std::collections::HashMap;
 
 use super::partition_border::{
-    partition_boundary_intersections, PartitionBorderHalfEdge, PartitionBorderSide,
+    partition_boundary_intersections, PartitionBorderEdgeKey, PartitionBorderHalfEdge,
+    PartitionBorderNodeKey, PartitionBorderSide,
 };
 
 /// Index of a node in the graph.
@@ -3037,23 +3038,140 @@ impl ComponentScratch {
         component_id: usize,
         export: PartitionBorderExport,
     ) -> Vec<PartitionBorderHalfEdge> {
-        (0..self.graph.directed_edges.len())
-            .filter_map(|local_dir_edge_id| {
-                let side = self.border_side(local_dir_edge_id, export.bbox)?;
-                let global_dir_edge_id = self.global_dir_edge_id(local_dir_edge_id)?;
-                let mut observation = self.graph.partition_border_half_edge_for_component(
-                    export.partition_id,
-                    component_id,
-                    local_dir_edge_id,
-                    side,
-                )?;
-                observation.local_dir_edge_id = global_dir_edge_id;
-                observation.local_face_successor = observation
-                    .local_face_successor
-                    .and_then(|successor| self.global_dir_edge_id(successor));
-                Some(observation)
-            })
+        let border_sides = (0..self.graph.directed_edges.len())
+            .map(|local_dir_edge_id| self.border_side(local_dir_edge_id, export.bbox))
+            .collect::<Vec<_>>();
+        let boundary_successors = self.local_face_boundary_successors(&border_sides);
+        let mut pending = Vec::new();
+        for (local_dir_edge_id, side) in border_sides.into_iter().enumerate() {
+            let Some(side) = side else {
+                continue;
+            };
+            let Some(global_dir_edge_id) = self.global_dir_edge_id(local_dir_edge_id) else {
+                continue;
+            };
+            let Some(mut observation) = self.graph.partition_border_half_edge_for_component(
+                export.partition_id,
+                component_id,
+                local_dir_edge_id,
+                side,
+            ) else {
+                continue;
+            };
+            observation.local_dir_edge_id = global_dir_edge_id;
+            observation.local_face_successor = observation
+                .local_face_successor
+                .and_then(|successor| self.global_dir_edge_id(successor));
+            let boundary_successor = boundary_successors
+                .get(local_dir_edge_id)
+                .copied()
+                .flatten()
+                .and_then(|successor| {
+                    Some((
+                        self.global_dir_edge_id(successor)?,
+                        self.local_dir_edge_key(successor)?,
+                    ))
+                });
+            pending.push((observation, boundary_successor));
+        }
+
+        let mut observation_ids = HashMap::with_capacity(pending.len());
+        for (observation, _) in &pending {
+            observation_ids.insert(
+                (observation.local_dir_edge_id, observation.edge_key),
+                observation.observation_id(),
+            );
+        }
+        for (observation, boundary_successor) in &mut pending {
+            observation.local_face_boundary_successor =
+                boundary_successor.and_then(|identity| observation_ids.get(&identity).copied());
+        }
+        pending
+            .into_iter()
+            .map(|(observation, _)| observation)
             .collect()
+    }
+
+    fn local_face_boundary_successors(
+        &self,
+        border_sides: &[Option<PartitionBorderSide>],
+    ) -> Vec<Option<DirEdgeId>> {
+        let directed_edge_count = self.graph.directed_edges.len();
+        let mut boundary_successors = vec![None; directed_edge_count];
+        let mut visited = vec![false; directed_edge_count];
+        for start in 0..directed_edge_count {
+            if visited[start] {
+                continue;
+            }
+            let mut cycle = Vec::new();
+            let mut current = start;
+            let mut closed = false;
+            loop {
+                if current >= directed_edge_count || visited[current] {
+                    closed = current == start;
+                    break;
+                }
+                visited[current] = true;
+                cycle.push(current);
+                let Some(twin) = self
+                    .graph
+                    .directed_edges
+                    .get(current)
+                    .map(|edge| edge.sym_idx)
+                else {
+                    break;
+                };
+                let Some(next) = self
+                    .graph
+                    .directed_edges
+                    .get(twin)
+                    .and_then(|edge| edge.next_idx)
+                else {
+                    break;
+                };
+                current = next;
+                if current == start {
+                    closed = true;
+                    break;
+                }
+                if cycle.len() > directed_edge_count {
+                    break;
+                }
+            }
+            if !closed {
+                continue;
+            }
+            let border_edges = cycle
+                .iter()
+                .copied()
+                .filter(|&dir_edge_id| border_sides.get(dir_edge_id).is_some_and(Option::is_some))
+                .collect::<Vec<_>>();
+            if border_edges.is_empty() {
+                continue;
+            }
+            for (index, &dir_edge_id) in border_edges.iter().enumerate() {
+                boundary_successors[dir_edge_id] =
+                    Some(border_edges[(index + 1) % border_edges.len()]);
+            }
+        }
+        boundary_successors
+    }
+
+    fn local_dir_edge_key(&self, local_dir_edge_id: DirEdgeId) -> Option<PartitionBorderEdgeKey> {
+        let directed = self.graph.directed_edges.get(local_dir_edge_id)?;
+        let start = directed.src;
+        let end = directed.dst;
+        let start = PartitionBorderNodeKey::from_coord(Coord3D::new(
+            *self.graph.nodes_x.get(start)?,
+            *self.graph.nodes_y.get(start)?,
+            0.0,
+        ));
+        let end = PartitionBorderNodeKey::from_coord(Coord3D::new(
+            *self.graph.nodes_x.get(end)?,
+            *self.graph.nodes_y.get(end)?,
+            0.0,
+        ));
+        PartitionBorderEdgeKey::new(start, end)
     }
 
     fn global_dir_edge_id(&self, local_dir_edge_id: DirEdgeId) -> Option<DirEdgeId> {
@@ -3913,6 +4031,10 @@ mod arrangement_ring_invariant_tests {
             .iter()
             .filter(|observation| observation.face_ref.is_some())
             .all(|observation| observation.local_face_successor.is_some()));
+        assert!(observations
+            .iter()
+            .filter(|observation| observation.face_ref.is_some())
+            .all(|observation| observation.local_face_boundary_successor.is_some()));
     }
 
     #[test]

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -276,6 +276,9 @@ pub struct StitchingReport {
     pub partition_border_global_unbounded_face_count: usize,
     /// Planned faces that participate in at least one retained twin edge.
     pub partition_border_global_face_linked_count: usize,
+    /// Qualified observations whose local face boundary continuation was not
+    /// resolved to another retained border observation.
+    pub partition_border_global_face_missing_boundary_successor_count: usize,
     /// Face plans that passed immutable identity and twin-link validation.
     pub partition_border_global_face_validated_count: usize,
     /// Face-boundary candidates that passed observation-lineage validation.
@@ -284,6 +287,12 @@ pub struct StitchingReport {
     pub partition_border_global_face_validated_twin_count: usize,
     /// Validated face plans marked unbounded by their source arrangements.
     pub partition_border_global_face_validated_unbounded_count: usize,
+    /// Face-boundary transitions resolved for the mutation gate.
+    pub partition_border_global_face_boundary_transition_count: usize,
+    /// Face-boundary transitions that remain incomplete for mutation.
+    pub partition_border_global_face_mutation_missing_successor_count: usize,
+    /// Face plans whose retained transitions form one closed local cycle.
+    pub partition_border_global_face_mutation_ready_count: usize,
     /// Exact twin pairs whose observations also carried valid qualified local
     /// face references and were retained as face-level links.
     pub partition_border_face_twin_count: usize,
@@ -2321,6 +2330,12 @@ impl<'a> TiledPolygonizer<'a> {
             partition_border_global_face_validation.face_count,
             global_face_plan_count
         );
+        let partition_border_global_face_mutation_gate =
+            partition_border_graph.validate_global_face_mutation_gate(&self.execution_policy)?;
+        debug_assert_eq!(
+            partition_border_global_face_mutation_gate.face_count,
+            global_face_plan_count
+        );
         if let Some(trace) = trace.as_deref_mut() {
             trace.record_partition_border_reconciliation(partition_border_reconciliation);
             trace.record_partition_border_twin_application(partition_border_twin_application);
@@ -2334,6 +2349,9 @@ impl<'a> TiledPolygonizer<'a> {
             trace.record_partition_border_global_face_plan(partition_border_global_face_plan);
             trace.record_partition_border_global_face_validation(
                 partition_border_global_face_validation,
+            );
+            trace.record_partition_border_global_face_mutation_gate(
+                partition_border_global_face_mutation_gate,
             );
         }
         let unresolved = tile_reports.iter().any(Self::report_is_unresolved);
@@ -2580,6 +2598,8 @@ impl<'a> TiledPolygonizer<'a> {
                     .unbounded_face_count,
                 partition_border_global_face_linked_count: partition_border_global_face_plan
                     .linked_face_count,
+                partition_border_global_face_missing_boundary_successor_count:
+                    partition_border_global_face_plan.missing_boundary_successor_count,
                 partition_border_global_face_validated_count:
                     partition_border_global_face_validation.face_count,
                 partition_border_global_face_validated_candidate_count:
@@ -2588,6 +2608,12 @@ impl<'a> TiledPolygonizer<'a> {
                     partition_border_global_face_validation.twin_link_count,
                 partition_border_global_face_validated_unbounded_count:
                     partition_border_global_face_validation.unbounded_face_count,
+                partition_border_global_face_boundary_transition_count:
+                    partition_border_global_face_mutation_gate.boundary_transition_count,
+                partition_border_global_face_mutation_missing_successor_count:
+                    partition_border_global_face_mutation_gate.missing_boundary_successor_count,
+                partition_border_global_face_mutation_ready_count:
+                    partition_border_global_face_mutation_gate.mutation_ready_face_count,
                 partition_border_face_twin_count: applied_face_twin_count,
                 partition_border_face_twin_missing_face_count: partition_border_twin_application
                     .missing_face_ref_count,

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -179,6 +179,18 @@ mod tests {
                 .filter(|plan| !plan.twin_edge_keys.is_empty())
                 .count()
         );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_missing_boundary_successor_count,
+            result
+                .partition_border_graph
+                .global_face_plans()
+                .iter()
+                .flat_map(|plan| plan.candidates.iter())
+                .filter(|candidate| candidate.local_face_boundary_successor.is_none())
+                .count()
+        );
         let validation = result
             .partition_border_graph
             .validate_global_face_plans(&ExecutionPolicy::default())
@@ -206,6 +218,28 @@ mod tests {
                 .stitching_report
                 .partition_border_global_face_validated_unbounded_count,
             validation.unbounded_face_count
+        );
+        let mutation_gate = result
+            .partition_border_graph
+            .validate_global_face_mutation_gate(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_boundary_transition_count,
+            mutation_gate.boundary_transition_count
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_mutation_missing_successor_count,
+            mutation_gate.missing_boundary_successor_count
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_mutation_ready_count,
+            mutation_gate.mutation_ready_face_count
         );
         assert_eq!(result.polygons.len(), 2);
     }
@@ -328,6 +362,10 @@ mod tests {
                 && event.payload["representative_line_id"].as_u64().is_some()
                 && event.payload["component_id"].as_u64().is_some()
         }));
+        assert!(observations
+            .iter()
+            .filter(|event| event.payload["face_id"].is_number())
+            .all(|event| event.payload["local_face_boundary_successor"].is_object()));
         let reconciliation = traced
             .trace
             .events
@@ -480,6 +518,16 @@ mod tests {
                     .partition_border_global_face_linked_count as u64
             )
         );
+        assert_eq!(
+            global_face_plan.payload["missing_boundary_successor_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_missing_boundary_successor_count
+                    as u64
+            )
+        );
         let global_face_validation = traced
             .trace
             .events
@@ -520,6 +568,58 @@ mod tests {
                     .result
                     .stitching_report
                     .partition_border_global_face_validated_unbounded_count as u64
+            )
+        );
+        let global_face_gate = traced
+            .trace
+            .events
+            .iter()
+            .find(|event| event.kind == "partition_border_global_face_mutation_gate")
+            .expect("global face mutation gate evidence");
+        assert_eq!(
+            global_face_gate.payload["face_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_validated_count as u64
+            )
+        );
+        assert_eq!(
+            global_face_gate.payload["candidate_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_validated_candidate_count as u64
+            )
+        );
+        assert_eq!(
+            global_face_gate.payload["boundary_transition_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_boundary_transition_count as u64
+            )
+        );
+        assert_eq!(
+            global_face_gate.payload["missing_boundary_successor_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_mutation_missing_successor_count
+                    as u64
+            )
+        );
+        assert_eq!(
+            global_face_gate.payload["mutation_ready_face_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_mutation_ready_count as u64
             )
         );
     }

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -2,10 +2,10 @@
 
 use crate::fingerprint::{coordinate_fingerprint, float_bits};
 use crate::graph::partition_border::{
-    PartitionBorderGlobalComponentReconciliationStats, PartitionBorderGlobalFacePlanStats,
-    PartitionBorderGlobalFacePlanValidationStats, PartitionBorderHalfEdge,
-    PartitionBorderNodeReconciliationStats, PartitionBorderReconciliationStats,
-    PartitionBorderTwinApplicationStats,
+    PartitionBorderGlobalComponentReconciliationStats, PartitionBorderGlobalFaceMutationGateStats,
+    PartitionBorderGlobalFacePlanStats, PartitionBorderGlobalFacePlanValidationStats,
+    PartitionBorderHalfEdge, PartitionBorderNodeReconciliationStats,
+    PartitionBorderReconciliationStats, PartitionBorderTwinApplicationStats,
 };
 use crate::graph::planar_graph::PartitionBoundaryNodingStats;
 use crate::graph::{ExtractedRing, PlanarGraph};
@@ -686,6 +686,24 @@ impl TraceRecorderV1 {
                 "missing_successor_count": stats.missing_successor_count,
                 "unbounded_face_count": stats.unbounded_face_count,
                 "linked_face_count": stats.linked_face_count,
+                "missing_boundary_successor_count": stats.missing_boundary_successor_count,
+            }),
+        )
+    }
+
+    pub(crate) fn record_partition_border_global_face_mutation_gate(
+        &mut self,
+        stats: PartitionBorderGlobalFaceMutationGateStats,
+    ) -> bool {
+        self.record(
+            TraceStageV1::Graph,
+            "partition_border_global_face_mutation_gate",
+            serde_json::json!({
+                "face_count": stats.face_count,
+                "candidate_count": stats.candidate_count,
+                "boundary_transition_count": stats.boundary_transition_count,
+                "missing_boundary_successor_count": stats.missing_boundary_successor_count,
+                "mutation_ready_face_count": stats.mutation_ready_face_count,
             }),
         )
     }
@@ -716,6 +734,14 @@ impl TraceRecorderV1 {
                 .map(|bits| format!("0x{bits:016x}"))
                 .collect::<Vec<_>>()
         };
+        let boundary_successor = observation.local_face_boundary_successor.map(|successor| {
+            let (start, end) = successor.edge_key.endpoints();
+            serde_json::json!({
+                "partition_id": successor.partition_id,
+                "local_dir_edge_id": successor.local_dir_edge_id,
+                "edge_key": [endpoint(start), endpoint(end)],
+            })
+        });
         let (edge_start, edge_end) = observation.edge_key.endpoints();
         self.record(
             TraceStageV1::Graph,
@@ -733,6 +759,7 @@ impl TraceRecorderV1 {
                 "component_id": observation.component_id,
                 "local_face_successor": observation.local_face_successor,
                 "local_face_is_unbounded": observation.local_face_is_unbounded,
+                "local_face_boundary_successor": boundary_successor,
                 "source_count": observation.source_line_ids.len(),
                 "first_source_line_id": observation.source_line_ids.first(),
                 "last_source_line_id": observation.source_line_ids.last(),
@@ -752,6 +779,14 @@ impl TraceRecorderV1 {
                 .map(|bits| format!("0x{bits:016x}"))
                 .collect::<Vec<_>>()
         };
+        let boundary_successor = observation.local_face_boundary_successor.map(|successor| {
+            let (start, end) = successor.edge_key.endpoints();
+            serde_json::json!({
+                "partition_id": successor.partition_id,
+                "local_dir_edge_id": successor.local_dir_edge_id,
+                "edge_key": [endpoint(start), endpoint(end)],
+            })
+        });
         let (edge_start, edge_end) = observation.edge_key.endpoints();
         self.record(
             TraceStageV1::Graph,
@@ -764,6 +799,7 @@ impl TraceRecorderV1 {
                 "component_id": observation.component_id,
                 "local_face_successor": observation.local_face_successor,
                 "local_face_is_unbounded": observation.local_face_is_unbounded,
+                "local_face_boundary_successor": boundary_successor,
                 "representative_line_id": observation.representative_line_id,
                 "reason": reason,
             }),


### PR DESCRIPTION
Stack

- Parent: #1321 (`agent/p5-global-face-validation`, `e6c4830`)
- Children: none at creation

Delivered

- Walked each persisted local face cycle once and retained the first border observation reached after every qualified border half-edge.
- Resolved local boundary continuations to stable partition/local-edge/edge-span observation identities, preserving atomic spans and deterministic ordering.
- Added a non-mutating global-face mutation gate that reports closed local boundary cycles and fails closed on missing or cross-face identity.
- Added bounded report/trace evidence and regressions for incomplete cycles, closed cycles, cross-face corruption, tiled report consistency, and real arrangement export.
- Updated `ROADMAP.md` for explicit local boundary-transition readiness evidence.

Contract impact

- No public output or binding contract changes.
- No local `next` links, global `next` links, global face IDs, tiled polygons, provenance, Z decisions, or fallback behavior are mutated.
- Incomplete local evidence remains observational and leaves the current replicate-and-own output path unchanged.
- Contradictory transition identity fails closed before any future global mutation.

Validation

- `cargo fmt --all -- --check`
- `cargo test -p geo-polygonize-core global_face --lib` — 6 passed
- `cargo test -p geo-polygonize-core partition_border_export_qualifies_components_and_representatives --lib` — passed
- `cargo test -p geo-polygonize-core exports_physical_tile_border --lib` — passed
- `cargo test -p geo-polygonize-core trace_records_partition_boundary_noding_and_atomic_observations --lib` — passed
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings` — passed
- `DYLD_LIBRARY_PATH=/Library/Frameworks/Python.framework/Versions/3.11/lib cargo test --workspace --lib --tests --no-fail-fast` — 328 core unit tests and all workspace integration targets passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `cargo check --workspace --all-targets --no-default-features` — passed
- `git diff --check` — passed
- Generated binding changes were restored after the workspace test checkpoint.

Agent handoff

- Parent: #1321 (`agent/p5-global-face-validation`)
- Children: none
- Next branch: `agent/p5-global-face-transition-equivalence`
- Remaining risks: actual cross-partition global `next`/face assignment, exactly-one global unbounded-face proof, global cycle/source/Euler/face-walk validation, stitched extraction, untiled equivalence, differential fuzzing, and promotion evidence remain open.