### PR TITLE
feat(core): map cross-partition face transitions

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -473,6 +473,9 @@ Blocked by #1288.
 - [x] Materialize deterministic ordered local transition plans from the
   mutation gate, proving insertion-order equivalence while retaining
   incomplete cycles as evidence only.
+- [x] Position declared face-qualified twins inside those ordered cycles with
+  explicit mapped/unmapped and mutation-ready counts, without assigning global
+  `next` links or face IDs.
 - [ ] Apply unambiguous twins only across declared adjacent borders.
 - [ ] Reconcile canonical border nodes, source sets, representative IDs, and
   selected Z-policy decisions.

--- a/crates/geo-polygonize-core/src/graph/partition_border.rs
+++ b/crates/geo-polygonize-core/src/graph/partition_border.rs
@@ -669,6 +669,33 @@ pub(crate) struct PartitionBorderGlobalFaceTransitionPlanStats {
     pub(crate) incomplete_face_count: usize,
 }
 
+/// One declared face-qualified twin positioned inside the two deterministic
+/// local transition plans. This is a bridge for a future global walk; it does
+/// not assign a global successor or face identity.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(crate) struct PartitionBorderGlobalFaceTwinTransition {
+    pub(crate) edge_key: PartitionBorderEdgeKey,
+    pub(crate) forward_face_ref: PartitionFaceRef,
+    pub(crate) reverse_face_ref: PartitionFaceRef,
+    pub(crate) forward_observation_id: PartitionBorderObservationId,
+    pub(crate) reverse_observation_id: PartitionBorderObservationId,
+    pub(crate) forward_cycle_index: usize,
+    pub(crate) reverse_cycle_index: usize,
+    pub(crate) forward_cycle_closed: bool,
+    pub(crate) reverse_cycle_closed: bool,
+}
+
+/// Counts from positioning declared face twins in ordered local cycles.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct PartitionBorderGlobalFaceTwinTransitionStats {
+    pub(crate) face_count: usize,
+    pub(crate) transition_count: usize,
+    pub(crate) applied_twin_count: usize,
+    pub(crate) mapped_twin_count: usize,
+    pub(crate) unmapped_twin_count: usize,
+    pub(crate) mutation_ready_twin_count: usize,
+}
+
 /// Deterministic evidence for the declared-adjacency twin boundary.
 ///
 /// Only observations covered by a declared partition adjacency contribute to
@@ -698,6 +725,7 @@ pub struct PartitionBorderGraph {
     global_components: Vec<PartitionBorderGlobalComponent>,
     global_face_plans: Vec<PartitionBorderGlobalFacePlan>,
     global_face_transitions: Vec<PartitionBorderGlobalFaceTransitionPlan>,
+    global_face_twin_transitions: Vec<PartitionBorderGlobalFaceTwinTransition>,
 }
 
 impl PartitionBorderGraph {
@@ -736,6 +764,7 @@ impl PartitionBorderGraph {
         self.global_components.clear();
         self.global_face_plans.clear();
         self.global_face_transitions.clear();
+        self.global_face_twin_transitions.clear();
         Ok(())
     }
 
@@ -746,6 +775,7 @@ impl PartitionBorderGraph {
         self.global_components.clear();
         self.global_face_plans.clear();
         self.global_face_transitions.clear();
+        self.global_face_twin_transitions.clear();
     }
 
     pub fn node_count(&self) -> usize {
@@ -997,6 +1027,7 @@ impl PartitionBorderGraph {
         self.global_components.clear();
         self.global_face_plans.clear();
         self.global_face_transitions.clear();
+        self.global_face_twin_transitions.clear();
         Ok(stats)
     }
 
@@ -1138,6 +1169,7 @@ impl PartitionBorderGraph {
         self.global_components.clear();
         self.global_face_plans.clear();
         self.global_face_transitions.clear();
+        self.global_face_twin_transitions.clear();
         Ok(stats)
     }
 
@@ -1282,6 +1314,7 @@ impl PartitionBorderGraph {
         self.global_components = global_components;
         self.global_face_plans.clear();
         self.global_face_transitions.clear();
+        self.global_face_twin_transitions.clear();
         Ok(stats)
     }
 
@@ -1406,6 +1439,7 @@ impl PartitionBorderGraph {
         };
         self.global_face_plans = global_face_plans;
         self.global_face_transitions.clear();
+        self.global_face_twin_transitions.clear();
         Ok(stats)
     }
 
@@ -1912,11 +1946,151 @@ impl PartitionBorderGraph {
             incomplete_face_count,
         };
         self.global_face_transitions = transition_plans;
+        self.global_face_twin_transitions.clear();
         Ok(stats)
     }
 
     pub(crate) fn global_face_transitions(&self) -> &[PartitionBorderGlobalFaceTransitionPlan] {
         &self.global_face_transitions
+    }
+
+    /// Positions declared face-qualified twins in the ordered local face
+    /// cycles. A twin missing from an incomplete cycle is reported rather than
+    /// guessed; no global successor or face identity is assigned.
+    pub(crate) fn reconcile_global_face_twin_transitions(
+        &mut self,
+        execution_policy: &ExecutionPolicy,
+    ) -> crate::Result<PartitionBorderGlobalFaceTwinTransitionStats> {
+        execution_policy.check_cancelled("partition_border_global_face_twin_transitions")?;
+        execution_policy.check(
+            "partition_border_global_face_twin_transition_faces",
+            execution_policy.max_graph_nodes,
+            self.global_face_transitions.len(),
+        )?;
+        execution_policy.check(
+            "partition_border_global_face_twin_transition_edges",
+            execution_policy.max_graph_edges,
+            self.applied_face_twins.len(),
+        )?;
+
+        let mut positions =
+            BTreeMap::<PartitionBorderObservationId, (PartitionFaceRef, usize, bool)>::new();
+        let mut transition_count = 0usize;
+        for (plan_index, plan) in self.global_face_transitions.iter().enumerate() {
+            execution_policy.check_cancelled_every(
+                "partition_border_global_face_twin_transitions",
+                plan_index,
+            )?;
+            transition_count = transition_count
+                .checked_add(plan.boundary_observation_ids.len())
+                .ok_or_else(|| crate::PolygonizeError::InternalInvariantViolation {
+                    reason: "global face transition count overflow".to_string(),
+                })?;
+            for (cycle_index, observation_id) in
+                plan.boundary_observation_ids.iter().copied().enumerate()
+            {
+                let Some(observation) = self.observations.get(&observation_id) else {
+                    return Err(crate::PolygonizeError::InternalInvariantViolation {
+                        reason: format!(
+                            "global face transition observation {:?} is missing",
+                            observation_id
+                        ),
+                    });
+                };
+                if observation.observation_id() != observation_id
+                    || observation.face_ref != Some(plan.face_ref)
+                {
+                    return Err(crate::PolygonizeError::InternalInvariantViolation {
+                        reason: format!(
+                            "global face transition observation {:?} disagrees with face {:?}",
+                            observation_id, plan.face_ref
+                        ),
+                    });
+                }
+                if positions
+                    .insert(observation_id, (plan.face_ref, cycle_index, plan.closed))
+                    .is_some()
+                {
+                    return Err(crate::PolygonizeError::InternalInvariantViolation {
+                        reason: format!(
+                            "global face transition observation {:?} is duplicated",
+                            observation_id
+                        ),
+                    });
+                }
+            }
+        }
+
+        let mut links = BTreeSet::new();
+        let mut unmapped_twin_count = 0;
+        let mut mutation_ready_twin_count = 0;
+        for (twin_index, applied_twin) in self.applied_face_twins.iter().enumerate() {
+            execution_policy.check_cancelled_every(
+                "partition_border_global_face_twin_transitions",
+                twin_index,
+            )?;
+            let Some(&(forward_face_ref, forward_cycle_index, forward_cycle_closed)) =
+                positions.get(&applied_twin.twin.forward)
+            else {
+                unmapped_twin_count += 1;
+                continue;
+            };
+            let Some(&(reverse_face_ref, reverse_cycle_index, reverse_cycle_closed)) =
+                positions.get(&applied_twin.twin.reverse)
+            else {
+                unmapped_twin_count += 1;
+                continue;
+            };
+            if forward_face_ref != applied_twin.forward_face_ref
+                || reverse_face_ref != applied_twin.reverse_face_ref
+            {
+                return Err(crate::PolygonizeError::InternalInvariantViolation {
+                    reason: format!(
+                        "global face twin {:?} is positioned in the wrong face cycles",
+                        applied_twin.twin.edge_key
+                    ),
+                });
+            }
+            let link = PartitionBorderGlobalFaceTwinTransition {
+                edge_key: applied_twin.twin.edge_key,
+                forward_face_ref,
+                reverse_face_ref,
+                forward_observation_id: applied_twin.twin.forward,
+                reverse_observation_id: applied_twin.twin.reverse,
+                forward_cycle_index,
+                reverse_cycle_index,
+                forward_cycle_closed,
+                reverse_cycle_closed,
+            };
+            if !links.insert(link) {
+                return Err(crate::PolygonizeError::InternalInvariantViolation {
+                    reason: format!(
+                        "global face twin transition {:?} is duplicated",
+                        applied_twin.twin.edge_key
+                    ),
+                });
+            }
+            if forward_cycle_closed && reverse_cycle_closed {
+                mutation_ready_twin_count += 1;
+            }
+        }
+
+        let stats = PartitionBorderGlobalFaceTwinTransitionStats {
+            face_count: self.global_face_transitions.len(),
+            transition_count,
+            applied_twin_count: self.applied_face_twins.len(),
+            mapped_twin_count: links.len(),
+            unmapped_twin_count,
+            mutation_ready_twin_count,
+        };
+        self.global_face_twin_transitions = links.into_iter().collect();
+        Ok(stats)
+    }
+
+    pub(crate) fn global_face_twin_transitions(
+        &self,
+    ) -> &[PartitionBorderGlobalFaceTwinTransition] {
+        &self.global_face_twin_transitions
     }
 
     /// Merges source IDs and retains every distinct Z candidate for each
@@ -3297,6 +3471,95 @@ mod tests {
             error,
             crate::PolygonizeError::InternalInvariantViolation { ref reason }
                 if reason.contains("disagrees with its observation")
+        ));
+        assert_eq!(complete, before);
+    }
+
+    #[test]
+    fn global_face_twin_transitions_position_declared_twins_deterministically() {
+        let mut incomplete = exact_face_twin_graph_with_successors();
+        incomplete
+            .apply_unambiguous_face_twins(&ExecutionPolicy::default())
+            .unwrap();
+        incomplete
+            .reconcile_global_face_plans(&ExecutionPolicy::default())
+            .unwrap();
+        incomplete
+            .reconcile_global_face_transitions(&ExecutionPolicy::default())
+            .unwrap();
+        let stats = incomplete
+            .reconcile_global_face_twin_transitions(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(
+            stats,
+            PartitionBorderGlobalFaceTwinTransitionStats {
+                face_count: 2,
+                transition_count: 2,
+                applied_twin_count: 1,
+                mapped_twin_count: 1,
+                unmapped_twin_count: 0,
+                mutation_ready_twin_count: 0,
+            }
+        );
+        assert_eq!(incomplete.global_face_twin_transitions().len(), 1);
+
+        let mut complete = exact_face_twin_graph_with_successors();
+        let observation_ids = complete.observations.keys().copied().collect::<Vec<_>>();
+        for observation_id in observation_ids {
+            complete
+                .observations
+                .get_mut(&observation_id)
+                .expect("observation identity")
+                .local_face_boundary_successor = Some(observation_id);
+        }
+        complete
+            .apply_unambiguous_face_twins(&ExecutionPolicy::default())
+            .unwrap();
+        complete
+            .reconcile_global_face_plans(&ExecutionPolicy::default())
+            .unwrap();
+        complete
+            .reconcile_global_face_transitions(&ExecutionPolicy::default())
+            .unwrap();
+        let stats = complete
+            .reconcile_global_face_twin_transitions(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(stats.mutation_ready_twin_count, 1);
+
+        let mut reordered = PartitionBorderGraph::default();
+        for adjacency in complete.adjacencies.iter().copied() {
+            reordered.declare_adjacency(adjacency);
+        }
+        for observation in complete.observations.values().rev().cloned() {
+            reordered.insert(observation).unwrap();
+        }
+        reordered
+            .apply_unambiguous_face_twins(&ExecutionPolicy::default())
+            .unwrap();
+        reordered
+            .reconcile_global_face_plans(&ExecutionPolicy::default())
+            .unwrap();
+        reordered
+            .reconcile_global_face_transitions(&ExecutionPolicy::default())
+            .unwrap();
+        reordered
+            .reconcile_global_face_twin_transitions(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(
+            reordered.global_face_twin_transitions(),
+            complete.global_face_twin_transitions()
+        );
+
+        let reverse_id = complete.observations.keys().nth(1).copied().unwrap();
+        complete.global_face_transitions[0].boundary_observation_ids[0] = reverse_id;
+        let before = complete.clone();
+        let error = complete
+            .reconcile_global_face_twin_transitions(&ExecutionPolicy::default())
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::InternalInvariantViolation { ref reason }
+                if reason.contains("disagrees with face")
         ));
         assert_eq!(complete, before);
     }

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -299,6 +299,12 @@ pub struct StitchingReport {
     pub partition_border_global_face_transition_closed_count: usize,
     /// Face plans retained with incomplete transition evidence.
     pub partition_border_global_face_transition_incomplete_count: usize,
+    /// Declared face-qualified twins positioned in local transition cycles.
+    pub partition_border_global_face_twin_transition_count: usize,
+    /// Declared twins whose two local cycles are mutation-ready.
+    pub partition_border_global_face_twin_transition_ready_count: usize,
+    /// Declared twins not present in both local transition cycles.
+    pub partition_border_global_face_twin_transition_unmapped_count: usize,
     /// Exact twin pairs whose observations also carried valid qualified local
     /// face references and were retained as face-level links.
     pub partition_border_face_twin_count: usize,
@@ -2350,6 +2356,14 @@ impl<'a> TiledPolygonizer<'a> {
             partition_border_global_face_transition_plan.face_count,
             global_face_transition_plan_count
         );
+        let partition_border_global_face_twin_transition = partition_border_graph
+            .reconcile_global_face_twin_transitions(&self.execution_policy)?;
+        let global_face_twin_transition_count =
+            partition_border_graph.global_face_twin_transitions().len();
+        debug_assert_eq!(
+            partition_border_global_face_twin_transition.mapped_twin_count,
+            global_face_twin_transition_count
+        );
         if let Some(trace) = trace.as_deref_mut() {
             trace.record_partition_border_reconciliation(partition_border_reconciliation);
             trace.record_partition_border_twin_application(partition_border_twin_application);
@@ -2369,6 +2383,9 @@ impl<'a> TiledPolygonizer<'a> {
             );
             trace.record_partition_border_global_face_transition_plan(
                 partition_border_global_face_transition_plan,
+            );
+            trace.record_partition_border_global_face_twin_transitions(
+                partition_border_global_face_twin_transition,
             );
         }
         let unresolved = tile_reports.iter().any(Self::report_is_unresolved);
@@ -2637,6 +2654,12 @@ impl<'a> TiledPolygonizer<'a> {
                     partition_border_global_face_transition_plan.closed_face_count,
                 partition_border_global_face_transition_incomplete_count:
                     partition_border_global_face_transition_plan.incomplete_face_count,
+                partition_border_global_face_twin_transition_count:
+                    partition_border_global_face_twin_transition.mapped_twin_count,
+                partition_border_global_face_twin_transition_ready_count:
+                    partition_border_global_face_twin_transition.mutation_ready_twin_count,
+                partition_border_global_face_twin_transition_unmapped_count:
+                    partition_border_global_face_twin_transition.unmapped_twin_count,
                 partition_border_face_twin_count: applied_face_twin_count,
                 partition_border_face_twin_missing_face_count: partition_border_twin_application
                     .missing_face_ref_count,

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -264,6 +264,28 @@ mod tests {
                 .partition_border_global_face_transition_incomplete_count,
             transition_plan.iter().filter(|plan| !plan.closed).count()
         );
+        let twin_transition_plan = result.partition_border_graph.global_face_twin_transitions();
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_twin_transition_count,
+            twin_transition_plan.len()
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_twin_transition_ready_count,
+            twin_transition_plan
+                .iter()
+                .filter(|link| link.forward_cycle_closed && link.reverse_cycle_closed)
+                .count()
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_twin_transition_unmapped_count,
+            result.stitching_report.partition_border_face_twin_count - twin_transition_plan.len()
+        );
         assert_eq!(result.polygons.len(), 2);
     }
 
@@ -694,6 +716,68 @@ mod tests {
                     .result
                     .stitching_report
                     .partition_border_global_face_transition_incomplete_count
+                    as u64
+            )
+        );
+        let global_face_twin_transition = traced
+            .trace
+            .events
+            .iter()
+            .find(|event| event.kind == "partition_border_global_face_twin_transitions")
+            .expect("global face twin transition evidence");
+        assert_eq!(
+            global_face_twin_transition.payload["face_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_plan_count as u64
+            )
+        );
+        assert_eq!(
+            global_face_twin_transition.payload["transition_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_transition_count as u64
+            )
+        );
+        assert_eq!(
+            global_face_twin_transition.payload["applied_twin_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_face_twin_count as u64
+            )
+        );
+        assert_eq!(
+            global_face_twin_transition.payload["mapped_twin_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_twin_transition_count as u64
+            )
+        );
+        assert_eq!(
+            global_face_twin_transition.payload["unmapped_twin_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_twin_transition_unmapped_count
+                    as u64
+            )
+        );
+        assert_eq!(
+            global_face_twin_transition.payload["mutation_ready_twin_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_twin_transition_ready_count
                     as u64
             )
         );

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -4,9 +4,9 @@ use crate::fingerprint::{coordinate_fingerprint, float_bits};
 use crate::graph::partition_border::{
     PartitionBorderGlobalComponentReconciliationStats, PartitionBorderGlobalFaceMutationGateStats,
     PartitionBorderGlobalFacePlanStats, PartitionBorderGlobalFacePlanValidationStats,
-    PartitionBorderGlobalFaceTransitionPlanStats, PartitionBorderHalfEdge,
-    PartitionBorderNodeReconciliationStats, PartitionBorderReconciliationStats,
-    PartitionBorderTwinApplicationStats,
+    PartitionBorderGlobalFaceTransitionPlanStats, PartitionBorderGlobalFaceTwinTransitionStats,
+    PartitionBorderHalfEdge, PartitionBorderNodeReconciliationStats,
+    PartitionBorderReconciliationStats, PartitionBorderTwinApplicationStats,
 };
 use crate::graph::planar_graph::PartitionBoundaryNodingStats;
 use crate::graph::{ExtractedRing, PlanarGraph};
@@ -723,6 +723,24 @@ impl TraceRecorderV1 {
                 "missing_boundary_successor_count": stats.missing_boundary_successor_count,
                 "closed_face_count": stats.closed_face_count,
                 "incomplete_face_count": stats.incomplete_face_count,
+            }),
+        )
+    }
+
+    pub(crate) fn record_partition_border_global_face_twin_transitions(
+        &mut self,
+        stats: PartitionBorderGlobalFaceTwinTransitionStats,
+    ) -> bool {
+        self.record(
+            TraceStageV1::Graph,
+            "partition_border_global_face_twin_transitions",
+            serde_json::json!({
+                "face_count": stats.face_count,
+                "transition_count": stats.transition_count,
+                "applied_twin_count": stats.applied_twin_count,
+                "mapped_twin_count": stats.mapped_twin_count,
+                "unmapped_twin_count": stats.unmapped_twin_count,
+                "mutation_ready_twin_count": stats.mutation_ready_twin_count,
             }),
         )
     }


### PR DESCRIPTION
Stack

- Parent: #1324 (`agent/p5-global-face-transition-equivalence`, `32b36ff`)
- Children: none at creation

Delivered

- Positioned every declared face-qualified twin that is present in the ordered local transition plans.
- Retained deterministic edge/face/observation identities and cycle indices for a future global walk.
- Reported mapped, unmapped, and mutation-ready twin counts without guessing missing incomplete-cycle transitions.
- Added deterministic insertion-order, corruption, tiled report, and bounded trace regressions.
- Updated `ROADMAP.md` for cross-partition transition-position evidence.

Contract impact

- No public output or binding contract changes.
- No local/global `next` links, global face IDs, tiled polygons, provenance, Z decisions, or fallback behavior are mutated.
- Missing twin positions remain explicit evidence and cannot authorize global stitching.
- Cross-face identity corruption fails closed before the map is committed.

Validation

- `cargo fmt --all -- --check`
- `cargo test -p geo-polygonize-core global_face --lib` — 8 passed
- `cargo test -p geo-polygonize-core exports_physical_tile_border --lib` — passed
- `cargo test -p geo-polygonize-core trace_records_partition_boundary_noding_and_atomic_observations --lib` — passed
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings` — passed
- `DYLD_LIBRARY_PATH=/Library/Frameworks/Python.framework/Versions/3.11/lib cargo test --workspace --lib --tests --no-fail-fast` — passed across all workspace unit and integration targets
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `cargo check --workspace --all-targets --no-default-features` — passed
- `git diff --check` — passed
- Generated binding changes were restored after the workspace test checkpoint.

Agent handoff

- Parent: #1324 (`agent/p5-global-face-transition-equivalence`)
- Children: none
- Next branch: `agent/p5-global-face-global-walk-invariants`
- Remaining risks: actual cross-partition global `next`/face assignment, exactly-one global unbounded-face proof, global cycle/source/Euler/face-walk validation, stitched extraction, untiled equivalence, differential fuzzing, and promotion evidence remain open.