### PR TITLE
feat(core): map global face edge lineage

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -502,6 +502,10 @@ Blocked by #1288.
 - [x] Retain deterministic candidate global face IDs for closed boundary
   mutation cycles; keep incomplete cycles explicitly unassigned and do not
   write candidate IDs into local observations or tiled output.
+- [x] Capture active local face-edge lineage and deterministically map local
+  symmetric/successor identities plus declared face-qualified twins into
+  global edge slots, validating geometry, provenance, Z, and cancellation
+  boundaries without mutating topology.
 - [ ] Apply unambiguous twins only across declared adjacent borders.
 - [ ] Reconcile canonical border nodes, source sets, representative IDs, and
   selected Z-policy decisions.

--- a/crates/geo-polygonize-core/src/graph/partition_border.rs
+++ b/crates/geo-polygonize-core/src/graph/partition_border.rs
@@ -405,6 +405,34 @@ impl PartitionBorderHalfEdge {
     }
 }
 
+/// One active directed edge captured from a processed tile-local component.
+/// Local directed-edge IDs remain qualified by partition and component so the
+/// future global graph can remap them without relying on tile iteration order.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct PartitionBorderLocalDirectedEdge {
+    pub(crate) local_dir_edge_id: DirEdgeId,
+    pub(crate) symmetric_local_dir_edge_id: DirEdgeId,
+    pub(crate) local_face_successor: Option<DirEdgeId>,
+    pub(crate) from: PartitionBorderNodeKey,
+    pub(crate) to: PartitionBorderNodeKey,
+    pub(crate) from_z_bits: u64,
+    pub(crate) to_z_bits: u64,
+    pub(crate) edge_key: PartitionBorderEdgeKey,
+    pub(crate) face_ref: Option<PartitionFaceRef>,
+    pub(crate) local_face_is_unbounded: bool,
+    pub(crate) source_line_ids: Vec<u32>,
+}
+
+/// Processed local face-edge lineage retained for a future global topology.
+/// It contains only active local arrangement edges; no global links are
+/// written while the snapshot is captured.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct PartitionBorderLocalFaceGraph {
+    pub(crate) partition_id: usize,
+    pub(crate) component_id: usize,
+    pub(crate) directed_edges: Vec<PartitionBorderLocalDirectedEdge>,
+}
+
 /// Declared shared border between two neighboring partitions.
 ///
 /// The exact border coordinate is part of the relationship, so geometrically
@@ -544,6 +572,42 @@ pub(crate) struct PartitionBorderTwinApplicationStats {
     pub(crate) applied_twin_count: usize,
     pub(crate) missing_face_ref_count: usize,
     pub(crate) invalid_face_ref_count: usize,
+}
+
+/// One deterministic global edge slot backed by an active tile-local edge.
+/// The local symmetric and successor identities are remapped into this slot
+/// space, while declared cross-border twins remain explicit side metadata.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct PartitionBorderGlobalFaceEdge {
+    pub(crate) global_dir_edge_id: usize,
+    pub(crate) partition_id: usize,
+    pub(crate) component_id: usize,
+    pub(crate) local_dir_edge_id: DirEdgeId,
+    pub(crate) symmetric_global_dir_edge_id: usize,
+    pub(crate) local_face_successor_global_dir_edge_id: Option<usize>,
+    pub(crate) cross_border_twin_global_dir_edge_id: Option<usize>,
+    pub(crate) from: PartitionBorderNodeKey,
+    pub(crate) to: PartitionBorderNodeKey,
+    pub(crate) from_z_bits: u64,
+    pub(crate) to_z_bits: u64,
+    pub(crate) edge_key: PartitionBorderEdgeKey,
+    pub(crate) face_ref: Option<PartitionFaceRef>,
+    pub(crate) local_face_is_unbounded: bool,
+    pub(crate) source_line_ids: Vec<u32>,
+}
+
+/// Counts from remapping active local face-edge lineage into deterministic
+/// global edge slots. No global node, twin, successor, or face ID is mutated.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct PartitionBorderGlobalFaceEdgeMapStats {
+    pub(crate) local_graph_count: usize,
+    pub(crate) component_count: usize,
+    pub(crate) directed_edge_count: usize,
+    pub(crate) local_successor_count: usize,
+    pub(crate) mapped_observation_count: usize,
+    pub(crate) mapped_twin_count: usize,
+    pub(crate) unmapped_twin_count: usize,
+    pub(crate) edge_map_ready: bool,
 }
 
 /// Canonical evidence for one border node after all physical observations
@@ -908,7 +972,9 @@ pub struct PartitionBorderGraph {
     observations: BTreeMap<PartitionBorderObservationId, PartitionBorderHalfEdge>,
     adjacencies: BTreeSet<PartitionBorderAdjacency>,
     edges: BTreeMap<PartitionBorderEdgeKey, BTreeSet<PartitionBorderHalfEdge>>,
+    local_face_graphs: Vec<PartitionBorderLocalFaceGraph>,
     applied_face_twins: Vec<PartitionBorderFaceTwin>,
+    global_face_edge_map: Vec<PartitionBorderGlobalFaceEdge>,
     reconciled_nodes: Vec<PartitionBorderNodePayload>,
     global_components: Vec<PartitionBorderGlobalComponent>,
     global_component_payloads: Vec<PartitionBorderGlobalComponentPayload>,
@@ -952,6 +1018,7 @@ impl PartitionBorderGraph {
             .or_default()
             .insert(half_edge.clone());
         self.observations.insert(observation_id, half_edge);
+        self.local_face_graphs.clear();
         self.applied_face_twins.clear();
         self.reconciled_nodes.clear();
         self.global_components.clear();
@@ -966,8 +1033,50 @@ impl PartitionBorderGraph {
         Ok(())
     }
 
+    pub(crate) fn insert_local_face_graph(
+        &mut self,
+        local_face_graph: PartitionBorderLocalFaceGraph,
+    ) -> crate::Result<()> {
+        if let Some(existing) = self.local_face_graphs.iter().find(|existing| {
+            existing.partition_id == local_face_graph.partition_id
+                && existing.component_id == local_face_graph.component_id
+        }) {
+            if existing == &local_face_graph {
+                return Ok(());
+            }
+            return Err(crate::PolygonizeError::InternalInvariantViolation {
+                reason: format!(
+                    "partition local face graph ({}, {}) conflicts with prior snapshot",
+                    local_face_graph.partition_id, local_face_graph.component_id
+                ),
+            });
+        }
+        self.local_face_graphs.push(local_face_graph);
+        self.local_face_graphs
+            .sort_unstable_by_key(|graph| (graph.partition_id, graph.component_id));
+        self.global_face_edge_map.clear();
+        self.applied_face_twins.clear();
+        self.global_components.clear();
+        self.global_component_payloads.clear();
+        self.global_face_plans.clear();
+        self.global_face_transitions.clear();
+        self.global_face_twin_transitions.clear();
+        self.global_face_next_candidates.clear();
+        self.global_face_identity_plans.clear();
+        self.global_face_next_mutation_plans.clear();
+        self.global_face_id_plans.clear();
+        self.global_face_edge_map.clear();
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn local_face_graphs(&self) -> &[PartitionBorderLocalFaceGraph] {
+        &self.local_face_graphs
+    }
+
     pub fn declare_adjacency(&mut self, adjacency: PartitionBorderAdjacency) {
         self.adjacencies.insert(adjacency);
+        self.global_face_edge_map.clear();
         self.applied_face_twins.clear();
         self.reconciled_nodes.clear();
         self.global_components.clear();
@@ -1236,11 +1345,280 @@ impl PartitionBorderGraph {
         self.global_face_identity_plans.clear();
         self.global_face_next_mutation_plans.clear();
         self.global_face_id_plans.clear();
+        self.global_face_edge_map.clear();
         Ok(stats)
     }
 
     pub(crate) fn applied_face_twins(&self) -> &[PartitionBorderFaceTwin] {
         &self.applied_face_twins
+    }
+
+    /// Remaps active tile-local face-edge lineage into deterministic global
+    /// edge slots and positions every available declared face twin in that
+    /// slot space. Missing local snapshots remain explicitly unmapped; any
+    /// malformed snapshot lineage fails closed before the map is committed.
+    pub(crate) fn reconcile_global_face_edge_map(
+        &mut self,
+        execution_policy: &ExecutionPolicy,
+    ) -> crate::Result<PartitionBorderGlobalFaceEdgeMapStats> {
+        execution_policy.check_cancelled("partition_border_global_face_edge_map")?;
+        execution_policy.check(
+            "partition_border_global_face_edge_map_components",
+            execution_policy.max_graph_nodes,
+            self.local_face_graphs.len(),
+        )?;
+        let directed_edge_count = self
+            .local_face_graphs
+            .iter()
+            .try_fold(0usize, |count, graph| {
+                count.checked_add(graph.directed_edges.len())
+            })
+            .ok_or_else(|| crate::PolygonizeError::InternalInvariantViolation {
+                reason: "global face edge map directed-edge count overflow".to_string(),
+            })?;
+        execution_policy.check(
+            "partition_border_global_face_edge_map_edges",
+            execution_policy.max_graph_edges,
+            directed_edge_count,
+        )?;
+
+        let mut edge_records = self
+            .local_face_graphs
+            .iter()
+            .flat_map(|graph| {
+                graph
+                    .directed_edges
+                    .iter()
+                    .map(move |edge| (graph.partition_id, graph.component_id, edge))
+            })
+            .collect::<Vec<_>>();
+        edge_records.sort_unstable_by_key(|(partition_id, component_id, edge)| {
+            (*partition_id, *component_id, edge.local_dir_edge_id)
+        });
+
+        let mut global_index_by_local = BTreeMap::<(usize, usize, DirEdgeId), usize>::new();
+        for (global_dir_edge_id, (partition_id, component_id, edge)) in
+            edge_records.iter().enumerate()
+        {
+            execution_policy.check_cancelled_every(
+                "partition_border_global_face_edge_map",
+                global_dir_edge_id,
+            )?;
+            if global_index_by_local
+                .insert(
+                    (*partition_id, *component_id, edge.local_dir_edge_id),
+                    global_dir_edge_id,
+                )
+                .is_some()
+            {
+                return Err(crate::PolygonizeError::InternalInvariantViolation {
+                    reason: format!(
+                        "global face edge map local directed edge ({}, {}, {}) is duplicated",
+                        partition_id, component_id, edge.local_dir_edge_id
+                    ),
+                });
+            }
+        }
+
+        let mut global_edges = Vec::with_capacity(edge_records.len());
+        let mut local_successor_count = 0usize;
+        for (global_dir_edge_id, (partition_id, component_id, edge)) in
+            edge_records.iter().enumerate()
+        {
+            let symmetric_global_dir_edge_id = *global_index_by_local
+                .get(&(
+                    *partition_id,
+                    *component_id,
+                    edge.symmetric_local_dir_edge_id,
+                ))
+                .ok_or_else(|| crate::PolygonizeError::InternalInvariantViolation {
+                    reason: format!(
+                        "global face edge map edge {} has no symmetric local edge",
+                        global_dir_edge_id
+                    ),
+                })?;
+            let symmetric = edge_records
+                .get(symmetric_global_dir_edge_id)
+                .ok_or_else(|| crate::PolygonizeError::InternalInvariantViolation {
+                    reason: format!(
+                        "global face edge map edge {} has invalid symmetric slot {}",
+                        global_dir_edge_id, symmetric_global_dir_edge_id
+                    ),
+                })?
+                .2;
+            if symmetric.edge_key != edge.edge_key
+                || symmetric.from != edge.to
+                || symmetric.to != edge.from
+                || symmetric.from_z_bits != edge.to_z_bits
+                || symmetric.to_z_bits != edge.from_z_bits
+                || symmetric.source_line_ids != edge.source_line_ids
+            {
+                return Err(crate::PolygonizeError::InternalInvariantViolation {
+                    reason: format!(
+                        "global face edge map edge {} disagrees with symmetric geometry",
+                        global_dir_edge_id
+                    ),
+                });
+            }
+            let local_face_successor_global_dir_edge_id = edge
+                .local_face_successor
+                .map(|local_face_successor| {
+                    global_index_by_local
+                        .get(&(*partition_id, *component_id, local_face_successor))
+                        .copied()
+                        .ok_or_else(|| crate::PolygonizeError::InternalInvariantViolation {
+                            reason: format!(
+                                "global face edge map edge {} has no local face successor",
+                                global_dir_edge_id
+                            ),
+                        })
+                })
+                .transpose()?;
+            if local_face_successor_global_dir_edge_id.is_some() {
+                local_successor_count += 1;
+            }
+            global_edges.push(PartitionBorderGlobalFaceEdge {
+                global_dir_edge_id,
+                partition_id: *partition_id,
+                component_id: *component_id,
+                local_dir_edge_id: edge.local_dir_edge_id,
+                symmetric_global_dir_edge_id,
+                local_face_successor_global_dir_edge_id,
+                cross_border_twin_global_dir_edge_id: None,
+                from: edge.from,
+                to: edge.to,
+                from_z_bits: edge.from_z_bits,
+                to_z_bits: edge.to_z_bits,
+                edge_key: edge.edge_key,
+                face_ref: edge.face_ref,
+                local_face_is_unbounded: edge.local_face_is_unbounded,
+                source_line_ids: edge.source_line_ids.clone(),
+            });
+        }
+
+        let mut observation_to_global = BTreeMap::<PartitionBorderObservationId, usize>::new();
+        let mut mapped_observation_count = 0usize;
+        for (observation_index, observation) in self.observations.values().enumerate() {
+            execution_policy.check_cancelled_every(
+                "partition_border_global_face_edge_map_observations",
+                observation_index,
+            )?;
+            let Some(face_ref) = observation.face_ref else {
+                continue;
+            };
+            let local_key = (
+                observation.partition_id,
+                face_ref.component_id,
+                observation.local_dir_edge_id,
+            );
+            let Some(&global_dir_edge_id) = global_index_by_local.get(&local_key) else {
+                continue;
+            };
+            let edge = &global_edges[global_dir_edge_id];
+            let expected_successor = observation
+                .local_face_successor
+                .map(|local_successor| {
+                    global_index_by_local
+                        .get(&(
+                            observation.partition_id,
+                            face_ref.component_id,
+                            local_successor,
+                        ))
+                        .copied()
+                        .ok_or_else(|| crate::PolygonizeError::InternalInvariantViolation {
+                            reason: format!(
+                                "global face edge map observation {:?} has no local successor lineage",
+                                observation.observation_id()
+                            ),
+                        })
+                })
+                .transpose()?;
+            if edge.edge_key != observation.edge_key
+                || edge.from != observation.from
+                || edge.to != observation.to
+                || edge.from_z_bits != observation.from_z_bits
+                || edge.to_z_bits != observation.to_z_bits
+                || edge.source_line_ids != observation.source_line_ids
+                || edge.face_ref != Some(face_ref)
+                || edge.local_face_successor_global_dir_edge_id != expected_successor
+                || edge.local_face_is_unbounded != observation.local_face_is_unbounded
+            {
+                return Err(crate::PolygonizeError::InternalInvariantViolation {
+                    reason: format!(
+                        "global face edge map observation {:?} disagrees with local lineage",
+                        observation.observation_id()
+                    ),
+                });
+            }
+            observation_to_global.insert(observation.observation_id(), global_dir_edge_id);
+            mapped_observation_count += 1;
+        }
+
+        let mut mapped_twin_count = 0usize;
+        let mut unmapped_twin_count = 0usize;
+        for (twin_index, twin) in self.applied_face_twins.iter().enumerate() {
+            execution_policy
+                .check_cancelled_every("partition_border_global_face_edge_map_twins", twin_index)?;
+            let Some(&forward_global_dir_edge_id) = observation_to_global.get(&twin.twin.forward)
+            else {
+                unmapped_twin_count += 1;
+                continue;
+            };
+            let Some(&reverse_global_dir_edge_id) = observation_to_global.get(&twin.twin.reverse)
+            else {
+                unmapped_twin_count += 1;
+                continue;
+            };
+            if forward_global_dir_edge_id == reverse_global_dir_edge_id
+                || global_edges[forward_global_dir_edge_id].edge_key != twin.twin.edge_key
+                || global_edges[reverse_global_dir_edge_id].edge_key != twin.twin.edge_key
+                || global_edges[forward_global_dir_edge_id].partition_id
+                    == global_edges[reverse_global_dir_edge_id].partition_id
+            {
+                return Err(crate::PolygonizeError::InternalInvariantViolation {
+                    reason: format!(
+                        "global face edge map twin {} has invalid cross-border lineage",
+                        twin_index
+                    ),
+                });
+            }
+            for (from, to) in [
+                (forward_global_dir_edge_id, reverse_global_dir_edge_id),
+                (reverse_global_dir_edge_id, forward_global_dir_edge_id),
+            ] {
+                if let Some(existing) = global_edges[from].cross_border_twin_global_dir_edge_id {
+                    if existing != to {
+                        return Err(crate::PolygonizeError::InternalInvariantViolation {
+                            reason: format!(
+                                "global face edge map edge {} has conflicting cross-border twins {} and {}",
+                                from, existing, to
+                            ),
+                        });
+                    }
+                } else {
+                    global_edges[from].cross_border_twin_global_dir_edge_id = Some(to);
+                }
+            }
+            mapped_twin_count += 1;
+        }
+
+        let stats = PartitionBorderGlobalFaceEdgeMapStats {
+            local_graph_count: self.local_face_graphs.len(),
+            component_count: self.local_face_graphs.len(),
+            directed_edge_count,
+            local_successor_count,
+            mapped_observation_count,
+            mapped_twin_count,
+            unmapped_twin_count,
+            edge_map_ready: unmapped_twin_count == 0,
+        };
+        self.global_face_edge_map = global_edges;
+        Ok(stats)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn global_face_edge_map(&self) -> &[PartitionBorderGlobalFaceEdge] {
+        &self.global_face_edge_map
     }
 
     /// Reconciles every exact border node without mutating observations or
@@ -4642,6 +5020,72 @@ mod tests {
         graph
     }
 
+    fn local_face_graph(
+        partition_id: usize,
+        component_id: usize,
+        first_local_dir_edge_id: DirEdgeId,
+        forward_face_id: usize,
+        from: Coord3D,
+        to: Coord3D,
+        source_line_id: u32,
+    ) -> PartitionBorderLocalFaceGraph {
+        let from_key = PartitionBorderNodeKey::from_coord(from);
+        let to_key = PartitionBorderNodeKey::from_coord(to);
+        let edge_key = PartitionBorderEdgeKey::new(from_key, to_key).unwrap();
+        let reverse_edge_key = edge_key;
+        let reverse_local_dir_edge_id = first_local_dir_edge_id + 1;
+        PartitionBorderLocalFaceGraph {
+            partition_id,
+            component_id,
+            directed_edges: vec![
+                PartitionBorderLocalDirectedEdge {
+                    local_dir_edge_id: first_local_dir_edge_id,
+                    symmetric_local_dir_edge_id: reverse_local_dir_edge_id,
+                    local_face_successor: Some(first_local_dir_edge_id),
+                    from: from_key,
+                    to: to_key,
+                    from_z_bits: canonical_coordinate_bits(from.z),
+                    to_z_bits: canonical_coordinate_bits(to.z),
+                    edge_key,
+                    face_ref: Some(face(partition_id, component_id, forward_face_id)),
+                    local_face_is_unbounded: false,
+                    source_line_ids: vec![source_line_id],
+                },
+                PartitionBorderLocalDirectedEdge {
+                    local_dir_edge_id: reverse_local_dir_edge_id,
+                    symmetric_local_dir_edge_id: first_local_dir_edge_id,
+                    local_face_successor: Some(reverse_local_dir_edge_id),
+                    from: to_key,
+                    to: from_key,
+                    from_z_bits: canonical_coordinate_bits(to.z),
+                    to_z_bits: canonical_coordinate_bits(from.z),
+                    edge_key: reverse_edge_key,
+                    face_ref: Some(face(partition_id, component_id, forward_face_id + 1)),
+                    local_face_is_unbounded: false,
+                    source_line_ids: vec![source_line_id],
+                },
+            ],
+        }
+    }
+
+    fn exact_face_edge_map_graph(reverse_snapshot_order: bool) -> PartitionBorderGraph {
+        let mut graph = exact_face_twin_graph();
+        for observation in graph.observations.values_mut() {
+            observation.local_face_successor = Some(observation.local_dir_edge_id);
+            observation.local_face_is_unbounded = false;
+        }
+        let first = local_face_graph(1, 4, 7, 9, coord(0.0, 0.0, 1.0), coord(2.0, 0.0, 2.0), 8);
+        let second = local_face_graph(2, 6, 9, 11, coord(2.0, 0.0, 20.0), coord(0.0, 0.0, 10.0), 7);
+        if reverse_snapshot_order {
+            graph.insert_local_face_graph(second).unwrap();
+            graph.insert_local_face_graph(first).unwrap();
+        } else {
+            graph.insert_local_face_graph(first).unwrap();
+            graph.insert_local_face_graph(second).unwrap();
+        }
+        graph
+    }
+
     fn prepared_global_face_walk_graph(closed: bool, unbounded: [bool; 2]) -> PartitionBorderGraph {
         let mut graph = exact_face_twin_graph_with_successors();
         for (observation_index, observation) in graph.observations.values_mut().enumerate() {
@@ -4777,6 +5221,149 @@ mod tests {
         assert!(planar
             .partition_border_half_edge(4, 0, PartitionBorderSide::MinY)
             .is_none());
+    }
+
+    #[test]
+    fn global_face_edge_map_is_deterministic_and_maps_face_twins() {
+        let mut graph = exact_face_edge_map_graph(false);
+        graph
+            .apply_unambiguous_face_twins(&ExecutionPolicy::default())
+            .unwrap();
+        let stats = graph
+            .reconcile_global_face_edge_map(&ExecutionPolicy::default())
+            .unwrap();
+
+        assert_eq!(stats.local_graph_count, 2);
+        assert_eq!(stats.component_count, 2);
+        assert_eq!(stats.directed_edge_count, 4);
+        assert_eq!(stats.local_successor_count, 4);
+        assert_eq!(stats.mapped_observation_count, 2);
+        assert_eq!(stats.mapped_twin_count, 1);
+        assert_eq!(stats.unmapped_twin_count, 0);
+        assert!(stats.edge_map_ready);
+        assert_eq!(
+            graph
+                .global_face_edge_map
+                .iter()
+                .map(|edge| (
+                    edge.partition_id,
+                    edge.component_id,
+                    edge.local_dir_edge_id,
+                    edge.symmetric_global_dir_edge_id,
+                    edge.local_face_successor_global_dir_edge_id,
+                    edge.cross_border_twin_global_dir_edge_id,
+                    edge.from_z_bits,
+                    edge.to_z_bits,
+                    edge.source_line_ids.clone(),
+                ))
+                .collect::<Vec<_>>(),
+            vec![
+                (
+                    1,
+                    4,
+                    7,
+                    1,
+                    Some(0),
+                    Some(2),
+                    1.0f64.to_bits(),
+                    2.0f64.to_bits(),
+                    vec![8]
+                ),
+                (
+                    1,
+                    4,
+                    8,
+                    0,
+                    Some(1),
+                    None,
+                    2.0f64.to_bits(),
+                    1.0f64.to_bits(),
+                    vec![8]
+                ),
+                (
+                    2,
+                    6,
+                    9,
+                    3,
+                    Some(2),
+                    Some(0),
+                    20.0f64.to_bits(),
+                    10.0f64.to_bits(),
+                    vec![7]
+                ),
+                (
+                    2,
+                    6,
+                    10,
+                    2,
+                    Some(3),
+                    None,
+                    10.0f64.to_bits(),
+                    20.0f64.to_bits(),
+                    vec![7]
+                ),
+            ]
+        );
+
+        let mut reordered = exact_face_edge_map_graph(true);
+        reordered
+            .apply_unambiguous_face_twins(&ExecutionPolicy::default())
+            .unwrap();
+        reordered
+            .reconcile_global_face_edge_map(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(graph.global_face_edge_map, reordered.global_face_edge_map);
+    }
+
+    #[test]
+    fn global_face_edge_map_is_atomic_and_bounded() {
+        let mut malformed = exact_face_edge_map_graph(false);
+        malformed
+            .apply_unambiguous_face_twins(&ExecutionPolicy::default())
+            .unwrap();
+        malformed
+            .reconcile_global_face_edge_map(&ExecutionPolicy::default())
+            .unwrap();
+        let before = malformed.global_face_edge_map.clone();
+        malformed.local_face_graphs[0].directed_edges[0].symmetric_local_dir_edge_id = 999;
+        assert!(matches!(
+            malformed.reconcile_global_face_edge_map(&ExecutionPolicy::default()),
+            Err(crate::PolygonizeError::InternalInvariantViolation { .. })
+        ));
+        assert_eq!(malformed.global_face_edge_map, before);
+
+        let mut limited = exact_face_edge_map_graph(false);
+        let error = limited
+            .reconcile_global_face_edge_map(&ExecutionPolicy {
+                max_graph_edges: Some(3),
+                ..Default::default()
+            })
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::ResourceLimitExceeded {
+                ref stage,
+                limit: 3,
+                observed: 4,
+            } if stage == "partition_border_global_face_edge_map_edges"
+        ));
+        assert!(limited.global_face_edge_map.is_empty());
+
+        let token = CancellationToken::new();
+        token.cancel();
+        let mut cancelled = exact_face_edge_map_graph(false);
+        let error = cancelled
+            .reconcile_global_face_edge_map(&ExecutionPolicy {
+                cancellation_token: Some(token),
+                ..Default::default()
+            })
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::Cancelled { ref stage }
+                if stage == "partition_border_global_face_edge_map"
+        ));
+        assert!(cancelled.global_face_edge_map.is_empty());
     }
 
     #[test]

--- a/crates/geo-polygonize-core/src/graph/planar_graph.rs
+++ b/crates/geo-polygonize-core/src/graph/planar_graph.rs
@@ -14,7 +14,8 @@ use std::collections::HashMap;
 
 use super::partition_border::{
     partition_boundary_intersections, PartitionBorderEdgeKey, PartitionBorderHalfEdge,
-    PartitionBorderNodeKey, PartitionBorderSide,
+    PartitionBorderLocalDirectedEdge, PartitionBorderLocalFaceGraph, PartitionBorderNodeKey,
+    PartitionBorderSide,
 };
 
 /// Index of a node in the graph.
@@ -133,6 +134,14 @@ type ComponentOutput = (
     Vec<Vec<Coord3D>>,
     Vec<ExtractedRing>,
     Vec<ExtractedRing>,
+);
+
+type ComponentProcessingResult = (
+    ComponentOutput,
+    Vec<PartitionBorderHalfEdge>,
+    Vec<PartitionBorderLocalFaceGraph>,
+    bool,
+    ComponentMemoryStats,
 );
 
 struct ComponentPartition {
@@ -2581,15 +2590,11 @@ impl PlanarGraph {
         noding_postcondition_validated: bool,
         capture_byte_limit: Option<usize>,
         border_export: Option<PartitionBorderExport>,
-    ) -> crate::Result<(
-        ComponentOutput,
-        Vec<PartitionBorderHalfEdge>,
-        bool,
-        ComponentMemoryStats,
-    )> {
+    ) -> crate::Result<ComponentProcessingResult> {
         let (partitions, mut memory_stats) = self.active_component_partitions(execution_policy)?;
         let mut merged = ComponentOutput::default();
         let mut border_observations = Vec::new();
+        let mut local_face_graphs = Vec::new();
         memory_stats.execution_worker_count = 1;
 
         let capture_truncated = if border_export.is_some() || capture_byte_limit.is_some() {
@@ -2602,7 +2607,7 @@ impl PlanarGraph {
                     partition,
                     execution_policy,
                 )?;
-                let (output, observations, scratch_stats) = scratch.process(
+                let (output, observations, local_face_graph, scratch_stats) = scratch.process(
                     component_id,
                     include_graph_ids,
                     include_source_ids,
@@ -2618,6 +2623,9 @@ impl PlanarGraph {
                     component_output_coordinate_capacity(&merged),
                 );
                 border_observations.extend(observations);
+                if let Some(local_face_graph) = local_face_graph {
+                    local_face_graphs.push(local_face_graph);
+                }
             }
             capture_budget.is_some_and(|budget| budget.truncated())
         } else {
@@ -2674,8 +2682,9 @@ impl PlanarGraph {
             };
 
             for output in outputs {
-                let (output, observations, scratch_stats) = output?;
+                let (output, observations, local_face_graph, scratch_stats) = output?;
                 debug_assert!(observations.is_empty());
+                debug_assert!(local_face_graph.is_none());
                 memory_stats.merge_execution(&scratch_stats);
                 append_component_output(&mut merged, output);
                 memory_stats.observe_merged_output(
@@ -2686,7 +2695,13 @@ impl PlanarGraph {
             false
         };
 
-        Ok((merged, border_observations, capture_truncated, memory_stats))
+        Ok((
+            merged,
+            border_observations,
+            local_face_graphs,
+            capture_truncated,
+            memory_stats,
+        ))
     }
 
     /// Validates Euler's planar relation for the active maximal-ring graph.
@@ -2974,6 +2989,7 @@ impl ComponentScratch {
     ) -> crate::Result<(
         ComponentOutput,
         Vec<PartitionBorderHalfEdge>,
+        Option<PartitionBorderLocalFaceGraph>,
         ComponentMemoryStats,
     )> {
         let is_new_scratch_instance = self.processed_components == 0;
@@ -3012,6 +3028,15 @@ impl ComponentScratch {
         let observations = border_export
             .map(|export| self.partition_border_observations(component_id, export))
             .unwrap_or_default();
+        let local_face_graph = border_export
+            .map(|export| {
+                self.partition_border_local_face_graph(
+                    export.partition_id,
+                    component_id,
+                    execution_policy,
+                )
+            })
+            .transpose()?;
         self.remap_rings(&mut maximal, component_id, include_graph_ids)?;
         self.remap_rings(&mut minimal, component_id, include_graph_ids)?;
         self.processed_components = self.processed_components.saturating_add(1);
@@ -3029,8 +3054,138 @@ impl ComponentScratch {
         Ok((
             (dangles, cut_edges, maximal, minimal),
             observations,
+            local_face_graph,
             scratch_stats,
         ))
+    }
+
+    fn partition_border_local_face_graph(
+        &self,
+        partition_id: usize,
+        component_id: usize,
+        execution_policy: &ExecutionPolicy,
+    ) -> crate::Result<PartitionBorderLocalFaceGraph> {
+        execution_policy.check_cancelled("partition_border_local_face_graph")?;
+        let mut global_dir_edge_ids = vec![None; self.graph.directed_edges.len()];
+        for (local_edge_id, edge) in self.graph.edges.iter().enumerate() {
+            execution_policy
+                .check_cancelled_every("partition_border_local_face_graph_edges", local_edge_id)?;
+            if edge.deleted
+                || edge
+                    .dir_edges
+                    .iter()
+                    .any(|&dir_edge_id| self.graph.directed_edges[dir_edge_id].is_marked)
+            {
+                continue;
+            }
+            let Some(global_dir_edges) = self.global_dir_edge_ids.get(local_edge_id) else {
+                return Err(crate::PolygonizeError::InternalInvariantViolation {
+                    reason: format!(
+                        "partition local face graph edge {} has no global directed identity",
+                        local_edge_id
+                    ),
+                });
+            };
+            for (local_dir_edge_id, &global_dir_edge_id) in
+                edge.dir_edges.iter().zip(global_dir_edges)
+            {
+                global_dir_edge_ids[*local_dir_edge_id] = Some(global_dir_edge_id);
+            }
+        }
+
+        let mut directed_edges = Vec::new();
+        for (local_dir_edge_id, directed) in self.graph.directed_edges.iter().enumerate() {
+            execution_policy
+                .check_cancelled_every("partition_border_local_face_graph", local_dir_edge_id)?;
+            let Some(global_local_dir_edge_id) = global_dir_edge_ids[local_dir_edge_id] else {
+                continue;
+            };
+            let edge = self.graph.edges.get(directed.edge_idx).ok_or_else(|| {
+                crate::PolygonizeError::InternalInvariantViolation {
+                    reason: format!(
+                        "partition local face graph directed edge {} has no parent edge",
+                        local_dir_edge_id
+                    ),
+                }
+            })?;
+            let symmetric_local_dir_edge_id =
+                global_dir_edge_ids[directed.sym_idx].ok_or_else(|| {
+                    crate::PolygonizeError::InternalInvariantViolation {
+                        reason: format!(
+                        "partition local face graph directed edge {} has no active symmetric edge",
+                        local_dir_edge_id
+                    ),
+                    }
+                })?;
+            let local_face_successor = directed
+                .face_id
+                .and_then(|_| self.graph.directed_edges.get(directed.sym_idx))
+                .and_then(|symmetric| symmetric.next_idx)
+                .map(|local_successor| {
+                    global_dir_edge_ids
+                        .get(local_successor)
+                        .copied()
+                        .flatten()
+                        .ok_or_else(|| {
+                            crate::PolygonizeError::InternalInvariantViolation {
+                                reason: format!(
+                                    "partition local face graph directed edge {} has no active successor",
+                                    local_dir_edge_id
+                                ),
+                            }
+                        })
+                })
+                .transpose()?;
+            let from = directed.src;
+            let to = directed.dst;
+            let from_key = PartitionBorderNodeKey::from_coord(Coord3D::new(
+                self.graph.nodes_x[from],
+                self.graph.nodes_y[from],
+                0.0,
+            ));
+            let to_key = PartitionBorderNodeKey::from_coord(Coord3D::new(
+                self.graph.nodes_x[to],
+                self.graph.nodes_y[to],
+                0.0,
+            ));
+            let edge_key = PartitionBorderEdgeKey::new(from_key, to_key).ok_or_else(|| {
+                crate::PolygonizeError::InternalInvariantViolation {
+                    reason: format!(
+                        "partition local face graph directed edge {} is degenerate",
+                        local_dir_edge_id
+                    ),
+                }
+            })?;
+            let mut source_line_ids = edge.sources.line_ids.to_vec();
+            source_line_ids.sort_unstable();
+            source_line_ids.dedup();
+            directed_edges.push(PartitionBorderLocalDirectedEdge {
+                local_dir_edge_id: global_local_dir_edge_id,
+                symmetric_local_dir_edge_id,
+                local_face_successor,
+                from: from_key,
+                to: to_key,
+                from_z_bits: canonical_coordinate_bits(self.graph.nodes_z[from]),
+                to_z_bits: canonical_coordinate_bits(self.graph.nodes_z[to]),
+                edge_key,
+                face_ref: directed.face_id.map(|face_id| {
+                    crate::types::LocalFaceRef {
+                        component_id,
+                        face_id,
+                    }
+                    .in_partition(partition_id)
+                }),
+                local_face_is_unbounded: directed
+                    .face_id
+                    .is_some_and(|face_id| self.graph.unbounded_face_ids.contains(&face_id)),
+                source_line_ids,
+            });
+        }
+        Ok(PartitionBorderLocalFaceGraph {
+            partition_id,
+            component_id,
+            directed_edges,
+        })
     }
 
     fn partition_border_observations(
@@ -3952,7 +4107,7 @@ mod arrangement_ring_invariant_tests {
         }
 
         let policy = ExecutionPolicy::default();
-        let ((_, _, _, rings), _, _, _) = graph
+        let ((_, _, _, rings), _, _, _, _) = graph
             .process_components_with_execution_policy(true, true, &policy, true, None, None)
             .unwrap();
         let refs = rings
@@ -3994,7 +4149,7 @@ mod arrangement_ring_invariant_tests {
             20,
         );
 
-        let (_, observations, _, _) = graph
+        let (_, observations, local_face_graphs, _, _) = graph
             .process_components_with_execution_policy(
                 true,
                 true,
@@ -4013,6 +4168,10 @@ mod arrangement_ring_invariant_tests {
             .map(|observation| observation.component_id)
             .collect::<std::collections::BTreeSet<_>>();
         assert_eq!(component_ids, std::collections::BTreeSet::from([0, 1]));
+        assert_eq!(local_face_graphs.len(), 2);
+        assert!(local_face_graphs
+            .iter()
+            .all(|graph| !graph.directed_edges.is_empty()));
 
         let representative_ids = observations
             .iter()

--- a/crates/geo-polygonize-core/src/graph/tests.rs
+++ b/crates/geo-polygonize-core/src/graph/tests.rs
@@ -695,7 +695,7 @@ mod tests {
         }
 
         let component_ids = graph.active_component_ids();
-        let ((dangles, cut_edges, maximal, rings), _, capture_truncated, memory_stats) = graph
+        let ((dangles, cut_edges, maximal, rings), _, _, capture_truncated, memory_stats) = graph
             .process_components_with_execution_policy(
                 true,
                 true,

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -3,7 +3,7 @@ use crate::diagnostics::{
     ContainmentStats, NodingIterationStats, PolygonizerDiagnostics, ZConflictStats,
 };
 use crate::error::{PolygonizeError, Result};
-use crate::graph::partition_border::PartitionBorderHalfEdge;
+use crate::graph::partition_border::{PartitionBorderHalfEdge, PartitionBorderLocalFaceGraph};
 use crate::graph::planar_graph::{PartitionBorderExport, PartitionBoundaryNodingStats};
 use crate::graph::{ExtractedRing, PlanarGraph};
 use crate::noding::hot_pixel::HotPixelNoder;
@@ -53,6 +53,7 @@ pub struct Polygonizer {
     trace: Option<TraceRecorderV1>,
     partition_border_export: Option<PartitionBorderExport>,
     partition_border_observations: Vec<PartitionBorderHalfEdge>,
+    partition_border_local_face_graphs: Vec<PartitionBorderLocalFaceGraph>,
     boundary_noding_stats: PartitionBoundaryNodingStats,
 }
 
@@ -355,6 +356,7 @@ pub fn polygonize_with_workspace_and_execution_policy(
         trace: None,
         partition_border_export: None,
         partition_border_observations: Vec::new(),
+        partition_border_local_face_graphs: Vec::new(),
         boundary_noding_stats: PartitionBoundaryNodingStats::default(),
     };
     runner.input_line_strings = source_line_strings_for_segments(lines);
@@ -376,6 +378,7 @@ impl Polygonizer {
             trace: None,
             partition_border_export: None,
             partition_border_observations: Vec::new(),
+            partition_border_local_face_graphs: Vec::new(),
             boundary_noding_stats: PartitionBoundaryNodingStats::default(),
         }
     }
@@ -390,6 +393,7 @@ impl Polygonizer {
             trace: None,
             partition_border_export: None,
             partition_border_observations: Vec::new(),
+            partition_border_local_face_graphs: Vec::new(),
             boundary_noding_stats: PartitionBoundaryNodingStats::default(),
         }
     }
@@ -769,15 +773,25 @@ impl Polygonizer {
     ) -> Result<(
         PolygonizerResult,
         Vec<PartitionBorderHalfEdge>,
+        Vec<PartitionBorderLocalFaceGraph>,
         PartitionBoundaryNodingStats,
     )> {
         self.partition_border_export = Some(PartitionBorderExport { partition_id, bbox });
         self.partition_border_observations.clear();
+        self.partition_border_local_face_graphs.clear();
         self.boundary_noding_stats = PartitionBoundaryNodingStats::default();
         let result = self.polygonize();
         self.partition_border_export = None;
         let observations = std::mem::take(&mut self.partition_border_observations);
-        result.map(|result| (result, observations, self.boundary_noding_stats))
+        let local_face_graphs = std::mem::take(&mut self.partition_border_local_face_graphs);
+        result.map(|result| {
+            (
+                result,
+                observations,
+                local_face_graphs,
+                self.boundary_noding_stats,
+            )
+        })
     }
 
     /// Computes polygons while recording a bounded topology trace.
@@ -880,6 +894,7 @@ impl Polygonizer {
         let (
             (mut dangles, mut cut_edges, maximal, rings_with_ids),
             _,
+            _,
             capture_truncated,
             component_memory_stats,
         ) = self.graph.process_components_with_execution_policy(
@@ -893,19 +908,22 @@ impl Polygonizer {
         let border_observations = if let (Some(graph), Some(export)) =
             (boundary_graph.as_mut(), self.partition_border_export)
         {
-            let (_, observations, _, _) = graph.process_components_with_execution_policy(
-                self.options.node_input,
-                include_source_ids,
-                &self.execution_policy,
-                noding_postcondition_validated,
-                None,
-                Some(export),
-            )?;
-            observations
+            let (_, observations, local_face_graphs, _, _) = graph
+                .process_components_with_execution_policy(
+                    self.options.node_input,
+                    include_source_ids,
+                    &self.execution_policy,
+                    noding_postcondition_validated,
+                    None,
+                    Some(export),
+                )?;
+            (observations, local_face_graphs)
         } else {
-            Vec::new()
+            (Vec::new(), Vec::new())
         };
+        let (border_observations, local_face_graphs) = border_observations;
         self.partition_border_observations = border_observations;
+        self.partition_border_local_face_graphs = local_face_graphs;
         if let Some(trace) = self.trace.as_mut() {
             for observation in &self.partition_border_observations {
                 if !trace.record_partition_border_observation(observation) {

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -1,6 +1,7 @@
 use crate::diagnostics::ExecutionWorkTracker;
 use crate::graph::partition_border::{
-    PartitionBorderAdjacency, PartitionBorderGraph, PartitionBorderHalfEdge, PartitionBorderSide,
+    PartitionBorderAdjacency, PartitionBorderGraph, PartitionBorderHalfEdge,
+    PartitionBorderLocalFaceGraph, PartitionBorderSide,
 };
 use crate::index::{IndexedEnvelope, RStarBackend};
 use crate::noding::hot_pixel::HotPixelNoder;
@@ -410,6 +411,20 @@ pub struct StitchingReport {
     /// Exact twin pairs declined because a face reference was malformed or
     /// did not match its observation's partition.
     pub partition_border_face_twin_invalid_face_count: usize,
+    /// Processed local face-component snapshots retained for global mapping.
+    pub partition_border_global_face_edge_map_local_graph_count: usize,
+    /// Active directed edges remapped into deterministic global edge slots.
+    pub partition_border_global_face_edge_map_directed_edge_count: usize,
+    /// Local face successors successfully remapped into global edge slots.
+    pub partition_border_global_face_edge_map_local_successor_count: usize,
+    /// Face-qualified border observations mapped to active local edge slots.
+    pub partition_border_global_face_edge_map_observation_count: usize,
+    /// Applied face twins mapped across two active local edge slots.
+    pub partition_border_global_face_edge_map_twin_count: usize,
+    /// Applied face twins without complete local edge snapshots.
+    pub partition_border_global_face_edge_map_unmapped_twin_count: usize,
+    /// Whether every applied face twin mapped to active local edge slots.
+    pub partition_border_global_face_edge_map_ready: bool,
     /// Whether indexed components were recovered by component or region fallback.
     /// This is operational metadata; strict validation uses `coverage_resolution`.
     pub component_fallback_used: bool,
@@ -497,6 +512,7 @@ type TileProcessResult = (
     TileReport,
     Vec<TileOwnershipDecision>,
     Vec<PartitionBorderHalfEdge>,
+    Vec<PartitionBorderLocalFaceGraph>,
     bool,
     crate::graph::planar_graph::PartitionBoundaryNodingStats,
 );
@@ -1090,13 +1106,14 @@ impl<'a> TiledPolygonizer<'a> {
                 report,
                 Vec::new(),
                 Vec::new(),
+                Vec::new(),
                 false,
                 crate::graph::planar_graph::PartitionBoundaryNodingStats::default(),
             ));
         }
 
         // Run polygonization
-        let (result, border_observations, boundary_noding_stats) = local_poly
+        let (result, border_observations, local_face_graphs, boundary_noding_stats) = local_poly
             .polygonize_with_partition_border_export_and_stats(partition_id, tile_bbox)?;
         report.polygon_count = result.polygons.len();
         report.dangle_count = result.dangles.len();
@@ -1174,6 +1191,7 @@ impl<'a> TiledPolygonizer<'a> {
             report,
             ownership_decisions,
             border_observations,
+            local_face_graphs,
             capture_budget.is_some_and(|budget| budget.truncated()),
             boundary_noding_stats,
         ))
@@ -1617,7 +1635,7 @@ impl<'a> TiledPolygonizer<'a> {
             return Ok(result);
         };
         let mut retry_attempts = Vec::new();
-        let mut capture_truncated = result.4;
+        let mut capture_truncated = result.5;
         for attempt in 1..=policy.max_attempts {
             if !Self::report_has_retry_evidence(&result.1) || buffer >= policy.max_buffer {
                 break;
@@ -1651,7 +1669,7 @@ impl<'a> TiledPolygonizer<'a> {
                 buffer,
                 capture_byte_limit,
             )?;
-            capture_truncated |= result.4;
+            capture_truncated |= result.5;
             let resolved = !Self::report_is_unresolved(&result.1);
             retry_attempts.push(TileRetryAttempt {
                 attempt,
@@ -1665,7 +1683,7 @@ impl<'a> TiledPolygonizer<'a> {
         }
         result.1.retry_exhausted = Self::report_has_retry_evidence(&result.1);
         result.1.retry_attempts = retry_attempts;
-        result.4 = capture_truncated;
+        result.5 = capture_truncated;
         Ok(result)
     }
 
@@ -2255,6 +2273,7 @@ impl<'a> TiledPolygonizer<'a> {
         let mut tile_polygons = Vec::with_capacity(tiles.len());
         let mut tile_reports = Vec::with_capacity(tiles.len());
         let mut partition_border_graph = PartitionBorderGraph::default();
+        let mut partition_border_local_face_graphs = Vec::new();
         if trace_ownership {
             for (tile_index, tile) in tiles.into_iter().enumerate() {
                 let capture_byte_limit = trace.as_ref().and_then(|trace| {
@@ -2267,6 +2286,7 @@ impl<'a> TiledPolygonizer<'a> {
                     report,
                     ownership_decisions,
                     border_observations,
+                    local_face_graphs,
                     capture_truncated,
                     boundary_noding_stats,
                 ) = self.process_tile_with_retries(
@@ -2335,6 +2355,7 @@ impl<'a> TiledPolygonizer<'a> {
                         return Err(error);
                     }
                 }
+                partition_border_local_face_graphs.extend(local_face_graphs);
                 tile_polygons.push(polygons);
                 tile_reports.push(report);
             }
@@ -2394,18 +2415,24 @@ impl<'a> TiledPolygonizer<'a> {
                 .collect();
 
             for result in tile_results? {
-                let (polygons, report, _, border_observations, _, _) = result;
+                let (polygons, report, _, border_observations, local_face_graphs, _, _) = result;
                 for observation in border_observations {
                     partition_border_graph.insert(observation)?;
                 }
+                partition_border_local_face_graphs.extend(local_face_graphs);
                 tile_polygons.push(polygons);
                 tile_reports.push(report);
             }
+        }
+        for local_face_graph in partition_border_local_face_graphs {
+            partition_border_graph.insert_local_face_graph(local_face_graph)?;
         }
         self.declare_partition_adjacencies(&mut partition_border_graph, &tile_reports)?;
         let partition_border_reconciliation = partition_border_graph.reconciliation_stats();
         let partition_border_twin_application =
             partition_border_graph.apply_unambiguous_face_twins(&self.execution_policy)?;
+        let partition_border_global_face_edge_map =
+            partition_border_graph.reconcile_global_face_edge_map(&self.execution_policy)?;
         let applied_face_twin_count = partition_border_graph.applied_face_twins().len();
         debug_assert_eq!(
             applied_face_twin_count,
@@ -2509,6 +2536,9 @@ impl<'a> TiledPolygonizer<'a> {
         if let Some(trace) = trace.as_deref_mut() {
             trace.record_partition_border_reconciliation(partition_border_reconciliation);
             trace.record_partition_border_twin_application(partition_border_twin_application);
+            trace.record_partition_border_global_face_edge_map(
+                partition_border_global_face_edge_map,
+            );
             trace.record_partition_border_node_reconciliation(
                 partition_border_node_reconciliation,
                 self.options.z,
@@ -2925,6 +2955,20 @@ impl<'a> TiledPolygonizer<'a> {
                     .missing_face_ref_count,
                 partition_border_face_twin_invalid_face_count: partition_border_twin_application
                     .invalid_face_ref_count,
+                partition_border_global_face_edge_map_local_graph_count:
+                    partition_border_global_face_edge_map.local_graph_count,
+                partition_border_global_face_edge_map_directed_edge_count:
+                    partition_border_global_face_edge_map.directed_edge_count,
+                partition_border_global_face_edge_map_local_successor_count:
+                    partition_border_global_face_edge_map.local_successor_count,
+                partition_border_global_face_edge_map_observation_count:
+                    partition_border_global_face_edge_map.mapped_observation_count,
+                partition_border_global_face_edge_map_twin_count:
+                    partition_border_global_face_edge_map.mapped_twin_count,
+                partition_border_global_face_edge_map_unmapped_twin_count:
+                    partition_border_global_face_edge_map.unmapped_twin_count,
+                partition_border_global_face_edge_map_ready: partition_border_global_face_edge_map
+                    .edge_map_ready,
                 component_fallback_used,
                 untiled_fallback_attempted,
                 untiled_fallback_authoritative,

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -94,6 +94,60 @@ mod tests {
                     .partition_border_face_twin_invalid_face_count,
             reconciliation.matched_twin_count
         );
+        let global_face_edge_map = result.partition_border_graph.global_face_edge_map();
+        let global_face_edge_map_stats = result
+            .partition_border_graph
+            .clone()
+            .reconcile_global_face_edge_map(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_edge_map_local_graph_count,
+            result.partition_border_graph.local_face_graphs().len()
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_edge_map_directed_edge_count,
+            global_face_edge_map.len()
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_edge_map_local_successor_count,
+            global_face_edge_map_stats.local_successor_count
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_edge_map_observation_count,
+            global_face_edge_map_stats.mapped_observation_count
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_edge_map_twin_count,
+            global_face_edge_map_stats.mapped_twin_count
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_edge_map_unmapped_twin_count,
+            global_face_edge_map_stats.unmapped_twin_count
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_face_edge_map_ready,
+            global_face_edge_map_stats.edge_map_ready
+        );
+        assert!(global_face_edge_map.iter().all(|edge| {
+            edge.symmetric_global_dir_edge_id < global_face_edge_map.len()
+                && edge
+                    .local_face_successor_global_dir_edge_id
+                    .is_none_or(|successor| successor < global_face_edge_map.len())
+        }));
         assert_eq!(
             result
                 .stitching_report
@@ -709,7 +763,7 @@ mod tests {
                 44,
             ),
         ]);
-        let (_, observations, stats) = polygonizer
+        let (_, observations, local_face_graphs, stats) = polygonizer
             .polygonize_with_partition_border_export_and_stats(
                 7,
                 Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 10.0, y: 1.0 }),
@@ -719,6 +773,11 @@ mod tests {
         assert_eq!(stats.added_node_count, 2);
         assert_eq!(stats.added_edge_count, 2);
         assert_eq!(stats.split_event_count, 2);
+        assert_eq!(local_face_graphs.len(), 1);
+        assert!(local_face_graphs[0]
+            .directed_edges
+            .iter()
+            .all(|edge| edge.face_ref.is_some()));
 
         let border = observations
             .iter()
@@ -845,6 +904,68 @@ mod tests {
             application.payload["candidate_twin_count"]
                 .as_u64()
                 .unwrap()
+        );
+        let edge_map = traced
+            .trace
+            .events
+            .iter()
+            .find(|event| event.kind == "partition_border_global_face_edge_map")
+            .expect("global face edge map evidence");
+        assert_eq!(
+            edge_map.payload["local_graph_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_edge_map_local_graph_count as u64
+            )
+        );
+        assert_eq!(
+            edge_map.payload["directed_edge_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_edge_map_directed_edge_count
+                    as u64
+            )
+        );
+        assert_eq!(
+            edge_map.payload["mapped_observation_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_edge_map_observation_count as u64
+            )
+        );
+        assert_eq!(
+            edge_map.payload["mapped_twin_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_edge_map_twin_count as u64
+            )
+        );
+        assert_eq!(
+            edge_map.payload["unmapped_twin_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_edge_map_unmapped_twin_count
+                    as u64
+            )
+        );
+        assert_eq!(
+            edge_map.payload["edge_map_ready"].as_bool(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_face_edge_map_ready
+            )
         );
         let node_reconciliation = traced
             .trace

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -3,14 +3,15 @@
 use crate::fingerprint::{coordinate_fingerprint, float_bits};
 use crate::graph::partition_border::{
     PartitionBorderGlobalComponentPayloadStats, PartitionBorderGlobalComponentReconciliationStats,
-    PartitionBorderGlobalFaceEulerWitnessStats, PartitionBorderGlobalFaceIdPlanStats,
-    PartitionBorderGlobalFaceIdentityPlanStats, PartitionBorderGlobalFaceMutationGateStats,
-    PartitionBorderGlobalFaceNextCandidateStats, PartitionBorderGlobalFaceNextMutationPlanStats,
-    PartitionBorderGlobalFacePlanStats, PartitionBorderGlobalFacePlanValidationStats,
-    PartitionBorderGlobalFaceTransitionPlanStats, PartitionBorderGlobalFaceTwinTransitionStats,
-    PartitionBorderGlobalFaceWalkInvariantStats, PartitionBorderGlobalUnboundedFaceProofStats,
-    PartitionBorderHalfEdge, PartitionBorderNodeReconciliationStats,
-    PartitionBorderReconciliationStats, PartitionBorderTwinApplicationStats,
+    PartitionBorderGlobalFaceEdgeMapStats, PartitionBorderGlobalFaceEulerWitnessStats,
+    PartitionBorderGlobalFaceIdPlanStats, PartitionBorderGlobalFaceIdentityPlanStats,
+    PartitionBorderGlobalFaceMutationGateStats, PartitionBorderGlobalFaceNextCandidateStats,
+    PartitionBorderGlobalFaceNextMutationPlanStats, PartitionBorderGlobalFacePlanStats,
+    PartitionBorderGlobalFacePlanValidationStats, PartitionBorderGlobalFaceTransitionPlanStats,
+    PartitionBorderGlobalFaceTwinTransitionStats, PartitionBorderGlobalFaceWalkInvariantStats,
+    PartitionBorderGlobalUnboundedFaceProofStats, PartitionBorderHalfEdge,
+    PartitionBorderNodeReconciliationStats, PartitionBorderReconciliationStats,
+    PartitionBorderTwinApplicationStats,
 };
 use crate::graph::planar_graph::PartitionBoundaryNodingStats;
 use crate::graph::{ExtractedRing, PlanarGraph};
@@ -641,6 +642,26 @@ impl TraceRecorderV1 {
                 "applied_twin_count": stats.applied_twin_count,
                 "missing_face_ref_count": stats.missing_face_ref_count,
                 "invalid_face_ref_count": stats.invalid_face_ref_count,
+            }),
+        )
+    }
+
+    pub(crate) fn record_partition_border_global_face_edge_map(
+        &mut self,
+        stats: PartitionBorderGlobalFaceEdgeMapStats,
+    ) -> bool {
+        self.record(
+            TraceStageV1::Graph,
+            "partition_border_global_face_edge_map",
+            serde_json::json!({
+                "local_graph_count": stats.local_graph_count,
+                "component_count": stats.component_count,
+                "directed_edge_count": stats.directed_edge_count,
+                "local_successor_count": stats.local_successor_count,
+                "mapped_observation_count": stats.mapped_observation_count,
+                "mapped_twin_count": stats.mapped_twin_count,
+                "unmapped_twin_count": stats.unmapped_twin_count,
+                "edge_map_ready": stats.edge_map_ready,
             }),
         )
     }


### PR DESCRIPTION
## Stack
- Parent: #1335 (`agent/p5-global-face-global-id-plan`, `b8a6527`)
- Children: #1338 (`agent/p5-global-face-node-reconcile`, `df9c32c`)

## Delivered
- Retain processed tile-local active face-edge lineage after boundary noding and local face assignment.
- Map qualified local directed-edge IDs into deterministic global edge slots with symmetric and local-successor links.
- Map declared face-qualified twins into cross-border global edge slots while retaining explicit unmapped evidence.
- Validate geometry, endpoint Z bits, source provenance, face references, successor lineage, and unbounded markers before atomic map publication.
- Emit bounded report and trace evidence; leave local topology, global face IDs, tiled output, and production dispatch unchanged.
- Update `ROADMAP.md` P5.3 with the completed edge-lineage evidence slice.

## Contract impact
Evidence-only. No public output, local `next`, global `next`, face IDs, node IDs, provenance output, Z policy, serial/parallel behavior, or replicate-and-own semantics change. Incomplete or absent local snapshots remain explicitly unmapped; malformed lineage fails closed before replacing a prior map.

## Validation
- `cargo test -p geo-polygonize-core global_face_edge_map --lib`
- `cargo test -p geo-polygonize-core reports_tile_topology_and_merge_counts --lib`
- `cargo test -p geo-polygonize-core trace_records_partition_boundary_noding_and_atomic_observations --lib`
- `cargo test -p geo-polygonize-core exports_physical_tile_border_observations_before_scratch_is_released --lib`
- `DYLD_LIBRARY_PATH=/Library/Frameworks/Python.framework/Versions/3.11/lib cargo test --workspace --lib --tests --no-fail-fast`
- `DYLD_LIBRARY_PATH=/Library/Frameworks/Python.framework/Versions/3.11/lib cargo test -p geo-polygonize-core --no-default-features --lib --tests`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check && git diff --check`
- Full workspace: 345 core unit tests plus all workspace integration targets passed.

## Agent handoff
- Exact parent: #1335 (`agent/p5-global-face-global-id-plan`, `b8a6527`)
- Exact children: #1338 (`agent/p5-global-face-node-reconcile`, `df9c32c`)
- Next branch: `agent/p5-global-face-next-apply`
- Next slice: build a fail-closed global successor/twin application plan using mapped edge and node slots, still retaining mutation evidence only until complete global topology exists.