### PR TITLE
feat(core): witness global face Euler boundary

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -486,6 +486,10 @@ Blocked by #1288.
 - [x] Retain deterministic component-level border payload merges for source IDs,
   representative IDs, endpoint Z candidates, selected Z policy, and conflict
   counts without writing global nodes or face payloads.
+- [x] Retain a deterministic border-only Euler witness over unique boundary
+  vertices, edges, closed cycles, and component arithmetic; keep it diagnostic
+  and explicitly do not treat it as a planar Euler proof for the incomplete
+  global arrangement.
 - [ ] Apply unambiguous twins only across declared adjacent borders.
 - [ ] Reconcile canonical border nodes, source sets, representative IDs, and
   selected Z-policy decisions.

--- a/crates/geo-polygonize-core/src/graph/partition_border.rs
+++ b/crates/geo-polygonize-core/src/graph/partition_border.rs
@@ -762,6 +762,25 @@ pub(crate) struct PartitionBorderGlobalUnboundedFaceProofStats {
     pub(crate) proof_ready: bool,
 }
 
+/// Counts from an Euler witness over retained partition-border evidence.
+///
+/// The witness deliberately names its measurements as boundary-only values:
+/// the exported graph does not yet contain the complete interior arrangement,
+/// so `boundary_euler_consistent` is diagnostic evidence and is not a planar
+/// Euler proof or permission to assign global face IDs.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct PartitionBorderGlobalFaceEulerWitnessStats {
+    pub(crate) component_count: usize,
+    pub(crate) transition_face_count: usize,
+    pub(crate) closed_boundary_cycle_count: usize,
+    pub(crate) boundary_vertex_count: usize,
+    pub(crate) boundary_edge_count: usize,
+    pub(crate) cross_component_edge_count: usize,
+    pub(crate) boundary_euler_lhs: i64,
+    pub(crate) boundary_euler_rhs: i64,
+    pub(crate) boundary_euler_consistent: bool,
+}
+
 /// Deterministic evidence for the declared-adjacency twin boundary.
 ///
 /// Only observations covered by a declared partition adjacency contribute to
@@ -2965,6 +2984,231 @@ impl PartitionBorderGraph {
         })
     }
 
+    /// Builds a deterministic Euler witness from the retained border cycles.
+    ///
+    /// This intentionally does not claim planar completeness: each measured
+    /// vertex and edge is still limited to exported partition-border evidence.
+    /// A mismatch remains a diagnostic boundary, while a match does not permit
+    /// global topology mutation or face identity assignment.
+    #[cfg(test)]
+    pub(crate) fn validate_global_face_euler_witness(
+        &self,
+        execution_policy: &ExecutionPolicy,
+    ) -> crate::Result<PartitionBorderGlobalFaceEulerWitnessStats> {
+        execution_policy.check_cancelled("partition_border_global_face_euler_witness")?;
+        let walk = self.validate_global_face_walk_invariants(execution_policy)?;
+        self.validate_global_face_euler_witness_with_walk(execution_policy, walk)
+    }
+
+    pub(crate) fn validate_global_face_euler_witness_with_walk(
+        &self,
+        execution_policy: &ExecutionPolicy,
+        walk: PartitionBorderGlobalFaceWalkInvariantStats,
+    ) -> crate::Result<PartitionBorderGlobalFaceEulerWitnessStats> {
+        execution_policy.check_cancelled("partition_border_global_face_euler_witness")?;
+        execution_policy.check(
+            "partition_border_global_face_euler_witness_faces",
+            execution_policy.max_graph_nodes,
+            self.global_face_transitions.len(),
+        )?;
+        let transition_edge_count = self
+            .global_face_transitions
+            .iter()
+            .try_fold(0usize, |count, transition| {
+                count.checked_add(transition.boundary_observation_ids.len())
+            })
+            .ok_or_else(|| crate::PolygonizeError::InternalInvariantViolation {
+                reason: "global face Euler witness transition count overflow".to_string(),
+            })?;
+        execution_policy.check(
+            "partition_border_global_face_euler_witness_edges",
+            execution_policy.max_graph_edges,
+            transition_edge_count,
+        )?;
+        execution_policy.check(
+            "partition_border_global_face_euler_witness_nodes",
+            execution_policy.max_graph_nodes,
+            self.reconciled_nodes.len(),
+        )?;
+        if walk.face_count != self.global_face_transitions.len()
+            || walk.transition_count != transition_edge_count
+        {
+            return Err(crate::PolygonizeError::InternalInvariantViolation {
+                reason: format!(
+                    "global face Euler witness walk mismatch: faces={}, transitions={}, walk_faces={}, walk_transitions={}",
+                    self.global_face_transitions.len(),
+                    transition_edge_count,
+                    walk.face_count,
+                    walk.transition_count
+                ),
+            });
+        }
+
+        let mut component_by_face = BTreeMap::<PartitionFaceRef, usize>::new();
+        for (component_position, component) in self.global_components.iter().enumerate() {
+            execution_policy.check_cancelled_every(
+                "partition_border_global_face_euler_witness_components",
+                component_position,
+            )?;
+            for face_ref in &component.face_refs {
+                if component_by_face
+                    .insert(*face_ref, component_position)
+                    .is_some()
+                {
+                    return Err(crate::PolygonizeError::InternalInvariantViolation {
+                        reason: format!(
+                            "global face Euler witness face {:?} belongs to multiple components",
+                            face_ref
+                        ),
+                    });
+                }
+            }
+        }
+
+        let mut node_keys = BTreeSet::new();
+        for (node_index, node) in self.reconciled_nodes.iter().enumerate() {
+            execution_policy.check_cancelled_every(
+                "partition_border_global_face_euler_witness_nodes",
+                node_index,
+            )?;
+            if !node_keys.insert(node.key) {
+                return Err(crate::PolygonizeError::InternalInvariantViolation {
+                    reason: format!(
+                        "global face Euler witness reconciled node {:?} is duplicated",
+                        node.key
+                    ),
+                });
+            }
+        }
+
+        let mut boundary_vertices = BTreeSet::new();
+        let mut boundary_edges = BTreeSet::new();
+        let mut edge_component = BTreeMap::<PartitionBorderEdgeKey, usize>::new();
+        let mut cross_component_edges = BTreeSet::new();
+        let mut closed_boundary_cycle_count = 0usize;
+        for (transition_index, transition) in self.global_face_transitions.iter().enumerate() {
+            execution_policy.check_cancelled_every(
+                "partition_border_global_face_euler_witness",
+                transition_index,
+            )?;
+            let Some(&component_index) = component_by_face.get(&transition.face_ref) else {
+                return Err(crate::PolygonizeError::InternalInvariantViolation {
+                    reason: format!(
+                        "global face Euler witness transition {:?} has no component",
+                        transition.face_ref
+                    ),
+                });
+            };
+            if transition.closed {
+                closed_boundary_cycle_count = closed_boundary_cycle_count
+                    .checked_add(1)
+                    .ok_or_else(|| crate::PolygonizeError::InternalInvariantViolation {
+                        reason: "global face Euler witness cycle count overflow".to_string(),
+                    })?;
+            }
+            let component = &self.global_components[component_index];
+            for (observation_index, observation_id) in transition
+                .boundary_observation_ids
+                .iter()
+                .copied()
+                .enumerate()
+            {
+                execution_policy.check_cancelled_every(
+                    "partition_border_global_face_euler_witness_edges",
+                    observation_index,
+                )?;
+                let Some(observation) = self.observations.get(&observation_id) else {
+                    return Err(crate::PolygonizeError::InternalInvariantViolation {
+                        reason: format!(
+                            "global face Euler witness observation {:?} is missing",
+                            observation_id
+                        ),
+                    });
+                };
+                if observation.face_ref != Some(transition.face_ref) {
+                    return Err(crate::PolygonizeError::InternalInvariantViolation {
+                        reason: format!(
+                            "global face Euler witness observation {:?} crosses face {:?}",
+                            observation_id, transition.face_ref
+                        ),
+                    });
+                }
+                if !node_keys.contains(&observation.from) || !node_keys.contains(&observation.to) {
+                    return Err(crate::PolygonizeError::InternalInvariantViolation {
+                        reason: format!(
+                            "global face Euler witness observation {:?} has unreconciled endpoints",
+                            observation_id
+                        ),
+                    });
+                }
+                if !component.border_node_keys.contains(&observation.from)
+                    || !component.border_node_keys.contains(&observation.to)
+                {
+                    return Err(crate::PolygonizeError::InternalInvariantViolation {
+                        reason: format!(
+                            "global face Euler witness observation {:?} leaves component {}",
+                            observation_id, component_index
+                        ),
+                    });
+                }
+                if let Some(previous_component) =
+                    edge_component.insert(observation.edge_key, component_index)
+                {
+                    if previous_component != component_index {
+                        cross_component_edges.insert(observation.edge_key);
+                    }
+                }
+                boundary_edges.insert(observation.edge_key);
+                boundary_vertices.insert(observation.from);
+                boundary_vertices.insert(observation.to);
+            }
+        }
+        if closed_boundary_cycle_count != walk.closed_face_count {
+            return Err(crate::PolygonizeError::InternalInvariantViolation {
+                reason: format!(
+                    "global face Euler witness closed-cycle mismatch: cycles={}, walk={}",
+                    closed_boundary_cycle_count, walk.closed_face_count
+                ),
+            });
+        }
+
+        let boundary_vertex_count = boundary_vertices.len();
+        let boundary_edge_count = boundary_edges.len();
+        let cross_component_edge_count = cross_component_edges.len();
+        let to_i64 = |label: &str, value: usize| {
+            i64::try_from(value).map_err(|_| crate::PolygonizeError::InternalInvariantViolation {
+                reason: format!("global face Euler witness {label} count overflows i64"),
+            })
+        };
+        let boundary_vertex_count_i64 = to_i64("vertex", boundary_vertex_count)?;
+        let boundary_edge_count_i64 = to_i64("edge", boundary_edge_count)?;
+        let closed_boundary_cycle_count_i64 = to_i64("cycle", closed_boundary_cycle_count)?;
+        let boundary_euler_lhs = boundary_vertex_count_i64
+            .checked_sub(boundary_edge_count_i64)
+            .and_then(|value| value.checked_add(closed_boundary_cycle_count_i64))
+            .ok_or_else(|| crate::PolygonizeError::InternalInvariantViolation {
+                reason: "global face Euler witness lhs overflow".to_string(),
+            })?;
+        let boundary_euler_rhs = to_i64("component", self.global_components.len())?
+            .checked_add(1)
+            .ok_or_else(|| crate::PolygonizeError::InternalInvariantViolation {
+                reason: "global face Euler witness rhs overflow".to_string(),
+            })?;
+
+        Ok(PartitionBorderGlobalFaceEulerWitnessStats {
+            component_count: self.global_components.len(),
+            transition_face_count: self.global_face_transitions.len(),
+            closed_boundary_cycle_count,
+            boundary_vertex_count,
+            boundary_edge_count,
+            cross_component_edge_count,
+            boundary_euler_lhs,
+            boundary_euler_rhs,
+            boundary_euler_consistent: cross_component_edge_count == 0
+                && boundary_euler_lhs == boundary_euler_rhs,
+        })
+    }
+
     /// Applies a conservative proof boundary to local-unbounded evidence.
     /// Exactly one local unbounded marker is a candidate only when every face
     /// cycle is closed, every border twin is mapped, and every unbounded-face
@@ -4805,6 +5049,90 @@ mod tests {
             cancelled,
             crate::PolygonizeError::Cancelled { ref stage }
                 if stage == "partition_border_global_face_walk_invariants"
+        ));
+    }
+
+    #[test]
+    fn global_face_euler_witness_is_explicitly_border_only_and_fail_closed() {
+        let graph = prepared_global_face_walk_graph(true, [false, false]);
+        let stats = graph
+            .validate_global_face_euler_witness(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(
+            stats,
+            PartitionBorderGlobalFaceEulerWitnessStats {
+                component_count: 1,
+                transition_face_count: 2,
+                closed_boundary_cycle_count: 2,
+                boundary_vertex_count: 2,
+                boundary_edge_count: 1,
+                cross_component_edge_count: 0,
+                boundary_euler_lhs: 3,
+                boundary_euler_rhs: 2,
+                boundary_euler_consistent: false,
+            }
+        );
+
+        let incomplete = prepared_global_face_walk_graph(false, [false, false]);
+        let stats = incomplete
+            .validate_global_face_euler_witness(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(stats.closed_boundary_cycle_count, 0);
+        assert_eq!(stats.boundary_euler_lhs, 1);
+        assert!(!stats.boundary_euler_consistent);
+
+        let walk = graph
+            .validate_global_face_walk_invariants(&ExecutionPolicy::default())
+            .unwrap();
+        let error = graph
+            .validate_global_face_euler_witness_with_walk(
+                &ExecutionPolicy {
+                    max_graph_nodes: Some(1),
+                    ..Default::default()
+                },
+                walk,
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::ResourceLimitExceeded {
+                ref stage,
+                limit: 1,
+                observed: 2,
+            } if stage == "partition_border_global_face_euler_witness_faces"
+        ));
+
+        let token = CancellationToken::new();
+        token.cancel();
+        let error = graph
+            .validate_global_face_euler_witness_with_walk(
+                &ExecutionPolicy {
+                    cancellation_token: Some(token),
+                    ..Default::default()
+                },
+                walk,
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::Cancelled { ref stage }
+                if stage == "partition_border_global_face_euler_witness"
+        ));
+
+        let mut malformed = graph.clone();
+        malformed.global_face_transitions[0].boundary_observation_ids[0] =
+            PartitionBorderObservationId {
+                partition_id: 99,
+                local_dir_edge_id: 99,
+                edge_key: malformed.global_face_transitions[0].boundary_observation_ids[0].edge_key,
+            };
+        let error = malformed
+            .validate_global_face_euler_witness(&ExecutionPolicy::default())
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::InternalInvariantViolation { ref reason }
+                if reason.contains("absent candidate")
         ));
     }
 

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -329,6 +329,22 @@ pub struct StitchingReport {
     pub partition_border_global_face_walk_unbounded_component_count: usize,
     /// Cycle rank of the retained face/twin connectivity graph, not planar Euler.
     pub partition_border_global_face_walk_face_adjacency_cycle_rank: usize,
+    /// Face cycles counted by the retained border-only Euler witness.
+    pub partition_border_global_face_euler_transition_face_count: usize,
+    /// Closed cycles counted by the retained border-only Euler witness.
+    pub partition_border_global_face_euler_closed_boundary_cycle_count: usize,
+    /// Unique XY vertices in retained border-only Euler evidence.
+    pub partition_border_global_face_euler_boundary_vertex_count: usize,
+    /// Unique undirected edges in retained border-only Euler evidence.
+    pub partition_border_global_face_euler_boundary_edge_count: usize,
+    /// Border spans observed in more than one retained face component.
+    pub partition_border_global_face_euler_cross_component_edge_count: usize,
+    /// V - E + closed cycles for retained border-only evidence.
+    pub partition_border_global_face_euler_boundary_lhs: i64,
+    /// C + 1 for retained border-only evidence.
+    pub partition_border_global_face_euler_boundary_rhs: i64,
+    /// Whether the retained border-only arithmetic happens to balance.
+    pub partition_border_global_face_euler_boundary_consistent: bool,
     /// Conservative exactly-one-local-marker unbounded-face candidates.
     pub partition_border_global_unbounded_face_proof_candidate_count: usize,
     /// Whether the conservative unbounded-face proof gate is ready.
@@ -2414,6 +2430,11 @@ impl<'a> TiledPolygonizer<'a> {
             partition_border_global_face_walk_invariants.mapped_twin_count,
             global_face_twin_transition_count
         );
+        let partition_border_global_face_euler_witness = partition_border_graph
+            .validate_global_face_euler_witness_with_walk(
+                &self.execution_policy,
+                partition_border_global_face_walk_invariants,
+            )?;
         let partition_border_global_unbounded_face_proof = partition_border_graph
             .validate_global_unbounded_face_proof_with_walk(
                 &self.execution_policy,
@@ -2447,6 +2468,9 @@ impl<'a> TiledPolygonizer<'a> {
             );
             trace.record_partition_border_global_face_walk_invariants(
                 partition_border_global_face_walk_invariants,
+            );
+            trace.record_partition_border_global_face_euler_witness(
+                partition_border_global_face_euler_witness,
             );
             trace.record_partition_border_global_unbounded_face_proof(
                 partition_border_global_unbounded_face_proof,
@@ -2748,6 +2772,22 @@ impl<'a> TiledPolygonizer<'a> {
                     partition_border_global_face_walk_invariants.unbounded_component_count,
                 partition_border_global_face_walk_face_adjacency_cycle_rank:
                     partition_border_global_face_walk_invariants.face_adjacency_cycle_rank,
+                partition_border_global_face_euler_transition_face_count:
+                    partition_border_global_face_euler_witness.transition_face_count,
+                partition_border_global_face_euler_closed_boundary_cycle_count:
+                    partition_border_global_face_euler_witness.closed_boundary_cycle_count,
+                partition_border_global_face_euler_boundary_vertex_count:
+                    partition_border_global_face_euler_witness.boundary_vertex_count,
+                partition_border_global_face_euler_boundary_edge_count:
+                    partition_border_global_face_euler_witness.boundary_edge_count,
+                partition_border_global_face_euler_cross_component_edge_count:
+                    partition_border_global_face_euler_witness.cross_component_edge_count,
+                partition_border_global_face_euler_boundary_lhs:
+                    partition_border_global_face_euler_witness.boundary_euler_lhs,
+                partition_border_global_face_euler_boundary_rhs:
+                    partition_border_global_face_euler_witness.boundary_euler_rhs,
+                partition_border_global_face_euler_boundary_consistent:
+                    partition_border_global_face_euler_witness.boundary_euler_consistent,
                 partition_border_global_unbounded_face_proof_candidate_count:
                     partition_border_global_unbounded_face_proof.candidate_count,
                 partition_border_global_unbounded_face_proof_ready:

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -381,6 +381,60 @@ mod tests {
                 .partition_border_global_face_walk_face_adjacency_cycle_rank,
             face_walk.face_adjacency_cycle_rank
         );
+        let face_euler = result
+            .partition_border_graph
+            .validate_global_face_euler_witness(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_euler_transition_face_count,
+            face_euler.transition_face_count
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_euler_closed_boundary_cycle_count,
+            face_euler.closed_boundary_cycle_count
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_euler_boundary_vertex_count,
+            face_euler.boundary_vertex_count
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_euler_boundary_edge_count,
+            face_euler.boundary_edge_count
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_euler_cross_component_edge_count,
+            face_euler.cross_component_edge_count
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_euler_boundary_lhs,
+            face_euler.boundary_euler_lhs
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_euler_boundary_rhs,
+            face_euler.boundary_euler_rhs
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_euler_boundary_consistent,
+            face_euler.boundary_euler_consistent
+        );
+        assert!(face_euler.cross_component_edge_count > 0);
+        assert!(!face_euler.boundary_euler_consistent);
         let unbounded_proof = result
             .partition_border_graph
             .validate_global_unbounded_face_proof(&ExecutionPolicy::default())
@@ -1039,6 +1093,78 @@ mod tests {
                     as u64
             )
         );
+        let global_face_euler = traced
+            .trace
+            .events
+            .iter()
+            .find(|event| event.kind == "partition_border_global_face_euler_witness")
+            .expect("global face Euler witness evidence");
+        assert_eq!(
+            global_face_euler.payload["transition_face_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_euler_transition_face_count
+                    as u64
+            )
+        );
+        assert_eq!(
+            global_face_euler.payload["closed_boundary_cycle_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_euler_closed_boundary_cycle_count
+                    as u64
+            )
+        );
+        assert_eq!(
+            global_face_euler.payload["boundary_vertex_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_euler_boundary_vertex_count
+                    as u64
+            )
+        );
+        assert_eq!(
+            global_face_euler.payload["boundary_edge_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_euler_boundary_edge_count as u64
+            )
+        );
+        assert_eq!(
+            global_face_euler.payload["boundary_euler_lhs"].as_i64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_euler_boundary_lhs
+            )
+        );
+        assert_eq!(
+            global_face_euler.payload["boundary_euler_rhs"].as_i64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_euler_boundary_rhs
+            )
+        );
+        assert_eq!(
+            global_face_euler.payload["boundary_euler_consistent"].as_bool(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_euler_boundary_consistent
+            )
+        );
         let unbounded_proof = traced
             .trace
             .events
@@ -1052,6 +1178,16 @@ mod tests {
                     .result
                     .stitching_report
                     .partition_border_global_unbounded_face_proof_candidate_count
+                    as u64
+            )
+        );
+        assert_eq!(
+            global_face_euler.payload["cross_component_edge_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_euler_cross_component_edge_count
                     as u64
             )
         );

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -3,12 +3,12 @@
 use crate::fingerprint::{coordinate_fingerprint, float_bits};
 use crate::graph::partition_border::{
     PartitionBorderGlobalComponentPayloadStats, PartitionBorderGlobalComponentReconciliationStats,
-    PartitionBorderGlobalFaceMutationGateStats, PartitionBorderGlobalFacePlanStats,
-    PartitionBorderGlobalFacePlanValidationStats, PartitionBorderGlobalFaceTransitionPlanStats,
-    PartitionBorderGlobalFaceTwinTransitionStats, PartitionBorderGlobalFaceWalkInvariantStats,
-    PartitionBorderGlobalUnboundedFaceProofStats, PartitionBorderHalfEdge,
-    PartitionBorderNodeReconciliationStats, PartitionBorderReconciliationStats,
-    PartitionBorderTwinApplicationStats,
+    PartitionBorderGlobalFaceEulerWitnessStats, PartitionBorderGlobalFaceMutationGateStats,
+    PartitionBorderGlobalFacePlanStats, PartitionBorderGlobalFacePlanValidationStats,
+    PartitionBorderGlobalFaceTransitionPlanStats, PartitionBorderGlobalFaceTwinTransitionStats,
+    PartitionBorderGlobalFaceWalkInvariantStats, PartitionBorderGlobalUnboundedFaceProofStats,
+    PartitionBorderHalfEdge, PartitionBorderNodeReconciliationStats,
+    PartitionBorderReconciliationStats, PartitionBorderTwinApplicationStats,
 };
 use crate::graph::planar_graph::PartitionBoundaryNodingStats;
 use crate::graph::{ExtractedRing, PlanarGraph};
@@ -807,6 +807,27 @@ impl TraceRecorderV1 {
                 "unbounded_face_not_ready_twin_count": stats.unbounded_face_not_ready_twin_count,
                 "candidate_count": stats.candidate_count,
                 "proof_ready": stats.proof_ready,
+            }),
+        )
+    }
+
+    pub(crate) fn record_partition_border_global_face_euler_witness(
+        &mut self,
+        stats: PartitionBorderGlobalFaceEulerWitnessStats,
+    ) -> bool {
+        self.record(
+            TraceStageV1::Graph,
+            "partition_border_global_face_euler_witness",
+            serde_json::json!({
+                "component_count": stats.component_count,
+                "transition_face_count": stats.transition_face_count,
+                "closed_boundary_cycle_count": stats.closed_boundary_cycle_count,
+                "boundary_vertex_count": stats.boundary_vertex_count,
+                "boundary_edge_count": stats.boundary_edge_count,
+                "cross_component_edge_count": stats.cross_component_edge_count,
+                "boundary_euler_lhs": stats.boundary_euler_lhs,
+                "boundary_euler_rhs": stats.boundary_euler_rhs,
+                "boundary_euler_consistent": stats.boundary_euler_consistent,
             }),
         )
     }


### PR DESCRIPTION
Stack

- Parent: `main` (`bebfd41`)
- Children: #1331 (`agent/p5-global-face-next-candidate-plan`, `3ec6174`)

Delivered

- Added a deterministic retained Euler witness over the exported partition-border face cycles.
- Counted unique boundary vertices, unique undirected boundary edges, closed transition cycles, and component arithmetic.
- Reported `V - E + closed_cycles` versus `components + 1` as signed evidence with overflow checks.
- Recorded border spans observed in multiple retained face components instead of treating the expected boundary-only overlap as corruption.
- Added graph-level fail-closed limit, cancellation, malformed-lineage, incomplete-cycle, tiled-report, trace, and regression coverage.
- Updated `ROADMAP.md` with the explicit border-only proof boundary.

Contract impact

- Additive `StitchingReport` counters and a `partition_border_global_face_euler_witness` trace event expose diagnostic evidence only.
- The witness is intentionally border-only: it does not contain the complete interior arrangement and therefore does not claim planar Euler validity.
- A matching arithmetic result would not authorize global `next` links, face IDs, unbounded-face selection, output extraction, fallback replacement, or component-local polygon append behavior.
- Cross-component edge reuse and any arithmetic mismatch remain explicit non-promotion evidence.
- No local adjacency, global topology, provenance, Z decisions, polygon output, bindings, or fallback behavior is mutated.

Validation

- `cargo test -p geo-polygonize-core global_face_euler_witness --lib` — passed.
- `cargo test -p geo-polygonize-core exports_physical_tile_border_observations_before_scratch_is_released --lib` — passed.
- `cargo test -p geo-polygonize-core trace_records_partition_boundary_noding_and_atomic_observations --lib` — passed.
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings` — passed.
- `DYLD_LIBRARY_PATH=/Library/Frameworks/Python.framework/Versions/3.11/lib cargo test --workspace --lib --tests --no-fail-fast` — 336 core unit tests and all workspace integration targets passed.
- `cargo fmt --all -- --check` — passed.
- `cargo clippy --workspace --all-targets -- -D warnings` — passed.
- `DYLD_LIBRARY_PATH=/Library/Frameworks/Python.framework/Versions/3.11/lib cargo test -p geo-polygonize-core --no-default-features --lib --tests` — 336 tests and all core integration targets passed.
- Generated bindings were restored; `git diff --check` passed.

Agent handoff

- Parent: `main` (`bebfd41`).
- Children: #1331 (`agent/p5-global-face-next-candidate-plan`, `3ec6174`).
- Next branch: `agent/p5-global-face-face-identity-plan`.
- Disproved finding: the current tiled fixture reuses at least one physical border span across retained face components, so a border-only Euler count cannot be treated as a planar arrangement proof.
- Remaining risks: applying twins to a global topology, deterministic global `next`/face IDs, one global unbounded face, complete interior Euler validation, stitched extraction, untiled equivalence, differential fuzzing, and promotion evidence remain open.
