### PR TITLE
feat(core): gate global unbounded face proof

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -480,6 +480,9 @@ Blocked by #1288.
   payload/source/Z lineage, and face-adjacency connectivity as evidence;
   preserve incomplete cycles and local-unbounded multiplicity without claiming
   global face IDs or a planar Euler proof.
+- [x] Add a conservative exactly-one-local-marker unbounded-face proof gate;
+  report closed-cycle and twin-readiness requirements, and reject multiple local
+  unbounded markers rather than guessing their global identity.
 - [ ] Apply unambiguous twins only across declared adjacent borders.
 - [ ] Reconcile canonical border nodes, source sets, representative IDs, and
   selected Z-policy decisions.

--- a/crates/geo-polygonize-core/src/graph/partition_border.rs
+++ b/crates/geo-polygonize-core/src/graph/partition_border.rs
@@ -717,6 +717,23 @@ pub(crate) struct PartitionBorderGlobalFaceWalkInvariantStats {
     pub(crate) face_adjacency_cycle_rank: usize,
 }
 
+/// Evidence for the conservative single-marker global-unbounded-face proof
+/// gate. A `proof_ready` result is intentionally narrower than the full
+/// global face-identification problem: multiple local unbounded markers remain
+/// unresolved rather than being merged by assumption.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct PartitionBorderGlobalUnboundedFaceProofStats {
+    pub(crate) face_count: usize,
+    pub(crate) local_unbounded_face_count: usize,
+    pub(crate) unbounded_component_count: usize,
+    pub(crate) closed_unbounded_face_count: usize,
+    pub(crate) unbounded_face_twin_count: usize,
+    pub(crate) unbounded_face_unmapped_twin_count: usize,
+    pub(crate) unbounded_face_not_ready_twin_count: usize,
+    pub(crate) candidate_count: usize,
+    pub(crate) proof_ready: bool,
+}
+
 /// Deterministic evidence for the declared-adjacency twin boundary.
 ///
 /// Only observations covered by a declared partition adjacency contribute to
@@ -2730,6 +2747,91 @@ impl PartitionBorderGraph {
         })
     }
 
+    /// Applies a conservative proof boundary to local-unbounded evidence.
+    /// Exactly one local unbounded marker is a candidate only when every face
+    /// cycle is closed, every border twin is mapped, and every unbounded-face
+    /// twin is mutation-ready. Multiple local markers, including markers that
+    /// share one retained connected component, remain unresolved evidence.
+    #[cfg(test)]
+    pub(crate) fn validate_global_unbounded_face_proof(
+        &self,
+        execution_policy: &ExecutionPolicy,
+    ) -> crate::Result<PartitionBorderGlobalUnboundedFaceProofStats> {
+        execution_policy.check_cancelled("partition_border_global_unbounded_face_proof")?;
+        let walk = self.validate_global_face_walk_invariants(execution_policy)?;
+        self.validate_global_unbounded_face_proof_with_walk(execution_policy, walk)
+    }
+
+    pub(crate) fn validate_global_unbounded_face_proof_with_walk(
+        &self,
+        execution_policy: &ExecutionPolicy,
+        walk: PartitionBorderGlobalFaceWalkInvariantStats,
+    ) -> crate::Result<PartitionBorderGlobalUnboundedFaceProofStats> {
+        execution_policy.check_cancelled("partition_border_global_unbounded_face_proof")?;
+        let unbounded_faces = self
+            .global_face_plans
+            .iter()
+            .filter(|plan| plan.local_face_is_unbounded)
+            .map(|plan| plan.face_ref)
+            .collect::<BTreeSet<_>>();
+        let local_unbounded_face_count = unbounded_faces.len();
+        let closed_unbounded_face_count = self
+            .global_face_transitions
+            .iter()
+            .filter(|transition| transition.local_face_is_unbounded && transition.closed)
+            .count();
+        let mapped_twin_links = self
+            .global_face_twin_transitions
+            .iter()
+            .map(|link| (link.edge_key, link))
+            .collect::<BTreeMap<_, _>>();
+        let mut unbounded_face_twin_count = 0usize;
+        let mut unbounded_face_unmapped_twin_count = 0usize;
+        let mut unbounded_face_not_ready_twin_count = 0usize;
+        for (twin_index, twin) in self.applied_face_twins.iter().enumerate() {
+            execution_policy.check_cancelled_every(
+                "partition_border_global_unbounded_face_proof_twins",
+                twin_index,
+            )?;
+            if !unbounded_faces.contains(&twin.forward_face_ref)
+                && !unbounded_faces.contains(&twin.reverse_face_ref)
+            {
+                continue;
+            }
+            unbounded_face_twin_count += 1;
+            let Some(link) = mapped_twin_links.get(&twin.twin.edge_key) else {
+                unbounded_face_unmapped_twin_count += 1;
+                continue;
+            };
+            if !(link.forward_cycle_closed && link.reverse_cycle_closed) {
+                unbounded_face_not_ready_twin_count += 1;
+            }
+        }
+        let candidate_count = usize::from(local_unbounded_face_count == 1);
+        let proof_ready = candidate_count == 1
+            && walk.face_count > 0
+            && walk.closed_face_count == walk.face_count
+            && closed_unbounded_face_count == 1
+            && walk.unbounded_component_count == 1
+            && walk.unmapped_twin_count == 0
+            && walk.source_complete_twin_count == walk.applied_twin_count
+            && unbounded_face_unmapped_twin_count == 0
+            && unbounded_face_not_ready_twin_count == 0;
+        debug_assert!(unbounded_face_unmapped_twin_count == 0 || !proof_ready);
+
+        Ok(PartitionBorderGlobalUnboundedFaceProofStats {
+            face_count: walk.face_count,
+            local_unbounded_face_count,
+            unbounded_component_count: walk.unbounded_component_count,
+            closed_unbounded_face_count,
+            unbounded_face_twin_count,
+            unbounded_face_unmapped_twin_count,
+            unbounded_face_not_ready_twin_count,
+            candidate_count,
+            proof_ready,
+        })
+    }
+
     /// Merges source IDs and retains every distinct Z candidate for each
     /// canonical endpoint. No Z conflict policy is applied here.
     pub fn reconcile_twin_payloads(&self) -> Vec<PartitionBorderTwinPayload> {
@@ -2930,10 +3032,10 @@ mod tests {
         graph
     }
 
-    fn prepared_global_face_walk_graph(closed: bool, unbounded: bool) -> PartitionBorderGraph {
+    fn prepared_global_face_walk_graph(closed: bool, unbounded: [bool; 2]) -> PartitionBorderGraph {
         let mut graph = exact_face_twin_graph_with_successors();
-        for observation in graph.observations.values_mut() {
-            observation.local_face_is_unbounded = unbounded;
+        for (observation_index, observation) in graph.observations.values_mut().enumerate() {
+            observation.local_face_is_unbounded = unbounded[observation_index];
             if closed {
                 observation.local_face_boundary_successor = Some(observation.observation_id());
             }
@@ -4232,7 +4334,7 @@ mod tests {
 
     #[test]
     fn global_face_walk_invariants_validate_cycles_payload_and_connectivity() {
-        let graph = prepared_global_face_walk_graph(true, false);
+        let graph = prepared_global_face_walk_graph(true, [false, false]);
         let before = graph.clone();
         let stats = graph
             .validate_global_face_walk_invariants(&ExecutionPolicy::default())
@@ -4256,7 +4358,7 @@ mod tests {
         );
         assert_eq!(graph, before);
 
-        let incomplete = prepared_global_face_walk_graph(false, false);
+        let incomplete = prepared_global_face_walk_graph(false, [false, false]);
         let stats = incomplete
             .validate_global_face_walk_invariants(&ExecutionPolicy::default())
             .unwrap();
@@ -4265,7 +4367,7 @@ mod tests {
         assert_eq!(stats.mapped_twin_count, 1);
         assert_eq!(stats.source_complete_twin_count, 1);
 
-        let unbounded = prepared_global_face_walk_graph(true, true);
+        let unbounded = prepared_global_face_walk_graph(true, [true, true]);
         let stats = unbounded
             .validate_global_face_walk_invariants(&ExecutionPolicy::default())
             .unwrap();
@@ -4275,7 +4377,7 @@ mod tests {
 
     #[test]
     fn global_face_walk_invariants_fail_closed_on_cycle_payload_and_limits() {
-        let mut cycle_corruption = prepared_global_face_walk_graph(true, false);
+        let mut cycle_corruption = prepared_global_face_walk_graph(true, [false, false]);
         let reverse_id = cycle_corruption
             .observations
             .keys()
@@ -4294,7 +4396,7 @@ mod tests {
         ));
         assert_eq!(cycle_corruption, before);
 
-        let mut payload_corruption = prepared_global_face_walk_graph(true, false);
+        let mut payload_corruption = prepared_global_face_walk_graph(true, [false, false]);
         payload_corruption.applied_face_twins[0]
             .payload
             .source_line_ids
@@ -4310,7 +4412,7 @@ mod tests {
         ));
         assert_eq!(payload_corruption, before);
 
-        let limited = prepared_global_face_walk_graph(true, false);
+        let limited = prepared_global_face_walk_graph(true, [false, false]);
         let error = limited
             .validate_global_face_walk_invariants(&ExecutionPolicy {
                 max_graph_nodes: Some(1),
@@ -4328,7 +4430,7 @@ mod tests {
 
         let token = CancellationToken::new();
         token.cancel();
-        let cancelled = prepared_global_face_walk_graph(true, false)
+        let cancelled = prepared_global_face_walk_graph(true, [false, false])
             .validate_global_face_walk_invariants(&ExecutionPolicy {
                 cancellation_token: Some(token),
                 ..Default::default()
@@ -4339,6 +4441,45 @@ mod tests {
             crate::PolygonizeError::Cancelled { ref stage }
                 if stage == "partition_border_global_face_walk_invariants"
         ));
+    }
+
+    #[test]
+    fn global_unbounded_face_proof_is_conservative_about_marker_multiplicity() {
+        let single = prepared_global_face_walk_graph(true, [true, false]);
+        assert_eq!(
+            single
+                .validate_global_unbounded_face_proof(&ExecutionPolicy::default())
+                .unwrap(),
+            PartitionBorderGlobalUnboundedFaceProofStats {
+                face_count: 2,
+                local_unbounded_face_count: 1,
+                unbounded_component_count: 1,
+                closed_unbounded_face_count: 1,
+                unbounded_face_twin_count: 1,
+                unbounded_face_unmapped_twin_count: 0,
+                unbounded_face_not_ready_twin_count: 0,
+                candidate_count: 1,
+                proof_ready: true,
+            }
+        );
+
+        let multiple = prepared_global_face_walk_graph(true, [true, true]);
+        let stats = multiple
+            .validate_global_unbounded_face_proof(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(stats.local_unbounded_face_count, 2);
+        assert_eq!(stats.unbounded_component_count, 1);
+        assert_eq!(stats.candidate_count, 0);
+        assert!(!stats.proof_ready);
+
+        let incomplete = prepared_global_face_walk_graph(false, [true, false]);
+        let stats = incomplete
+            .validate_global_unbounded_face_proof(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(stats.candidate_count, 1);
+        assert_eq!(stats.closed_unbounded_face_count, 0);
+        assert_eq!(stats.unbounded_face_not_ready_twin_count, 1);
+        assert!(!stats.proof_ready);
     }
 
     #[test]

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -315,6 +315,16 @@ pub struct StitchingReport {
     pub partition_border_global_face_walk_unbounded_component_count: usize,
     /// Cycle rank of the retained face/twin connectivity graph, not planar Euler.
     pub partition_border_global_face_walk_face_adjacency_cycle_rank: usize,
+    /// Conservative exactly-one-local-marker unbounded-face candidates.
+    pub partition_border_global_unbounded_face_proof_candidate_count: usize,
+    /// Whether the conservative unbounded-face proof gate is ready.
+    pub partition_border_global_unbounded_face_proof_ready: bool,
+    /// Unbounded-face candidates whose local cycles are closed.
+    pub partition_border_global_unbounded_face_proof_closed_count: usize,
+    /// Unbounded-face twins absent from the retained twin-position map.
+    pub partition_border_global_unbounded_face_proof_unmapped_twin_count: usize,
+    /// Unbounded-face twins whose opposite local cycle is incomplete.
+    pub partition_border_global_unbounded_face_proof_not_ready_twin_count: usize,
     /// Exact twin pairs whose observations also carried valid qualified local
     /// face references and were retained as face-level links.
     pub partition_border_face_twin_count: usize,
@@ -2384,6 +2394,11 @@ impl<'a> TiledPolygonizer<'a> {
             partition_border_global_face_walk_invariants.mapped_twin_count,
             global_face_twin_transition_count
         );
+        let partition_border_global_unbounded_face_proof = partition_border_graph
+            .validate_global_unbounded_face_proof_with_walk(
+                &self.execution_policy,
+                partition_border_global_face_walk_invariants,
+            )?;
         if let Some(trace) = trace.as_deref_mut() {
             trace.record_partition_border_reconciliation(partition_border_reconciliation);
             trace.record_partition_border_twin_application(partition_border_twin_application);
@@ -2409,6 +2424,9 @@ impl<'a> TiledPolygonizer<'a> {
             );
             trace.record_partition_border_global_face_walk_invariants(
                 partition_border_global_face_walk_invariants,
+            );
+            trace.record_partition_border_global_unbounded_face_proof(
+                partition_border_global_unbounded_face_proof,
             );
         }
         let unresolved = tile_reports.iter().any(Self::report_is_unresolved);
@@ -2693,6 +2711,16 @@ impl<'a> TiledPolygonizer<'a> {
                     partition_border_global_face_walk_invariants.unbounded_component_count,
                 partition_border_global_face_walk_face_adjacency_cycle_rank:
                     partition_border_global_face_walk_invariants.face_adjacency_cycle_rank,
+                partition_border_global_unbounded_face_proof_candidate_count:
+                    partition_border_global_unbounded_face_proof.candidate_count,
+                partition_border_global_unbounded_face_proof_ready:
+                    partition_border_global_unbounded_face_proof.proof_ready,
+                partition_border_global_unbounded_face_proof_closed_count:
+                    partition_border_global_unbounded_face_proof.closed_unbounded_face_count,
+                partition_border_global_unbounded_face_proof_unmapped_twin_count:
+                    partition_border_global_unbounded_face_proof.unbounded_face_unmapped_twin_count,
+                partition_border_global_unbounded_face_proof_not_ready_twin_count:
+                    partition_border_global_unbounded_face_proof.unbounded_face_not_ready_twin_count,
                 partition_border_face_twin_count: applied_face_twin_count,
                 partition_border_face_twin_missing_face_count: partition_border_twin_application
                     .missing_face_ref_count,

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -320,6 +320,40 @@ mod tests {
                 .partition_border_global_face_walk_face_adjacency_cycle_rank,
             face_walk.face_adjacency_cycle_rank
         );
+        let unbounded_proof = result
+            .partition_border_graph
+            .validate_global_unbounded_face_proof(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_unbounded_face_proof_candidate_count,
+            unbounded_proof.candidate_count
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_unbounded_face_proof_ready,
+            unbounded_proof.proof_ready
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_unbounded_face_proof_closed_count,
+            unbounded_proof.closed_unbounded_face_count
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_unbounded_face_proof_unmapped_twin_count,
+            unbounded_proof.unbounded_face_unmapped_twin_count
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_unbounded_face_proof_not_ready_twin_count,
+            unbounded_proof.unbounded_face_not_ready_twin_count
+        );
         assert_eq!(result.polygons.len(), 2);
     }
 
@@ -866,6 +900,61 @@ mod tests {
                     .result
                     .stitching_report
                     .partition_border_global_face_walk_face_adjacency_cycle_rank
+                    as u64
+            )
+        );
+        let unbounded_proof = traced
+            .trace
+            .events
+            .iter()
+            .find(|event| event.kind == "partition_border_global_unbounded_face_proof")
+            .expect("global unbounded face proof evidence");
+        assert_eq!(
+            unbounded_proof.payload["candidate_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_unbounded_face_proof_candidate_count
+                    as u64
+            )
+        );
+        assert_eq!(
+            unbounded_proof.payload["proof_ready"].as_bool(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_unbounded_face_proof_ready
+            )
+        );
+        assert_eq!(
+            unbounded_proof.payload["closed_unbounded_face_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_unbounded_face_proof_closed_count
+                    as u64
+            )
+        );
+        assert_eq!(
+            unbounded_proof.payload["unbounded_face_unmapped_twin_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_unbounded_face_proof_unmapped_twin_count
+                    as u64
+            )
+        );
+        assert_eq!(
+            unbounded_proof.payload["unbounded_face_not_ready_twin_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_unbounded_face_proof_not_ready_twin_count
                     as u64
             )
         );

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -5,9 +5,9 @@ use crate::graph::partition_border::{
     PartitionBorderGlobalComponentReconciliationStats, PartitionBorderGlobalFaceMutationGateStats,
     PartitionBorderGlobalFacePlanStats, PartitionBorderGlobalFacePlanValidationStats,
     PartitionBorderGlobalFaceTransitionPlanStats, PartitionBorderGlobalFaceTwinTransitionStats,
-    PartitionBorderGlobalFaceWalkInvariantStats, PartitionBorderHalfEdge,
-    PartitionBorderNodeReconciliationStats, PartitionBorderReconciliationStats,
-    PartitionBorderTwinApplicationStats,
+    PartitionBorderGlobalFaceWalkInvariantStats, PartitionBorderGlobalUnboundedFaceProofStats,
+    PartitionBorderHalfEdge, PartitionBorderNodeReconciliationStats,
+    PartitionBorderReconciliationStats, PartitionBorderTwinApplicationStats,
 };
 use crate::graph::planar_graph::PartitionBoundaryNodingStats;
 use crate::graph::{ExtractedRing, PlanarGraph};
@@ -766,6 +766,27 @@ impl TraceRecorderV1 {
                 "unbounded_component_count": stats.unbounded_component_count,
                 "source_complete_twin_count": stats.source_complete_twin_count,
                 "face_adjacency_cycle_rank": stats.face_adjacency_cycle_rank,
+            }),
+        )
+    }
+
+    pub(crate) fn record_partition_border_global_unbounded_face_proof(
+        &mut self,
+        stats: PartitionBorderGlobalUnboundedFaceProofStats,
+    ) -> bool {
+        self.record(
+            TraceStageV1::Graph,
+            "partition_border_global_unbounded_face_proof",
+            serde_json::json!({
+                "face_count": stats.face_count,
+                "local_unbounded_face_count": stats.local_unbounded_face_count,
+                "unbounded_component_count": stats.unbounded_component_count,
+                "closed_unbounded_face_count": stats.closed_unbounded_face_count,
+                "unbounded_face_twin_count": stats.unbounded_face_twin_count,
+                "unbounded_face_unmapped_twin_count": stats.unbounded_face_unmapped_twin_count,
+                "unbounded_face_not_ready_twin_count": stats.unbounded_face_not_ready_twin_count,
+                "candidate_count": stats.candidate_count,
+                "proof_ready": stats.proof_ready,
             }),
         )
     }


### PR DESCRIPTION
Stack

- Parent: #1326 (`agent/p5-global-face-global-walk-invariants`, `ac31b20`)
- Children: #1329 (`agent/p5-global-face-payload-merge`, `da11c4e`)

Delivered

- Added a conservative exactly-one-local-marker global-unbounded-face proof gate.
- Required every retained face cycle to be closed, every border twin to be mapped, and every source/twin payload to remain complete before `proof_ready` can be true.
- Reported local-unbounded marker count, connected-component multiplicity, closed candidates, unready/unmapped boundary twins, and candidate/proof status.
- Added single-marker-ready, multiple-marker-rejected, incomplete-cycle, tiled report, and bounded trace regressions.
- Reused already-validated walk stats in the tiled path to avoid a second full invariant traversal.
- Updated `ROADMAP.md` without marking the broad global-unbounded-face item complete.

Contract impact

- No global `next` links, global face IDs, stitched polygons, provenance output, Z decisions, or fallback behavior are mutated.
- No geometry or binding output contract changes; additive evidence fields were added to `StitchingReport` and a bounded trace event.
- A single local marker is only a conservative candidate; multiple local markers remain unresolved even when they share one retained component.
- `proof_ready` is not exposed as permission to select stitched output or replace untiled fallback.
- Incomplete or unmapped twin evidence fails the proof gate without guessing a global face identity.

Validation

- `cargo test -p geo-polygonize-core global_unbounded_face --lib` — passed
- `cargo test -p geo-polygonize-core global_face --lib` — 10 passed
- `cargo test -p geo-polygonize-core exports_physical_tile_border --lib` — passed
- `cargo test -p geo-polygonize-core trace_records_partition_boundary_noding_and_atomic_observations --lib` — passed
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings` — passed
- `DYLD_LIBRARY_PATH=/Library/Frameworks/Python.framework/Versions/3.11/lib cargo test --workspace --lib --tests --no-fail-fast` — 333 core unit tests and all workspace integration targets passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `cargo check --workspace --all-targets --no-default-features` — passed
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed
- Generated binding changes were restored after the workspace checkpoint.

Agent handoff

- Parent: #1326 (`agent/p5-global-face-global-walk-invariants`)
- Children: #1329 (`agent/p5-global-face-payload-merge`)
- Next branch: `agent/p5-global-face-euler-witness`
- Remaining risks: actual global topology mutation, canonical border-node writes, deterministic global face IDs, multi-marker global-unbounded proof, planar Euler validation, stitched extraction, untiled equivalence, differential fuzzing, and promotion evidence remain open.
