### PR TITLE
feat(core): validate canonical border node payloads

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -520,8 +520,9 @@ Blocked by #1288.
 - [x] Gate detached topology application on unambiguous twins remaining backed
   by declared adjacent borders and reciprocal global edge slots; retain
   malformed or incomplete evidence as not ready without mutating topology.
-- [ ] Reconcile canonical border nodes, source sets, representative IDs, and
-  selected Z-policy decisions.
+- [x] Reconcile canonical border nodes, source sets, representative IDs, face
+  lineage, and selected Z-policy decisions against active global face-node
+  slots, while allowing canonical-only non-face-qualified observations.
 - [x] Reconcile deterministic global connected components and verify that
   every face-qualified detached edge is covered exactly once without duplicate
   faces or twin ownership.

--- a/crates/geo-polygonize-core/src/graph/partition_border.rs
+++ b/crates/geo-polygonize-core/src/graph/partition_border.rs
@@ -805,6 +805,29 @@ pub(crate) struct PartitionBorderNodeReconciliationStats {
     pub(crate) z_conflict_count: usize,
 }
 
+/// Counts the fail-closed bridge between canonical border-node payloads and
+/// active global face-node slots. Canonical-only nodes are retained as valid
+/// evidence because they may belong to dangles or other non-face-qualified
+/// observations; every active global node must still be a payload-consistent
+/// projection of its canonical node.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct PartitionBorderCanonicalNodeValidationStats {
+    pub(crate) canonical_node_count: usize,
+    pub(crate) global_node_count: usize,
+    pub(crate) mapped_global_node_count: usize,
+    pub(crate) canonical_only_node_count: usize,
+    pub(crate) source_set_mismatch_count: usize,
+    pub(crate) representative_set_mismatch_count: usize,
+    pub(crate) face_set_mismatch_count: usize,
+    pub(crate) z_candidate_mismatch_count: usize,
+    pub(crate) selected_z_mismatch_count: usize,
+    pub(crate) z_policy_mismatch_count: usize,
+    pub(crate) z_conflict_mismatch_count: usize,
+    pub(crate) edge_endpoint_mismatch_count: usize,
+    pub(crate) invalid_global_node_id_count: usize,
+    pub(crate) reconciliation_ready: bool,
+}
+
 /// One deterministic connected component of qualified partition-border face
 /// evidence. This is retained for a future global arrangement; it does not
 /// rewrite local face IDs, adjacency, or tiled output.
@@ -2224,7 +2247,6 @@ impl PartitionBorderGraph {
                 ));
             }
         }
-
         let mut reconciled_nodes = Vec::with_capacity(evidence.len());
         let mut stats = PartitionBorderNodeReconciliationStats {
             node_count: evidence.len(),
@@ -2317,6 +2339,149 @@ impl PartitionBorderGraph {
 
     pub(crate) fn reconciled_border_nodes(&self) -> &[PartitionBorderNodePayload] {
         &self.reconciled_nodes
+    }
+
+    /// Validates that every active global face-node slot is a consistent
+    /// projection of the canonical border-node payload at the same XY key.
+    /// Canonical-only nodes remain allowed because not every physical border
+    /// observation is face-qualified. This method is evidence only and does
+    /// not mutate nodes, edges, observations, topology, or output.
+    pub(crate) fn validate_canonical_border_nodes(
+        &self,
+        execution_policy: &ExecutionPolicy,
+    ) -> crate::Result<PartitionBorderCanonicalNodeValidationStats> {
+        execution_policy.check_cancelled("partition_border_canonical_node_validation")?;
+        execution_policy.check(
+            "partition_border_canonical_node_validation_nodes",
+            execution_policy.max_graph_nodes,
+            self.reconciled_nodes.len(),
+        )?;
+        execution_policy.check(
+            "partition_border_canonical_node_validation_global_nodes",
+            execution_policy.max_graph_nodes,
+            self.global_face_nodes.len(),
+        )?;
+        execution_policy.check(
+            "partition_border_canonical_node_validation_edges",
+            execution_policy.max_graph_edges,
+            self.global_face_edge_map.len(),
+        )?;
+
+        let canonical_by_key = self
+            .reconciled_nodes
+            .iter()
+            .map(|node| (node.key, node))
+            .collect::<BTreeMap<_, _>>();
+        if canonical_by_key.len() != self.reconciled_nodes.len() {
+            return Err(crate::PolygonizeError::InternalInvariantViolation {
+                reason: "canonical border-node reconciliation contains duplicate keys".to_string(),
+            });
+        }
+
+        let mut stats = PartitionBorderCanonicalNodeValidationStats {
+            canonical_node_count: self.reconciled_nodes.len(),
+            global_node_count: self.global_face_nodes.len(),
+            canonical_only_node_count: self
+                .reconciled_nodes
+                .iter()
+                .filter(|node| {
+                    !self
+                        .global_face_nodes
+                        .iter()
+                        .any(|global| global.key == node.key)
+                })
+                .count(),
+            ..Default::default()
+        };
+        let set_is_subset = |left: &[u32], right: &[u32]| {
+            left.iter().all(|value| right.binary_search(value).is_ok())
+        };
+        let face_set_is_subset = |left: &[PartitionFaceRef], right: &[PartitionFaceRef]| {
+            left.iter().all(|value| right.binary_search(value).is_ok())
+        };
+        let z_set_is_subset = |left: &[u64], right: &[u64]| {
+            left.iter().all(|value| right.binary_search(value).is_ok())
+        };
+
+        for (global_index, global_node) in self.global_face_nodes.iter().enumerate() {
+            execution_policy.check_cancelled_every(
+                "partition_border_canonical_node_validation_nodes",
+                global_index,
+            )?;
+            if global_node.global_node_id != global_index
+                || !canonical_by_key.contains_key(&global_node.key)
+            {
+                stats.invalid_global_node_id_count += 1;
+                continue;
+            }
+            let canonical = canonical_by_key[&global_node.key];
+            stats.mapped_global_node_count += 1;
+            if !set_is_subset(&global_node.source_line_ids, &canonical.source_line_ids) {
+                stats.source_set_mismatch_count += 1;
+            }
+            if !set_is_subset(
+                &global_node.representative_line_ids,
+                &canonical.representative_line_ids,
+            ) {
+                stats.representative_set_mismatch_count += 1;
+            }
+            let mut canonical_face_refs = canonical.face_refs.clone();
+            canonical_face_refs.extend(
+                self.global_face_edge_map
+                    .iter()
+                    .filter(|edge| edge.from == global_node.key || edge.to == global_node.key)
+                    .filter_map(|edge| edge.face_ref),
+            );
+            canonical_face_refs.sort_unstable();
+            canonical_face_refs.dedup();
+            if !face_set_is_subset(&global_node.face_refs, &canonical_face_refs) {
+                stats.face_set_mismatch_count += 1;
+            }
+            if !z_set_is_subset(&global_node.z_bits, &canonical.z_bits) {
+                stats.z_candidate_mismatch_count += 1;
+            }
+            if global_node.selected_z_bits != canonical.selected_z_bits {
+                stats.selected_z_mismatch_count += 1;
+            }
+            if global_node.selected_z_policy != canonical.selected_z_policy
+                || global_node.conflict_tolerance_bits != canonical.conflict_tolerance_bits
+            {
+                stats.z_policy_mismatch_count += 1;
+            }
+            if global_node.z_conflict != canonical.z_conflict {
+                stats.z_conflict_mismatch_count += 1;
+            }
+        }
+
+        for (edge_index, edge) in self.global_face_edge_map.iter().enumerate() {
+            execution_policy.check_cancelled_every(
+                "partition_border_canonical_node_validation_edges",
+                edge_index,
+            )?;
+            for (key, node_id) in [
+                (edge.from, edge.from_global_node_id),
+                (edge.to, edge.to_global_node_id),
+            ] {
+                let valid = node_id
+                    .and_then(|node_id| self.global_face_nodes.get(node_id))
+                    .is_some_and(|node| node.key == key);
+                if !valid {
+                    stats.edge_endpoint_mismatch_count += 1;
+                }
+            }
+        }
+
+        stats.reconciliation_ready = stats.mapped_global_node_count == stats.global_node_count
+            && stats.source_set_mismatch_count == 0
+            && stats.representative_set_mismatch_count == 0
+            && stats.face_set_mismatch_count == 0
+            && stats.z_candidate_mismatch_count == 0
+            && stats.selected_z_mismatch_count == 0
+            && stats.z_policy_mismatch_count == 0
+            && stats.z_conflict_mismatch_count == 0
+            && stats.edge_endpoint_mismatch_count == 0
+            && stats.invalid_global_node_id_count == 0;
+        Ok(stats)
     }
 
     /// Reconciles qualified face references into deterministic connected
@@ -7728,6 +7893,106 @@ mod tests {
                 if stage == "partition_border_global_face_nodes"
         ));
         assert!(cancelled.global_face_nodes.is_empty());
+    }
+
+    #[test]
+    fn canonical_border_nodes_validate_active_global_payloads_without_mutation() {
+        let mut graph = exact_face_edge_map_graph(false);
+        graph
+            .apply_unambiguous_face_twins(&ExecutionPolicy::default())
+            .unwrap();
+        graph
+            .reconcile_global_face_edge_map(&ExecutionPolicy::default())
+            .unwrap();
+        graph
+            .reconcile_global_face_nodes(ZOptions::default(), &ExecutionPolicy::default())
+            .unwrap();
+        graph
+            .reconcile_border_nodes(ZOptions::default(), &ExecutionPolicy::default())
+            .unwrap();
+        let before = graph.clone();
+        let stats = graph
+            .validate_canonical_border_nodes(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(
+            stats,
+            PartitionBorderCanonicalNodeValidationStats {
+                canonical_node_count: 2,
+                global_node_count: 2,
+                mapped_global_node_count: 2,
+                canonical_only_node_count: 0,
+                reconciliation_ready: true,
+                ..Default::default()
+            }
+        );
+        assert_eq!(graph, before);
+
+        graph.global_face_nodes[0].selected_z_bits = 0;
+        let stats = graph
+            .validate_canonical_border_nodes(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(stats.selected_z_mismatch_count, 1);
+        assert!(!stats.reconciliation_ready);
+    }
+
+    #[test]
+    fn canonical_border_node_validation_is_bounded_and_cancellable() {
+        let mut limited = exact_face_edge_map_graph(false);
+        limited
+            .apply_unambiguous_face_twins(&ExecutionPolicy::default())
+            .unwrap();
+        limited
+            .reconcile_global_face_edge_map(&ExecutionPolicy::default())
+            .unwrap();
+        limited
+            .reconcile_global_face_nodes(ZOptions::default(), &ExecutionPolicy::default())
+            .unwrap();
+        limited
+            .reconcile_border_nodes(ZOptions::default(), &ExecutionPolicy::default())
+            .unwrap();
+        let before = limited.clone();
+        let error = limited
+            .validate_canonical_border_nodes(&ExecutionPolicy {
+                max_graph_nodes: Some(1),
+                ..Default::default()
+            })
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::ResourceLimitExceeded {
+                ref stage,
+                limit: 1,
+                observed: 2,
+            } if stage == "partition_border_canonical_node_validation_nodes"
+        ));
+        assert_eq!(limited, before);
+
+        let token = CancellationToken::new();
+        token.cancel();
+        let mut cancelled = exact_face_edge_map_graph(false);
+        cancelled
+            .apply_unambiguous_face_twins(&ExecutionPolicy::default())
+            .unwrap();
+        cancelled
+            .reconcile_global_face_edge_map(&ExecutionPolicy::default())
+            .unwrap();
+        cancelled
+            .reconcile_global_face_nodes(ZOptions::default(), &ExecutionPolicy::default())
+            .unwrap();
+        cancelled
+            .reconcile_border_nodes(ZOptions::default(), &ExecutionPolicy::default())
+            .unwrap();
+        let error = cancelled
+            .validate_canonical_border_nodes(&ExecutionPolicy {
+                cancellation_token: Some(token),
+                ..Default::default()
+            })
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::Cancelled { ref stage }
+                if stage == "partition_border_canonical_node_validation"
+        ));
     }
 
     #[test]

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -261,6 +261,16 @@ pub struct StitchingReport {
     /// Reconciled border nodes whose Z candidates exceed the configured
     /// conflict tolerance.
     pub partition_border_node_z_conflict_count: usize,
+    /// Canonical border nodes available to the detached global face graph.
+    pub partition_border_canonical_node_count: usize,
+    /// Active global face-node slots checked against canonical payloads.
+    pub partition_border_canonical_global_node_count: usize,
+    /// Active global face-node slots with a canonical payload match.
+    pub partition_border_canonical_mapped_global_node_count: usize,
+    /// Canonical-only nodes retained for non-face-qualified evidence.
+    pub partition_border_canonical_only_node_count: usize,
+    /// Whether active global face-node payloads reconcile with canonical nodes.
+    pub partition_border_canonical_node_reconciliation_ready: bool,
     /// Deterministic connected components of qualified border-face evidence.
     pub partition_border_global_component_count: usize,
     /// Retained deterministic payload plans for qualified border components.
@@ -2601,6 +2611,8 @@ impl<'a> TiledPolygonizer<'a> {
             reconciled_border_node_count,
             partition_border_node_reconciliation.node_count
         );
+        let partition_border_canonical_node_validation =
+            partition_border_graph.validate_canonical_border_nodes(&self.execution_policy)?;
         let partition_border_global_component_reconciliation =
             partition_border_graph.reconcile_global_components(&self.execution_policy)?;
         let global_component_count = partition_border_graph.global_components().len();
@@ -2745,6 +2757,9 @@ impl<'a> TiledPolygonizer<'a> {
             trace.record_partition_border_node_reconciliation(
                 partition_border_node_reconciliation,
                 self.options.z,
+            );
+            trace.record_partition_border_canonical_node_validation(
+                partition_border_canonical_node_validation,
             );
             trace.record_partition_border_global_component_reconciliation(
                 partition_border_global_component_reconciliation,
@@ -3047,6 +3062,16 @@ impl<'a> TiledPolygonizer<'a> {
                 partition_border_reconciled_node_count: reconciled_border_node_count,
                 partition_border_node_z_conflict_count: partition_border_node_reconciliation
                     .z_conflict_count,
+                partition_border_canonical_node_count: partition_border_canonical_node_validation
+                    .canonical_node_count,
+                partition_border_canonical_global_node_count:
+                    partition_border_canonical_node_validation.global_node_count,
+                partition_border_canonical_mapped_global_node_count:
+                    partition_border_canonical_node_validation.mapped_global_node_count,
+                partition_border_canonical_only_node_count:
+                    partition_border_canonical_node_validation.canonical_only_node_count,
+                partition_border_canonical_node_reconciliation_ready:
+                    partition_border_canonical_node_validation.reconciliation_ready,
                 partition_border_global_component_count: global_component_count,
                 partition_border_global_component_payload_count:
                     partition_border_global_component_payloads.component_count,

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -2,13 +2,13 @@
 
 use crate::fingerprint::{coordinate_fingerprint, float_bits};
 use crate::graph::partition_border::{
-    PartitionBorderGlobalComponentCoverageStats, PartitionBorderGlobalComponentPayloadStats,
-    PartitionBorderGlobalComponentReconciliationStats, PartitionBorderGlobalFaceEdgeMapStats,
-    PartitionBorderGlobalFaceEulerWitnessStats, PartitionBorderGlobalFaceIdApplicationStats,
-    PartitionBorderGlobalFaceIdMutationStats, PartitionBorderGlobalFaceIdPlanStats,
-    PartitionBorderGlobalFaceIdentityPlanStats, PartitionBorderGlobalFaceMutationGateStats,
-    PartitionBorderGlobalFaceNextApplicationStats, PartitionBorderGlobalFaceNextCandidateStats,
-    PartitionBorderGlobalFaceNextMutationPlanStats,
+    PartitionBorderCanonicalNodeValidationStats, PartitionBorderGlobalComponentCoverageStats,
+    PartitionBorderGlobalComponentPayloadStats, PartitionBorderGlobalComponentReconciliationStats,
+    PartitionBorderGlobalFaceEdgeMapStats, PartitionBorderGlobalFaceEulerWitnessStats,
+    PartitionBorderGlobalFaceIdApplicationStats, PartitionBorderGlobalFaceIdMutationStats,
+    PartitionBorderGlobalFaceIdPlanStats, PartitionBorderGlobalFaceIdentityPlanStats,
+    PartitionBorderGlobalFaceMutationGateStats, PartitionBorderGlobalFaceNextApplicationStats,
+    PartitionBorderGlobalFaceNextCandidateStats, PartitionBorderGlobalFaceNextMutationPlanStats,
     PartitionBorderGlobalFaceNodeReconciliationStats, PartitionBorderGlobalFacePlanStats,
     PartitionBorderGlobalFacePlanValidationStats, PartitionBorderGlobalFaceTransitionPlanStats,
     PartitionBorderGlobalFaceTwinTransitionStats, PartitionBorderGlobalFaceWalkInvariantStats,
@@ -792,6 +792,32 @@ impl TraceRecorderV1 {
                 "z_conflict_count": stats.z_conflict_count,
                 "z_policy": format!("{:?}", z_options.policy),
                 "conflict_tolerance": format!("0x{:016x}", z_options.conflict_tolerance.to_bits()),
+            }),
+        )
+    }
+
+    pub(crate) fn record_partition_border_canonical_node_validation(
+        &mut self,
+        stats: PartitionBorderCanonicalNodeValidationStats,
+    ) -> bool {
+        self.record(
+            TraceStageV1::Graph,
+            "partition_border_canonical_node_validation",
+            serde_json::json!({
+                "canonical_node_count": stats.canonical_node_count,
+                "global_node_count": stats.global_node_count,
+                "mapped_global_node_count": stats.mapped_global_node_count,
+                "canonical_only_node_count": stats.canonical_only_node_count,
+                "source_set_mismatch_count": stats.source_set_mismatch_count,
+                "representative_set_mismatch_count": stats.representative_set_mismatch_count,
+                "face_set_mismatch_count": stats.face_set_mismatch_count,
+                "z_candidate_mismatch_count": stats.z_candidate_mismatch_count,
+                "selected_z_mismatch_count": stats.selected_z_mismatch_count,
+                "z_policy_mismatch_count": stats.z_policy_mismatch_count,
+                "z_conflict_mismatch_count": stats.z_conflict_mismatch_count,
+                "edge_endpoint_mismatch_count": stats.edge_endpoint_mismatch_count,
+                "invalid_global_node_id_count": stats.invalid_global_node_id_count,
+                "reconciliation_ready": stats.reconciliation_ready,
             }),
         )
     }


### PR DESCRIPTION
## Stack
- Parent: `origin/main` at `b2bac89` (`ci(github): remove flaky cargo-binstall bootstrap`)
- Children: none

## Delivered
- Added bounded, cancellable, read-only validation that every active global face-node slot is a consistent projection of canonical border-node source, representative, face, Z-candidate, selected-policy, and conflict evidence.
- Allowed canonical-only nodes for dangles and other non-face-qualified observations.
- Added report and trace evidence, regression coverage, and marked only canonical border-node reconciliation complete in `ROADMAP.md`.

## Contract impact
- Additive report and trace evidence only; local topology, detached global topology, tiled polygon output, provenance, Z behavior, serial/parallel behavior, limits, and cancellation semantics remain unchanged.
- No global `next` links, global face IDs, unbounded-face promotion, or stitched output are promoted.

## Validation
- `cargo test -p geo-polygonize-core canonical_border_node --lib`
- `cargo test -p geo-polygonize-core --lib` (367 passed)
- `cargo test --workspace --no-default-features` (all workspace tests and doc tests passed)
- `cargo clippy --workspace --all-targets --no-default-features -- -D warnings`
- `cargo fmt --all` and `git diff --check`
- The separate allocation benchmark executable started by `cargo test --workspace --all-targets --no-default-features` was intentionally interrupted after the correctness suites passed; it was benchmark-only and CPU-active.

## Agent handoff
- Parent: `main` at `b2bac89`
- Children: none
- Next branch: `agent/p5-global-face-global-next-links` or a fresh descendant for detached global identity integration after this PR merges.
- Remaining P5.3 risks: global `next`/face-ID promotion, exactly-one global unbounded face, full invariant validation, stitched extraction, untiled equivalence, fuzzing, and performance evidence remain open.