### PR TITLE
feat(core): plan global face next candidates

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -490,6 +490,9 @@ Blocked by #1288.
   vertices, edges, closed cycles, and component arithmetic; keep it diagnostic
   and explicitly do not treat it as a planar Euler proof for the incomplete
   global arrangement.
+- [x] Retain deterministic cross-tile global-next splice candidates from mapped
+  twins and local cycle predecessors/successors; keep incomplete or conflicting
+  assignments fail-closed without writing local `next` links or global face IDs.
 - [ ] Apply unambiguous twins only across declared adjacent borders.
 - [ ] Reconcile canonical border nodes, source sets, representative IDs, and
   selected Z-policy decisions.

--- a/crates/geo-polygonize-core/src/graph/partition_border.rs
+++ b/crates/geo-polygonize-core/src/graph/partition_border.rs
@@ -781,6 +781,36 @@ pub(crate) struct PartitionBorderGlobalFaceEulerWitnessStats {
     pub(crate) boundary_euler_consistent: bool,
 }
 
+/// One retained candidate for splicing two local face cycles across a mapped
+/// partition-border twin. The predecessor/successor identities remain in the
+/// local observation space; no global `next` link or face ID is assigned.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(crate) struct PartitionBorderGlobalFaceNextCandidate {
+    pub(crate) component_index: usize,
+    pub(crate) edge_key: PartitionBorderEdgeKey,
+    pub(crate) forward_face_ref: PartitionFaceRef,
+    pub(crate) reverse_face_ref: PartitionFaceRef,
+    pub(crate) forward_observation_id: PartitionBorderObservationId,
+    pub(crate) reverse_observation_id: PartitionBorderObservationId,
+    pub(crate) forward_predecessor: Option<PartitionBorderObservationId>,
+    pub(crate) reverse_predecessor: Option<PartitionBorderObservationId>,
+    pub(crate) forward_successor: Option<PartitionBorderObservationId>,
+    pub(crate) reverse_successor: Option<PartitionBorderObservationId>,
+    pub(crate) forward_global_successor: Option<PartitionBorderObservationId>,
+    pub(crate) reverse_global_successor: Option<PartitionBorderObservationId>,
+    pub(crate) ready: bool,
+}
+
+/// Counts from retaining global-next splice candidates without applying them.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct PartitionBorderGlobalFaceNextCandidateStats {
+    pub(crate) component_count: usize,
+    pub(crate) twin_candidate_count: usize,
+    pub(crate) ready_candidate_count: usize,
+    pub(crate) incomplete_candidate_count: usize,
+    pub(crate) global_successor_count: usize,
+}
+
 /// Deterministic evidence for the declared-adjacency twin boundary.
 ///
 /// Only observations covered by a declared partition adjacency contribute to
@@ -812,6 +842,7 @@ pub struct PartitionBorderGraph {
     global_face_plans: Vec<PartitionBorderGlobalFacePlan>,
     global_face_transitions: Vec<PartitionBorderGlobalFaceTransitionPlan>,
     global_face_twin_transitions: Vec<PartitionBorderGlobalFaceTwinTransition>,
+    global_face_next_candidates: Vec<PartitionBorderGlobalFaceNextCandidate>,
 }
 
 impl PartitionBorderGraph {
@@ -852,6 +883,7 @@ impl PartitionBorderGraph {
         self.global_face_plans.clear();
         self.global_face_transitions.clear();
         self.global_face_twin_transitions.clear();
+        self.global_face_next_candidates.clear();
         Ok(())
     }
 
@@ -864,6 +896,7 @@ impl PartitionBorderGraph {
         self.global_face_plans.clear();
         self.global_face_transitions.clear();
         self.global_face_twin_transitions.clear();
+        self.global_face_next_candidates.clear();
     }
 
     pub fn node_count(&self) -> usize {
@@ -1117,6 +1150,7 @@ impl PartitionBorderGraph {
         self.global_face_plans.clear();
         self.global_face_transitions.clear();
         self.global_face_twin_transitions.clear();
+        self.global_face_next_candidates.clear();
         Ok(stats)
     }
 
@@ -1260,6 +1294,7 @@ impl PartitionBorderGraph {
         self.global_face_plans.clear();
         self.global_face_transitions.clear();
         self.global_face_twin_transitions.clear();
+        self.global_face_next_candidates.clear();
         Ok(stats)
     }
 
@@ -1406,6 +1441,7 @@ impl PartitionBorderGraph {
         self.global_face_plans.clear();
         self.global_face_transitions.clear();
         self.global_face_twin_transitions.clear();
+        self.global_face_next_candidates.clear();
         Ok(stats)
     }
 
@@ -1715,6 +1751,7 @@ impl PartitionBorderGraph {
         self.global_face_plans = global_face_plans;
         self.global_face_transitions.clear();
         self.global_face_twin_transitions.clear();
+        self.global_face_next_candidates.clear();
         Ok(stats)
     }
 
@@ -2222,6 +2259,7 @@ impl PartitionBorderGraph {
         };
         self.global_face_transitions = transition_plans;
         self.global_face_twin_transitions.clear();
+        self.global_face_next_candidates.clear();
         Ok(stats)
     }
 
@@ -2359,6 +2397,7 @@ impl PartitionBorderGraph {
             mutation_ready_twin_count,
         };
         self.global_face_twin_transitions = links.into_iter().collect();
+        self.global_face_next_candidates.clear();
         Ok(stats)
     }
 
@@ -2366,6 +2405,270 @@ impl PartitionBorderGraph {
         &self,
     ) -> &[PartitionBorderGlobalFaceTwinTransition] {
         &self.global_face_twin_transitions
+    }
+
+    /// Retains deterministic cross-tile successor splice candidates from
+    /// mapped twins and local cycle positions. Incomplete cycles remain
+    /// explicit candidates with `ready == false`; conflicting successor
+    /// assignments fail closed before the candidate vector is committed.
+    #[cfg(test)]
+    pub(crate) fn reconcile_global_face_next_candidates(
+        &mut self,
+        execution_policy: &ExecutionPolicy,
+    ) -> crate::Result<PartitionBorderGlobalFaceNextCandidateStats> {
+        execution_policy.check_cancelled("partition_border_global_face_next_candidates")?;
+        let walk = self.validate_global_face_walk_invariants(execution_policy)?;
+        self.reconcile_global_face_next_candidates_with_walk(execution_policy, walk)
+    }
+
+    pub(crate) fn reconcile_global_face_next_candidates_with_walk(
+        &mut self,
+        execution_policy: &ExecutionPolicy,
+        walk: PartitionBorderGlobalFaceWalkInvariantStats,
+    ) -> crate::Result<PartitionBorderGlobalFaceNextCandidateStats> {
+        execution_policy.check_cancelled("partition_border_global_face_next_candidates")?;
+        execution_policy.check(
+            "partition_border_global_face_next_candidates_faces",
+            execution_policy.max_graph_nodes,
+            self.global_face_transitions.len(),
+        )?;
+        execution_policy.check(
+            "partition_border_global_face_next_candidates_twins",
+            execution_policy.max_graph_edges,
+            self.global_face_twin_transitions.len(),
+        )?;
+        execution_policy.check(
+            "partition_border_global_face_next_candidates_components",
+            execution_policy.max_graph_nodes,
+            self.global_components.len(),
+        )?;
+        if walk.face_count != self.global_face_transitions.len()
+            || walk.mapped_twin_count != self.global_face_twin_transitions.len()
+        {
+            return Err(crate::PolygonizeError::InternalInvariantViolation {
+                reason: format!(
+                    "global face next candidate walk mismatch: faces={}, walk_faces={}, twins={}, walk_twins={}",
+                    self.global_face_transitions.len(),
+                    walk.face_count,
+                    self.global_face_twin_transitions.len(),
+                    walk.mapped_twin_count
+                ),
+            });
+        }
+
+        let mut component_by_face = BTreeMap::<PartitionFaceRef, usize>::new();
+        for (component_position, component) in self.global_components.iter().enumerate() {
+            execution_policy.check_cancelled_every(
+                "partition_border_global_face_next_candidates_components",
+                component_position,
+            )?;
+            for face_ref in &component.face_refs {
+                if component_by_face
+                    .insert(*face_ref, component_position)
+                    .is_some()
+                {
+                    return Err(crate::PolygonizeError::InternalInvariantViolation {
+                        reason: format!(
+                            "global face next candidate face {:?} belongs to multiple components",
+                            face_ref
+                        ),
+                    });
+                }
+            }
+        }
+
+        let mut transition_by_face = BTreeMap::<PartitionFaceRef, usize>::new();
+        for (transition_index, transition) in self.global_face_transitions.iter().enumerate() {
+            if transition_by_face
+                .insert(transition.face_ref, transition_index)
+                .is_some()
+            {
+                return Err(crate::PolygonizeError::InternalInvariantViolation {
+                    reason: format!(
+                        "global face next candidate transition {:?} is duplicated",
+                        transition.face_ref
+                    ),
+                });
+            }
+        }
+
+        let mut candidates = Vec::with_capacity(self.global_face_twin_transitions.len());
+        let mut global_successors =
+            BTreeMap::<PartitionBorderObservationId, PartitionBorderObservationId>::new();
+        let mut ready_candidate_count = 0usize;
+        let mut incomplete_candidate_count = 0usize;
+        for (twin_index, link) in self.global_face_twin_transitions.iter().enumerate() {
+            execution_policy.check_cancelled_every(
+                "partition_border_global_face_next_candidates",
+                twin_index,
+            )?;
+            let Some(&component_index) = component_by_face.get(&link.forward_face_ref) else {
+                return Err(crate::PolygonizeError::InternalInvariantViolation {
+                    reason: format!(
+                        "global face next candidate twin {:?} has no component",
+                        link.edge_key
+                    ),
+                });
+            };
+            if component_by_face.get(&link.reverse_face_ref) != Some(&component_index) {
+                return Err(crate::PolygonizeError::InternalInvariantViolation {
+                    reason: format!(
+                        "global face next candidate twin {:?} crosses components",
+                        link.edge_key
+                    ),
+                });
+            }
+            let Some(&forward_transition_index) = transition_by_face.get(&link.forward_face_ref)
+            else {
+                return Err(crate::PolygonizeError::InternalInvariantViolation {
+                    reason: format!(
+                        "global face next candidate twin {:?} has no forward transition",
+                        link.edge_key
+                    ),
+                });
+            };
+            let Some(&reverse_transition_index) = transition_by_face.get(&link.reverse_face_ref)
+            else {
+                return Err(crate::PolygonizeError::InternalInvariantViolation {
+                    reason: format!(
+                        "global face next candidate twin {:?} has no reverse transition",
+                        link.edge_key
+                    ),
+                });
+            };
+            let forward_transition = &self.global_face_transitions[forward_transition_index];
+            let reverse_transition = &self.global_face_transitions[reverse_transition_index];
+            let cycle_position = |transition: &PartitionBorderGlobalFaceTransitionPlan,
+                                  observation_id: PartitionBorderObservationId,
+                                  cycle_index: usize|
+             -> crate::Result<
+                Option<(PartitionBorderObservationId, PartitionBorderObservationId)>,
+            > {
+                if !transition.closed {
+                    return Ok(None);
+                }
+                let Some(&position_observation_id) =
+                    transition.boundary_observation_ids.get(cycle_index)
+                else {
+                    return Err(crate::PolygonizeError::InternalInvariantViolation {
+                        reason: format!(
+                            "global face next candidate twin {:?} has an invalid cycle position",
+                            link.edge_key
+                        ),
+                    });
+                };
+                if position_observation_id != observation_id
+                    || transition.boundary_observation_ids.is_empty()
+                {
+                    return Err(crate::PolygonizeError::InternalInvariantViolation {
+                        reason: format!(
+                            "global face next candidate twin {:?} disagrees with its cycle position",
+                            link.edge_key
+                        ),
+                    });
+                }
+                let cycle_len = transition.boundary_observation_ids.len();
+                let predecessor_index = (cycle_index + cycle_len - 1) % cycle_len;
+                let successor_index = (cycle_index + 1) % cycle_len;
+                Ok(Some((
+                    transition.boundary_observation_ids[predecessor_index],
+                    transition.boundary_observation_ids[successor_index],
+                )))
+            };
+            let forward_position = cycle_position(
+                forward_transition,
+                link.forward_observation_id,
+                link.forward_cycle_index,
+            )?;
+            let reverse_position = cycle_position(
+                reverse_transition,
+                link.reverse_observation_id,
+                link.reverse_cycle_index,
+            )?;
+            let ready = forward_position.is_some() && reverse_position.is_some();
+            let (
+                forward_predecessor,
+                forward_successor,
+                reverse_predecessor,
+                reverse_successor,
+                forward_global_successor,
+                reverse_global_successor,
+            ) = match (forward_position, reverse_position) {
+                (
+                    Some((forward_predecessor, forward_successor)),
+                    Some((reverse_predecessor, reverse_successor)),
+                ) => {
+                    let assignments = [
+                        (forward_predecessor, reverse_successor),
+                        (reverse_predecessor, forward_successor),
+                    ];
+                    for (predecessor, successor) in assignments {
+                        if let Some(existing) = global_successors.insert(predecessor, successor) {
+                            if existing != successor {
+                                return Err(crate::PolygonizeError::InternalInvariantViolation {
+                                    reason: format!(
+                                        "global face next candidate predecessor {:?} has conflicting successors {:?} and {:?}",
+                                        predecessor, existing, successor
+                                    ),
+                                });
+                            }
+                        }
+                    }
+                    (
+                        Some(forward_predecessor),
+                        Some(forward_successor),
+                        Some(reverse_predecessor),
+                        Some(reverse_successor),
+                        Some(reverse_successor),
+                        Some(forward_successor),
+                    )
+                }
+                (forward_position, reverse_position) => {
+                    incomplete_candidate_count += 1;
+                    (
+                        forward_position.map(|(predecessor, _successor)| predecessor),
+                        forward_position.map(|(_predecessor, successor)| successor),
+                        reverse_position.map(|(predecessor, _successor)| predecessor),
+                        reverse_position.map(|(_predecessor, successor)| successor),
+                        None,
+                        None,
+                    )
+                }
+            };
+            if ready {
+                ready_candidate_count += 1;
+            }
+            candidates.push(PartitionBorderGlobalFaceNextCandidate {
+                component_index,
+                edge_key: link.edge_key,
+                forward_face_ref: link.forward_face_ref,
+                reverse_face_ref: link.reverse_face_ref,
+                forward_observation_id: link.forward_observation_id,
+                reverse_observation_id: link.reverse_observation_id,
+                forward_predecessor,
+                reverse_predecessor,
+                forward_successor,
+                reverse_successor,
+                forward_global_successor,
+                reverse_global_successor,
+                ready,
+            });
+        }
+
+        let stats = PartitionBorderGlobalFaceNextCandidateStats {
+            component_count: self.global_components.len(),
+            twin_candidate_count: candidates.len(),
+            ready_candidate_count,
+            incomplete_candidate_count,
+            global_successor_count: global_successors.len(),
+        };
+        self.global_face_next_candidates = candidates;
+        Ok(stats)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn global_face_next_candidates(&self) -> &[PartitionBorderGlobalFaceNextCandidate] {
+        &self.global_face_next_candidates
     }
 
     /// Validates the retained face-walk, twin, payload, and face-adjacency
@@ -5134,6 +5437,191 @@ mod tests {
             crate::PolygonizeError::InternalInvariantViolation { ref reason }
                 if reason.contains("absent candidate")
         ));
+    }
+
+    #[test]
+    fn global_face_next_candidates_are_deterministic_and_non_mutating() {
+        let graph = prepared_global_face_walk_graph(true, [false, false]);
+        let stats = graph
+            .clone()
+            .reconcile_global_face_next_candidates(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(
+            stats,
+            PartitionBorderGlobalFaceNextCandidateStats {
+                component_count: 1,
+                twin_candidate_count: 1,
+                ready_candidate_count: 1,
+                incomplete_candidate_count: 0,
+                global_successor_count: 2,
+            }
+        );
+
+        let mut complete = graph.clone();
+        let before = complete.clone();
+        let stats = complete
+            .reconcile_global_face_next_candidates(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(stats.ready_candidate_count, 1);
+        assert_ne!(complete, before);
+        let candidate = complete
+            .global_face_next_candidates()
+            .first()
+            .copied()
+            .expect("global next candidate");
+        assert!(candidate.ready);
+        assert_eq!(candidate.component_index, 0);
+        assert_eq!(
+            candidate.forward_predecessor,
+            Some(candidate.forward_observation_id)
+        );
+        assert_eq!(
+            candidate.forward_successor,
+            Some(candidate.forward_observation_id)
+        );
+        assert_eq!(
+            candidate.reverse_predecessor,
+            Some(candidate.reverse_observation_id)
+        );
+        assert_eq!(
+            candidate.reverse_successor,
+            Some(candidate.reverse_observation_id)
+        );
+        assert_eq!(
+            candidate.forward_global_successor,
+            Some(candidate.reverse_observation_id)
+        );
+        assert_eq!(
+            candidate.reverse_global_successor,
+            Some(candidate.forward_observation_id)
+        );
+        assert_eq!(complete.global_face_plans(), before.global_face_plans());
+        assert_eq!(
+            complete.global_face_transitions(),
+            before.global_face_transitions()
+        );
+        assert_eq!(
+            complete.global_face_twin_transitions(),
+            before.global_face_twin_transitions()
+        );
+
+        let mut reordered = PartitionBorderGraph::default();
+        for adjacency in graph.adjacencies.iter().copied() {
+            reordered.declare_adjacency(adjacency);
+        }
+        for observation in graph.observations.values().rev().cloned() {
+            reordered.insert(observation).unwrap();
+        }
+        reordered
+            .apply_unambiguous_face_twins(&ExecutionPolicy::default())
+            .unwrap();
+        reordered
+            .reconcile_border_nodes(ZOptions::default(), &ExecutionPolicy::default())
+            .unwrap();
+        reordered
+            .reconcile_global_components(&ExecutionPolicy::default())
+            .unwrap();
+        reordered
+            .reconcile_global_face_plans(&ExecutionPolicy::default())
+            .unwrap();
+        reordered
+            .reconcile_global_face_transitions(&ExecutionPolicy::default())
+            .unwrap();
+        reordered
+            .reconcile_global_face_twin_transitions(&ExecutionPolicy::default())
+            .unwrap();
+        reordered
+            .reconcile_global_face_next_candidates(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(
+            reordered.global_face_next_candidates(),
+            complete.global_face_next_candidates()
+        );
+    }
+
+    #[test]
+    fn global_face_next_candidates_preserve_incomplete_cycles_and_fail_closed() {
+        let mut incomplete = prepared_global_face_walk_graph(false, [false, false]);
+        let stats = incomplete
+            .reconcile_global_face_next_candidates(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(
+            stats,
+            PartitionBorderGlobalFaceNextCandidateStats {
+                component_count: 1,
+                twin_candidate_count: 1,
+                ready_candidate_count: 0,
+                incomplete_candidate_count: 1,
+                global_successor_count: 0,
+            }
+        );
+        let candidate = incomplete
+            .global_face_next_candidates()
+            .first()
+            .copied()
+            .expect("incomplete global next candidate");
+        assert!(!candidate.ready);
+        assert_eq!(candidate.forward_predecessor, None);
+        assert_eq!(candidate.forward_successor, None);
+        assert_eq!(candidate.reverse_predecessor, None);
+        assert_eq!(candidate.reverse_successor, None);
+        assert_eq!(candidate.forward_global_successor, None);
+        assert_eq!(candidate.reverse_global_successor, None);
+
+        let graph = prepared_global_face_walk_graph(true, [false, false]);
+        let walk = graph
+            .validate_global_face_walk_invariants(&ExecutionPolicy::default())
+            .unwrap();
+        let error = graph
+            .clone()
+            .reconcile_global_face_next_candidates_with_walk(
+                &ExecutionPolicy {
+                    max_graph_edges: Some(0),
+                    ..Default::default()
+                },
+                walk,
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::ResourceLimitExceeded {
+                ref stage,
+                limit: 0,
+                observed: 1,
+            } if stage == "partition_border_global_face_next_candidates_twins"
+        ));
+
+        let token = CancellationToken::new();
+        token.cancel();
+        let error = graph
+            .clone()
+            .reconcile_global_face_next_candidates_with_walk(
+                &ExecutionPolicy {
+                    cancellation_token: Some(token),
+                    ..Default::default()
+                },
+                walk,
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::Cancelled { ref stage }
+                if stage == "partition_border_global_face_next_candidates"
+        ));
+
+        let mut malformed = graph.clone();
+        malformed.global_face_twin_transitions[0].forward_cycle_index += 1;
+        let before = malformed.clone();
+        let error = malformed
+            .reconcile_global_face_next_candidates(&ExecutionPolicy::default())
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::InternalInvariantViolation { ref reason }
+                if reason.contains("cycle")
+        ));
+        assert_eq!(malformed, before);
+        assert!(malformed.global_face_next_candidates().is_empty());
     }
 
     #[test]

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -345,6 +345,14 @@ pub struct StitchingReport {
     pub partition_border_global_face_euler_boundary_rhs: i64,
     /// Whether the retained border-only arithmetic happens to balance.
     pub partition_border_global_face_euler_boundary_consistent: bool,
+    /// Qualified cross-tile twins retained as deterministic global-next candidates.
+    pub partition_border_global_face_next_candidate_count: usize,
+    /// Candidate twins whose two local cycles provide a complete splice witness.
+    pub partition_border_global_face_next_ready_candidate_count: usize,
+    /// Candidate twins with incomplete local-cycle evidence.
+    pub partition_border_global_face_next_incomplete_candidate_count: usize,
+    /// Distinct predecessor-to-successor assignments retained without mutation.
+    pub partition_border_global_face_next_global_successor_count: usize,
     /// Conservative exactly-one-local-marker unbounded-face candidates.
     pub partition_border_global_unbounded_face_proof_candidate_count: usize,
     /// Whether the conservative unbounded-face proof gate is ready.
@@ -2435,6 +2443,11 @@ impl<'a> TiledPolygonizer<'a> {
                 &self.execution_policy,
                 partition_border_global_face_walk_invariants,
             )?;
+        let partition_border_global_face_next_candidates = partition_border_graph
+            .reconcile_global_face_next_candidates_with_walk(
+                &self.execution_policy,
+                partition_border_global_face_walk_invariants,
+            )?;
         let partition_border_global_unbounded_face_proof = partition_border_graph
             .validate_global_unbounded_face_proof_with_walk(
                 &self.execution_policy,
@@ -2471,6 +2484,9 @@ impl<'a> TiledPolygonizer<'a> {
             );
             trace.record_partition_border_global_face_euler_witness(
                 partition_border_global_face_euler_witness,
+            );
+            trace.record_partition_border_global_face_next_candidates(
+                partition_border_global_face_next_candidates,
             );
             trace.record_partition_border_global_unbounded_face_proof(
                 partition_border_global_unbounded_face_proof,
@@ -2788,6 +2804,14 @@ impl<'a> TiledPolygonizer<'a> {
                     partition_border_global_face_euler_witness.boundary_euler_rhs,
                 partition_border_global_face_euler_boundary_consistent:
                     partition_border_global_face_euler_witness.boundary_euler_consistent,
+                partition_border_global_face_next_candidate_count:
+                    partition_border_global_face_next_candidates.twin_candidate_count,
+                partition_border_global_face_next_ready_candidate_count:
+                    partition_border_global_face_next_candidates.ready_candidate_count,
+                partition_border_global_face_next_incomplete_candidate_count:
+                    partition_border_global_face_next_candidates.incomplete_candidate_count,
+                partition_border_global_face_next_global_successor_count:
+                    partition_border_global_face_next_candidates.global_successor_count,
                 partition_border_global_unbounded_face_proof_candidate_count:
                     partition_border_global_unbounded_face_proof.candidate_count,
                 partition_border_global_unbounded_face_proof_ready:

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -13,6 +13,7 @@ mod tests {
         TileRetryPolicy, TiledPolygonizeError, TiledPolygonizer,
     };
     use geo::{Contains, Coord, Geometry, LineString, MultiLineString, Rect};
+    use std::collections::BTreeSet;
 
     #[test]
     fn exports_physical_tile_border_observations_before_scratch_is_released() {
@@ -435,6 +436,62 @@ mod tests {
         );
         assert!(face_euler.cross_component_edge_count > 0);
         assert!(!face_euler.boundary_euler_consistent);
+        let next_candidates = result.partition_border_graph.global_face_next_candidates();
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_next_candidate_count,
+            next_candidates.len()
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_next_ready_candidate_count,
+            next_candidates
+                .iter()
+                .filter(|candidate| candidate.ready)
+                .count()
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_next_incomplete_candidate_count,
+            next_candidates
+                .iter()
+                .filter(|candidate| !candidate.ready)
+                .count()
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_next_candidate_count,
+            twin_transition_plan.len()
+        );
+        assert!(next_candidates
+            .iter()
+            .all(|candidate| candidate.forward_global_successor.is_some() == candidate.ready));
+        let global_successor_count = next_candidates
+            .iter()
+            .flat_map(|candidate| {
+                [
+                    candidate
+                        .forward_predecessor
+                        .zip(candidate.forward_global_successor),
+                    candidate
+                        .reverse_predecessor
+                        .zip(candidate.reverse_global_successor),
+                ]
+            })
+            .flatten()
+            .map(|(predecessor, _successor)| predecessor)
+            .collect::<BTreeSet<_>>()
+            .len();
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_next_global_successor_count,
+            global_successor_count
+        );
         let unbounded_proof = result
             .partition_border_graph
             .validate_global_unbounded_face_proof(&ExecutionPolicy::default())
@@ -1163,6 +1220,50 @@ mod tests {
                     .result
                     .stitching_report
                     .partition_border_global_face_euler_boundary_consistent
+            )
+        );
+        let global_face_next_candidates = traced
+            .trace
+            .events
+            .iter()
+            .find(|event| event.kind == "partition_border_global_face_next_candidates")
+            .expect("global face next candidate evidence");
+        assert_eq!(
+            global_face_next_candidates.payload["twin_candidate_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_next_candidate_count as u64
+            )
+        );
+        assert_eq!(
+            global_face_next_candidates.payload["ready_candidate_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_next_ready_candidate_count as u64
+            )
+        );
+        assert_eq!(
+            global_face_next_candidates.payload["incomplete_candidate_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_next_incomplete_candidate_count
+                    as u64
+            )
+        );
+        assert_eq!(
+            global_face_next_candidates.payload["global_successor_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_next_global_successor_count
+                    as u64
             )
         );
         let unbounded_proof = traced

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -4,11 +4,12 @@ use crate::fingerprint::{coordinate_fingerprint, float_bits};
 use crate::graph::partition_border::{
     PartitionBorderGlobalComponentPayloadStats, PartitionBorderGlobalComponentReconciliationStats,
     PartitionBorderGlobalFaceEulerWitnessStats, PartitionBorderGlobalFaceMutationGateStats,
-    PartitionBorderGlobalFacePlanStats, PartitionBorderGlobalFacePlanValidationStats,
-    PartitionBorderGlobalFaceTransitionPlanStats, PartitionBorderGlobalFaceTwinTransitionStats,
-    PartitionBorderGlobalFaceWalkInvariantStats, PartitionBorderGlobalUnboundedFaceProofStats,
-    PartitionBorderHalfEdge, PartitionBorderNodeReconciliationStats,
-    PartitionBorderReconciliationStats, PartitionBorderTwinApplicationStats,
+    PartitionBorderGlobalFaceNextCandidateStats, PartitionBorderGlobalFacePlanStats,
+    PartitionBorderGlobalFacePlanValidationStats, PartitionBorderGlobalFaceTransitionPlanStats,
+    PartitionBorderGlobalFaceTwinTransitionStats, PartitionBorderGlobalFaceWalkInvariantStats,
+    PartitionBorderGlobalUnboundedFaceProofStats, PartitionBorderHalfEdge,
+    PartitionBorderNodeReconciliationStats, PartitionBorderReconciliationStats,
+    PartitionBorderTwinApplicationStats,
 };
 use crate::graph::planar_graph::PartitionBoundaryNodingStats;
 use crate::graph::{ExtractedRing, PlanarGraph};
@@ -828,6 +829,23 @@ impl TraceRecorderV1 {
                 "boundary_euler_lhs": stats.boundary_euler_lhs,
                 "boundary_euler_rhs": stats.boundary_euler_rhs,
                 "boundary_euler_consistent": stats.boundary_euler_consistent,
+            }),
+        )
+    }
+
+    pub(crate) fn record_partition_border_global_face_next_candidates(
+        &mut self,
+        stats: PartitionBorderGlobalFaceNextCandidateStats,
+    ) -> bool {
+        self.record(
+            TraceStageV1::Graph,
+            "partition_border_global_face_next_candidates",
+            serde_json::json!({
+                "component_count": stats.component_count,
+                "twin_candidate_count": stats.twin_candidate_count,
+                "ready_candidate_count": stats.ready_candidate_count,
+                "incomplete_candidate_count": stats.incomplete_candidate_count,
+                "global_successor_count": stats.global_successor_count,
             }),
         )
     }


### PR DESCRIPTION
Stack

- Parent: #1330 (`agent/p5-global-face-euler-witness`, `9b26edc`)
- Children: #1333 (`agent/p5-global-face-face-identity-plan`, `94961e3`)

Delivered

- Retained deterministic global-next splice candidates for every mapped,
  face-qualified partition-border twin.
- Derived local predecessor/successor identities from ordered local transition
  cycles and recorded the two prospective cross-cycle successor assignments.
- Preserved incomplete cycles as explicit not-ready candidates and rejected
  conflicting predecessor assignments before committing candidate evidence.
- Added bounded/cancellable, atomic graph validation plus insertion-order
  equivalence regressions.
- Added additive stitching-report and topology-trace evidence and updated the
  P5.3 roadmap evidence line.

Contract impact

- This PR is evidence-only: it never writes local `next` links, global face
  IDs, global nodes, or tiled output.
- Candidate readiness is not a stitching or unbounded-face proof; incomplete
  cycles remain not-ready and conflicting assignments fail closed.
- Existing canonical output, provenance, representative IDs, Z policy,
  serial/parallel behavior, limits, and cancellation contracts are unchanged.

Validation

- `cargo test -p geo-polygonize-core global_face_next_candidates --lib -- --nocapture`
- `cargo test -p geo-polygonize-core exports_physical_tile_border_observations_before_scratch_is_released --lib`
- `cargo test -p geo-polygonize-core trace_records_partition_boundary_noding_and_atomic_observations --lib`
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings`
- `DYLD_LIBRARY_PATH=/Library/Frameworks/Python.framework/Versions/3.11/lib cargo test --workspace --lib --tests --no-fail-fast` (338 core unit tests plus workspace integration targets)
- `DYLD_LIBRARY_PATH=/Library/Frameworks/Python.framework/Versions/3.11/lib cargo test -p geo-polygonize-core --no-default-features --lib --tests` (338 core unit tests plus core integration targets)
- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `git diff --check`
- Generated bindings were restored and the untracked `FingerprintDiffV1.ts` export was removed.

Agent handoff

- Parent: #1330 (`agent/p5-global-face-euler-witness`, `9b26edc`)
- Children: #1333 (`agent/p5-global-face-face-identity-plan`, `94961e3`)
- Next branch: `agent/p5-global-face-apply-plan`
- Remaining: actual global `next` writes, deterministic global face IDs, one
  global unbounded face, full stitched arrangement validation, extraction, and
  untiled equivalence remain open.
- Disproved finding: the existing tiled fixture still reuses at least one
  physical border span across retained face components, so the border-only
  Euler witness remains non-planar diagnostic evidence and cannot authorize
  global face promotion.
