### PR TITLE
feat(core): plan global face transitions

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -470,6 +470,9 @@ Blocked by #1288.
 - [x] Retain deterministic local face-boundary successor identities and report
   closed-cycle mutation readiness without assigning global `next` links, face
   IDs, or tiled output.
+- [x] Materialize deterministic ordered local transition plans from the
+  mutation gate, proving insertion-order equivalence while retaining
+  incomplete cycles as evidence only.
 - [ ] Apply unambiguous twins only across declared adjacent borders.
 - [ ] Reconcile canonical border nodes, source sets, representative IDs, and
   selected Z-policy decisions.

--- a/crates/geo-polygonize-core/src/graph/partition_border.rs
+++ b/crates/geo-polygonize-core/src/graph/partition_border.rs
@@ -646,6 +646,29 @@ pub(crate) struct PartitionBorderGlobalFaceMutationGateStats {
     pub(crate) mutation_ready_face_count: usize,
 }
 
+/// One deterministic local boundary cycle retained as input to a future
+/// global face mutation. The ordered observation IDs are evidence only; this
+/// record does not assign global directed-edge links or face IDs.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct PartitionBorderGlobalFaceTransitionPlan {
+    pub(crate) face_ref: PartitionFaceRef,
+    pub(crate) boundary_observation_ids: Vec<PartitionBorderObservationId>,
+    pub(crate) twin_edge_keys: Vec<PartitionBorderEdgeKey>,
+    pub(crate) local_face_is_unbounded: bool,
+    pub(crate) closed: bool,
+}
+
+/// Counts from deterministic local boundary-transition plan materialization.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct PartitionBorderGlobalFaceTransitionPlanStats {
+    pub(crate) face_count: usize,
+    pub(crate) candidate_count: usize,
+    pub(crate) boundary_transition_count: usize,
+    pub(crate) missing_boundary_successor_count: usize,
+    pub(crate) closed_face_count: usize,
+    pub(crate) incomplete_face_count: usize,
+}
+
 /// Deterministic evidence for the declared-adjacency twin boundary.
 ///
 /// Only observations covered by a declared partition adjacency contribute to
@@ -674,6 +697,7 @@ pub struct PartitionBorderGraph {
     reconciled_nodes: Vec<PartitionBorderNodePayload>,
     global_components: Vec<PartitionBorderGlobalComponent>,
     global_face_plans: Vec<PartitionBorderGlobalFacePlan>,
+    global_face_transitions: Vec<PartitionBorderGlobalFaceTransitionPlan>,
 }
 
 impl PartitionBorderGraph {
@@ -711,6 +735,7 @@ impl PartitionBorderGraph {
         self.reconciled_nodes.clear();
         self.global_components.clear();
         self.global_face_plans.clear();
+        self.global_face_transitions.clear();
         Ok(())
     }
 
@@ -720,6 +745,7 @@ impl PartitionBorderGraph {
         self.reconciled_nodes.clear();
         self.global_components.clear();
         self.global_face_plans.clear();
+        self.global_face_transitions.clear();
     }
 
     pub fn node_count(&self) -> usize {
@@ -970,6 +996,7 @@ impl PartitionBorderGraph {
         self.applied_face_twins = applied_face_twins;
         self.global_components.clear();
         self.global_face_plans.clear();
+        self.global_face_transitions.clear();
         Ok(stats)
     }
 
@@ -1110,6 +1137,7 @@ impl PartitionBorderGraph {
         self.reconciled_nodes = reconciled_nodes;
         self.global_components.clear();
         self.global_face_plans.clear();
+        self.global_face_transitions.clear();
         Ok(stats)
     }
 
@@ -1253,6 +1281,7 @@ impl PartitionBorderGraph {
         };
         self.global_components = global_components;
         self.global_face_plans.clear();
+        self.global_face_transitions.clear();
         Ok(stats)
     }
 
@@ -1376,6 +1405,7 @@ impl PartitionBorderGraph {
             missing_boundary_successor_count,
         };
         self.global_face_plans = global_face_plans;
+        self.global_face_transitions.clear();
         Ok(stats)
     }
 
@@ -1755,6 +1785,138 @@ impl PartitionBorderGraph {
             missing_boundary_successor_count,
             mutation_ready_face_count,
         })
+    }
+
+    /// Materializes deterministic ordered local boundary-transition plans
+    /// after the mutation gate passes. Incomplete faces are retained with
+    /// their sorted candidate identities and `closed == false`; no global
+    /// `next` links or face IDs are assigned.
+    pub(crate) fn reconcile_global_face_transitions(
+        &mut self,
+        execution_policy: &ExecutionPolicy,
+    ) -> crate::Result<PartitionBorderGlobalFaceTransitionPlanStats> {
+        execution_policy.check_cancelled("partition_border_global_face_transition_plan")?;
+        let gate = self.validate_global_face_mutation_gate(execution_policy)?;
+        execution_policy.check(
+            "partition_border_global_face_transition_faces",
+            execution_policy.max_graph_nodes,
+            self.global_face_plans.len(),
+        )?;
+        execution_policy.check(
+            "partition_border_global_face_transition_edges",
+            execution_policy.max_graph_edges,
+            gate.candidate_count,
+        )?;
+
+        let mut candidate_faces = BTreeMap::<PartitionBorderObservationId, PartitionFaceRef>::new();
+        for plan in &self.global_face_plans {
+            for candidate in &plan.candidates {
+                candidate_faces.insert(candidate.observation_id, plan.face_ref);
+            }
+        }
+
+        let mut transition_plans = Vec::with_capacity(self.global_face_plans.len());
+        let mut closed_face_count = 0;
+        let mut incomplete_face_count = 0;
+        for (plan_index, plan) in self.global_face_plans.iter().enumerate() {
+            execution_policy.check_cancelled_every(
+                "partition_border_global_face_transition_plan",
+                plan_index,
+            )?;
+            let mut successors =
+                BTreeMap::<PartitionBorderObservationId, PartitionBorderObservationId>::new();
+            let mut complete = !plan.candidates.is_empty();
+            for (candidate_index, candidate) in plan.candidates.iter().enumerate() {
+                execution_policy.check_cancelled_every(
+                    "partition_border_global_face_transition_candidates",
+                    candidate_index,
+                )?;
+                let Some(boundary_successor) = candidate.local_face_boundary_successor else {
+                    complete = false;
+                    continue;
+                };
+                let Some(successor_observation) = self.observations.get(&boundary_successor) else {
+                    return Err(crate::PolygonizeError::InternalInvariantViolation {
+                        reason: format!(
+                            "global face transition successor {:?} is missing",
+                            boundary_successor
+                        ),
+                    });
+                };
+                if successor_observation.face_ref != Some(plan.face_ref) {
+                    return Err(crate::PolygonizeError::InternalInvariantViolation {
+                        reason: format!(
+                            "global face transition successor {:?} crosses face {:?}",
+                            boundary_successor, plan.face_ref
+                        ),
+                    });
+                }
+                if candidate_faces.get(&boundary_successor) == Some(&plan.face_ref) {
+                    successors.insert(candidate.observation_id, boundary_successor);
+                } else {
+                    complete = false;
+                }
+            }
+
+            let mut ordered_observation_ids = Vec::with_capacity(plan.candidates.len());
+            if complete && successors.len() == plan.candidates.len() {
+                let start = plan.candidates[0].observation_id;
+                let mut visited = BTreeSet::new();
+                let mut current = start;
+                loop {
+                    if !visited.insert(current) {
+                        if current == start && visited.len() == plan.candidates.len() {
+                            break;
+                        }
+                        complete = false;
+                        break;
+                    }
+                    ordered_observation_ids.push(current);
+                    let Some(&next) = successors.get(&current) else {
+                        complete = false;
+                        break;
+                    };
+                    current = next;
+                    if ordered_observation_ids.len() > plan.candidates.len() {
+                        complete = false;
+                        break;
+                    }
+                }
+            }
+            if !complete || ordered_observation_ids.len() != plan.candidates.len() {
+                complete = false;
+                incomplete_face_count += 1;
+                ordered_observation_ids = plan
+                    .candidates
+                    .iter()
+                    .map(|candidate| candidate.observation_id)
+                    .collect();
+            } else {
+                closed_face_count += 1;
+            }
+            transition_plans.push(PartitionBorderGlobalFaceTransitionPlan {
+                face_ref: plan.face_ref,
+                boundary_observation_ids: ordered_observation_ids,
+                twin_edge_keys: plan.twin_edge_keys.clone(),
+                local_face_is_unbounded: plan.local_face_is_unbounded,
+                closed: complete,
+            });
+        }
+
+        let stats = PartitionBorderGlobalFaceTransitionPlanStats {
+            face_count: transition_plans.len(),
+            candidate_count: gate.candidate_count,
+            boundary_transition_count: gate.boundary_transition_count,
+            missing_boundary_successor_count: gate.missing_boundary_successor_count,
+            closed_face_count,
+            incomplete_face_count,
+        };
+        self.global_face_transitions = transition_plans;
+        Ok(stats)
+    }
+
+    pub(crate) fn global_face_transitions(&self) -> &[PartitionBorderGlobalFaceTransitionPlan] {
+        &self.global_face_transitions
     }
 
     /// Merges source IDs and retains every distinct Z candidate for each
@@ -3050,6 +3212,93 @@ mod tests {
             crate::PolygonizeError::InternalInvariantViolation { ref reason }
                 if reason.contains("crosses face")
         ));
+    }
+
+    #[test]
+    fn global_face_transition_plans_are_ordered_equivalent_and_fail_closed() {
+        let mut incomplete = exact_face_twin_graph_with_successors();
+        incomplete
+            .apply_unambiguous_face_twins(&ExecutionPolicy::default())
+            .unwrap();
+        incomplete
+            .reconcile_global_face_plans(&ExecutionPolicy::default())
+            .unwrap();
+        let stats = incomplete
+            .reconcile_global_face_transitions(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(
+            stats,
+            PartitionBorderGlobalFaceTransitionPlanStats {
+                face_count: 2,
+                candidate_count: 2,
+                boundary_transition_count: 0,
+                missing_boundary_successor_count: 2,
+                closed_face_count: 0,
+                incomplete_face_count: 2,
+            }
+        );
+        assert!(incomplete
+            .global_face_transitions()
+            .iter()
+            .all(|plan| !plan.closed && plan.boundary_observation_ids.len() == 1));
+
+        let mut complete = exact_face_twin_graph_with_successors();
+        let observation_ids = complete.observations.keys().copied().collect::<Vec<_>>();
+        for observation_id in observation_ids {
+            complete
+                .observations
+                .get_mut(&observation_id)
+                .expect("observation identity")
+                .local_face_boundary_successor = Some(observation_id);
+        }
+        complete
+            .apply_unambiguous_face_twins(&ExecutionPolicy::default())
+            .unwrap();
+        complete
+            .reconcile_global_face_plans(&ExecutionPolicy::default())
+            .unwrap();
+        let stats = complete
+            .reconcile_global_face_transitions(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(stats.closed_face_count, 2);
+        assert_eq!(stats.incomplete_face_count, 0);
+        assert!(complete
+            .global_face_transitions()
+            .iter()
+            .all(|plan| plan.closed && plan.boundary_observation_ids.len() == 1));
+        let mut reordered = PartitionBorderGraph::default();
+        for adjacency in complete.adjacencies.iter().copied() {
+            reordered.declare_adjacency(adjacency);
+        }
+        for observation in complete.observations.values().rev().cloned() {
+            reordered.insert(observation).unwrap();
+        }
+        reordered
+            .apply_unambiguous_face_twins(&ExecutionPolicy::default())
+            .unwrap();
+        reordered
+            .reconcile_global_face_plans(&ExecutionPolicy::default())
+            .unwrap();
+        reordered
+            .reconcile_global_face_transitions(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(
+            reordered.global_face_transitions(),
+            complete.global_face_transitions()
+        );
+
+        complete.global_face_plans[0].candidates[0].local_face_boundary_successor =
+            Some(complete.global_face_plans[1].candidates[0].observation_id);
+        let before = complete.clone();
+        let error = complete
+            .reconcile_global_face_transitions(&ExecutionPolicy::default())
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::InternalInvariantViolation { ref reason }
+                if reason.contains("disagrees with its observation")
+        ));
+        assert_eq!(complete, before);
     }
 
     #[test]

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -293,6 +293,12 @@ pub struct StitchingReport {
     pub partition_border_global_face_mutation_missing_successor_count: usize,
     /// Face plans whose retained transitions form one closed local cycle.
     pub partition_border_global_face_mutation_ready_count: usize,
+    /// Face-boundary transitions retained in deterministic cycle order.
+    pub partition_border_global_face_transition_count: usize,
+    /// Face plans with a complete closed transition cycle.
+    pub partition_border_global_face_transition_closed_count: usize,
+    /// Face plans retained with incomplete transition evidence.
+    pub partition_border_global_face_transition_incomplete_count: usize,
     /// Exact twin pairs whose observations also carried valid qualified local
     /// face references and were retained as face-level links.
     pub partition_border_face_twin_count: usize,
@@ -2336,6 +2342,14 @@ impl<'a> TiledPolygonizer<'a> {
             partition_border_global_face_mutation_gate.face_count,
             global_face_plan_count
         );
+        let partition_border_global_face_transition_plan =
+            partition_border_graph.reconcile_global_face_transitions(&self.execution_policy)?;
+        let global_face_transition_plan_count =
+            partition_border_graph.global_face_transitions().len();
+        debug_assert_eq!(
+            partition_border_global_face_transition_plan.face_count,
+            global_face_transition_plan_count
+        );
         if let Some(trace) = trace.as_deref_mut() {
             trace.record_partition_border_reconciliation(partition_border_reconciliation);
             trace.record_partition_border_twin_application(partition_border_twin_application);
@@ -2352,6 +2366,9 @@ impl<'a> TiledPolygonizer<'a> {
             );
             trace.record_partition_border_global_face_mutation_gate(
                 partition_border_global_face_mutation_gate,
+            );
+            trace.record_partition_border_global_face_transition_plan(
+                partition_border_global_face_transition_plan,
             );
         }
         let unresolved = tile_reports.iter().any(Self::report_is_unresolved);
@@ -2614,6 +2631,12 @@ impl<'a> TiledPolygonizer<'a> {
                     partition_border_global_face_mutation_gate.missing_boundary_successor_count,
                 partition_border_global_face_mutation_ready_count:
                     partition_border_global_face_mutation_gate.mutation_ready_face_count,
+                partition_border_global_face_transition_count:
+                    partition_border_global_face_transition_plan.boundary_transition_count,
+                partition_border_global_face_transition_closed_count:
+                    partition_border_global_face_transition_plan.closed_face_count,
+                partition_border_global_face_transition_incomplete_count:
+                    partition_border_global_face_transition_plan.incomplete_face_count,
                 partition_border_face_twin_count: applied_face_twin_count,
                 partition_border_face_twin_missing_face_count: partition_border_twin_application
                     .missing_face_ref_count,

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -241,6 +241,29 @@ mod tests {
                 .partition_border_global_face_mutation_ready_count,
             mutation_gate.mutation_ready_face_count
         );
+        let transition_plan = result.partition_border_graph.global_face_transitions();
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_transition_count,
+            transition_plan
+                .iter()
+                .filter(|plan| plan.closed)
+                .map(|plan| plan.boundary_observation_ids.len())
+                .sum::<usize>()
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_transition_closed_count,
+            transition_plan.iter().filter(|plan| plan.closed).count()
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_transition_incomplete_count,
+            transition_plan.iter().filter(|plan| !plan.closed).count()
+        );
         assert_eq!(result.polygons.len(), 2);
     }
 
@@ -620,6 +643,58 @@ mod tests {
                     .result
                     .stitching_report
                     .partition_border_global_face_mutation_ready_count as u64
+            )
+        );
+        let global_face_transition_plan = traced
+            .trace
+            .events
+            .iter()
+            .find(|event| event.kind == "partition_border_global_face_transition_plan")
+            .expect("global face transition plan evidence");
+        assert_eq!(
+            global_face_transition_plan.payload["face_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_plan_count as u64
+            )
+        );
+        assert_eq!(
+            global_face_transition_plan.payload["candidate_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_candidate_count as u64
+            )
+        );
+        assert_eq!(
+            global_face_transition_plan.payload["boundary_transition_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_transition_count as u64
+            )
+        );
+        assert_eq!(
+            global_face_transition_plan.payload["closed_face_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_transition_closed_count as u64
+            )
+        );
+        assert_eq!(
+            global_face_transition_plan.payload["incomplete_face_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_transition_incomplete_count
+                    as u64
             )
         );
     }

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -4,8 +4,9 @@ use crate::fingerprint::{coordinate_fingerprint, float_bits};
 use crate::graph::partition_border::{
     PartitionBorderGlobalComponentReconciliationStats, PartitionBorderGlobalFaceMutationGateStats,
     PartitionBorderGlobalFacePlanStats, PartitionBorderGlobalFacePlanValidationStats,
-    PartitionBorderHalfEdge, PartitionBorderNodeReconciliationStats,
-    PartitionBorderReconciliationStats, PartitionBorderTwinApplicationStats,
+    PartitionBorderGlobalFaceTransitionPlanStats, PartitionBorderHalfEdge,
+    PartitionBorderNodeReconciliationStats, PartitionBorderReconciliationStats,
+    PartitionBorderTwinApplicationStats,
 };
 use crate::graph::planar_graph::PartitionBoundaryNodingStats;
 use crate::graph::{ExtractedRing, PlanarGraph};
@@ -704,6 +705,24 @@ impl TraceRecorderV1 {
                 "boundary_transition_count": stats.boundary_transition_count,
                 "missing_boundary_successor_count": stats.missing_boundary_successor_count,
                 "mutation_ready_face_count": stats.mutation_ready_face_count,
+            }),
+        )
+    }
+
+    pub(crate) fn record_partition_border_global_face_transition_plan(
+        &mut self,
+        stats: PartitionBorderGlobalFaceTransitionPlanStats,
+    ) -> bool {
+        self.record(
+            TraceStageV1::Graph,
+            "partition_border_global_face_transition_plan",
+            serde_json::json!({
+                "face_count": stats.face_count,
+                "candidate_count": stats.candidate_count,
+                "boundary_transition_count": stats.boundary_transition_count,
+                "missing_boundary_successor_count": stats.missing_boundary_successor_count,
+                "closed_face_count": stats.closed_face_count,
+                "incomplete_face_count": stats.incomplete_face_count,
             }),
         )
     }


### PR DESCRIPTION
Stack

- Parent: #1323 (`agent/p5-global-arrangement-mutation-gate`, `070d996`)
- Children: #1325 (`agent/p5-global-face-cross-partition-map`)

Delivered

- Materialized deterministic ordered local face-boundary transition plans from the mutation gate.
- Retained closed cycles in face-walk order and incomplete cycles as explicit `closed: false` evidence.
- Preserved twin edge keys and unbounded-face markers for the future global arrangement writer.
- Added insertion-order equivalence and cross-face corruption regressions, plus tiled report and trace counts.
- Updated `ROADMAP.md` for ordered transition-plan evidence.

Contract impact

- No public output or binding contract changes.
- No local or global `next` links, face IDs, tiled polygons, provenance, Z decisions, or fallback behavior are mutated.
- Incomplete cycles remain observational and cannot authorize global topology mutation.
- Cross-face successor identity fails closed before a transition plan is committed.

Validation

- `cargo fmt --all -- --check`
- `cargo test -p geo-polygonize-core global_face --lib` — 7 passed
- `cargo test -p geo-polygonize-core exports_physical_tile_border --lib` — passed
- `cargo test -p geo-polygonize-core trace_records_partition_boundary_noding_and_atomic_observations --lib` — passed
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings` — passed
- `DYLD_LIBRARY_PATH=/Library/Frameworks/Python.framework/Versions/3.11/lib cargo test --workspace --lib --tests --no-fail-fast` — 329 core unit tests and all workspace integration targets passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `cargo check --workspace --all-targets --no-default-features` — passed
- `git diff --check` — passed
- Generated binding changes were restored after the workspace test checkpoint.

Agent handoff

- Parent: #1323 (`agent/p5-global-arrangement-mutation-gate`)
- Children: #1325 (`agent/p5-global-face-cross-partition-map`)
- Next branch: `agent/p5-global-face-global-walk-invariants`
- Remaining risks: actual cross-partition global `next`/face assignment, exactly-one global unbounded-face proof, global cycle/source/Euler/face-walk validation, stitched extraction, untiled equivalence, differential fuzzing, and promotion evidence remain open.