### PR TITLE
ci(github): remove flaky cargo-binstall bootstrap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,9 +266,6 @@ jobs:
           node-version: '22'
           cache: 'npm'
 
-      - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@main
-
       - name: Build WASM package
         env:
           THREADS_TOOLCHAIN: nightly-2026-07-15

--- a/.github/workflows/cross-architecture-benchmarks.yml
+++ b/.github/workflows/cross-architecture-benchmarks.yml
@@ -102,8 +102,6 @@ jobs:
 
       - run: npm ci
 
-      - uses: cargo-bins/cargo-binstall@main
-
       - name: Build and benchmark scalar package
         run: |
           set -o pipefail

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -78,9 +78,6 @@ jobs:
           args: --no-progress README.md docs
           fail: true
 
-      - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@main
-
       - name: Build Site Wasm Library
         run: npm run build:site-lib
         env:

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -72,11 +72,34 @@ jobs:
       - name: Generate Docs Metadata
         run: npm run docs:gen
 
+      - name: Install Lychee
+        env:
+          LYCHEE_VERSION: v0.24.2
+        run: |
+          set -euo pipefail
+          arch="$(uname -m)"
+          filename="lychee-${arch}-unknown-linux-gnu.tar.gz"
+          url="https://github.com/lycheeverse/lychee/releases/download/lychee-${LYCHEE_VERSION}/${filename}"
+          install_dir="${RUNNER_TEMP}/lychee"
+          mkdir -p "${install_dir}"
+          for attempt in 1 2 3 4 5; do
+            echo "Downloading Lychee (attempt ${attempt}/5)"
+            if curl --fail --location --retry 3 --retry-all-errors --retry-delay 2 \
+              --output "${install_dir}/${filename}" "${url}"; then
+              break
+            fi
+            if [ "${attempt}" -eq 5 ]; then
+              echo "Lychee download failed after ${attempt} attempts" >&2
+              exit 1
+            fi
+            rm -f "${install_dir}/${filename}"
+            sleep 2
+          done
+          tar -xzf "${install_dir}/${filename}" -C "${install_dir}"
+          echo "${install_dir}" >> "${GITHUB_PATH}"
+
       - name: Check documentation links
-        uses: lycheeverse/lychee-action@v2
-        with:
-          args: --no-progress README.md docs
-          fail: true
+        run: lychee --no-progress README.md docs
 
       - name: Build Site Wasm Library
         run: npm run build:site-lib

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -39,9 +39,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@main
-
       - name: Build WebAssembly and TypeScript
         run: npm run build
 

--- a/scripts/build_wasm.sh
+++ b/scripts/build_wasm.sh
@@ -38,14 +38,10 @@ setup_wasm_tools() {
 
     if ! command -v wasm-bindgen &> /dev/null || [ "$(wasm-bindgen --version | awk '{print $2}')" != "$WASM_BINDGEN_VERSION" ]; then
         echo "Installing wasm-bindgen-cli $WASM_BINDGEN_VERSION..."
-        if command -v cargo-binstall &> /dev/null; then
-            cargo binstall -y wasm-bindgen-cli --version $WASM_BINDGEN_VERSION
-        else
-            cargo install wasm-bindgen-cli --version $WASM_BINDGEN_VERSION
-        fi
+        cargo install wasm-bindgen-cli --version $WASM_BINDGEN_VERSION --locked
     fi
     if ! command -v wasm-bindgen &> /dev/null; then
-        cargo install --force wasm-bindgen-cli --version $WASM_BINDGEN_VERSION
+        cargo install --force wasm-bindgen-cli --version $WASM_BINDGEN_VERSION --locked
     fi
     WASM_BINDGEN_BIN="$(command -v wasm-bindgen)"
 

--- a/scripts/build_wasm.sh
+++ b/scripts/build_wasm.sh
@@ -47,11 +47,11 @@ setup_wasm_tools() {
 
     if [ "$SITE_BUILD" != "1" ] && ! command -v wasm-opt &> /dev/null; then
         echo "wasm-opt not found. Attempting to install via npm..."
-        npm install -g --allow-scripts=wasm-opt wasm-opt
-        if ! command -v wasm-opt &> /dev/null; then
-            echo "Warning: wasm-opt could not be installed. Build will proceed without optimization."
-        else
+        if npm install -g --allow-scripts=wasm-opt wasm-opt \
+            && command -v wasm-opt &> /dev/null; then
             echo "Successfully installed wasm-opt: $(wasm-opt --version)"
+        else
+            echo "Warning: wasm-opt could not be installed. Build will proceed without optimization."
         fi
     elif [ "$SITE_BUILD" != "1" ]; then
         echo "Found wasm-opt: $(wasm-opt --version)"


### PR DESCRIPTION
## Stack\n- Parent: main (origin/main, 1ac41ae)\n- Children: none at creation\n- Next branch: agent/p5-global-face-global-next-links\n\n## Delivered\n- Remove the unpinned cargo-binstall release-download bootstrap from CI, docs, cross-architecture WASM benchmarks, and npm publishing.\n- Install the exact wasm-bindgen CLI through Cargo with --locked via scripts/build_wasm.sh.\n- Make optional wasm-opt installation genuinely non-fatal so WASM builds continue unoptimized when the Binaryen archive is unavailable.\n- Replace the docs action's single Lychee download with a bounded retrying install; link-check failures still fail the job.\n\n## Contract impact\n- No Rust geometry, topology, provenance, Z, deterministic-output, API, package, or release-contract changes.\n- WASM artifacts and build commands remain unchanged after tool installation; optimization remains opportunistic as documented.\n- Link validation remains fail-closed on Lychee execution results; only transient tool-download failures are retried.\n- This addresses the observed GitHub archive/socket failures before the actual WASM/docs work ran.\n\n## Validation\n- actionlint passed.\n- bash -n scripts/build_wasm.sh passed.\n- git diff --check passed.\n- Observed failures classified: WASM scalar/SIMD and Wasm crossover failed on Binaryen archive socket hang-up; Docs failed on Lychee archive exit 56; CI Required was the aggregate.\n- Merged-main Rust, release tests, Python ABI wheel, and Release Contract passed.\n\n## Agent handoff\n- Exact parent: main / 1ac41ae\n- Exact children: none at creation\n- Exact next branch: agent/p5-global-face-global-next-links\n- After this PR validates, continue the detached global next-link integration slice; keep public/local topology promotion gated.