### PR TITLE
feat(core): gate global face next application

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -496,6 +496,9 @@ Blocked by #1288.
 - [x] Retain boundary-only deterministic global face identity cycle candidates
   from prospective successors; require a closed permutation walk and keep
   incomplete or non-permutation components from receiving global face IDs.
+- [x] Retain a fail-closed global-next mutation plan from validated identity
+  cycles; require exact cycle assignments while keeping local and global links
+  unwritten until a real global topology exists.
 - [ ] Apply unambiguous twins only across declared adjacent borders.
 - [ ] Reconcile canonical border nodes, source sets, representative IDs, and
   selected Z-policy decisions.

--- a/crates/geo-polygonize-core/src/graph/partition_border.rs
+++ b/crates/geo-polygonize-core/src/graph/partition_border.rs
@@ -834,6 +834,29 @@ pub(crate) struct PartitionBorderGlobalFaceIdentityPlanStats {
     pub(crate) permutation_ready: bool,
 }
 
+/// One retained global-next assignment set derived from a validated identity
+/// cycle. The pair vectors are evidence for a future global topology mutation;
+/// no local or global directed-edge link is written.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct PartitionBorderGlobalFaceNextMutationPlan {
+    pub(crate) component_index: usize,
+    pub(crate) boundary_observation_ids: Vec<PartitionBorderObservationId>,
+    pub(crate) successor_observation_ids: Vec<PartitionBorderObservationId>,
+    pub(crate) closed: bool,
+}
+
+/// Counts from the fail-closed global-next mutation gate.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct PartitionBorderGlobalFaceNextMutationPlanStats {
+    pub(crate) component_count: usize,
+    pub(crate) boundary_observation_count: usize,
+    pub(crate) plan_count: usize,
+    pub(crate) candidate_link_count: usize,
+    pub(crate) ready_component_count: usize,
+    pub(crate) incomplete_component_count: usize,
+    pub(crate) mutation_ready: bool,
+}
+
 /// Deterministic evidence for the declared-adjacency twin boundary.
 ///
 /// Only observations covered by a declared partition adjacency contribute to
@@ -867,6 +890,7 @@ pub struct PartitionBorderGraph {
     global_face_twin_transitions: Vec<PartitionBorderGlobalFaceTwinTransition>,
     global_face_next_candidates: Vec<PartitionBorderGlobalFaceNextCandidate>,
     global_face_identity_plans: Vec<PartitionBorderGlobalFaceIdentityPlan>,
+    global_face_next_mutation_plans: Vec<PartitionBorderGlobalFaceNextMutationPlan>,
 }
 
 impl PartitionBorderGraph {
@@ -909,6 +933,7 @@ impl PartitionBorderGraph {
         self.global_face_twin_transitions.clear();
         self.global_face_next_candidates.clear();
         self.global_face_identity_plans.clear();
+        self.global_face_next_mutation_plans.clear();
         Ok(())
     }
 
@@ -923,6 +948,7 @@ impl PartitionBorderGraph {
         self.global_face_twin_transitions.clear();
         self.global_face_next_candidates.clear();
         self.global_face_identity_plans.clear();
+        self.global_face_next_mutation_plans.clear();
     }
 
     pub fn node_count(&self) -> usize {
@@ -1178,6 +1204,7 @@ impl PartitionBorderGraph {
         self.global_face_twin_transitions.clear();
         self.global_face_next_candidates.clear();
         self.global_face_identity_plans.clear();
+        self.global_face_next_mutation_plans.clear();
         Ok(stats)
     }
 
@@ -1323,6 +1350,7 @@ impl PartitionBorderGraph {
         self.global_face_twin_transitions.clear();
         self.global_face_next_candidates.clear();
         self.global_face_identity_plans.clear();
+        self.global_face_next_mutation_plans.clear();
         Ok(stats)
     }
 
@@ -1471,6 +1499,7 @@ impl PartitionBorderGraph {
         self.global_face_twin_transitions.clear();
         self.global_face_next_candidates.clear();
         self.global_face_identity_plans.clear();
+        self.global_face_next_mutation_plans.clear();
         Ok(stats)
     }
 
@@ -1782,6 +1811,7 @@ impl PartitionBorderGraph {
         self.global_face_twin_transitions.clear();
         self.global_face_next_candidates.clear();
         self.global_face_identity_plans.clear();
+        self.global_face_next_mutation_plans.clear();
         Ok(stats)
     }
 
@@ -2291,6 +2321,7 @@ impl PartitionBorderGraph {
         self.global_face_twin_transitions.clear();
         self.global_face_next_candidates.clear();
         self.global_face_identity_plans.clear();
+        self.global_face_next_mutation_plans.clear();
         Ok(stats)
     }
 
@@ -2430,6 +2461,7 @@ impl PartitionBorderGraph {
         self.global_face_twin_transitions = links.into_iter().collect();
         self.global_face_next_candidates.clear();
         self.global_face_identity_plans.clear();
+        self.global_face_next_mutation_plans.clear();
         Ok(stats)
     }
 
@@ -3069,6 +3101,186 @@ impl PartitionBorderGraph {
     #[cfg(test)]
     pub(crate) fn global_face_identity_plans(&self) -> &[PartitionBorderGlobalFaceIdentityPlan] {
         &self.global_face_identity_plans
+    }
+
+    /// Retains the exact prospective global-next assignments from validated
+    /// identity cycles. This is a mutation gate only: it does not write any
+    /// local or global directed-edge links.
+    #[cfg(test)]
+    pub(crate) fn reconcile_global_face_next_mutation_plans(
+        &mut self,
+        execution_policy: &ExecutionPolicy,
+    ) -> crate::Result<PartitionBorderGlobalFaceNextMutationPlanStats> {
+        execution_policy.check_cancelled("partition_border_global_face_next_mutation_plans")?;
+        let walk = self.validate_global_face_walk_invariants(execution_policy)?;
+        if self.global_face_identity_plans.is_empty() && !self.global_components.is_empty() {
+            self.reconcile_global_face_next_candidates_with_walk(execution_policy, walk)?;
+            self.reconcile_global_face_identity_plans_with_walk(execution_policy, walk)?;
+        }
+        self.reconcile_global_face_next_mutation_plans_with_walk(execution_policy, walk)
+    }
+
+    pub(crate) fn reconcile_global_face_next_mutation_plans_with_walk(
+        &mut self,
+        execution_policy: &ExecutionPolicy,
+        walk: PartitionBorderGlobalFaceWalkInvariantStats,
+    ) -> crate::Result<PartitionBorderGlobalFaceNextMutationPlanStats> {
+        execution_policy.check_cancelled("partition_border_global_face_next_mutation_plans")?;
+        execution_policy.check(
+            "partition_border_global_face_next_mutation_plans_faces",
+            execution_policy.max_graph_nodes,
+            self.global_face_transitions.len(),
+        )?;
+        execution_policy.check(
+            "partition_border_global_face_next_mutation_plans_observations",
+            execution_policy.max_graph_edges,
+            walk.transition_count,
+        )?;
+        execution_policy.check(
+            "partition_border_global_face_next_mutation_plans_components",
+            execution_policy.max_graph_nodes,
+            self.global_components.len(),
+        )?;
+        if walk.face_count != self.global_face_transitions.len()
+            || walk.mapped_twin_count != self.global_face_twin_transitions.len()
+            || self
+                .global_face_identity_plans
+                .iter()
+                .any(|plan| plan.component_index >= self.global_components.len())
+        {
+            return Err(crate::PolygonizeError::InternalInvariantViolation {
+                reason: "global face next mutation plan evidence mismatch".to_string(),
+            });
+        }
+
+        let mut plans = Vec::with_capacity(self.global_face_identity_plans.len());
+        let mut seen_components = BTreeSet::new();
+        let mut seen_observations = BTreeSet::new();
+        let mut incomplete_components = BTreeSet::new();
+        let mut successor_by_observation =
+            BTreeMap::<PartitionBorderObservationId, PartitionBorderObservationId>::new();
+        let mut boundary_observation_count = 0usize;
+        let mut candidate_link_count = 0usize;
+        for (plan_index, identity_plan) in self.global_face_identity_plans.iter().enumerate() {
+            execution_policy.check_cancelled_every(
+                "partition_border_global_face_next_mutation_plans",
+                plan_index,
+            )?;
+            seen_components.insert(identity_plan.component_index);
+            let mut cycle_observations = BTreeSet::new();
+            for observation_id in &identity_plan.boundary_observation_ids {
+                if !cycle_observations.insert(*observation_id)
+                    || !seen_observations.insert(*observation_id)
+                {
+                    return Err(crate::PolygonizeError::InternalInvariantViolation {
+                        reason: format!(
+                            "global face next mutation plan observation {:?} is duplicated",
+                            observation_id
+                        ),
+                    });
+                }
+            }
+            boundary_observation_count = boundary_observation_count
+                .checked_add(identity_plan.boundary_observation_ids.len())
+                .ok_or_else(|| crate::PolygonizeError::InternalInvariantViolation {
+                    reason: "global face next mutation plan observation count overflow".to_string(),
+                })?;
+            if !identity_plan.closed {
+                incomplete_components.insert(identity_plan.component_index);
+                plans.push(PartitionBorderGlobalFaceNextMutationPlan {
+                    component_index: identity_plan.component_index,
+                    boundary_observation_ids: identity_plan.boundary_observation_ids.clone(),
+                    successor_observation_ids: Vec::new(),
+                    closed: false,
+                });
+                continue;
+            }
+            if identity_plan.boundary_observation_ids.is_empty() {
+                return Err(crate::PolygonizeError::InternalInvariantViolation {
+                    reason: format!(
+                        "global face next mutation plan component {} has invalid cycle lengths",
+                        identity_plan.component_index
+                    ),
+                });
+            }
+            for (cycle_index, predecessor) in
+                identity_plan.boundary_observation_ids.iter().enumerate()
+            {
+                execution_policy.check_cancelled_every(
+                    "partition_border_global_face_next_mutation_plan_links",
+                    cycle_index,
+                )?;
+                let successor = identity_plan.boundary_observation_ids
+                    [(cycle_index + 1) % identity_plan.boundary_observation_ids.len()];
+                if !cycle_observations.contains(&successor) {
+                    return Err(crate::PolygonizeError::InternalInvariantViolation {
+                        reason: format!(
+                            "global face next mutation plan component {} disagrees with its identity cycle",
+                            identity_plan.component_index
+                        ),
+                    });
+                }
+                if successor_by_observation
+                    .insert(*predecessor, successor)
+                    .is_some()
+                {
+                    return Err(crate::PolygonizeError::InternalInvariantViolation {
+                        reason: format!(
+                            "global face next mutation plan predecessor {:?} is duplicated",
+                            predecessor
+                        ),
+                    });
+                }
+            }
+            candidate_link_count = candidate_link_count
+                .checked_add(identity_plan.boundary_observation_ids.len())
+                .ok_or_else(|| crate::PolygonizeError::InternalInvariantViolation {
+                    reason: "global face next mutation plan link count overflow".to_string(),
+                })?;
+            plans.push(PartitionBorderGlobalFaceNextMutationPlan {
+                component_index: identity_plan.component_index,
+                boundary_observation_ids: identity_plan.boundary_observation_ids.clone(),
+                successor_observation_ids: (0..identity_plan.boundary_observation_ids.len())
+                    .map(|cycle_index| {
+                        identity_plan.boundary_observation_ids
+                            [(cycle_index + 1) % identity_plan.boundary_observation_ids.len()]
+                    })
+                    .collect(),
+                closed: true,
+            });
+        }
+
+        if seen_components.len() != self.global_components.len() {
+            return Err(crate::PolygonizeError::InternalInvariantViolation {
+                reason: format!(
+                    "global face next mutation plan omits components: planned={}, components={}",
+                    seen_components.len(),
+                    self.global_components.len()
+                ),
+            });
+        }
+        let ready_component_count = self
+            .global_components
+            .len()
+            .saturating_sub(incomplete_components.len());
+        let stats = PartitionBorderGlobalFaceNextMutationPlanStats {
+            component_count: self.global_components.len(),
+            boundary_observation_count,
+            plan_count: plans.len(),
+            candidate_link_count,
+            ready_component_count,
+            incomplete_component_count: incomplete_components.len(),
+            mutation_ready: incomplete_components.is_empty(),
+        };
+        self.global_face_next_mutation_plans = plans;
+        Ok(stats)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn global_face_next_mutation_plans(
+        &self,
+    ) -> &[PartitionBorderGlobalFaceNextMutationPlan] {
+        &self.global_face_next_mutation_plans
     }
 
     /// Validates the retained face-walk, twin, payload, and face-adjacency
@@ -6167,6 +6379,99 @@ mod tests {
         ));
         assert_eq!(malformed, before);
         assert!(malformed.global_face_identity_plans().is_empty());
+    }
+
+    #[test]
+    fn global_face_next_mutation_plans_are_atomic_and_require_closed_cycles() {
+        let graph = prepared_global_face_walk_graph(true, [false, false]);
+        let mut complete = graph.clone();
+        let before = complete.clone();
+        let stats = complete
+            .reconcile_global_face_next_mutation_plans(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(
+            stats,
+            PartitionBorderGlobalFaceNextMutationPlanStats {
+                component_count: 1,
+                boundary_observation_count: 2,
+                plan_count: 1,
+                candidate_link_count: 2,
+                ready_component_count: 1,
+                incomplete_component_count: 0,
+                mutation_ready: true,
+            }
+        );
+        let mutation_plan = complete
+            .global_face_next_mutation_plans()
+            .first()
+            .expect("global next mutation plan");
+        assert!(mutation_plan.closed);
+        assert_eq!(
+            mutation_plan.boundary_observation_ids.len(),
+            mutation_plan.successor_observation_ids.len()
+        );
+        assert_eq!(complete.global_face_plans(), before.global_face_plans());
+        assert_eq!(
+            complete.global_face_transitions(),
+            before.global_face_transitions()
+        );
+        assert_eq!(
+            complete.global_face_twin_transitions(),
+            before.global_face_twin_transitions()
+        );
+
+        let mut incomplete = prepared_global_face_walk_graph(false, [false, false]);
+        let stats = incomplete
+            .reconcile_global_face_next_mutation_plans(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(stats.component_count, 1);
+        assert_eq!(stats.boundary_observation_count, 2);
+        assert_eq!(stats.plan_count, 1);
+        assert_eq!(stats.candidate_link_count, 0);
+        assert_eq!(stats.ready_component_count, 0);
+        assert_eq!(stats.incomplete_component_count, 1);
+        assert!(!stats.mutation_ready);
+        assert!(!incomplete.global_face_next_mutation_plans()[0].closed);
+
+        let mut malformed = graph.clone();
+        malformed
+            .reconcile_global_face_identity_plans(&ExecutionPolicy::default())
+            .unwrap();
+        malformed.global_face_identity_plans[0].boundary_observation_ids[1] =
+            malformed.global_face_identity_plans[0].boundary_observation_ids[0];
+        let before = malformed.clone();
+        let error = malformed
+            .reconcile_global_face_next_mutation_plans(&ExecutionPolicy::default())
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::InternalInvariantViolation { ref reason }
+                if reason.contains("observation") && reason.contains("duplicated")
+        ));
+        assert_eq!(malformed, before);
+        assert!(malformed.global_face_next_mutation_plans().is_empty());
+
+        let walk = graph
+            .validate_global_face_walk_invariants(&ExecutionPolicy::default())
+            .unwrap();
+        let error = graph
+            .clone()
+            .reconcile_global_face_next_mutation_plans_with_walk(
+                &ExecutionPolicy {
+                    max_graph_nodes: Some(1),
+                    ..Default::default()
+                },
+                walk,
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::ResourceLimitExceeded {
+                ref stage,
+                limit: 1,
+                observed: 2,
+            } if stage == "partition_border_global_face_next_mutation_plans_faces"
+        ));
     }
 
     #[test]

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -365,6 +365,18 @@ pub struct StitchingReport {
     pub partition_border_global_face_identity_boundary_observation_count: usize,
     /// Whether all retained boundary evidence forms closed permutation cycles.
     pub partition_border_global_face_identity_permutation_ready: bool,
+    /// Boundary-only global-next mutation plans retained from identity cycles.
+    pub partition_border_global_face_next_mutation_plan_count: usize,
+    /// Prospective global-next links retained without applying them.
+    pub partition_border_global_face_next_mutation_candidate_link_count: usize,
+    /// Boundary observations covered by the prospective mutation plan.
+    pub partition_border_global_face_next_mutation_boundary_observation_count: usize,
+    /// Components whose prospective global-next plan is complete.
+    pub partition_border_global_face_next_mutation_ready_component_count: usize,
+    /// Components whose prospective global-next plan remains incomplete.
+    pub partition_border_global_face_next_mutation_incomplete_component_count: usize,
+    /// Whether the prospective global-next plan is safe to apply later.
+    pub partition_border_global_face_next_mutation_ready: bool,
     /// Conservative exactly-one-local-marker unbounded-face candidates.
     pub partition_border_global_unbounded_face_proof_candidate_count: usize,
     /// Whether the conservative unbounded-face proof gate is ready.
@@ -2465,6 +2477,11 @@ impl<'a> TiledPolygonizer<'a> {
                 &self.execution_policy,
                 partition_border_global_face_walk_invariants,
             )?;
+        let partition_border_global_face_next_mutation_plans = partition_border_graph
+            .reconcile_global_face_next_mutation_plans_with_walk(
+                &self.execution_policy,
+                partition_border_global_face_walk_invariants,
+            )?;
         let partition_border_global_unbounded_face_proof = partition_border_graph
             .validate_global_unbounded_face_proof_with_walk(
                 &self.execution_policy,
@@ -2507,6 +2524,9 @@ impl<'a> TiledPolygonizer<'a> {
             );
             trace.record_partition_border_global_face_identity_plans(
                 partition_border_global_face_identity_plans,
+            );
+            trace.record_partition_border_global_face_next_mutation_plans(
+                partition_border_global_face_next_mutation_plans,
             );
             trace.record_partition_border_global_unbounded_face_proof(
                 partition_border_global_unbounded_face_proof,
@@ -2844,6 +2864,18 @@ impl<'a> TiledPolygonizer<'a> {
                     partition_border_global_face_identity_plans.boundary_observation_count,
                 partition_border_global_face_identity_permutation_ready:
                     partition_border_global_face_identity_plans.permutation_ready,
+                partition_border_global_face_next_mutation_plan_count:
+                    partition_border_global_face_next_mutation_plans.plan_count,
+                partition_border_global_face_next_mutation_candidate_link_count:
+                    partition_border_global_face_next_mutation_plans.candidate_link_count,
+                partition_border_global_face_next_mutation_boundary_observation_count:
+                    partition_border_global_face_next_mutation_plans.boundary_observation_count,
+                partition_border_global_face_next_mutation_ready_component_count:
+                    partition_border_global_face_next_mutation_plans.ready_component_count,
+                partition_border_global_face_next_mutation_incomplete_component_count:
+                    partition_border_global_face_next_mutation_plans.incomplete_component_count,
+                partition_border_global_face_next_mutation_ready:
+                    partition_border_global_face_next_mutation_plans.mutation_ready,
                 partition_border_global_unbounded_face_proof_candidate_count:
                     partition_border_global_unbounded_face_proof.candidate_count,
                 partition_border_global_unbounded_face_proof_ready:

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -555,6 +555,53 @@ mod tests {
                 .partition_border_global_face_identity_permutation_ready,
             identity_stats.permutation_ready
         );
+        let mutation_plans = result
+            .partition_border_graph
+            .global_face_next_mutation_plans();
+        let mutation_stats = result
+            .partition_border_graph
+            .clone()
+            .reconcile_global_face_next_mutation_plans(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_next_mutation_plan_count,
+            mutation_plans.len()
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_next_mutation_candidate_link_count,
+            mutation_plans
+                .iter()
+                .map(|plan| plan.successor_observation_ids.len())
+                .sum::<usize>()
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_next_mutation_boundary_observation_count,
+            mutation_stats.boundary_observation_count
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_next_mutation_ready_component_count,
+            mutation_stats.ready_component_count
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_next_mutation_incomplete_component_count,
+            mutation_stats.incomplete_component_count
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_next_mutation_ready,
+            mutation_stats.mutation_ready
+        );
         let unbounded_proof = result
             .partition_border_graph
             .validate_global_unbounded_face_proof(&ExecutionPolicy::default())
@@ -1392,6 +1439,60 @@ mod tests {
                     .result
                     .stitching_report
                     .partition_border_global_face_identity_permutation_ready
+            )
+        );
+        let global_face_next_mutation_plans = traced
+            .trace
+            .events
+            .iter()
+            .find(|event| event.kind == "partition_border_global_face_next_mutation_plans")
+            .expect("global face next mutation plan evidence");
+        assert_eq!(
+            global_face_next_mutation_plans.payload["plan_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_next_mutation_plan_count as u64
+            )
+        );
+        assert_eq!(
+            global_face_next_mutation_plans.payload["candidate_link_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_next_mutation_candidate_link_count
+                    as u64
+            )
+        );
+        assert_eq!(
+            global_face_next_mutation_plans.payload["ready_component_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_next_mutation_ready_component_count
+                    as u64
+            )
+        );
+        assert_eq!(
+            global_face_next_mutation_plans.payload["incomplete_component_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_next_mutation_incomplete_component_count
+                    as u64
+            )
+        );
+        assert_eq!(
+            global_face_next_mutation_plans.payload["mutation_ready"].as_bool(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_next_mutation_ready
             )
         );
         let unbounded_proof = traced

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -5,11 +5,12 @@ use crate::graph::partition_border::{
     PartitionBorderGlobalComponentPayloadStats, PartitionBorderGlobalComponentReconciliationStats,
     PartitionBorderGlobalFaceEulerWitnessStats, PartitionBorderGlobalFaceIdentityPlanStats,
     PartitionBorderGlobalFaceMutationGateStats, PartitionBorderGlobalFaceNextCandidateStats,
-    PartitionBorderGlobalFacePlanStats, PartitionBorderGlobalFacePlanValidationStats,
-    PartitionBorderGlobalFaceTransitionPlanStats, PartitionBorderGlobalFaceTwinTransitionStats,
-    PartitionBorderGlobalFaceWalkInvariantStats, PartitionBorderGlobalUnboundedFaceProofStats,
-    PartitionBorderHalfEdge, PartitionBorderNodeReconciliationStats,
-    PartitionBorderReconciliationStats, PartitionBorderTwinApplicationStats,
+    PartitionBorderGlobalFaceNextMutationPlanStats, PartitionBorderGlobalFacePlanStats,
+    PartitionBorderGlobalFacePlanValidationStats, PartitionBorderGlobalFaceTransitionPlanStats,
+    PartitionBorderGlobalFaceTwinTransitionStats, PartitionBorderGlobalFaceWalkInvariantStats,
+    PartitionBorderGlobalUnboundedFaceProofStats, PartitionBorderHalfEdge,
+    PartitionBorderNodeReconciliationStats, PartitionBorderReconciliationStats,
+    PartitionBorderTwinApplicationStats,
 };
 use crate::graph::planar_graph::PartitionBoundaryNodingStats;
 use crate::graph::{ExtractedRing, PlanarGraph};
@@ -865,6 +866,25 @@ impl TraceRecorderV1 {
                 "incomplete_component_count": stats.incomplete_component_count,
                 "non_permutation_component_count": stats.non_permutation_component_count,
                 "permutation_ready": stats.permutation_ready,
+            }),
+        )
+    }
+
+    pub(crate) fn record_partition_border_global_face_next_mutation_plans(
+        &mut self,
+        stats: PartitionBorderGlobalFaceNextMutationPlanStats,
+    ) -> bool {
+        self.record(
+            TraceStageV1::Graph,
+            "partition_border_global_face_next_mutation_plans",
+            serde_json::json!({
+                "component_count": stats.component_count,
+                "boundary_observation_count": stats.boundary_observation_count,
+                "plan_count": stats.plan_count,
+                "candidate_link_count": stats.candidate_link_count,
+                "ready_component_count": stats.ready_component_count,
+                "incomplete_component_count": stats.incomplete_component_count,
+                "mutation_ready": stats.mutation_ready,
             }),
         )
     }


### PR DESCRIPTION
Stack

- Parent: #1333 (`agent/p5-global-face-face-identity-plan`, `94961e3`)
- Children: none at creation

Delivered

- Retained a deterministic boundary-only global-next mutation plan derived
  from validated global face identity cycles.
- Required exact closed cycle assignments before exposing prospective successor
  links; incomplete components retain zero links and remain not-ready.
- Preserved local transition maps, local twins, and global topology links as
  read-only evidence; no topology mutation or global face ID assignment occurs.
- Added bounded, cancellable, atomic, malformed, incomplete, deterministic,
  report, and topology-trace regressions.
- Added additive stitching-report and topology-trace evidence and updated the
  P5.3 roadmap evidence line.

Contract impact

- This PR is evidence-only: it never writes local or global `next` links,
  assigns global face IDs, mutates global nodes, selects an unbounded face, or
  changes tiled output.
- `mutation_ready` means only that validated boundary identity cycles can
  provide exact prospective successors; it is not a proof of complete
  interior topology, containment, Euler validity, or untiled equivalence.
- Incomplete identity plans and malformed mutation evidence fail closed without
  partially committing a plan.
- Existing canonical output, provenance, representative IDs, Z policy,
  serial/parallel behavior, limits, and cancellation contracts are unchanged.

Validation

- `cargo test -p geo-polygonize-core global_face_next_mutation_plans --lib`
- `cargo test -p geo-polygonize-core exports_physical_tile_border_observations_before_scratch_is_released --lib`
- `cargo test -p geo-polygonize-core trace_records_partition_boundary_noding_and_atomic_observations --lib`
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings`
- `DYLD_LIBRARY_PATH=/Library/Frameworks/Python.framework/Versions/3.11/lib cargo test --workspace --lib --tests --no-fail-fast` (341 core unit tests plus workspace integration targets)
- `DYLD_LIBRARY_PATH=/Library/Frameworks/Python.framework/Versions/3.11/lib cargo test -p geo-polygonize-core --no-default-features --lib --tests` (341 core unit tests plus core integration targets)
- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `git diff --check`
- Generated bindings were restored and the untracked `FingerprintDiffV1.ts` export was removed.

Agent handoff

- Parent: #1333 (`agent/p5-global-face-face-identity-plan`, `94961e3`)
- Children: none at creation
- Next branch: `agent/p5-global-face-global-id-plan`
- Remaining: apply only validated twins into a future global topology, assign
  deterministic global face IDs, prove one global unbounded face, validate full
  interior Euler/source/Z invariants, extract stitched output, compare untiled
  results, fuzz partitioning, and publish promotion evidence.
- Disproved finding: the existing tiled fixture still reuses at least one
  physical border span across retained face components, so all mutation plans
  remain boundary-only evidence and cannot authorize global face promotion.
