### PR TITLE
feat(core): plan global face identities

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -493,6 +493,9 @@ Blocked by #1288.
 - [x] Retain deterministic cross-tile global-next splice candidates from mapped
   twins and local cycle predecessors/successors; keep incomplete or conflicting
   assignments fail-closed without writing local `next` links or global face IDs.
+- [x] Retain boundary-only deterministic global face identity cycle candidates
+  from prospective successors; require a closed permutation walk and keep
+  incomplete or non-permutation components from receiving global face IDs.
 - [ ] Apply unambiguous twins only across declared adjacent borders.
 - [ ] Reconcile canonical border nodes, source sets, representative IDs, and
   selected Z-policy decisions.

--- a/crates/geo-polygonize-core/src/graph/partition_border.rs
+++ b/crates/geo-polygonize-core/src/graph/partition_border.rs
@@ -811,6 +811,29 @@ pub(crate) struct PartitionBorderGlobalFaceNextCandidateStats {
     pub(crate) global_successor_count: usize,
 }
 
+/// One retained candidate global face cycle assembled from local transitions
+/// and prospective cross-border successors. The ordered observations and face
+/// references are evidence only; no global face ID is assigned.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct PartitionBorderGlobalFaceIdentityPlan {
+    pub(crate) component_index: usize,
+    pub(crate) boundary_observation_ids: Vec<PartitionBorderObservationId>,
+    pub(crate) face_refs: Vec<PartitionFaceRef>,
+    pub(crate) closed: bool,
+}
+
+/// Counts from retaining boundary-only global face identity candidates.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct PartitionBorderGlobalFaceIdentityPlanStats {
+    pub(crate) component_count: usize,
+    pub(crate) boundary_observation_count: usize,
+    pub(crate) candidate_cycle_count: usize,
+    pub(crate) closed_cycle_count: usize,
+    pub(crate) incomplete_component_count: usize,
+    pub(crate) non_permutation_component_count: usize,
+    pub(crate) permutation_ready: bool,
+}
+
 /// Deterministic evidence for the declared-adjacency twin boundary.
 ///
 /// Only observations covered by a declared partition adjacency contribute to
@@ -843,6 +866,7 @@ pub struct PartitionBorderGraph {
     global_face_transitions: Vec<PartitionBorderGlobalFaceTransitionPlan>,
     global_face_twin_transitions: Vec<PartitionBorderGlobalFaceTwinTransition>,
     global_face_next_candidates: Vec<PartitionBorderGlobalFaceNextCandidate>,
+    global_face_identity_plans: Vec<PartitionBorderGlobalFaceIdentityPlan>,
 }
 
 impl PartitionBorderGraph {
@@ -884,6 +908,7 @@ impl PartitionBorderGraph {
         self.global_face_transitions.clear();
         self.global_face_twin_transitions.clear();
         self.global_face_next_candidates.clear();
+        self.global_face_identity_plans.clear();
         Ok(())
     }
 
@@ -897,6 +922,7 @@ impl PartitionBorderGraph {
         self.global_face_transitions.clear();
         self.global_face_twin_transitions.clear();
         self.global_face_next_candidates.clear();
+        self.global_face_identity_plans.clear();
     }
 
     pub fn node_count(&self) -> usize {
@@ -1151,6 +1177,7 @@ impl PartitionBorderGraph {
         self.global_face_transitions.clear();
         self.global_face_twin_transitions.clear();
         self.global_face_next_candidates.clear();
+        self.global_face_identity_plans.clear();
         Ok(stats)
     }
 
@@ -1295,6 +1322,7 @@ impl PartitionBorderGraph {
         self.global_face_transitions.clear();
         self.global_face_twin_transitions.clear();
         self.global_face_next_candidates.clear();
+        self.global_face_identity_plans.clear();
         Ok(stats)
     }
 
@@ -1442,6 +1470,7 @@ impl PartitionBorderGraph {
         self.global_face_transitions.clear();
         self.global_face_twin_transitions.clear();
         self.global_face_next_candidates.clear();
+        self.global_face_identity_plans.clear();
         Ok(stats)
     }
 
@@ -1752,6 +1781,7 @@ impl PartitionBorderGraph {
         self.global_face_transitions.clear();
         self.global_face_twin_transitions.clear();
         self.global_face_next_candidates.clear();
+        self.global_face_identity_plans.clear();
         Ok(stats)
     }
 
@@ -2260,6 +2290,7 @@ impl PartitionBorderGraph {
         self.global_face_transitions = transition_plans;
         self.global_face_twin_transitions.clear();
         self.global_face_next_candidates.clear();
+        self.global_face_identity_plans.clear();
         Ok(stats)
     }
 
@@ -2398,6 +2429,7 @@ impl PartitionBorderGraph {
         };
         self.global_face_twin_transitions = links.into_iter().collect();
         self.global_face_next_candidates.clear();
+        self.global_face_identity_plans.clear();
         Ok(stats)
     }
 
@@ -2669,6 +2701,374 @@ impl PartitionBorderGraph {
     #[cfg(test)]
     pub(crate) fn global_face_next_candidates(&self) -> &[PartitionBorderGlobalFaceNextCandidate] {
         &self.global_face_next_candidates
+    }
+
+    /// Retains boundary-only global face identity candidates from the local
+    /// transition cycles and prospective cross-border successors. The wrapper
+    /// validates the preceding evidence first; no global face ID is assigned.
+    #[cfg(test)]
+    pub(crate) fn reconcile_global_face_identity_plans(
+        &mut self,
+        execution_policy: &ExecutionPolicy,
+    ) -> crate::Result<PartitionBorderGlobalFaceIdentityPlanStats> {
+        execution_policy.check_cancelled("partition_border_global_face_identity_plans")?;
+        let walk = self.validate_global_face_walk_invariants(execution_policy)?;
+        if self.global_face_next_candidates.len() != self.global_face_twin_transitions.len() {
+            self.reconcile_global_face_next_candidates_with_walk(execution_policy, walk)?;
+        }
+        self.reconcile_global_face_identity_plans_with_walk(execution_policy, walk)
+    }
+
+    pub(crate) fn reconcile_global_face_identity_plans_with_walk(
+        &mut self,
+        execution_policy: &ExecutionPolicy,
+        walk: PartitionBorderGlobalFaceWalkInvariantStats,
+    ) -> crate::Result<PartitionBorderGlobalFaceIdentityPlanStats> {
+        execution_policy.check_cancelled("partition_border_global_face_identity_plans")?;
+        execution_policy.check(
+            "partition_border_global_face_identity_plans_faces",
+            execution_policy.max_graph_nodes,
+            self.global_face_transitions.len(),
+        )?;
+        execution_policy.check(
+            "partition_border_global_face_identity_plans_observations",
+            execution_policy.max_graph_edges,
+            walk.transition_count,
+        )?;
+        execution_policy.check(
+            "partition_border_global_face_identity_plans_components",
+            execution_policy.max_graph_nodes,
+            self.global_components.len(),
+        )?;
+        if walk.face_count != self.global_face_transitions.len()
+            || walk.mapped_twin_count != self.global_face_twin_transitions.len()
+            || self.global_face_next_candidates.len() != self.global_face_twin_transitions.len()
+        {
+            return Err(crate::PolygonizeError::InternalInvariantViolation {
+                reason: format!(
+                    "global face identity plan evidence mismatch: faces={}, walk_faces={}, twins={}, walk_twins={}, next_candidates={}",
+                    self.global_face_transitions.len(),
+                    walk.face_count,
+                    self.global_face_twin_transitions.len(),
+                    walk.mapped_twin_count,
+                    self.global_face_next_candidates.len()
+                ),
+            });
+        }
+
+        let mut component_by_face = BTreeMap::<PartitionFaceRef, usize>::new();
+        for (component_index, component) in self.global_components.iter().enumerate() {
+            execution_policy.check_cancelled_every(
+                "partition_border_global_face_identity_plans_components",
+                component_index,
+            )?;
+            for face_ref in &component.face_refs {
+                if component_by_face
+                    .insert(*face_ref, component_index)
+                    .is_some()
+                {
+                    return Err(crate::PolygonizeError::InternalInvariantViolation {
+                        reason: format!(
+                            "global face identity plan face {:?} belongs to multiple components",
+                            face_ref
+                        ),
+                    });
+                }
+            }
+        }
+
+        let mut face_by_observation =
+            BTreeMap::<PartitionBorderObservationId, PartitionFaceRef>::new();
+        let mut observations_by_component =
+            BTreeMap::<usize, BTreeSet<PartitionBorderObservationId>>::new();
+        let mut face_refs_by_component = BTreeMap::<usize, BTreeSet<PartitionFaceRef>>::new();
+        let mut successor_by_observation =
+            BTreeMap::<PartitionBorderObservationId, PartitionBorderObservationId>::new();
+        let mut incomplete_components = BTreeSet::new();
+        for (transition_index, transition) in self.global_face_transitions.iter().enumerate() {
+            execution_policy.check_cancelled_every(
+                "partition_border_global_face_identity_plans_transitions",
+                transition_index,
+            )?;
+            let Some(&component_index) = component_by_face.get(&transition.face_ref) else {
+                return Err(crate::PolygonizeError::InternalInvariantViolation {
+                    reason: format!(
+                        "global face identity plan transition {:?} has no component",
+                        transition.face_ref
+                    ),
+                });
+            };
+            face_refs_by_component
+                .entry(component_index)
+                .or_default()
+                .insert(transition.face_ref);
+            let observations = observations_by_component
+                .entry(component_index)
+                .or_default();
+            for observation_id in transition.boundary_observation_ids.iter().copied() {
+                if face_by_observation
+                    .insert(observation_id, transition.face_ref)
+                    .is_some()
+                {
+                    return Err(crate::PolygonizeError::InternalInvariantViolation {
+                        reason: format!(
+                            "global face identity plan observation {:?} is duplicated",
+                            observation_id
+                        ),
+                    });
+                }
+                observations.insert(observation_id);
+            }
+            if !transition.closed {
+                incomplete_components.insert(component_index);
+                continue;
+            }
+            if transition.boundary_observation_ids.is_empty() {
+                return Err(crate::PolygonizeError::InternalInvariantViolation {
+                    reason: format!(
+                        "global face identity plan transition {:?} is closed but empty",
+                        transition.face_ref
+                    ),
+                });
+            }
+            let cycle_len = transition.boundary_observation_ids.len();
+            for (cycle_index, observation_id) in transition
+                .boundary_observation_ids
+                .iter()
+                .copied()
+                .enumerate()
+            {
+                execution_policy.check_cancelled_every(
+                    "partition_border_global_face_identity_plans_transition_observations",
+                    cycle_index,
+                )?;
+                let successor = transition.boundary_observation_ids[(cycle_index + 1) % cycle_len];
+                if successor_by_observation
+                    .insert(observation_id, successor)
+                    .is_some()
+                {
+                    return Err(crate::PolygonizeError::InternalInvariantViolation {
+                        reason: format!(
+                            "global face identity plan observation {:?} has duplicate local successors",
+                            observation_id
+                        ),
+                    });
+                }
+            }
+        }
+
+        let mut global_successor_overrides =
+            BTreeMap::<PartitionBorderObservationId, PartitionBorderObservationId>::new();
+        for (candidate_index, candidate) in self.global_face_next_candidates.iter().enumerate() {
+            execution_policy.check_cancelled_every(
+                "partition_border_global_face_identity_plans_candidates",
+                candidate_index,
+            )?;
+            if !candidate.ready {
+                if candidate.forward_global_successor.is_some()
+                    || candidate.reverse_global_successor.is_some()
+                {
+                    return Err(crate::PolygonizeError::InternalInvariantViolation {
+                        reason: format!(
+                            "global face identity plan candidate {:?} is incomplete but has a global successor",
+                            candidate.edge_key
+                        ),
+                    });
+                }
+                continue;
+            }
+            let Some(forward_predecessor) = candidate.forward_predecessor else {
+                return Err(crate::PolygonizeError::InternalInvariantViolation {
+                    reason: format!(
+                        "global face identity plan candidate {:?} lacks a forward predecessor",
+                        candidate.edge_key
+                    ),
+                });
+            };
+            let Some(reverse_predecessor) = candidate.reverse_predecessor else {
+                return Err(crate::PolygonizeError::InternalInvariantViolation {
+                    reason: format!(
+                        "global face identity plan candidate {:?} lacks a reverse predecessor",
+                        candidate.edge_key
+                    ),
+                });
+            };
+            let Some(forward_successor) = candidate.forward_global_successor else {
+                return Err(crate::PolygonizeError::InternalInvariantViolation {
+                    reason: format!(
+                        "global face identity plan candidate {:?} lacks a forward global successor",
+                        candidate.edge_key
+                    ),
+                });
+            };
+            let Some(reverse_successor) = candidate.reverse_global_successor else {
+                return Err(crate::PolygonizeError::InternalInvariantViolation {
+                    reason: format!(
+                        "global face identity plan candidate {:?} lacks a reverse global successor",
+                        candidate.edge_key
+                    ),
+                });
+            };
+            for (predecessor, successor) in [
+                (forward_predecessor, forward_successor),
+                (reverse_predecessor, reverse_successor),
+            ] {
+                if !successor_by_observation.contains_key(&predecessor) {
+                    return Err(crate::PolygonizeError::InternalInvariantViolation {
+                        reason: format!(
+                            "global face identity plan candidate {:?} overrides an absent predecessor {:?}",
+                            candidate.edge_key, predecessor
+                        ),
+                    });
+                }
+                if let Some(existing) = global_successor_overrides.insert(predecessor, successor) {
+                    if existing != successor {
+                        return Err(crate::PolygonizeError::InternalInvariantViolation {
+                            reason: format!(
+                                "global face identity plan predecessor {:?} has conflicting successors {:?} and {:?}",
+                                predecessor, existing, successor
+                            ),
+                        });
+                    }
+                }
+            }
+        }
+        for (predecessor, successor) in global_successor_overrides {
+            successor_by_observation.insert(predecessor, successor);
+        }
+
+        let mut plans = Vec::new();
+        let mut closed_cycle_count = 0usize;
+        let mut non_permutation_component_count = 0usize;
+        for component_index in 0..self.global_components.len() {
+            execution_policy.check_cancelled_every(
+                "partition_border_global_face_identity_plans_cycles",
+                component_index,
+            )?;
+            let observations = observations_by_component
+                .get(&component_index)
+                .cloned()
+                .unwrap_or_default();
+            let face_refs = face_refs_by_component
+                .get(&component_index)
+                .cloned()
+                .unwrap_or_default();
+            if observations.is_empty() || incomplete_components.contains(&component_index) {
+                incomplete_components.insert(component_index);
+                plans.push(PartitionBorderGlobalFaceIdentityPlan {
+                    component_index,
+                    boundary_observation_ids: observations.into_iter().collect(),
+                    face_refs: face_refs.into_iter().collect(),
+                    closed: false,
+                });
+                continue;
+            }
+
+            let mut incoming_count = BTreeMap::<PartitionBorderObservationId, usize>::new();
+            let mut non_permutation = false;
+            for observation_id in &observations {
+                let Some(&successor) = successor_by_observation.get(observation_id) else {
+                    non_permutation = true;
+                    continue;
+                };
+                if !observations.contains(&successor) {
+                    non_permutation = true;
+                    continue;
+                }
+                *incoming_count.entry(successor).or_default() += 1;
+            }
+            if incoming_count.len() != observations.len()
+                || observations
+                    .iter()
+                    .any(|observation_id| incoming_count.get(observation_id) != Some(&1))
+            {
+                non_permutation = true;
+            }
+            if non_permutation {
+                non_permutation_component_count += 1;
+                plans.push(PartitionBorderGlobalFaceIdentityPlan {
+                    component_index,
+                    boundary_observation_ids: observations.into_iter().collect(),
+                    face_refs: face_refs.into_iter().collect(),
+                    closed: false,
+                });
+                continue;
+            }
+
+            let mut remaining = observations.clone();
+            let mut component_cycles = Vec::new();
+            while let Some(&start) = remaining.first() {
+                let mut cycle = Vec::new();
+                let mut current = start;
+                loop {
+                    if !remaining.remove(&current) {
+                        non_permutation = true;
+                        break;
+                    }
+                    cycle.push(current);
+                    let Some(&successor) = successor_by_observation.get(&current) else {
+                        non_permutation = true;
+                        break;
+                    };
+                    if successor == start {
+                        break;
+                    }
+                    if !remaining.contains(&successor) {
+                        non_permutation = true;
+                        break;
+                    }
+                    current = successor;
+                }
+                if non_permutation {
+                    break;
+                }
+                component_cycles.push(cycle);
+            }
+            if non_permutation {
+                non_permutation_component_count += 1;
+                plans.push(PartitionBorderGlobalFaceIdentityPlan {
+                    component_index,
+                    boundary_observation_ids: observations.into_iter().collect(),
+                    face_refs: face_refs.into_iter().collect(),
+                    closed: false,
+                });
+                continue;
+            }
+            for cycle in component_cycles {
+                let cycle_face_refs = cycle
+                    .iter()
+                    .filter_map(|observation_id| face_by_observation.get(observation_id))
+                    .copied()
+                    .collect::<BTreeSet<_>>();
+                plans.push(PartitionBorderGlobalFaceIdentityPlan {
+                    component_index,
+                    boundary_observation_ids: cycle,
+                    face_refs: cycle_face_refs.into_iter().collect(),
+                    closed: true,
+                });
+                closed_cycle_count += 1;
+            }
+        }
+
+        let boundary_observation_count =
+            observations_by_component.values().map(BTreeSet::len).sum();
+        let stats = PartitionBorderGlobalFaceIdentityPlanStats {
+            component_count: self.global_components.len(),
+            boundary_observation_count,
+            candidate_cycle_count: plans.len(),
+            closed_cycle_count,
+            incomplete_component_count: incomplete_components.len(),
+            non_permutation_component_count,
+            permutation_ready: incomplete_components.is_empty()
+                && non_permutation_component_count == 0,
+        };
+        self.global_face_identity_plans = plans;
+        Ok(stats)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn global_face_identity_plans(&self) -> &[PartitionBorderGlobalFaceIdentityPlan] {
+        &self.global_face_identity_plans
     }
 
     /// Validates the retained face-walk, twin, payload, and face-adjacency
@@ -5622,6 +6022,151 @@ mod tests {
         ));
         assert_eq!(malformed, before);
         assert!(malformed.global_face_next_candidates().is_empty());
+    }
+
+    #[test]
+    fn global_face_identity_plans_are_deterministic_and_boundary_only() {
+        let graph = prepared_global_face_walk_graph(true, [false, false]);
+        let mut complete = graph.clone();
+        let stats = complete
+            .reconcile_global_face_identity_plans(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(
+            stats,
+            PartitionBorderGlobalFaceIdentityPlanStats {
+                component_count: 1,
+                boundary_observation_count: 2,
+                candidate_cycle_count: 1,
+                closed_cycle_count: 1,
+                incomplete_component_count: 0,
+                non_permutation_component_count: 0,
+                permutation_ready: true,
+            }
+        );
+        let plan = complete
+            .global_face_identity_plans()
+            .first()
+            .expect("global face identity candidate");
+        assert!(plan.closed);
+        assert_eq!(plan.component_index, 0);
+        assert_eq!(plan.boundary_observation_ids.len(), 2);
+        assert_eq!(plan.face_refs.len(), 2);
+        assert_eq!(complete.global_face_plans(), graph.global_face_plans());
+        assert_eq!(
+            complete.global_face_transitions(),
+            graph.global_face_transitions()
+        );
+        assert_eq!(
+            complete.global_face_twin_transitions(),
+            graph.global_face_twin_transitions()
+        );
+
+        let mut reordered = PartitionBorderGraph::default();
+        for adjacency in graph.adjacencies.iter().copied() {
+            reordered.declare_adjacency(adjacency);
+        }
+        for observation in graph.observations.values().rev().cloned() {
+            reordered.insert(observation).unwrap();
+        }
+        reordered
+            .apply_unambiguous_face_twins(&ExecutionPolicy::default())
+            .unwrap();
+        reordered
+            .reconcile_border_nodes(ZOptions::default(), &ExecutionPolicy::default())
+            .unwrap();
+        reordered
+            .reconcile_global_components(&ExecutionPolicy::default())
+            .unwrap();
+        reordered
+            .reconcile_global_face_plans(&ExecutionPolicy::default())
+            .unwrap();
+        reordered
+            .reconcile_global_face_transitions(&ExecutionPolicy::default())
+            .unwrap();
+        reordered
+            .reconcile_global_face_twin_transitions(&ExecutionPolicy::default())
+            .unwrap();
+        reordered
+            .reconcile_global_face_identity_plans(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(
+            reordered.global_face_identity_plans(),
+            complete.global_face_identity_plans()
+        );
+    }
+
+    #[test]
+    fn global_face_identity_plans_fail_closed_for_incomplete_and_non_permutation_walks() {
+        let mut incomplete = prepared_global_face_walk_graph(false, [false, false]);
+        let stats = incomplete
+            .reconcile_global_face_identity_plans(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(stats.boundary_observation_count, 2);
+        assert_eq!(stats.candidate_cycle_count, 1);
+        assert_eq!(stats.closed_cycle_count, 0);
+        assert_eq!(stats.incomplete_component_count, 1);
+        assert_eq!(stats.non_permutation_component_count, 0);
+        assert!(!stats.permutation_ready);
+        assert!(!incomplete.global_face_identity_plans()[0].closed);
+
+        let mut non_permutation = prepared_global_face_walk_graph(true, [false, false]);
+        non_permutation
+            .reconcile_global_face_next_candidates(&ExecutionPolicy::default())
+            .unwrap();
+        let candidate = non_permutation.global_face_next_candidates()[0];
+        non_permutation.global_face_next_candidates[0].forward_global_successor =
+            Some(PartitionBorderObservationId {
+                partition_id: 99,
+                local_dir_edge_id: 99,
+                edge_key: candidate.edge_key,
+            });
+        let stats = non_permutation
+            .reconcile_global_face_identity_plans(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(stats.incomplete_component_count, 0);
+        assert_eq!(stats.non_permutation_component_count, 1);
+        assert!(!stats.permutation_ready);
+        assert!(!non_permutation.global_face_identity_plans()[0].closed);
+
+        let graph = prepared_global_face_walk_graph(true, [false, false]);
+        let walk = graph
+            .validate_global_face_walk_invariants(&ExecutionPolicy::default())
+            .unwrap();
+        let error = graph
+            .clone()
+            .reconcile_global_face_identity_plans_with_walk(
+                &ExecutionPolicy {
+                    max_graph_nodes: Some(1),
+                    ..Default::default()
+                },
+                walk,
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::ResourceLimitExceeded {
+                ref stage,
+                limit: 1,
+                observed: 2,
+            } if stage == "partition_border_global_face_identity_plans_faces"
+        ));
+
+        let mut malformed = prepared_global_face_walk_graph(true, [false, false]);
+        malformed
+            .reconcile_global_face_next_candidates(&ExecutionPolicy::default())
+            .unwrap();
+        malformed.global_face_next_candidates[0].forward_global_successor = None;
+        let before = malformed.clone();
+        let error = malformed
+            .reconcile_global_face_identity_plans(&ExecutionPolicy::default())
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::InternalInvariantViolation { ref reason }
+                if reason.contains("forward global successor")
+        ));
+        assert_eq!(malformed, before);
+        assert!(malformed.global_face_identity_plans().is_empty());
     }
 
     #[test]

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -353,6 +353,18 @@ pub struct StitchingReport {
     pub partition_border_global_face_next_incomplete_candidate_count: usize,
     /// Distinct predecessor-to-successor assignments retained without mutation.
     pub partition_border_global_face_next_global_successor_count: usize,
+    /// Boundary-only global face cycle candidates retained from local cycles.
+    pub partition_border_global_face_identity_candidate_cycle_count: usize,
+    /// Candidate global face cycles whose prospective successor walk is closed.
+    pub partition_border_global_face_identity_closed_cycle_count: usize,
+    /// Components with incomplete local boundary evidence.
+    pub partition_border_global_face_identity_incomplete_component_count: usize,
+    /// Components whose prospective successor map is not a permutation.
+    pub partition_border_global_face_identity_non_permutation_component_count: usize,
+    /// Boundary observations retained in the identity candidate plan.
+    pub partition_border_global_face_identity_boundary_observation_count: usize,
+    /// Whether all retained boundary evidence forms closed permutation cycles.
+    pub partition_border_global_face_identity_permutation_ready: bool,
     /// Conservative exactly-one-local-marker unbounded-face candidates.
     pub partition_border_global_unbounded_face_proof_candidate_count: usize,
     /// Whether the conservative unbounded-face proof gate is ready.
@@ -2448,6 +2460,11 @@ impl<'a> TiledPolygonizer<'a> {
                 &self.execution_policy,
                 partition_border_global_face_walk_invariants,
             )?;
+        let partition_border_global_face_identity_plans = partition_border_graph
+            .reconcile_global_face_identity_plans_with_walk(
+                &self.execution_policy,
+                partition_border_global_face_walk_invariants,
+            )?;
         let partition_border_global_unbounded_face_proof = partition_border_graph
             .validate_global_unbounded_face_proof_with_walk(
                 &self.execution_policy,
@@ -2487,6 +2504,9 @@ impl<'a> TiledPolygonizer<'a> {
             );
             trace.record_partition_border_global_face_next_candidates(
                 partition_border_global_face_next_candidates,
+            );
+            trace.record_partition_border_global_face_identity_plans(
+                partition_border_global_face_identity_plans,
             );
             trace.record_partition_border_global_unbounded_face_proof(
                 partition_border_global_unbounded_face_proof,
@@ -2812,6 +2832,18 @@ impl<'a> TiledPolygonizer<'a> {
                     partition_border_global_face_next_candidates.incomplete_candidate_count,
                 partition_border_global_face_next_global_successor_count:
                     partition_border_global_face_next_candidates.global_successor_count,
+                partition_border_global_face_identity_candidate_cycle_count:
+                    partition_border_global_face_identity_plans.candidate_cycle_count,
+                partition_border_global_face_identity_closed_cycle_count:
+                    partition_border_global_face_identity_plans.closed_cycle_count,
+                partition_border_global_face_identity_incomplete_component_count:
+                    partition_border_global_face_identity_plans.incomplete_component_count,
+                partition_border_global_face_identity_non_permutation_component_count:
+                    partition_border_global_face_identity_plans.non_permutation_component_count,
+                partition_border_global_face_identity_boundary_observation_count:
+                    partition_border_global_face_identity_plans.boundary_observation_count,
+                partition_border_global_face_identity_permutation_ready:
+                    partition_border_global_face_identity_plans.permutation_ready,
                 partition_border_global_unbounded_face_proof_candidate_count:
                     partition_border_global_unbounded_face_proof.candidate_count,
                 partition_border_global_unbounded_face_proof_ready:

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -492,6 +492,69 @@ mod tests {
                 .partition_border_global_face_next_global_successor_count,
             global_successor_count
         );
+        let identity_plans = result.partition_border_graph.global_face_identity_plans();
+        let identity_stats = result
+            .partition_border_graph
+            .clone()
+            .reconcile_global_face_identity_plans(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_identity_candidate_cycle_count,
+            identity_plans.len()
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_identity_closed_cycle_count,
+            identity_plans.iter().filter(|plan| plan.closed).count()
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_identity_boundary_observation_count,
+            identity_plans
+                .iter()
+                .map(|plan| plan.boundary_observation_ids.len())
+                .sum::<usize>()
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_identity_candidate_cycle_count,
+            identity_stats.candidate_cycle_count
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_identity_closed_cycle_count,
+            identity_stats.closed_cycle_count
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_identity_boundary_observation_count,
+            identity_stats.boundary_observation_count
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_identity_incomplete_component_count,
+            identity_stats.incomplete_component_count
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_identity_non_permutation_component_count,
+            identity_stats.non_permutation_component_count
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_identity_permutation_ready,
+            identity_stats.permutation_ready
+        );
         let unbounded_proof = result
             .partition_border_graph
             .validate_global_unbounded_face_proof(&ExecutionPolicy::default())
@@ -1264,6 +1327,71 @@ mod tests {
                     .stitching_report
                     .partition_border_global_face_next_global_successor_count
                     as u64
+            )
+        );
+        let global_face_identity_plans = traced
+            .trace
+            .events
+            .iter()
+            .find(|event| event.kind == "partition_border_global_face_identity_plans")
+            .expect("global face identity plan evidence");
+        assert_eq!(
+            global_face_identity_plans.payload["candidate_cycle_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_identity_candidate_cycle_count
+                    as u64
+            )
+        );
+        assert_eq!(
+            global_face_identity_plans.payload["boundary_observation_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_identity_boundary_observation_count
+                    as u64
+            )
+        );
+        assert_eq!(
+            global_face_identity_plans.payload["closed_cycle_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_identity_closed_cycle_count
+                    as u64
+            )
+        );
+        assert_eq!(
+            global_face_identity_plans.payload["incomplete_component_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_identity_incomplete_component_count
+                    as u64
+            )
+        );
+        assert_eq!(
+            global_face_identity_plans.payload["non_permutation_component_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_identity_non_permutation_component_count
+                    as u64
+            )
+        );
+        assert_eq!(
+            global_face_identity_plans.payload["permutation_ready"].as_bool(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_identity_permutation_ready
             )
         );
         let unbounded_proof = traced

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -3,13 +3,13 @@
 use crate::fingerprint::{coordinate_fingerprint, float_bits};
 use crate::graph::partition_border::{
     PartitionBorderGlobalComponentPayloadStats, PartitionBorderGlobalComponentReconciliationStats,
-    PartitionBorderGlobalFaceEulerWitnessStats, PartitionBorderGlobalFaceMutationGateStats,
-    PartitionBorderGlobalFaceNextCandidateStats, PartitionBorderGlobalFacePlanStats,
-    PartitionBorderGlobalFacePlanValidationStats, PartitionBorderGlobalFaceTransitionPlanStats,
-    PartitionBorderGlobalFaceTwinTransitionStats, PartitionBorderGlobalFaceWalkInvariantStats,
-    PartitionBorderGlobalUnboundedFaceProofStats, PartitionBorderHalfEdge,
-    PartitionBorderNodeReconciliationStats, PartitionBorderReconciliationStats,
-    PartitionBorderTwinApplicationStats,
+    PartitionBorderGlobalFaceEulerWitnessStats, PartitionBorderGlobalFaceIdentityPlanStats,
+    PartitionBorderGlobalFaceMutationGateStats, PartitionBorderGlobalFaceNextCandidateStats,
+    PartitionBorderGlobalFacePlanStats, PartitionBorderGlobalFacePlanValidationStats,
+    PartitionBorderGlobalFaceTransitionPlanStats, PartitionBorderGlobalFaceTwinTransitionStats,
+    PartitionBorderGlobalFaceWalkInvariantStats, PartitionBorderGlobalUnboundedFaceProofStats,
+    PartitionBorderHalfEdge, PartitionBorderNodeReconciliationStats,
+    PartitionBorderReconciliationStats, PartitionBorderTwinApplicationStats,
 };
 use crate::graph::planar_graph::PartitionBoundaryNodingStats;
 use crate::graph::{ExtractedRing, PlanarGraph};
@@ -846,6 +846,25 @@ impl TraceRecorderV1 {
                 "ready_candidate_count": stats.ready_candidate_count,
                 "incomplete_candidate_count": stats.incomplete_candidate_count,
                 "global_successor_count": stats.global_successor_count,
+            }),
+        )
+    }
+
+    pub(crate) fn record_partition_border_global_face_identity_plans(
+        &mut self,
+        stats: PartitionBorderGlobalFaceIdentityPlanStats,
+    ) -> bool {
+        self.record(
+            TraceStageV1::Graph,
+            "partition_border_global_face_identity_plans",
+            serde_json::json!({
+                "component_count": stats.component_count,
+                "boundary_observation_count": stats.boundary_observation_count,
+                "candidate_cycle_count": stats.candidate_cycle_count,
+                "closed_cycle_count": stats.closed_cycle_count,
+                "incomplete_component_count": stats.incomplete_component_count,
+                "non_permutation_component_count": stats.non_permutation_component_count,
+                "permutation_ready": stats.permutation_ready,
             }),
         )
     }


### PR DESCRIPTION
Stack

- Parent: #1331 (`agent/p5-global-face-next-candidate-plan`, `3ec6174`)
- Children: #1334 (`agent/p5-global-face-apply-plan`, `9d5c303`)

Delivered

- Retained deterministic boundary-only global face identity cycle candidates
  by combining ordered local transition successors with prospective cross-border
  successor overrides.
- Verified incoming/outgoing permutation structure per retained global
  component and emitted closed candidate cycles with deterministic observation
  and face-reference order.
- Preserved incomplete local components and non-permutation successor maps as
  not-ready evidence; malformed candidate lineage fails closed before plan
  commit.
- Added bounded/cancellable, atomic, insertion-order, incomplete, malformed,
  and non-permutation regressions.
- Added additive stitching-report and topology-trace evidence and updated the
  P5.3 roadmap evidence line.

Contract impact

- This PR is evidence-only: it never writes local or global `next` links,
  assigns global face IDs, mutates global nodes, selects an unbounded face, or
  changes tiled output.
- `permutation_ready` means only that the retained boundary observation map is
  a closed permutation; it is not a proof of complete interior topology,
  containment, Euler validity, or untiled equivalence.
- Incomplete and non-permutation components remain not-ready, and malformed
  identity evidence fails closed without partially committing a plan.
- Existing canonical output, provenance, representative IDs, Z policy,
  serial/parallel behavior, limits, and cancellation contracts are unchanged.

Validation

- `cargo test -p geo-polygonize-core global_face_identity_plans --lib -- --nocapture`
- `cargo test -p geo-polygonize-core exports_physical_tile_border_observations_before_scratch_is_released --lib`
- `cargo test -p geo-polygonize-core trace_records_partition_boundary_noding_and_atomic_observations --lib`
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings`
- `DYLD_LIBRARY_PATH=/Library/Frameworks/Python.framework/Versions/3.11/lib cargo test --workspace --lib --tests --no-fail-fast` (340 core unit tests plus workspace integration targets)
- `DYLD_LIBRARY_PATH=/Library/Frameworks/Python.framework/Versions/3.11/lib cargo test -p geo-polygonize-core --no-default-features --lib --tests` (340 core unit tests plus core integration targets)
- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `git diff --check`
- Generated bindings were restored and the untracked `FingerprintDiffV1.ts` export was removed.

Agent handoff

- Parent: #1331 (`agent/p5-global-face-next-candidate-plan`, `3ec6174`)
- Children: #1334 (`agent/p5-global-face-apply-plan`, `9d5c303`)
- Next branch: `agent/p5-global-face-global-id-plan`
- Remaining: apply only validated twins into a future global topology, assign
  deterministic global face IDs, prove one global unbounded face, validate full
  interior Euler/source/Z invariants, extract stitched output, compare untiled
  results, fuzz partitioning, and publish promotion evidence.
- Disproved finding: the existing tiled fixture still reuses at least one
  physical border span across retained face components, so all identity plans
  remain boundary-only evidence and cannot authorize global face promotion.
