### PR TITLE
feat(core): gate global topology application

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -517,7 +517,9 @@ Blocked by #1288.
 - [x] Materialize a detached full global directed-edge successor candidate from
   local successors plus validated boundary overrides, and require complete
   one-in/one-out endpoint-continuous closed cycles before any future mutation.
-- [ ] Apply unambiguous twins only across declared adjacent borders.
+- [x] Gate detached topology application on unambiguous twins remaining backed
+  by declared adjacent borders and reciprocal global edge slots; retain
+  malformed or incomplete evidence as not ready without mutating topology.
 - [ ] Reconcile canonical border nodes, source sets, representative IDs, and
   selected Z-policy decisions.
 - [ ] Reconcile deterministic global connected components.

--- a/crates/geo-polygonize-core/src/graph/partition_border.rs
+++ b/crates/geo-polygonize-core/src/graph/partition_border.rs
@@ -711,6 +711,24 @@ pub(crate) struct PartitionBorderGlobalTopologyCandidateStats {
     pub(crate) candidate_ready: bool,
 }
 
+/// Counts from the final evidence gate before a future global topology
+/// mutation. This gate proves that detached successor links and every
+/// cross-border twin are still backed by declared adjacency; it writes no
+/// production topology.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct PartitionBorderGlobalTopologyApplicationGateStats {
+    pub(crate) edge_count: usize,
+    pub(crate) candidate_successor_count: usize,
+    pub(crate) declared_adjacency_count: usize,
+    pub(crate) applied_twin_count: usize,
+    pub(crate) mapped_twin_count: usize,
+    pub(crate) unmapped_twin_count: usize,
+    pub(crate) invalid_twin_count: usize,
+    pub(crate) predecessor_conflict_count: usize,
+    pub(crate) node_discontinuity_count: usize,
+    pub(crate) application_ready: bool,
+}
+
 /// Canonical evidence for one border node after all physical observations
 /// have been grouped by exact XY identity. The selected Z value is retained
 /// as a policy decision, while every candidate and contributing identity
@@ -4865,6 +4883,205 @@ impl PartitionBorderGraph {
         self.global_topology_candidate.as_ref()
     }
 
+    /// Validates the detached candidate against declared-adjacency twin
+    /// evidence immediately before any future global topology mutation. The
+    /// gate is deliberately observational: it never rewrites edge, twin, or
+    /// local arrangement links.
+    pub(crate) fn validate_global_topology_application_gate(
+        &self,
+        execution_policy: &ExecutionPolicy,
+    ) -> crate::Result<PartitionBorderGlobalTopologyApplicationGateStats> {
+        execution_policy.check_cancelled("partition_border_global_topology_application_gate")?;
+        execution_policy.check(
+            "partition_border_global_topology_application_gate_edges",
+            execution_policy.max_graph_edges,
+            self.global_face_edge_map.len(),
+        )?;
+        execution_policy.check(
+            "partition_border_global_topology_application_gate_twins",
+            execution_policy.max_graph_edges,
+            self.applied_face_twins.len(),
+        )?;
+        let Some(candidate) = self.global_topology_candidate.as_ref() else {
+            return Err(crate::PolygonizeError::InternalInvariantViolation {
+                reason: "global topology application gate has no detached candidate".to_string(),
+            });
+        };
+        let edge_count = self.global_face_edge_map.len();
+        if candidate.next_global_dir_edge_ids.len() != edge_count {
+            return Err(crate::PolygonizeError::InternalInvariantViolation {
+                reason: format!(
+                    "global topology application gate candidate length mismatch: candidate={}, edges={}",
+                    candidate.next_global_dir_edge_ids.len(),
+                    edge_count
+                ),
+            });
+        }
+
+        let mut edge_slot_by_local = BTreeMap::<(usize, usize, DirEdgeId), usize>::new();
+        for (edge_index, edge) in self.global_face_edge_map.iter().enumerate() {
+            execution_policy.check_cancelled_every(
+                "partition_border_global_topology_application_gate_edges",
+                edge_index,
+            )?;
+            if edge.global_dir_edge_id != edge_index
+                || edge_slot_by_local
+                    .insert(
+                        (edge.partition_id, edge.component_id, edge.local_dir_edge_id),
+                        edge_index,
+                    )
+                    .is_some()
+            {
+                return Err(crate::PolygonizeError::InternalInvariantViolation {
+                    reason: format!(
+                        "global topology application gate has invalid edge slot {}",
+                        edge_index
+                    ),
+                });
+            }
+        }
+
+        let mut edge_slot_by_observation = BTreeMap::<PartitionBorderObservationId, usize>::new();
+        for (observation_index, observation) in self.observations.values().enumerate() {
+            execution_policy.check_cancelled_every(
+                "partition_border_global_topology_application_gate_observations",
+                observation_index,
+            )?;
+            let component_id = observation
+                .face_ref
+                .map_or(observation.component_id, |face_ref| face_ref.component_id);
+            if let Some(&edge_index) = edge_slot_by_local.get(&(
+                observation.partition_id,
+                component_id,
+                observation.local_dir_edge_id,
+            )) {
+                edge_slot_by_observation.insert(observation.observation_id(), edge_index);
+            }
+        }
+
+        let mut candidate_successor_count = 0usize;
+        let mut predecessor_by_edge = BTreeMap::<usize, usize>::new();
+        let mut predecessor_conflict_count = 0usize;
+        let mut node_discontinuity_count = 0usize;
+        for (edge_index, successor) in candidate.next_global_dir_edge_ids.iter().enumerate() {
+            execution_policy.check_cancelled_every(
+                "partition_border_global_topology_application_gate_successors",
+                edge_index,
+            )?;
+            let Some(successor_index) = successor else {
+                continue;
+            };
+            if *successor_index >= edge_count {
+                return Err(crate::PolygonizeError::InternalInvariantViolation {
+                    reason: format!(
+                        "global topology application gate edge {} has invalid successor {}",
+                        edge_index, successor_index
+                    ),
+                });
+            }
+            candidate_successor_count += 1;
+            let edge = &self.global_face_edge_map[edge_index];
+            let successor_edge = &self.global_face_edge_map[*successor_index];
+            if edge.to_global_node_id != successor_edge.from_global_node_id {
+                node_discontinuity_count += 1;
+            }
+            if predecessor_by_edge
+                .insert(*successor_index, edge_index)
+                .is_some()
+            {
+                predecessor_conflict_count += 1;
+            }
+        }
+
+        let mut mapped_twin_pairs = BTreeSet::<(usize, usize)>::new();
+        let mut invalid_twin_count = 0usize;
+        for (twin_index, applied_twin) in self.applied_face_twins.iter().enumerate() {
+            execution_policy.check_cancelled_every(
+                "partition_border_global_topology_application_gate_twins",
+                twin_index,
+            )?;
+            let Some(forward) = self.observations.get(&applied_twin.twin.forward) else {
+                invalid_twin_count += 1;
+                continue;
+            };
+            let Some(reverse) = self.observations.get(&applied_twin.twin.reverse) else {
+                invalid_twin_count += 1;
+                continue;
+            };
+            if !self
+                .adjacencies
+                .iter()
+                .any(|adjacency| adjacency.matches(forward, reverse))
+            {
+                invalid_twin_count += 1;
+                continue;
+            }
+            let Some(&forward_index) = edge_slot_by_observation.get(&applied_twin.twin.forward)
+            else {
+                continue;
+            };
+            let Some(&reverse_index) = edge_slot_by_observation.get(&applied_twin.twin.reverse)
+            else {
+                continue;
+            };
+            let forward_edge = &self.global_face_edge_map[forward_index];
+            let reverse_edge = &self.global_face_edge_map[reverse_index];
+            if forward_edge.cross_border_twin_global_dir_edge_id != Some(reverse_index)
+                || reverse_edge.cross_border_twin_global_dir_edge_id != Some(forward_index)
+                || forward_edge.partition_id == reverse_edge.partition_id
+            {
+                invalid_twin_count += 1;
+                continue;
+            }
+            mapped_twin_pairs.insert(if forward_index < reverse_index {
+                (forward_index, reverse_index)
+            } else {
+                (reverse_index, forward_index)
+            });
+        }
+
+        let mut edge_map_twin_pairs = BTreeSet::<(usize, usize)>::new();
+        for (edge_index, edge) in self.global_face_edge_map.iter().enumerate() {
+            let Some(twin_index) = edge.cross_border_twin_global_dir_edge_id else {
+                continue;
+            };
+            if twin_index >= edge_count {
+                return Err(crate::PolygonizeError::InternalInvariantViolation {
+                    reason: format!(
+                        "global topology application gate edge {} has invalid twin {}",
+                        edge_index, twin_index
+                    ),
+                });
+            }
+            edge_map_twin_pairs.insert(if edge_index < twin_index {
+                (edge_index, twin_index)
+            } else {
+                (twin_index, edge_index)
+            });
+        }
+        let unmapped_twin_count = edge_map_twin_pairs.difference(&mapped_twin_pairs).count();
+        let application_ready = candidate_successor_count == edge_count
+            && predecessor_by_edge.len() == edge_count
+            && predecessor_conflict_count == 0
+            && node_discontinuity_count == 0
+            && invalid_twin_count == 0
+            && unmapped_twin_count == 0
+            && mapped_twin_pairs.len() == edge_map_twin_pairs.len();
+
+        Ok(PartitionBorderGlobalTopologyApplicationGateStats {
+            edge_count,
+            candidate_successor_count,
+            declared_adjacency_count: self.adjacencies.len(),
+            applied_twin_count: self.applied_face_twins.len(),
+            mapped_twin_count: mapped_twin_pairs.len(),
+            unmapped_twin_count,
+            invalid_twin_count,
+            predecessor_conflict_count,
+            node_discontinuity_count,
+            application_ready,
+        })
+    }
+
     /// Validates the retained face-walk, twin, payload, and face-adjacency
     /// evidence before any global topology mutation. Closed local cycles must
     /// preserve their declared successor identities, every mapped twin must
@@ -6744,6 +6961,95 @@ mod tests {
         assert_eq!(stats.incomplete_application_plan_count, 1);
         assert!(!stats.candidate_ready);
         assert!(incomplete.global_topology_candidate().is_some());
+    }
+
+    #[test]
+    fn global_topology_application_gate_requires_declared_twins_and_complete_candidate() {
+        let mut graph = exact_global_topology_candidate_graph();
+        graph
+            .reconcile_global_topology_candidate(&ExecutionPolicy::default())
+            .unwrap();
+        let stats = graph
+            .validate_global_topology_application_gate(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(
+            stats,
+            PartitionBorderGlobalTopologyApplicationGateStats {
+                edge_count: 4,
+                candidate_successor_count: 4,
+                declared_adjacency_count: 1,
+                applied_twin_count: 1,
+                mapped_twin_count: 1,
+                unmapped_twin_count: 0,
+                invalid_twin_count: 0,
+                predecessor_conflict_count: 0,
+                node_discontinuity_count: 0,
+                application_ready: true,
+            }
+        );
+
+        graph.adjacencies.clear();
+        let stats = graph
+            .validate_global_topology_application_gate(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(stats.invalid_twin_count, 1);
+        assert_eq!(stats.unmapped_twin_count, 1);
+        assert!(!stats.application_ready);
+
+        let mut incomplete = exact_global_topology_candidate_graph();
+        incomplete
+            .reconcile_global_topology_candidate(&ExecutionPolicy::default())
+            .unwrap();
+        incomplete
+            .global_topology_candidate
+            .as_mut()
+            .unwrap()
+            .next_global_dir_edge_ids[0] = None;
+        let stats = incomplete
+            .validate_global_topology_application_gate(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(stats.candidate_successor_count, 3);
+        assert!(!stats.application_ready);
+    }
+
+    #[test]
+    fn global_topology_application_gate_is_bounded_and_cancellable() {
+        let mut limited = exact_global_topology_candidate_graph();
+        limited
+            .reconcile_global_topology_candidate(&ExecutionPolicy::default())
+            .unwrap();
+        let error = limited
+            .validate_global_topology_application_gate(&ExecutionPolicy {
+                max_graph_edges: Some(3),
+                ..Default::default()
+            })
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::ResourceLimitExceeded {
+                ref stage,
+                limit: 3,
+                observed: 4,
+            } if stage == "partition_border_global_topology_application_gate_edges"
+        ));
+
+        let token = CancellationToken::new();
+        token.cancel();
+        let mut cancelled = exact_global_topology_candidate_graph();
+        cancelled
+            .reconcile_global_topology_candidate(&ExecutionPolicy::default())
+            .unwrap();
+        let error = cancelled
+            .validate_global_topology_application_gate(&ExecutionPolicy {
+                cancellation_token: Some(token),
+                ..Default::default()
+            })
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::Cancelled { ref stage }
+                if stage == "partition_border_global_topology_application_gate"
+        ));
     }
 
     #[test]

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -479,6 +479,26 @@ pub struct StitchingReport {
     pub partition_border_global_topology_candidate_incomplete_application_plan_count: usize,
     /// Whether the detached candidate is a complete cycle system.
     pub partition_border_global_topology_candidate_ready: bool,
+    /// Edge slots checked by the final detached-topology application gate.
+    pub partition_border_global_topology_application_gate_edge_count: usize,
+    /// Candidate successor links checked by the final application gate.
+    pub partition_border_global_topology_application_gate_successor_count: usize,
+    /// Declared partition adjacencies available to the application gate.
+    pub partition_border_global_topology_application_gate_adjacency_count: usize,
+    /// Face-qualified twins retained from declared-adjacency application.
+    pub partition_border_global_topology_application_gate_applied_twin_count: usize,
+    /// Twin pairs mapped into reciprocal global edge slots.
+    pub partition_border_global_topology_application_gate_mapped_twin_count: usize,
+    /// Global twin pairs without complete applied evidence.
+    pub partition_border_global_topology_application_gate_unmapped_twin_count: usize,
+    /// Applied twin records rejected by the final adjacency/lineage gate.
+    pub partition_border_global_topology_application_gate_invalid_twin_count: usize,
+    /// Candidate successor targets with multiple predecessors at the gate.
+    pub partition_border_global_topology_application_gate_predecessor_conflict_count: usize,
+    /// Candidate links with discontinuous endpoint node slots at the gate.
+    pub partition_border_global_topology_application_gate_node_discontinuity_count: usize,
+    /// Whether the detached candidate is safe for a future mutation phase.
+    pub partition_border_global_topology_application_gate_ready: bool,
     /// Whether indexed components were recovered by component or region fallback.
     /// This is operational metadata; strict validation uses `coverage_resolution`.
     pub component_fallback_used: bool,
@@ -2588,6 +2608,8 @@ impl<'a> TiledPolygonizer<'a> {
             .reconcile_global_face_next_application_plans(&self.execution_policy)?;
         let partition_border_global_topology_candidate =
             partition_border_graph.reconcile_global_topology_candidate(&self.execution_policy)?;
+        let partition_border_global_topology_application_gate = partition_border_graph
+            .validate_global_topology_application_gate(&self.execution_policy)?;
         let partition_border_global_unbounded_face_proof = partition_border_graph
             .validate_global_unbounded_face_proof_with_walk(
                 &self.execution_policy,
@@ -2646,6 +2668,9 @@ impl<'a> TiledPolygonizer<'a> {
             );
             trace.record_partition_border_global_topology_candidate(
                 partition_border_global_topology_candidate,
+            );
+            trace.record_partition_border_global_topology_application_gate(
+                partition_border_global_topology_application_gate,
             );
             trace.record_partition_border_global_unbounded_face_proof(
                 partition_border_global_unbounded_face_proof,
@@ -3090,6 +3115,26 @@ impl<'a> TiledPolygonizer<'a> {
                     partition_border_global_topology_candidate.incomplete_application_plan_count,
                 partition_border_global_topology_candidate_ready:
                     partition_border_global_topology_candidate.candidate_ready,
+                partition_border_global_topology_application_gate_edge_count:
+                    partition_border_global_topology_application_gate.edge_count,
+                partition_border_global_topology_application_gate_successor_count:
+                    partition_border_global_topology_application_gate.candidate_successor_count,
+                partition_border_global_topology_application_gate_adjacency_count:
+                    partition_border_global_topology_application_gate.declared_adjacency_count,
+                partition_border_global_topology_application_gate_applied_twin_count:
+                    partition_border_global_topology_application_gate.applied_twin_count,
+                partition_border_global_topology_application_gate_mapped_twin_count:
+                    partition_border_global_topology_application_gate.mapped_twin_count,
+                partition_border_global_topology_application_gate_unmapped_twin_count:
+                    partition_border_global_topology_application_gate.unmapped_twin_count,
+                partition_border_global_topology_application_gate_invalid_twin_count:
+                    partition_border_global_topology_application_gate.invalid_twin_count,
+                partition_border_global_topology_application_gate_predecessor_conflict_count:
+                    partition_border_global_topology_application_gate.predecessor_conflict_count,
+                partition_border_global_topology_application_gate_node_discontinuity_count:
+                    partition_border_global_topology_application_gate.node_discontinuity_count,
+                partition_border_global_topology_application_gate_ready:
+                    partition_border_global_topology_application_gate.application_ready,
                 component_fallback_used,
                 untiled_fallback_attempted,
                 untiled_fallback_authoritative,

--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -348,6 +348,70 @@ mod tests {
             global_topology_candidate.next_global_dir_edge_ids.len(),
             global_topology_candidate_stats.edge_count
         );
+        let global_topology_application_gate_stats = result
+            .partition_border_graph
+            .validate_global_topology_application_gate(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_topology_application_gate_edge_count,
+            global_topology_application_gate_stats.edge_count
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_topology_application_gate_successor_count,
+            global_topology_application_gate_stats.candidate_successor_count
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_topology_application_gate_adjacency_count,
+            global_topology_application_gate_stats.declared_adjacency_count
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_topology_application_gate_applied_twin_count,
+            global_topology_application_gate_stats.applied_twin_count
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_topology_application_gate_mapped_twin_count,
+            global_topology_application_gate_stats.mapped_twin_count
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_topology_application_gate_unmapped_twin_count,
+            global_topology_application_gate_stats.unmapped_twin_count
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_topology_application_gate_invalid_twin_count,
+            global_topology_application_gate_stats.invalid_twin_count
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_topology_application_gate_predecessor_conflict_count,
+            global_topology_application_gate_stats.predecessor_conflict_count
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_topology_application_gate_node_discontinuity_count,
+            global_topology_application_gate_stats.node_discontinuity_count
+        );
+        assert_eq!(
+            result
+                .stitching_report
+                .partition_border_global_topology_application_gate_ready,
+            global_topology_application_gate_stats.application_ready
+        );
         assert_eq!(
             result
                 .stitching_report
@@ -1424,6 +1488,111 @@ mod tests {
                     .result
                     .stitching_report
                     .partition_border_global_topology_candidate_ready
+            )
+        );
+        let topology_application_gate = traced
+            .trace
+            .events
+            .iter()
+            .find(|event| event.kind == "partition_border_global_topology_application_gate")
+            .expect("global topology application gate evidence");
+        assert_eq!(
+            topology_application_gate.payload["edge_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_topology_application_gate_edge_count
+                    as u64
+            )
+        );
+        assert_eq!(
+            topology_application_gate.payload["candidate_successor_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_topology_application_gate_successor_count
+                    as u64
+            )
+        );
+        assert_eq!(
+            topology_application_gate.payload["declared_adjacency_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_topology_application_gate_adjacency_count
+                    as u64
+            )
+        );
+        assert_eq!(
+            topology_application_gate.payload["applied_twin_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_topology_application_gate_applied_twin_count
+                    as u64
+            )
+        );
+        assert_eq!(
+            topology_application_gate.payload["mapped_twin_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_topology_application_gate_mapped_twin_count
+                    as u64
+            )
+        );
+        assert_eq!(
+            topology_application_gate.payload["unmapped_twin_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_topology_application_gate_unmapped_twin_count
+                    as u64
+            )
+        );
+        assert_eq!(
+            topology_application_gate.payload["invalid_twin_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_topology_application_gate_invalid_twin_count
+                    as u64
+            )
+        );
+        assert_eq!(
+            topology_application_gate.payload["predecessor_conflict_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_topology_application_gate_predecessor_conflict_count
+                    as u64
+            )
+        );
+        assert_eq!(
+            topology_application_gate.payload["node_discontinuity_count"].as_u64(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_topology_application_gate_node_discontinuity_count
+                    as u64
+            )
+        );
+        assert_eq!(
+            topology_application_gate.payload["application_ready"].as_bool(),
+            Some(
+                traced
+                    .result
+                    .stitching_report
+                    .partition_border_global_topology_application_gate_ready
             )
         );
         let node_reconciliation = traced

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -10,9 +10,10 @@ use crate::graph::partition_border::{
     PartitionBorderGlobalFaceNodeReconciliationStats, PartitionBorderGlobalFacePlanStats,
     PartitionBorderGlobalFacePlanValidationStats, PartitionBorderGlobalFaceTransitionPlanStats,
     PartitionBorderGlobalFaceTwinTransitionStats, PartitionBorderGlobalFaceWalkInvariantStats,
-    PartitionBorderGlobalTopologyCandidateStats, PartitionBorderGlobalUnboundedFaceProofStats,
-    PartitionBorderHalfEdge, PartitionBorderNodeReconciliationStats,
-    PartitionBorderReconciliationStats, PartitionBorderTwinApplicationStats,
+    PartitionBorderGlobalTopologyApplicationGateStats, PartitionBorderGlobalTopologyCandidateStats,
+    PartitionBorderGlobalUnboundedFaceProofStats, PartitionBorderHalfEdge,
+    PartitionBorderNodeReconciliationStats, PartitionBorderReconciliationStats,
+    PartitionBorderTwinApplicationStats,
 };
 use crate::graph::planar_graph::PartitionBoundaryNodingStats;
 use crate::graph::{ExtractedRing, PlanarGraph};
@@ -727,6 +728,28 @@ impl TraceRecorderV1 {
                 "node_discontinuity_count": stats.node_discontinuity_count,
                 "incomplete_application_plan_count": stats.incomplete_application_plan_count,
                 "candidate_ready": stats.candidate_ready,
+            }),
+        )
+    }
+
+    pub(crate) fn record_partition_border_global_topology_application_gate(
+        &mut self,
+        stats: PartitionBorderGlobalTopologyApplicationGateStats,
+    ) -> bool {
+        self.record(
+            TraceStageV1::Graph,
+            "partition_border_global_topology_application_gate",
+            serde_json::json!({
+                "edge_count": stats.edge_count,
+                "candidate_successor_count": stats.candidate_successor_count,
+                "declared_adjacency_count": stats.declared_adjacency_count,
+                "applied_twin_count": stats.applied_twin_count,
+                "mapped_twin_count": stats.mapped_twin_count,
+                "unmapped_twin_count": stats.unmapped_twin_count,
+                "invalid_twin_count": stats.invalid_twin_count,
+                "predecessor_conflict_count": stats.predecessor_conflict_count,
+                "node_discontinuity_count": stats.node_discontinuity_count,
+                "application_ready": stats.application_ready,
             }),
         )
     }


### PR DESCRIPTION
## Stack
- Parent: main (`origin/main`, `5864f26`)
- Children: #1342 (`agent/p5-global-face-global-components`, `cf39a4b`)
- Next branch: `agent/p5-global-face-global-face-ids`

## Delivered
- Add a final detached-topology application gate requiring complete candidate successors, one-predecessor ownership, endpoint-node continuity, and reciprocal global edge slots.
- Verify every applied face-qualified twin remains backed by a declared adjacent partition border; reject malformed or unmapped twin evidence without mutating topology.
- Expose bounded/cancellable report and trace evidence, preserve lifecycle contracts, and add regression coverage for complete, incomplete, undeclared, limited, and cancelled cases.
- Mark the roadmap’s declared-adjacency twin application item complete without claiming global topology mutation or output extraction.

## Contract impact
- No public API or production polygon output changes.
- Local/global `next` links, face IDs, provenance, representative IDs, Z values, serial/parallel equality, resource limits, and cancellation behavior remain unchanged.
- `application_ready` is evidence-only and does not authorize a future mutation until global components, face IDs, unbounded identity, invariants, extraction, and untiled equivalence are complete.

## Validation
- Focused topology-application-gate, candidate, report, and trace tests.
- `DYLD_LIBRARY_PATH=/Library/Frameworks/Python.framework/Versions/3.11/lib cargo test --workspace --lib --tests --no-fail-fast` (353 core unit tests plus workspace integration targets)
- `DYLD_LIBRARY_PATH=/Library/Frameworks/Python.framework/Versions/3.11/lib cargo test -p geo-polygonize-core --no-default-features --lib --tests` (353 core unit tests plus core integration targets)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check` and `git diff --check`

## Agent handoff
- This is a fail-closed evidence gate only; no global DCEL conversion, `next` mutation, global face-ID assignment, unbounded-face promotion, or stitched output extraction is claimed.
- Nested-containment evidence still disproves independently polygonizing and appending component-local recovery output.
- Exact child: #1342 (`agent/p5-global-face-global-components`, `cf39a4b`).
- Exact next branch: `agent/p5-global-face-global-face-ids`, implementing global next-link and deterministic face-ID validation over the component-coverage evidence.
- Commit: `caf3c05`