### PR TITLE
feat(core): plan deterministic global face ids

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -499,6 +499,9 @@ Blocked by #1288.
 - [x] Retain a fail-closed global-next mutation plan from validated identity
   cycles; require exact cycle assignments while keeping local and global links
   unwritten until a real global topology exists.
+- [x] Retain deterministic candidate global face IDs for closed boundary
+  mutation cycles; keep incomplete cycles explicitly unassigned and do not
+  write candidate IDs into local observations or tiled output.
 - [ ] Apply unambiguous twins only across declared adjacent borders.
 - [ ] Reconcile canonical border nodes, source sets, representative IDs, and
   selected Z-policy decisions.

--- a/crates/geo-polygonize-core/src/graph/partition_border.rs
+++ b/crates/geo-polygonize-core/src/graph/partition_border.rs
@@ -857,6 +857,33 @@ pub(crate) struct PartitionBorderGlobalFaceNextMutationPlanStats {
     pub(crate) mutation_ready: bool,
 }
 
+/// One deterministic candidate global face identity derived from a validated
+/// boundary mutation cycle. The ID is evidence for a future complete global
+/// arrangement; it is never written into local observations or tiled output.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct PartitionBorderGlobalFaceIdPlan {
+    pub(crate) candidate_global_face_id: Option<usize>,
+    pub(crate) component_index: usize,
+    pub(crate) boundary_observation_ids: Vec<PartitionBorderObservationId>,
+    pub(crate) face_refs: Vec<PartitionFaceRef>,
+    pub(crate) local_unbounded_face_count: usize,
+    pub(crate) closed: bool,
+}
+
+/// Counts from assigning deterministic candidate IDs to closed boundary
+/// cycles. `assignment_ready` is deliberately narrower than global topology
+/// readiness: it says only that the retained boundary cycles are complete.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct PartitionBorderGlobalFaceIdPlanStats {
+    pub(crate) component_count: usize,
+    pub(crate) candidate_cycle_count: usize,
+    pub(crate) assigned_face_count: usize,
+    pub(crate) boundary_observation_count: usize,
+    pub(crate) unbounded_candidate_count: usize,
+    pub(crate) incomplete_plan_count: usize,
+    pub(crate) assignment_ready: bool,
+}
+
 /// Deterministic evidence for the declared-adjacency twin boundary.
 ///
 /// Only observations covered by a declared partition adjacency contribute to
@@ -891,6 +918,7 @@ pub struct PartitionBorderGraph {
     global_face_next_candidates: Vec<PartitionBorderGlobalFaceNextCandidate>,
     global_face_identity_plans: Vec<PartitionBorderGlobalFaceIdentityPlan>,
     global_face_next_mutation_plans: Vec<PartitionBorderGlobalFaceNextMutationPlan>,
+    global_face_id_plans: Vec<PartitionBorderGlobalFaceIdPlan>,
 }
 
 impl PartitionBorderGraph {
@@ -934,6 +962,7 @@ impl PartitionBorderGraph {
         self.global_face_next_candidates.clear();
         self.global_face_identity_plans.clear();
         self.global_face_next_mutation_plans.clear();
+        self.global_face_id_plans.clear();
         Ok(())
     }
 
@@ -949,6 +978,7 @@ impl PartitionBorderGraph {
         self.global_face_next_candidates.clear();
         self.global_face_identity_plans.clear();
         self.global_face_next_mutation_plans.clear();
+        self.global_face_id_plans.clear();
     }
 
     pub fn node_count(&self) -> usize {
@@ -1205,6 +1235,7 @@ impl PartitionBorderGraph {
         self.global_face_next_candidates.clear();
         self.global_face_identity_plans.clear();
         self.global_face_next_mutation_plans.clear();
+        self.global_face_id_plans.clear();
         Ok(stats)
     }
 
@@ -1351,6 +1382,7 @@ impl PartitionBorderGraph {
         self.global_face_next_candidates.clear();
         self.global_face_identity_plans.clear();
         self.global_face_next_mutation_plans.clear();
+        self.global_face_id_plans.clear();
         Ok(stats)
     }
 
@@ -1500,6 +1532,7 @@ impl PartitionBorderGraph {
         self.global_face_next_candidates.clear();
         self.global_face_identity_plans.clear();
         self.global_face_next_mutation_plans.clear();
+        self.global_face_id_plans.clear();
         Ok(stats)
     }
 
@@ -1812,6 +1845,7 @@ impl PartitionBorderGraph {
         self.global_face_next_candidates.clear();
         self.global_face_identity_plans.clear();
         self.global_face_next_mutation_plans.clear();
+        self.global_face_id_plans.clear();
         Ok(stats)
     }
 
@@ -2322,6 +2356,7 @@ impl PartitionBorderGraph {
         self.global_face_next_candidates.clear();
         self.global_face_identity_plans.clear();
         self.global_face_next_mutation_plans.clear();
+        self.global_face_id_plans.clear();
         Ok(stats)
     }
 
@@ -2462,6 +2497,7 @@ impl PartitionBorderGraph {
         self.global_face_next_candidates.clear();
         self.global_face_identity_plans.clear();
         self.global_face_next_mutation_plans.clear();
+        self.global_face_id_plans.clear();
         Ok(stats)
     }
 
@@ -3281,6 +3317,203 @@ impl PartitionBorderGraph {
         &self,
     ) -> &[PartitionBorderGlobalFaceNextMutationPlan] {
         &self.global_face_next_mutation_plans
+    }
+
+    /// Assigns deterministic candidate global face IDs to validated closed
+    /// boundary cycles. Incomplete cycles are retained with no ID, and this
+    /// plan never writes IDs into local observations, global topology, or
+    /// tiled output.
+    #[cfg(test)]
+    pub(crate) fn reconcile_global_face_id_plans(
+        &mut self,
+        execution_policy: &ExecutionPolicy,
+    ) -> crate::Result<PartitionBorderGlobalFaceIdPlanStats> {
+        execution_policy.check_cancelled("partition_border_global_face_id_plans")?;
+        let walk = self.validate_global_face_walk_invariants(execution_policy)?;
+        if self.global_face_next_mutation_plans.is_empty() && !self.global_components.is_empty() {
+            self.reconcile_global_face_next_candidates_with_walk(execution_policy, walk)?;
+            self.reconcile_global_face_identity_plans_with_walk(execution_policy, walk)?;
+            self.reconcile_global_face_next_mutation_plans_with_walk(execution_policy, walk)?;
+        }
+        self.reconcile_global_face_id_plans_with_walk(execution_policy, walk)
+    }
+
+    pub(crate) fn reconcile_global_face_id_plans_with_walk(
+        &mut self,
+        execution_policy: &ExecutionPolicy,
+        walk: PartitionBorderGlobalFaceWalkInvariantStats,
+    ) -> crate::Result<PartitionBorderGlobalFaceIdPlanStats> {
+        execution_policy.check_cancelled("partition_border_global_face_id_plans")?;
+        execution_policy.check(
+            "partition_border_global_face_id_plans_faces",
+            execution_policy.max_graph_nodes,
+            self.global_face_identity_plans.len(),
+        )?;
+        execution_policy.check(
+            "partition_border_global_face_id_plans_observations",
+            execution_policy.max_graph_edges,
+            walk.transition_count,
+        )?;
+        execution_policy.check(
+            "partition_border_global_face_id_plans_components",
+            execution_policy.max_graph_nodes,
+            self.global_components.len(),
+        )?;
+        if walk.face_count != self.global_face_transitions.len()
+            || self.global_face_identity_plans.len() != self.global_face_next_mutation_plans.len()
+        {
+            return Err(crate::PolygonizeError::InternalInvariantViolation {
+                reason: "global face ID plan evidence mismatch".to_string(),
+            });
+        }
+
+        let mut transition_unbounded_by_face = BTreeMap::<PartitionFaceRef, usize>::new();
+        for (transition_index, transition) in self.global_face_transitions.iter().enumerate() {
+            execution_policy.check_cancelled_every(
+                "partition_border_global_face_id_plans_transitions",
+                transition_index,
+            )?;
+            if transition_unbounded_by_face
+                .insert(
+                    transition.face_ref,
+                    usize::from(transition.local_face_is_unbounded),
+                )
+                .is_some()
+            {
+                return Err(crate::PolygonizeError::InternalInvariantViolation {
+                    reason: format!(
+                        "global face ID plan transition {:?} is duplicated",
+                        transition.face_ref
+                    ),
+                });
+            }
+        }
+
+        let mut plans = Vec::with_capacity(self.global_face_identity_plans.len());
+        let mut seen_components = BTreeSet::new();
+        let mut seen_observations = BTreeSet::new();
+        let mut boundary_observation_count = 0usize;
+        let mut incomplete_plan_count = 0usize;
+        let mut unbounded_candidate_count = 0usize;
+        for (plan_index, identity_plan) in self.global_face_identity_plans.iter().enumerate() {
+            execution_policy
+                .check_cancelled_every("partition_border_global_face_id_plans", plan_index)?;
+            if identity_plan.component_index >= self.global_components.len() {
+                return Err(crate::PolygonizeError::InternalInvariantViolation {
+                    reason: format!(
+                        "global face ID plan {} references missing component {}",
+                        plan_index, identity_plan.component_index
+                    ),
+                });
+            }
+            seen_components.insert(identity_plan.component_index);
+            let mutation_plan = &self.global_face_next_mutation_plans[plan_index];
+            if mutation_plan.component_index != identity_plan.component_index
+                || mutation_plan.boundary_observation_ids != identity_plan.boundary_observation_ids
+                || mutation_plan.closed != identity_plan.closed
+            {
+                return Err(crate::PolygonizeError::InternalInvariantViolation {
+                    reason: format!(
+                        "global face ID plan {} disagrees with its mutation plan",
+                        plan_index
+                    ),
+                });
+            }
+            for observation_id in &identity_plan.boundary_observation_ids {
+                if !seen_observations.insert(*observation_id) {
+                    return Err(crate::PolygonizeError::InternalInvariantViolation {
+                        reason: format!(
+                            "global face ID plan observation {:?} is duplicated",
+                            observation_id
+                        ),
+                    });
+                }
+            }
+            boundary_observation_count = boundary_observation_count
+                .checked_add(identity_plan.boundary_observation_ids.len())
+                .ok_or_else(|| crate::PolygonizeError::InternalInvariantViolation {
+                    reason: "global face ID plan observation count overflow".to_string(),
+                })?;
+            let local_unbounded_face_count = identity_plan
+                .face_refs
+                .iter()
+                .map(|face_ref| transition_unbounded_by_face.get(face_ref).copied())
+                .collect::<Option<Vec<_>>>()
+                .ok_or_else(|| crate::PolygonizeError::InternalInvariantViolation {
+                    reason: format!(
+                        "global face ID plan {} references a face without a transition",
+                        plan_index
+                    ),
+                })?
+                .into_iter()
+                .sum();
+            if local_unbounded_face_count > 0 && identity_plan.closed {
+                unbounded_candidate_count += 1;
+            }
+            if !identity_plan.closed {
+                incomplete_plan_count += 1;
+            }
+            plans.push(PartitionBorderGlobalFaceIdPlan {
+                candidate_global_face_id: None,
+                component_index: identity_plan.component_index,
+                boundary_observation_ids: identity_plan.boundary_observation_ids.clone(),
+                face_refs: identity_plan.face_refs.clone(),
+                local_unbounded_face_count,
+                closed: identity_plan.closed,
+            });
+        }
+        if seen_components.len() != self.global_components.len() {
+            return Err(crate::PolygonizeError::InternalInvariantViolation {
+                reason: format!(
+                    "global face ID plan omits components: planned={}, components={}",
+                    seen_components.len(),
+                    self.global_components.len()
+                ),
+            });
+        }
+
+        let mut closed_plan_indices = plans
+            .iter()
+            .enumerate()
+            .filter_map(|(index, plan)| plan.closed.then_some(index))
+            .collect::<Vec<_>>();
+        closed_plan_indices.sort_unstable_by(|left, right| {
+            plans[*left]
+                .component_index
+                .cmp(&plans[*right].component_index)
+                .then_with(|| {
+                    plans[*left]
+                        .boundary_observation_ids
+                        .cmp(&plans[*right].boundary_observation_ids)
+                })
+                .then_with(|| plans[*left].face_refs.cmp(&plans[*right].face_refs))
+        });
+        for (candidate_global_face_id, plan_index) in
+            closed_plan_indices.iter().copied().enumerate()
+        {
+            execution_policy.check_cancelled_every(
+                "partition_border_global_face_id_plans_cycles",
+                candidate_global_face_id,
+            )?;
+            plans[plan_index].candidate_global_face_id = Some(candidate_global_face_id);
+        }
+
+        let stats = PartitionBorderGlobalFaceIdPlanStats {
+            component_count: self.global_components.len(),
+            candidate_cycle_count: plans.len(),
+            assigned_face_count: closed_plan_indices.len(),
+            boundary_observation_count,
+            unbounded_candidate_count,
+            incomplete_plan_count,
+            assignment_ready: incomplete_plan_count == 0,
+        };
+        self.global_face_id_plans = plans;
+        Ok(stats)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn global_face_id_plans(&self) -> &[PartitionBorderGlobalFaceIdPlan] {
+        &self.global_face_id_plans
     }
 
     /// Validates the retained face-walk, twin, payload, and face-adjacency
@@ -6472,6 +6705,136 @@ mod tests {
                 observed: 2,
             } if stage == "partition_border_global_face_next_mutation_plans_faces"
         ));
+    }
+
+    #[test]
+    fn global_face_id_plans_assign_only_closed_boundary_cycles() {
+        let graph = prepared_global_face_walk_graph(true, [false, false]);
+        let mut complete = graph.clone();
+        let stats = complete
+            .reconcile_global_face_id_plans(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(
+            stats,
+            PartitionBorderGlobalFaceIdPlanStats {
+                component_count: 1,
+                candidate_cycle_count: 1,
+                assigned_face_count: 1,
+                boundary_observation_count: 2,
+                unbounded_candidate_count: 0,
+                incomplete_plan_count: 0,
+                assignment_ready: true,
+            }
+        );
+        let plan = complete
+            .global_face_id_plans()
+            .first()
+            .expect("global face ID plan");
+        assert_eq!(plan.candidate_global_face_id, Some(0));
+        assert!(plan.closed);
+        assert_eq!(plan.local_unbounded_face_count, 0);
+        assert_eq!(complete.global_face_plans(), graph.global_face_plans());
+
+        let mut incomplete = prepared_global_face_walk_graph(false, [false, false]);
+        let stats = incomplete
+            .reconcile_global_face_id_plans(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(stats.candidate_cycle_count, 1);
+        assert_eq!(stats.assigned_face_count, 0);
+        assert_eq!(stats.boundary_observation_count, 2);
+        assert_eq!(stats.incomplete_plan_count, 1);
+        assert!(!stats.assignment_ready);
+        assert_eq!(
+            incomplete.global_face_id_plans()[0].candidate_global_face_id,
+            None
+        );
+        assert!(!incomplete.global_face_id_plans()[0].closed);
+
+        let unbounded = prepared_global_face_walk_graph(true, [true, false]);
+        let mut unbounded = unbounded;
+        let stats = unbounded
+            .reconcile_global_face_id_plans(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(stats.unbounded_candidate_count, 1);
+        assert!(unbounded.global_face_id_plans()[0].closed);
+        assert_eq!(
+            unbounded.global_face_id_plans()[0].local_unbounded_face_count,
+            1
+        );
+    }
+
+    #[test]
+    fn global_face_id_plans_are_atomic_deterministic_and_bounded() {
+        let graph = prepared_global_face_walk_graph(true, [false, false]);
+        let walk = graph
+            .validate_global_face_walk_invariants(&ExecutionPolicy::default())
+            .unwrap();
+        let mut ready = graph.clone();
+        ready
+            .reconcile_global_face_next_candidates(&ExecutionPolicy::default())
+            .unwrap();
+        ready
+            .reconcile_global_face_identity_plans(&ExecutionPolicy::default())
+            .unwrap();
+        ready
+            .reconcile_global_face_next_mutation_plans(&ExecutionPolicy::default())
+            .unwrap();
+        let before = ready.clone();
+        let error = ready
+            .reconcile_global_face_id_plans_with_walk(
+                &ExecutionPolicy {
+                    max_graph_nodes: Some(0),
+                    ..Default::default()
+                },
+                walk,
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::ResourceLimitExceeded {
+                ref stage,
+                limit: 0,
+                observed: 1,
+            } if stage == "partition_border_global_face_id_plans_faces"
+        ));
+        assert_eq!(ready, before);
+
+        let token = CancellationToken::new();
+        token.cancel();
+        let error = graph
+            .clone()
+            .reconcile_global_face_id_plans_with_walk(
+                &ExecutionPolicy {
+                    cancellation_token: Some(token),
+                    ..Default::default()
+                },
+                walk,
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::Cancelled { ref stage }
+                if stage == "partition_border_global_face_id_plans"
+        ));
+
+        let mut malformed = graph.clone();
+        malformed
+            .reconcile_global_face_id_plans(&ExecutionPolicy::default())
+            .unwrap();
+        let before = malformed.clone();
+        malformed.global_face_next_mutation_plans[0].closed = false;
+        let error = malformed
+            .reconcile_global_face_id_plans_with_walk(&ExecutionPolicy::default(), walk)
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::InternalInvariantViolation { ref reason }
+                if reason.contains("disagrees")
+        ));
+        assert_eq!(
+            malformed.global_face_id_plans(),
+            before.global_face_id_plans()
+        );
     }
 
     #[test]

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -377,6 +377,20 @@ pub struct StitchingReport {
     pub partition_border_global_face_next_mutation_incomplete_component_count: usize,
     /// Whether the prospective global-next plan is safe to apply later.
     pub partition_border_global_face_next_mutation_ready: bool,
+    /// Boundary-only candidate global face cycles retained from the mutation
+    /// plan. These IDs are not assigned to local observations or output.
+    pub partition_border_global_face_id_candidate_cycle_count: usize,
+    /// Candidate global face IDs assigned to closed boundary cycles.
+    pub partition_border_global_face_id_assigned_count: usize,
+    /// Boundary observations covered by candidate global face ID plans.
+    pub partition_border_global_face_id_boundary_observation_count: usize,
+    /// Candidate cycles containing a local unbounded-face marker.
+    pub partition_border_global_face_id_unbounded_candidate_count: usize,
+    /// Candidate cycles retained without a global ID because their boundary
+    /// evidence is incomplete.
+    pub partition_border_global_face_id_incomplete_plan_count: usize,
+    /// Whether every retained boundary cycle received a candidate ID.
+    pub partition_border_global_face_id_assignment_ready: bool,
     /// Conservative exactly-one-local-marker unbounded-face candidates.
     pub partition_border_global_unbounded_face_proof_candidate_count: usize,
     /// Whether the conservative unbounded-face proof gate is ready.
@@ -2482,6 +2496,11 @@ impl<'a> TiledPolygonizer<'a> {
                 &self.execution_policy,
                 partition_border_global_face_walk_invariants,
             )?;
+        let partition_border_global_face_id_plans = partition_border_graph
+            .reconcile_global_face_id_plans_with_walk(
+                &self.execution_policy,
+                partition_border_global_face_walk_invariants,
+            )?;
         let partition_border_global_unbounded_face_proof = partition_border_graph
             .validate_global_unbounded_face_proof_with_walk(
                 &self.execution_policy,
@@ -2527,6 +2546,9 @@ impl<'a> TiledPolygonizer<'a> {
             );
             trace.record_partition_border_global_face_next_mutation_plans(
                 partition_border_global_face_next_mutation_plans,
+            );
+            trace.record_partition_border_global_face_id_plans(
+                partition_border_global_face_id_plans,
             );
             trace.record_partition_border_global_unbounded_face_proof(
                 partition_border_global_unbounded_face_proof,
@@ -2876,6 +2898,18 @@ impl<'a> TiledPolygonizer<'a> {
                     partition_border_global_face_next_mutation_plans.incomplete_component_count,
                 partition_border_global_face_next_mutation_ready:
                     partition_border_global_face_next_mutation_plans.mutation_ready,
+                partition_border_global_face_id_candidate_cycle_count:
+                    partition_border_global_face_id_plans.candidate_cycle_count,
+                partition_border_global_face_id_assigned_count:
+                    partition_border_global_face_id_plans.assigned_face_count,
+                partition_border_global_face_id_boundary_observation_count:
+                    partition_border_global_face_id_plans.boundary_observation_count,
+                partition_border_global_face_id_unbounded_candidate_count:
+                    partition_border_global_face_id_plans.unbounded_candidate_count,
+                partition_border_global_face_id_incomplete_plan_count:
+                    partition_border_global_face_id_plans.incomplete_plan_count,
+                partition_border_global_face_id_assignment_ready:
+                    partition_border_global_face_id_plans.assignment_ready,
                 partition_border_global_unbounded_face_proof_candidate_count:
                     partition_border_global_unbounded_face_proof.candidate_count,
                 partition_border_global_unbounded_face_proof_ready:

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -602,6 +602,51 @@ mod tests {
                 .partition_border_global_face_next_mutation_ready,
             mutation_stats.mutation_ready
         );
+        let id_plans = result.partition_border_graph.global_face_id_plans();
+        let id_stats = result
+            .partition_border_graph
+            .clone()
+            .reconcile_global_face_id_plans(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_id_candidate_cycle_count,
+            id_plans.len()
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_id_assigned_count,
+            id_plans
+                .iter()
+                .filter(|plan| plan.candidate_global_face_id.is_some())
+                .count()
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_id_boundary_observation_count,
+            id_stats.boundary_observation_count
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_id_unbounded_candidate_count,
+            id_stats.unbounded_candidate_count
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_id_incomplete_plan_count,
+            id_stats.incomplete_plan_count
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_id_assignment_ready,
+            id_stats.assignment_ready
+        );
         let unbounded_proof = result
             .partition_border_graph
             .validate_global_unbounded_face_proof(&ExecutionPolicy::default())
@@ -1493,6 +1538,68 @@ mod tests {
                     .result
                     .stitching_report
                     .partition_border_global_face_next_mutation_ready
+            )
+        );
+        let global_face_id_plans = traced
+            .trace
+            .events
+            .iter()
+            .find(|event| event.kind == "partition_border_global_face_id_plans")
+            .expect("global face ID plan evidence");
+        assert_eq!(
+            global_face_id_plans.payload["candidate_cycle_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_id_candidate_cycle_count as u64
+            )
+        );
+        assert_eq!(
+            global_face_id_plans.payload["assigned_face_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_id_assigned_count as u64
+            )
+        );
+        assert_eq!(
+            global_face_id_plans.payload["boundary_observation_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_id_boundary_observation_count
+                    as u64
+            )
+        );
+        assert_eq!(
+            global_face_id_plans.payload["unbounded_candidate_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_id_unbounded_candidate_count
+                    as u64
+            )
+        );
+        assert_eq!(
+            global_face_id_plans.payload["incomplete_plan_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_id_incomplete_plan_count as u64
+            )
+        );
+        assert_eq!(
+            global_face_id_plans.payload["assignment_ready"].as_bool(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_id_assignment_ready
             )
         );
         let unbounded_proof = traced

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -3,14 +3,14 @@
 use crate::fingerprint::{coordinate_fingerprint, float_bits};
 use crate::graph::partition_border::{
     PartitionBorderGlobalComponentPayloadStats, PartitionBorderGlobalComponentReconciliationStats,
-    PartitionBorderGlobalFaceEulerWitnessStats, PartitionBorderGlobalFaceIdentityPlanStats,
-    PartitionBorderGlobalFaceMutationGateStats, PartitionBorderGlobalFaceNextCandidateStats,
-    PartitionBorderGlobalFaceNextMutationPlanStats, PartitionBorderGlobalFacePlanStats,
-    PartitionBorderGlobalFacePlanValidationStats, PartitionBorderGlobalFaceTransitionPlanStats,
-    PartitionBorderGlobalFaceTwinTransitionStats, PartitionBorderGlobalFaceWalkInvariantStats,
-    PartitionBorderGlobalUnboundedFaceProofStats, PartitionBorderHalfEdge,
-    PartitionBorderNodeReconciliationStats, PartitionBorderReconciliationStats,
-    PartitionBorderTwinApplicationStats,
+    PartitionBorderGlobalFaceEulerWitnessStats, PartitionBorderGlobalFaceIdPlanStats,
+    PartitionBorderGlobalFaceIdentityPlanStats, PartitionBorderGlobalFaceMutationGateStats,
+    PartitionBorderGlobalFaceNextCandidateStats, PartitionBorderGlobalFaceNextMutationPlanStats,
+    PartitionBorderGlobalFacePlanStats, PartitionBorderGlobalFacePlanValidationStats,
+    PartitionBorderGlobalFaceTransitionPlanStats, PartitionBorderGlobalFaceTwinTransitionStats,
+    PartitionBorderGlobalFaceWalkInvariantStats, PartitionBorderGlobalUnboundedFaceProofStats,
+    PartitionBorderHalfEdge, PartitionBorderNodeReconciliationStats,
+    PartitionBorderReconciliationStats, PartitionBorderTwinApplicationStats,
 };
 use crate::graph::planar_graph::PartitionBoundaryNodingStats;
 use crate::graph::{ExtractedRing, PlanarGraph};
@@ -885,6 +885,25 @@ impl TraceRecorderV1 {
                 "ready_component_count": stats.ready_component_count,
                 "incomplete_component_count": stats.incomplete_component_count,
                 "mutation_ready": stats.mutation_ready,
+            }),
+        )
+    }
+
+    pub(crate) fn record_partition_border_global_face_id_plans(
+        &mut self,
+        stats: PartitionBorderGlobalFaceIdPlanStats,
+    ) -> bool {
+        self.record(
+            TraceStageV1::Graph,
+            "partition_border_global_face_id_plans",
+            serde_json::json!({
+                "component_count": stats.component_count,
+                "candidate_cycle_count": stats.candidate_cycle_count,
+                "assigned_face_count": stats.assigned_face_count,
+                "boundary_observation_count": stats.boundary_observation_count,
+                "unbounded_candidate_count": stats.unbounded_candidate_count,
+                "incomplete_plan_count": stats.incomplete_plan_count,
+                "assignment_ready": stats.assignment_ready,
             }),
         )
     }


### PR DESCRIPTION
Stack

- Parent: none; based on `main` at the merged P5.3 evidence stack
- Children: #1336 (`agent/p5-global-face-topology-edge-map`, `6a2bb88`)

Delivered

- Retained deterministic candidate global face IDs for every closed boundary
  mutation cycle, ordered by component, observation cycle, and face lineage.
- Kept incomplete cycles explicitly unassigned and reported their readiness
  separately from closed-cycle assignment.
- Counted local unbounded-face markers carried by each candidate without
  promoting any marker to the global unbounded face.
- Added atomic, deterministic, incomplete, malformed, cancellation, and
  resource-limit regressions.
- Added additive stitching-report and topology-trace evidence and updated the
  P5.3 roadmap evidence line.

Contract impact

- This PR is still boundary evidence: candidate IDs never enter local face
  observations, global topology links, polygon output, provenance, or Z
  decisions.
- `assignment_ready` means only that all retained boundary cycles are closed;
  it is not a proof of a complete global arrangement, containment, Euler
  validity, one global unbounded face, or untiled equivalence.
- Incomplete and malformed plans fail closed without partially committing
  candidate IDs.
- Existing canonical output, representative IDs, provenance, Z policy,
  serial/parallel behavior, resource limits, and cancellation contracts are
  unchanged.

Validation

- `cargo test -p geo-polygonize-core global_face_id_plans --lib`
- `cargo test -p geo-polygonize-core exports_physical_tile_border_observations_before_scratch_is_released --lib`
- `cargo test -p geo-polygonize-core trace_records_partition_boundary_noding_and_atomic_observations --lib`
- `DYLD_LIBRARY_PATH=/Library/Frameworks/Python.framework/Versions/3.11/lib cargo test --workspace --lib --tests --no-fail-fast` (343 core unit tests plus workspace integration targets)
- `DYLD_LIBRARY_PATH=/Library/Frameworks/Python.framework/Versions/3.11/lib cargo test -p geo-polygonize-core --no-default-features --lib --tests` (343 core unit tests plus core integration targets)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check` and `git diff --check`
- Generated bindings were restored and the untracked `FingerprintDiffV1.ts` export was removed.

Agent handoff

- Exact parent: none; based on `main` at the merged P5.3 evidence stack
- Exact children: #1336 (`agent/p5-global-face-topology-edge-map`, `6a2bb88`)
- Next branch: `agent/p5-global-face-node-reconcile`
- Remaining: capture complete local face topology, map declared twins to active
  directed-edge lineage, apply only those twins in a fail-closed global graph,
  reconcile canonical node payloads, build global `next` links and face IDs,
  prove one global unbounded face, validate interior Euler/source/Z invariants,
  extract stitched output, compare untiled results, fuzz partitioning, and
  publish promotion evidence.
- Disproved finding: the current tiled fixture still reuses a physical border
  span across retained face components, so candidate IDs remain boundary-only
  and cannot authorize global face promotion.
