### PR TITLE
ci(github): fix lychee install path

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -96,7 +96,9 @@ jobs:
             sleep 2
           done
           tar -xzf "${install_dir}/${filename}" -C "${install_dir}"
-          echo "${install_dir}" >> "${GITHUB_PATH}"
+          lychee_bin="${install_dir}/lychee-${arch}-unknown-linux-gnu/lychee"
+          test -x "${lychee_bin}"
+          dirname "${lychee_bin}" >> "${GITHUB_PATH}"
 
       - name: Check documentation links
         run: lychee --no-progress README.md docs


### PR DESCRIPTION
## Stack
Parent: #1357 (agent/p5-global-next-lineage-integration).
Children: none.
This child isolates the Docs workflow repair from the core implementation PR.

## Delivered
- Point the Docs workflow PATH at the nested Lychee binary directory produced by the v0.24.2 release archive.
- Assert the expected executable exists before publishing the directory through GITHUB_PATH.

## Contract impact
CI-only. No Rust, public API, generated bindings, runtime topology, output, provenance, Z, resource-limit, or cancellation behavior changes.

## Validation
- actionlint .github/workflows/docs-pages.yml (passed)
- Downloaded the x86_64 Lychee v0.24.2 archive and verified the nested executable path and executable bit.
- git diff --check (passed)

## Agent handoff
Parent: #1357. Children: none.
After merge, rerun the Docs workflow on the parent PR. The original failure was `lychee: command not found` after a successful download because the archive extracts under `lychee-x86_64-unknown-linux-gnu/`. Remaining risk is only hosted Docs workflow execution.