### PR TITLE
feat(core): commit gated detached successor links

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -534,6 +534,9 @@ Blocked by #1288.
 - [x] Combine detached topology, component, face-ID, unbounded, twin, cycle,
   source, Euler, and face-walk evidence into one bounded pre-mutation gate;
   retain incomplete proof without mutating topology.
+- [x] Atomically commit a validated detached global successor vector only after
+  the complete gate; keep local half-edge links, face IDs, and tiled output
+  untouched until their own promotion proofs exist.
 - [ ] Build global `next` links and deterministic global face IDs.
 - [ ] Identify exactly one global unbounded face.
 - [ ] Validate twin, cycle, source, Euler, and face-walk invariants.

--- a/crates/geo-polygonize-core/src/graph/partition_border.rs
+++ b/crates/geo-polygonize-core/src/graph/partition_border.rs
@@ -693,6 +693,17 @@ pub(crate) struct PartitionBorderGlobalTopologyCandidate {
     pub(crate) cycle_start_global_dir_edge_ids: Vec<usize>,
 }
 
+/// Counts the one atomic commit of detached global successor links. Face IDs
+/// remain a separate roadmap slice; no local face identity or output is
+/// changed by this mutation.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct PartitionBorderGlobalTopologyMutationStats {
+    pub(crate) edge_count: usize,
+    pub(crate) applied_next_count: usize,
+    pub(crate) mutation_ready: bool,
+    pub(crate) applied: bool,
+}
+
 /// Counts from validating a detached global directed-edge topology candidate.
 /// Readiness requires complete application evidence, one predecessor and one
 /// successor per edge, endpoint continuity, and closed cycles.
@@ -1179,6 +1190,7 @@ pub struct PartitionBorderGraph {
     global_face_id_plans: Vec<PartitionBorderGlobalFaceIdPlan>,
     global_face_next_application_plans: Vec<PartitionBorderGlobalFaceNextApplicationPlan>,
     global_topology_candidate: Option<PartitionBorderGlobalTopologyCandidate>,
+    global_next_global_dir_edge_ids: Vec<Option<usize>>,
 }
 
 impl PartitionBorderGraph {
@@ -1226,6 +1238,7 @@ impl PartitionBorderGraph {
         self.global_face_id_plans.clear();
         self.global_face_next_application_plans.clear();
         self.global_topology_candidate = None;
+        self.global_next_global_dir_edge_ids.clear();
         self.global_face_edge_map.clear();
         self.global_face_nodes.clear();
         Ok(())
@@ -5243,11 +5256,61 @@ impl PartitionBorderGraph {
         Ok(stats)
     }
 
+    /// Commits a validated candidate into a detached global successor buffer.
+    /// This is the first atomic mutation step, but it intentionally does not
+    /// rewrite local half-edge links, local face IDs, or tiled output.
+    pub(crate) fn apply_global_topology_candidate_with_gate(
+        &mut self,
+        execution_policy: &ExecutionPolicy,
+        mutation_gate: PartitionBorderGlobalTopologyMutationGateStats,
+        candidate: PartitionBorderGlobalTopologyCandidateStats,
+    ) -> crate::Result<PartitionBorderGlobalTopologyMutationStats> {
+        execution_policy.check_cancelled("partition_border_global_topology_mutation")?;
+        execution_policy.check(
+            "partition_border_global_topology_mutation_edges",
+            execution_policy.max_graph_edges,
+            self.global_face_edge_map.len(),
+        )?;
+        let Some(detached_candidate) = self.global_topology_candidate.as_ref() else {
+            return Err(crate::PolygonizeError::InternalInvariantViolation {
+                reason: "global topology mutation has no detached candidate".to_string(),
+            });
+        };
+        if detached_candidate.next_global_dir_edge_ids.len() != self.global_face_edge_map.len() {
+            return Err(crate::PolygonizeError::InternalInvariantViolation {
+                reason: "global topology mutation candidate length mismatch".to_string(),
+            });
+        }
+        let mutation_ready = mutation_gate.gate_ready && candidate.candidate_ready;
+        if !mutation_ready {
+            return Ok(PartitionBorderGlobalTopologyMutationStats {
+                edge_count: self.global_face_edge_map.len(),
+                applied_next_count: 0,
+                mutation_ready,
+                applied: false,
+            });
+        }
+        let next_global_dir_edge_ids = detached_candidate.next_global_dir_edge_ids.clone();
+        let applied_next_count = next_global_dir_edge_ids.iter().flatten().count();
+        self.global_next_global_dir_edge_ids = next_global_dir_edge_ids;
+        Ok(PartitionBorderGlobalTopologyMutationStats {
+            edge_count: self.global_face_edge_map.len(),
+            applied_next_count,
+            mutation_ready: true,
+            applied: true,
+        })
+    }
+
     #[cfg(test)]
     pub(crate) fn global_topology_candidate(
         &self,
     ) -> Option<&PartitionBorderGlobalTopologyCandidate> {
         self.global_topology_candidate.as_ref()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn global_next_global_dir_edge_ids(&self) -> &[Option<usize>] {
+        &self.global_next_global_dir_edge_ids
     }
 
     /// Validates the detached candidate against declared-adjacency twin
@@ -10160,6 +10223,44 @@ mod tests {
             crate::PolygonizeError::Cancelled { ref stage }
                 if stage == "partition_border_global_topology_mutation_gate"
         ));
+    }
+
+    #[test]
+    fn global_topology_mutation_commits_only_after_the_gate() {
+        let mut graph = exact_global_topology_candidate_graph();
+        let candidate = graph
+            .reconcile_global_topology_candidate(&ExecutionPolicy::default())
+            .unwrap();
+        let not_ready = graph
+            .apply_global_topology_candidate_with_gate(
+                &ExecutionPolicy::default(),
+                PartitionBorderGlobalTopologyMutationGateStats::default(),
+                candidate,
+            )
+            .unwrap();
+        assert!(!not_ready.applied);
+        assert!(graph.global_next_global_dir_edge_ids().is_empty());
+
+        let candidate = graph
+            .reconcile_global_topology_candidate(&ExecutionPolicy::default())
+            .unwrap();
+        let applied = graph
+            .apply_global_topology_candidate_with_gate(
+                &ExecutionPolicy::default(),
+                PartitionBorderGlobalTopologyMutationGateStats {
+                    gate_ready: true,
+                    ..Default::default()
+                },
+                candidate,
+            )
+            .unwrap();
+        assert!(applied.applied);
+        assert_eq!(applied.applied_next_count, 4);
+        assert_eq!(graph.global_next_global_dir_edge_ids().len(), 4);
+        assert!(graph
+            .global_next_global_dir_edge_ids()
+            .iter()
+            .all(Option::is_some));
     }
 
     #[test]

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -440,6 +440,10 @@ pub struct StitchingReport {
     pub partition_border_global_topology_mutation_gate_face_walk_ready: bool,
     pub partition_border_global_topology_mutation_gate_euler_evidence_ready: bool,
     pub partition_border_global_topology_mutation_gate_ready: bool,
+    /// Detached global successor links committed after the complete gate.
+    pub partition_border_global_topology_mutation_applied_next_count: usize,
+    pub partition_border_global_topology_mutation_ready: bool,
+    pub partition_border_global_topology_mutation_applied: bool,
     /// Unbounded-face candidates whose local cycles are closed.
     pub partition_border_global_unbounded_face_proof_closed_count: usize,
     /// Unbounded-face twins absent from the retained twin-position map.
@@ -2697,6 +2701,12 @@ impl<'a> TiledPolygonizer<'a> {
                 partition_border_global_face_walk_invariants,
                 partition_border_global_face_euler_witness,
             )?;
+        let partition_border_global_topology_mutation = partition_border_graph
+            .apply_global_topology_candidate_with_gate(
+                &self.execution_policy,
+                partition_border_global_topology_mutation_gate,
+                partition_border_global_topology_candidate,
+            )?;
         if let Some(trace) = trace.as_deref_mut() {
             trace.record_partition_border_reconciliation(partition_border_reconciliation);
             trace.record_partition_border_twin_application(partition_border_twin_application);
@@ -2768,6 +2778,9 @@ impl<'a> TiledPolygonizer<'a> {
             );
             trace.record_partition_border_global_topology_mutation_gate(
                 partition_border_global_topology_mutation_gate,
+            );
+            trace.record_partition_border_global_topology_mutation(
+                partition_border_global_topology_mutation,
             );
         }
         let unresolved = tile_reports.iter().any(Self::report_is_unresolved);
@@ -3193,6 +3206,12 @@ impl<'a> TiledPolygonizer<'a> {
                     partition_border_global_topology_mutation_gate.euler_evidence_ready,
                 partition_border_global_topology_mutation_gate_ready:
                     partition_border_global_topology_mutation_gate.gate_ready,
+                partition_border_global_topology_mutation_applied_next_count:
+                    partition_border_global_topology_mutation.applied_next_count,
+                partition_border_global_topology_mutation_ready:
+                    partition_border_global_topology_mutation.mutation_ready,
+                partition_border_global_topology_mutation_applied:
+                    partition_border_global_topology_mutation.applied,
                 partition_border_global_unbounded_face_proof_closed_count:
                     partition_border_global_unbounded_face_proof.closed_unbounded_face_count,
                 partition_border_global_unbounded_face_proof_unmapped_twin_count:

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -12,7 +12,7 @@ use crate::graph::partition_border::{
     PartitionBorderGlobalFacePlanValidationStats, PartitionBorderGlobalFaceTransitionPlanStats,
     PartitionBorderGlobalFaceTwinTransitionStats, PartitionBorderGlobalFaceWalkInvariantStats,
     PartitionBorderGlobalTopologyApplicationGateStats, PartitionBorderGlobalTopologyCandidateStats,
-    PartitionBorderGlobalTopologyMutationGateStats,
+    PartitionBorderGlobalTopologyMutationGateStats, PartitionBorderGlobalTopologyMutationStats,
     PartitionBorderGlobalUnboundedFaceApplicationStats,
     PartitionBorderGlobalUnboundedFaceProofStats, PartitionBorderHalfEdge,
     PartitionBorderNodeReconciliationStats, PartitionBorderReconciliationStats,
@@ -992,6 +992,22 @@ impl TraceRecorderV1 {
                 "face_walk_ready": stats.face_walk_ready,
                 "euler_evidence_ready": stats.euler_evidence_ready,
                 "gate_ready": stats.gate_ready,
+            }),
+        )
+    }
+
+    pub(crate) fn record_partition_border_global_topology_mutation(
+        &mut self,
+        stats: PartitionBorderGlobalTopologyMutationStats,
+    ) -> bool {
+        self.record(
+            TraceStageV1::Graph,
+            "partition_border_global_topology_mutation",
+            serde_json::json!({
+                "edge_count": stats.edge_count,
+                "applied_next_count": stats.applied_next_count,
+                "mutation_ready": stats.mutation_ready,
+                "applied": stats.applied,
             }),
         )
     }


### PR DESCRIPTION
## Stack\n- Parent: #1346 (agent/p5-global-face-invariants, 4356b0d)\n- Children: none at creation\n- Next branch: agent/p5-global-face-id-commit\n\n## Delivered\n- Added the first atomic global-topology mutation boundary: commit the validated detached successor vector only after the combined mutation gate and candidate are ready.\n- Threaded mutation counts/readiness through tiled StitchingReport and graph trace.\n- Added a regression proving incomplete evidence performs no commit and complete evidence commits all four detached successors.\n- Updated ROADMAP.md precisely; production local half-edge links, deterministic face IDs, extraction, and tiled output remain untouched.\n\n## Contract impact\n- No public polygon output, local half-edge next, face IDs, provenance, representative IDs, Z behavior, serial/parallel behavior, fallback behavior, or public API changes.\n- The committed vector is detached evidence only; it is not yet promoted into local arrangement topology or output.\n- Incomplete proof remains fail-closed and mutation-free.\n\n## Validation\n- Focused global topology mutation, report, and trace tests passed.\n- DYLD_LIBRARY_PATH=/Library/Frameworks/Python.framework/Versions/3.11/lib cargo test --workspace --lib --tests --no-fail-fast: passed, including 362 core unit tests and all workspace integration targets.\n- cargo test -p geo-polygonize-core --no-default-features --lib --tests --no-fail-fast: passed previously on the parent evidence slice; no-default behavior is unchanged by this detached-only commit.\n- cargo clippy --workspace --all-targets -- -D warnings: passed.\n- cargo fmt --all -- --check and git diff --check: passed.\n- Generated bindings restored; no package-lock changes.\n\n## Agent handoff\n- Exact parent: #1346 / agent/p5-global-face-invariants / 4356b0d\n- Exact children: none at creation\n- Exact next branch: agent/p5-global-face-id-commit\n- Continue with deterministic face-ID commit into detached global state only; do not assign local IDs or extract output until unbounded and containment contracts are proven.