### PR TITLE
feat(core): integrate detached global next lineage

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -551,6 +551,10 @@ Blocked by #1288.
 - [x] Cross-check detached per-edge face identity against successor cycles,
   reciprocal twins, source lineage, and retained face-walk/Euler evidence;
   preserve incomplete proofs without mutating topology or output.
+- [x] Cross-check the committed detached global successor permutation against
+  local face successors, retained boundary overrides, per-edge face identity,
+  and reciprocal face-qualified cross-partition twins without mutating
+  topology or output.
 - [ ] Build global `next` links and deterministic global face IDs.
 - [ ] Identify exactly one global unbounded face.
 - [ ] Validate twin, cycle, source, Euler, and face-walk invariants.

--- a/crates/geo-polygonize-core/src/graph/partition_border.rs
+++ b/crates/geo-polygonize-core/src/graph/partition_border.rs
@@ -764,6 +764,30 @@ pub(crate) struct PartitionBorderGlobalFaceIdentityInvariantStats {
     pub(crate) invariants_ready: bool,
 }
 
+/// Counts the final detached global-next lineage integration check. This
+/// proves that the committed successor permutation agrees with local face
+/// successors, retained boundary overrides, per-edge face identity, and
+/// cross-partition face-qualified twins without mutating topology or output.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct PartitionBorderGlobalNextLineageIntegrationStats {
+    pub(crate) edge_count: usize,
+    pub(crate) cycle_count: usize,
+    pub(crate) local_successor_count: usize,
+    pub(crate) override_count: usize,
+    pub(crate) integrated_successor_count: usize,
+    pub(crate) missing_candidate_successor_count: usize,
+    pub(crate) local_lineage_mismatch_count: usize,
+    pub(crate) override_lineage_mismatch_count: usize,
+    pub(crate) application_plan_link_count: usize,
+    pub(crate) unrepresented_application_link_count: usize,
+    pub(crate) committed_next_edge_count: usize,
+    pub(crate) committed_next_mismatch_count: usize,
+    pub(crate) twin_count: usize,
+    pub(crate) twin_lineage_mismatch_count: usize,
+    pub(crate) identity_ready: bool,
+    pub(crate) integration_ready: bool,
+}
+
 /// Counts from validating a detached global directed-edge topology candidate.
 /// Readiness requires complete application evidence, one predecessor and one
 /// successor per edge, endpoint continuity, and closed cycles.
@@ -6150,6 +6174,261 @@ impl PartitionBorderGraph {
             && stats.twin_mapping_mismatch_count == 0
             && stats.face_walk_ready
             && stats.euler_evidence_ready;
+        Ok(stats)
+    }
+
+    /// Validates that the detached successor permutation is the exact
+    /// integration of local face successors and retained cross-border
+    /// boundary overrides. The check also maps every retained face-qualified
+    /// twin back to its reciprocal global edge slots and verifies that the
+    /// committed detached successor buffer agrees with the candidate. This is
+    /// evidence only; local topology, public face IDs, and tiled output remain
+    /// untouched.
+    pub(crate) fn validate_global_next_lineage_integration(
+        &self,
+        execution_policy: &ExecutionPolicy,
+        identity: PartitionBorderGlobalFaceIdentityInvariantStats,
+    ) -> crate::Result<PartitionBorderGlobalNextLineageIntegrationStats> {
+        execution_policy.check_cancelled("partition_border_global_next_lineage_integration")?;
+        let edge_count = self.global_face_edge_map.len();
+        execution_policy.check(
+            "partition_border_global_next_lineage_integration_edges",
+            execution_policy.max_graph_edges,
+            edge_count,
+        )?;
+        let Some(candidate) = self.global_topology_candidate.as_ref() else {
+            return Err(crate::PolygonizeError::InternalInvariantViolation {
+                reason: "global next lineage integration has no detached topology candidate"
+                    .to_string(),
+            });
+        };
+        if candidate.next_global_dir_edge_ids.len() != edge_count {
+            return Err(crate::PolygonizeError::InternalInvariantViolation {
+                reason: format!(
+                    "global next lineage integration successor length mismatch: candidate={}, edges={}",
+                    candidate.next_global_dir_edge_ids.len(),
+                    edge_count
+                ),
+            });
+        }
+        execution_policy.check(
+            "partition_border_global_next_lineage_integration_cycles",
+            execution_policy.max_graph_nodes,
+            candidate.cycle_start_global_dir_edge_ids.len(),
+        )?;
+
+        let mut stats = PartitionBorderGlobalNextLineageIntegrationStats {
+            edge_count,
+            cycle_count: candidate.cycle_start_global_dir_edge_ids.len(),
+            identity_ready: identity.invariants_ready,
+            ..Default::default()
+        };
+        let mut expected_next = self
+            .global_face_edge_map
+            .iter()
+            .map(|edge| {
+                if edge.local_face_successor_global_dir_edge_id.is_some() {
+                    stats.local_successor_count += 1;
+                }
+                edge.local_face_successor_global_dir_edge_id
+            })
+            .collect::<Vec<_>>();
+        let mut override_edges = BTreeSet::new();
+        let mut override_by_edge = BTreeMap::<usize, usize>::new();
+        let mut application_links = BTreeSet::<(usize, usize)>::new();
+        for (plan_index, plan) in self.global_face_next_application_plans.iter().enumerate() {
+            execution_policy.check_cancelled_every(
+                "partition_border_global_next_lineage_integration_plans",
+                plan_index,
+            )?;
+            if !plan.closed || !plan.node_continuous {
+                continue;
+            }
+            if plan.global_dir_edge_ids.len() != plan.successor_global_dir_edge_ids.len() {
+                return Err(crate::PolygonizeError::InternalInvariantViolation {
+                    reason: format!(
+                        "global next lineage integration plan {} has mismatched successor lengths",
+                        plan_index
+                    ),
+                });
+            }
+            for (link_index, (&edge_index, &successor_index)) in plan
+                .global_dir_edge_ids
+                .iter()
+                .zip(&plan.successor_global_dir_edge_ids)
+                .enumerate()
+            {
+                execution_policy.check_cancelled_every(
+                    "partition_border_global_next_lineage_integration_links",
+                    link_index,
+                )?;
+                if edge_index >= edge_count || successor_index >= edge_count {
+                    return Err(crate::PolygonizeError::InternalInvariantViolation {
+                        reason: format!(
+                            "global next lineage integration plan {} references edge {} -> {} outside {} slots",
+                            plan_index, edge_index, successor_index, edge_count
+                        ),
+                    });
+                }
+                if self.global_face_edge_map[edge_index].to_global_node_id
+                    != self.global_face_edge_map[successor_index].from_global_node_id
+                {
+                    return Err(crate::PolygonizeError::InternalInvariantViolation {
+                        reason: format!(
+                            "global next lineage integration plan {} is not node-continuous at edge {}",
+                            plan_index, edge_index
+                        ),
+                    });
+                }
+                if override_by_edge
+                    .insert(edge_index, successor_index)
+                    .is_some_and(|existing| existing != successor_index)
+                {
+                    return Err(crate::PolygonizeError::InternalInvariantViolation {
+                        reason: format!(
+                            "global next lineage integration conflicts at edge {}",
+                            edge_index
+                        ),
+                    });
+                }
+                expected_next[edge_index] = Some(successor_index);
+                override_edges.insert(edge_index);
+                application_links.insert((edge_index, successor_index));
+            }
+        }
+        stats.override_count = override_edges.len();
+        stats.application_plan_link_count = application_links.len();
+
+        for (edge_index, (&expected, &actual)) in expected_next
+            .iter()
+            .zip(&candidate.next_global_dir_edge_ids)
+            .enumerate()
+        {
+            execution_policy.check_cancelled_every(
+                "partition_border_global_next_lineage_integration_edges",
+                edge_index,
+            )?;
+            match (expected, actual) {
+                (Some(expected), Some(actual)) if expected == actual => {
+                    stats.integrated_successor_count += 1;
+                }
+                (Some(_), None) => stats.missing_candidate_successor_count += 1,
+                (Some(_), Some(_)) if override_edges.contains(&edge_index) => {
+                    stats.override_lineage_mismatch_count += 1;
+                }
+                _ => stats.local_lineage_mismatch_count += 1,
+            }
+        }
+        stats.unrepresented_application_link_count = application_links
+            .iter()
+            .filter(|&&(edge_index, successor_index)| {
+                candidate.next_global_dir_edge_ids.get(edge_index).copied()
+                    != Some(Some(successor_index))
+            })
+            .count();
+
+        stats.committed_next_edge_count = self
+            .global_next_global_dir_edge_ids
+            .iter()
+            .flatten()
+            .count();
+        if self.global_next_global_dir_edge_ids.len() != edge_count {
+            stats.committed_next_mismatch_count = edge_count;
+        } else {
+            stats.committed_next_mismatch_count = self
+                .global_next_global_dir_edge_ids
+                .iter()
+                .zip(&candidate.next_global_dir_edge_ids)
+                .filter(|(committed, candidate)| committed != candidate)
+                .count();
+        }
+
+        let mut edge_slot_by_local = BTreeMap::<(usize, usize, DirEdgeId), usize>::new();
+        for (edge_index, edge) in self.global_face_edge_map.iter().enumerate() {
+            if edge_slot_by_local
+                .insert(
+                    (edge.partition_id, edge.component_id, edge.local_dir_edge_id),
+                    edge_index,
+                )
+                .is_some()
+            {
+                return Err(crate::PolygonizeError::InternalInvariantViolation {
+                    reason: format!(
+                        "global next lineage integration duplicates local edge identity at {}",
+                        edge_index
+                    ),
+                });
+            }
+        }
+        let mut edge_slot_by_observation = BTreeMap::<PartitionBorderObservationId, usize>::new();
+        for observation in self.observations.values() {
+            let component_id = observation
+                .face_ref
+                .map_or(observation.component_id, |face_ref| face_ref.component_id);
+            let Some(&edge_index) = edge_slot_by_local.get(&(
+                observation.partition_id,
+                component_id,
+                observation.local_dir_edge_id,
+            )) else {
+                continue;
+            };
+            let edge = &self.global_face_edge_map[edge_index];
+            if edge.edge_key != observation.edge_key || edge.face_ref != observation.face_ref {
+                return Err(crate::PolygonizeError::InternalInvariantViolation {
+                    reason: format!(
+                        "global next lineage integration observation {:?} disagrees with edge lineage",
+                        observation.observation_id()
+                    ),
+                });
+            }
+            if edge_slot_by_observation
+                .insert(observation.observation_id(), edge_index)
+                .is_some()
+            {
+                return Err(crate::PolygonizeError::InternalInvariantViolation {
+                    reason: format!(
+                        "global next lineage integration duplicates observation {:?}",
+                        observation.observation_id()
+                    ),
+                });
+            }
+        }
+        for (twin_index, twin) in self.global_face_twin_transitions.iter().enumerate() {
+            execution_policy.check_cancelled_every(
+                "partition_border_global_next_lineage_integration_twins",
+                twin_index,
+            )?;
+            stats.twin_count += 1;
+            let Some(&forward_index) = edge_slot_by_observation.get(&twin.forward_observation_id)
+            else {
+                stats.twin_lineage_mismatch_count += 1;
+                continue;
+            };
+            let Some(&reverse_index) = edge_slot_by_observation.get(&twin.reverse_observation_id)
+            else {
+                stats.twin_lineage_mismatch_count += 1;
+                continue;
+            };
+            let forward = &self.global_face_edge_map[forward_index];
+            let reverse = &self.global_face_edge_map[reverse_index];
+            if forward.face_ref != Some(twin.forward_face_ref)
+                || reverse.face_ref != Some(twin.reverse_face_ref)
+                || forward.cross_border_twin_global_dir_edge_id != Some(reverse_index)
+                || reverse.cross_border_twin_global_dir_edge_id != Some(forward_index)
+            {
+                stats.twin_lineage_mismatch_count += 1;
+            }
+        }
+
+        stats.integration_ready = stats.identity_ready
+            && stats.integrated_successor_count == edge_count
+            && stats.missing_candidate_successor_count == 0
+            && stats.local_lineage_mismatch_count == 0
+            && stats.override_lineage_mismatch_count == 0
+            && stats.unrepresented_application_link_count == 0
+            && stats.committed_next_edge_count == edge_count
+            && stats.committed_next_mismatch_count == 0
+            && stats.twin_lineage_mismatch_count == 0;
         Ok(stats)
     }
 
@@ -11611,6 +11890,186 @@ mod tests {
             error,
             crate::PolygonizeError::Cancelled { ref stage }
                 if stage == "partition_border_global_face_identity_invariants"
+        ));
+    }
+
+    #[test]
+    fn global_next_lineage_integration_matches_overrides_and_face_twins() {
+        let mut graph = exact_face_twin_graph();
+        let observations = graph.observations.values().cloned().collect::<Vec<_>>();
+        graph.global_face_edge_map = observations
+            .iter()
+            .enumerate()
+            .map(|(edge_index, observation)| PartitionBorderGlobalFaceEdge {
+                global_dir_edge_id: edge_index,
+                partition_id: observation.partition_id,
+                component_id: observation.face_ref.unwrap().component_id,
+                local_dir_edge_id: observation.local_dir_edge_id,
+                symmetric_global_dir_edge_id: 1 - edge_index,
+                local_face_successor_global_dir_edge_id: None,
+                cross_border_twin_global_dir_edge_id: Some(1 - edge_index),
+                from_global_node_id: Some(edge_index),
+                to_global_node_id: Some(1 - edge_index),
+                from: observation.from,
+                to: observation.to,
+                from_z_bits: observation.from_z_bits,
+                to_z_bits: observation.to_z_bits,
+                edge_key: observation.edge_key,
+                face_ref: observation.face_ref,
+                local_face_is_unbounded: observation.local_face_is_unbounded,
+                source_line_ids: observation.source_line_ids.clone(),
+            })
+            .collect();
+        graph.global_topology_candidate = Some(PartitionBorderGlobalTopologyCandidate {
+            next_global_dir_edge_ids: vec![Some(1), Some(0)],
+            cycle_start_global_dir_edge_ids: vec![0],
+        });
+        graph.global_next_global_dir_edge_ids = vec![Some(1), Some(0)];
+        graph.global_face_next_application_plans =
+            vec![PartitionBorderGlobalFaceNextApplicationPlan {
+                component_index: 0,
+                global_dir_edge_ids: vec![0, 1],
+                successor_global_dir_edge_ids: vec![1, 0],
+                closed: true,
+                node_continuous: true,
+            }];
+        graph.global_face_twin_transitions = vec![PartitionBorderGlobalFaceTwinTransition {
+            edge_key: observations[0].edge_key,
+            forward_face_ref: observations[0].face_ref.unwrap(),
+            reverse_face_ref: observations[1].face_ref.unwrap(),
+            forward_observation_id: observations[0].observation_id(),
+            reverse_observation_id: observations[1].observation_id(),
+            forward_cycle_index: 0,
+            reverse_cycle_index: 0,
+            forward_cycle_closed: true,
+            reverse_cycle_closed: true,
+        }];
+        let before = graph.clone();
+        let stats = graph
+            .validate_global_next_lineage_integration(
+                &ExecutionPolicy::default(),
+                PartitionBorderGlobalFaceIdentityInvariantStats {
+                    invariants_ready: true,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            stats,
+            PartitionBorderGlobalNextLineageIntegrationStats {
+                edge_count: 2,
+                cycle_count: 1,
+                override_count: 2,
+                integrated_successor_count: 2,
+                application_plan_link_count: 2,
+                committed_next_edge_count: 2,
+                twin_count: 1,
+                identity_ready: true,
+                integration_ready: true,
+                ..Default::default()
+            }
+        );
+        assert_eq!(graph, before);
+    }
+
+    #[test]
+    fn global_next_lineage_integration_rejects_successor_drift() {
+        let mut graph = exact_face_twin_graph();
+        let observations = graph.observations.values().cloned().collect::<Vec<_>>();
+        graph.global_face_edge_map = observations
+            .iter()
+            .enumerate()
+            .map(|(edge_index, observation)| PartitionBorderGlobalFaceEdge {
+                global_dir_edge_id: edge_index,
+                partition_id: observation.partition_id,
+                component_id: observation.face_ref.unwrap().component_id,
+                local_dir_edge_id: observation.local_dir_edge_id,
+                symmetric_global_dir_edge_id: 1 - edge_index,
+                local_face_successor_global_dir_edge_id: None,
+                cross_border_twin_global_dir_edge_id: Some(1 - edge_index),
+                from_global_node_id: Some(edge_index),
+                to_global_node_id: Some(1 - edge_index),
+                from: observation.from,
+                to: observation.to,
+                from_z_bits: observation.from_z_bits,
+                to_z_bits: observation.to_z_bits,
+                edge_key: observation.edge_key,
+                face_ref: observation.face_ref,
+                local_face_is_unbounded: observation.local_face_is_unbounded,
+                source_line_ids: observation.source_line_ids.clone(),
+            })
+            .collect();
+        graph.global_topology_candidate = Some(PartitionBorderGlobalTopologyCandidate {
+            next_global_dir_edge_ids: vec![Some(0), Some(1)],
+            cycle_start_global_dir_edge_ids: vec![0],
+        });
+        graph.global_next_global_dir_edge_ids = vec![Some(0), Some(1)];
+        graph.global_face_next_application_plans =
+            vec![PartitionBorderGlobalFaceNextApplicationPlan {
+                component_index: 0,
+                global_dir_edge_ids: vec![0, 1],
+                successor_global_dir_edge_ids: vec![1, 0],
+                closed: true,
+                node_continuous: true,
+            }];
+        let stats = graph
+            .validate_global_next_lineage_integration(
+                &ExecutionPolicy::default(),
+                PartitionBorderGlobalFaceIdentityInvariantStats {
+                    invariants_ready: true,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert!(!stats.integration_ready);
+        assert_eq!(stats.override_lineage_mismatch_count, 2);
+        assert_eq!(stats.committed_next_mismatch_count, 0);
+    }
+
+    #[test]
+    fn global_next_lineage_integration_is_bounded_and_cancellable() {
+        let mut graph = exact_global_topology_candidate_graph();
+        graph
+            .reconcile_global_topology_candidate(&ExecutionPolicy::default())
+            .unwrap();
+        graph.global_next_global_dir_edge_ids = graph
+            .global_topology_candidate()
+            .unwrap()
+            .next_global_dir_edge_ids
+            .clone();
+        let error = graph
+            .validate_global_next_lineage_integration(
+                &ExecutionPolicy {
+                    max_graph_edges: Some(0),
+                    ..Default::default()
+                },
+                PartitionBorderGlobalFaceIdentityInvariantStats::default(),
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::ResourceLimitExceeded {
+                ref stage,
+                limit: 0,
+                observed: 4,
+            } if stage == "partition_border_global_next_lineage_integration_edges"
+        ));
+
+        let token = CancellationToken::new();
+        token.cancel();
+        let error = graph
+            .validate_global_next_lineage_integration(
+                &ExecutionPolicy {
+                    cancellation_token: Some(token),
+                    ..Default::default()
+                },
+                PartitionBorderGlobalFaceIdentityInvariantStats::default(),
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::Cancelled { ref stage }
+                if stage == "partition_border_global_next_lineage_integration"
         ));
     }
 

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -485,6 +485,24 @@ pub struct StitchingReport {
     pub partition_border_global_face_identity_invariant_face_walk_ready: bool,
     pub partition_border_global_face_identity_invariant_euler_ready: bool,
     pub partition_border_global_face_identity_invariants_ready: bool,
+    /// Detached global-next integration evidence against local face lineage,
+    /// boundary overrides, committed successors, and face-qualified twins.
+    pub partition_border_global_next_lineage_integration_edge_count: usize,
+    pub partition_border_global_next_lineage_integration_cycle_count: usize,
+    pub partition_border_global_next_lineage_integration_local_successor_count: usize,
+    pub partition_border_global_next_lineage_integration_override_count: usize,
+    pub partition_border_global_next_lineage_integration_successor_count: usize,
+    pub partition_border_global_next_lineage_integration_missing_successor_count: usize,
+    pub partition_border_global_next_lineage_integration_local_mismatch_count: usize,
+    pub partition_border_global_next_lineage_integration_override_mismatch_count: usize,
+    pub partition_border_global_next_lineage_integration_plan_link_count: usize,
+    pub partition_border_global_next_lineage_integration_unrepresented_link_count: usize,
+    pub partition_border_global_next_lineage_integration_committed_next_count: usize,
+    pub partition_border_global_next_lineage_integration_committed_next_mismatch_count: usize,
+    pub partition_border_global_next_lineage_integration_twin_count: usize,
+    pub partition_border_global_next_lineage_integration_twin_mismatch_count: usize,
+    pub partition_border_global_next_lineage_integration_identity_ready: bool,
+    pub partition_border_global_next_lineage_integration_ready: bool,
     /// Unbounded-face candidates whose local cycles are closed.
     pub partition_border_global_unbounded_face_proof_closed_count: usize,
     /// Unbounded-face twins absent from the retained twin-position map.
@@ -2773,6 +2791,11 @@ impl<'a> TiledPolygonizer<'a> {
                 partition_border_global_face_walk_invariants,
                 partition_border_global_face_euler_witness,
             )?;
+        let partition_border_global_next_lineage_integration = partition_border_graph
+            .validate_global_next_lineage_integration(
+                &self.execution_policy,
+                partition_border_global_face_identity_invariants,
+            )?;
         if let Some(trace) = trace.as_deref_mut() {
             trace.record_partition_border_reconciliation(partition_border_reconciliation);
             trace.record_partition_border_twin_application(partition_border_twin_application);
@@ -2862,6 +2885,9 @@ impl<'a> TiledPolygonizer<'a> {
             );
             trace.record_partition_border_global_face_identity_invariants(
                 partition_border_global_face_identity_invariants,
+            );
+            trace.record_partition_border_global_next_lineage_integration(
+                partition_border_global_next_lineage_integration,
             );
         }
         let unresolved = tile_reports.iter().any(Self::report_is_unresolved);
@@ -3360,6 +3386,43 @@ impl<'a> TiledPolygonizer<'a> {
                     partition_border_global_face_identity_invariants.euler_evidence_ready,
                 partition_border_global_face_identity_invariants_ready:
                     partition_border_global_face_identity_invariants.invariants_ready,
+                partition_border_global_next_lineage_integration_edge_count:
+                    partition_border_global_next_lineage_integration.edge_count,
+                partition_border_global_next_lineage_integration_cycle_count:
+                    partition_border_global_next_lineage_integration.cycle_count,
+                partition_border_global_next_lineage_integration_local_successor_count:
+                    partition_border_global_next_lineage_integration.local_successor_count,
+                partition_border_global_next_lineage_integration_override_count:
+                    partition_border_global_next_lineage_integration.override_count,
+                partition_border_global_next_lineage_integration_successor_count:
+                    partition_border_global_next_lineage_integration.integrated_successor_count,
+                partition_border_global_next_lineage_integration_missing_successor_count:
+                    partition_border_global_next_lineage_integration
+                        .missing_candidate_successor_count,
+                partition_border_global_next_lineage_integration_local_mismatch_count:
+                    partition_border_global_next_lineage_integration.local_lineage_mismatch_count,
+                partition_border_global_next_lineage_integration_override_mismatch_count:
+                    partition_border_global_next_lineage_integration
+                        .override_lineage_mismatch_count,
+                partition_border_global_next_lineage_integration_plan_link_count:
+                    partition_border_global_next_lineage_integration.application_plan_link_count,
+                partition_border_global_next_lineage_integration_unrepresented_link_count:
+                    partition_border_global_next_lineage_integration
+                        .unrepresented_application_link_count,
+                partition_border_global_next_lineage_integration_committed_next_count:
+                    partition_border_global_next_lineage_integration.committed_next_edge_count,
+                partition_border_global_next_lineage_integration_committed_next_mismatch_count:
+                    partition_border_global_next_lineage_integration
+                        .committed_next_mismatch_count,
+                partition_border_global_next_lineage_integration_twin_count:
+                    partition_border_global_next_lineage_integration.twin_count,
+                partition_border_global_next_lineage_integration_twin_mismatch_count:
+                    partition_border_global_next_lineage_integration
+                        .twin_lineage_mismatch_count,
+                partition_border_global_next_lineage_integration_identity_ready:
+                    partition_border_global_next_lineage_integration.identity_ready,
+                partition_border_global_next_lineage_integration_ready:
+                    partition_border_global_next_lineage_integration.integration_ready,
                 partition_border_global_unbounded_face_proof_closed_count:
                     partition_border_global_unbounded_face_proof.closed_unbounded_face_count,
                 partition_border_global_unbounded_face_proof_unmapped_twin_count:

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -14,6 +14,7 @@ use crate::graph::partition_border::{
     PartitionBorderGlobalFaceNodeReconciliationStats, PartitionBorderGlobalFacePlanStats,
     PartitionBorderGlobalFacePlanValidationStats, PartitionBorderGlobalFaceTransitionPlanStats,
     PartitionBorderGlobalFaceTwinTransitionStats, PartitionBorderGlobalFaceWalkInvariantStats,
+    PartitionBorderGlobalNextLineageIntegrationStats,
     PartitionBorderGlobalTopologyApplicationGateStats, PartitionBorderGlobalTopologyCandidateStats,
     PartitionBorderGlobalTopologyMutationGateStats, PartitionBorderGlobalTopologyMutationStats,
     PartitionBorderGlobalUnboundedFaceApplicationStats,
@@ -1234,6 +1235,35 @@ impl TraceRecorderV1 {
                 "face_walk_ready": stats.face_walk_ready,
                 "euler_evidence_ready": stats.euler_evidence_ready,
                 "invariants_ready": stats.invariants_ready,
+            }),
+        )
+    }
+
+    pub(crate) fn record_partition_border_global_next_lineage_integration(
+        &mut self,
+        stats: PartitionBorderGlobalNextLineageIntegrationStats,
+    ) -> bool {
+        self.record(
+            TraceStageV1::Graph,
+            "partition_border_global_next_lineage_integration",
+            serde_json::json!({
+                "edge_count": stats.edge_count,
+                "cycle_count": stats.cycle_count,
+                "local_successor_count": stats.local_successor_count,
+                "override_count": stats.override_count,
+                "integrated_successor_count": stats.integrated_successor_count,
+                "missing_candidate_successor_count": stats.missing_candidate_successor_count,
+                "local_lineage_mismatch_count": stats.local_lineage_mismatch_count,
+                "override_lineage_mismatch_count": stats.override_lineage_mismatch_count,
+                "application_plan_link_count": stats.application_plan_link_count,
+                "unrepresented_application_link_count":
+                    stats.unrepresented_application_link_count,
+                "committed_next_edge_count": stats.committed_next_edge_count,
+                "committed_next_mismatch_count": stats.committed_next_mismatch_count,
+                "twin_count": stats.twin_count,
+                "twin_lineage_mismatch_count": stats.twin_lineage_mismatch_count,
+                "identity_ready": stats.identity_ready,
+                "integration_ready": stats.integration_ready,
             }),
         )
     }


### PR DESCRIPTION
## Stack
Parent: origin/main at 6e65db7 (merged PR #1356).
Children: none.
This PR is standalone because the prior stack is fully merged; no stack link is required.

## Delivered
- Added a read-only detached global-next lineage integration validator.
- Cross-checks local face successors, retained boundary overrides, committed detached successors, per-edge identity, and reciprocal face-qualified cross-partition twins.
- Emits bounded trace and StitchingReport evidence.
- Added positive, drift-rejection, bounded, cancellable, and non-mutation regression coverage.
- Updated ROADMAP.md with the precise completed evidence item while keeping global topology promotion open.

## Contract impact
Additive internal trace/report evidence only. Local half-edge next links, public face IDs, stitched output, provenance, Z handling, serial/parallel behavior, resource limits, and cancellation semantics remain unchanged. Incomplete application plans remain fail-closed and are retained as evidence rather than treated as malformed.

## Validation
- cargo test -p geo-polygonize-core --lib (374 passed)
- cargo test --workspace --no-default-features (passed)
- cargo clippy --workspace --all-targets --no-default-features -- -D warnings (passed)
- cargo fmt --all -- --check (passed)
- git diff --check (passed)
- Generated bindings restored after test execution.

## Agent handoff
Next branch: agent/p5-global-next-cycle-face-lineage.
Next slice: use the now-integrated detached successor/identity evidence to validate complete global cycle-to-face lineage and exact cycle ownership, still without promoting topology or extracting stitched output.
Remaining risks: broad P5.3 global topology promotion, exactly-one global unbounded-face promotion, stitched extraction, untiled equivalence, differential fuzzing, and performance/peak-memory evidence remain open.