### PR TITLE
feat(core): validate detached cycle face lineage

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -555,6 +555,10 @@ Blocked by #1288.
   local face successors, retained boundary overrides, per-edge face identity,
   and reciprocal face-qualified cross-partition twins without mutating
   topology or output.
+- [x] Map each detached closed successor cycle exactly once to its candidate
+  global face plan, validating observation slots, qualified local face
+  lineage, and local-unbounded marker lineage without mutating topology or
+  output.
 - [ ] Build global `next` links and deterministic global face IDs.
 - [ ] Identify exactly one global unbounded face.
 - [ ] Validate twin, cycle, source, Euler, and face-walk invariants.

--- a/crates/geo-polygonize-core/src/graph/partition_border.rs
+++ b/crates/geo-polygonize-core/src/graph/partition_border.rs
@@ -788,6 +788,32 @@ pub(crate) struct PartitionBorderGlobalNextLineageIntegrationStats {
     pub(crate) integration_ready: bool,
 }
 
+/// Counts detached cycle-to-face lineage integration. Every closed candidate
+/// cycle must map to exactly one candidate face plan whose observation slots,
+/// qualified local faces, and unbounded marker agree; this remains evidence
+/// only and never promotes topology or output.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct PartitionBorderGlobalCycleFaceLineageStats {
+    pub(crate) edge_count: usize,
+    pub(crate) cycle_count: usize,
+    pub(crate) plan_count: usize,
+    pub(crate) closed_cycle_count: usize,
+    pub(crate) mapped_cycle_count: usize,
+    pub(crate) incomplete_cycle_count: usize,
+    pub(crate) invalid_cycle_count: usize,
+    pub(crate) missing_face_id_count: usize,
+    pub(crate) duplicate_face_id_plan_count: usize,
+    pub(crate) unmapped_plan_count: usize,
+    pub(crate) cycle_plan_mismatch_count: usize,
+    pub(crate) cycle_face_ref_mismatch_count: usize,
+    pub(crate) duplicate_plan_face_ref_count: usize,
+    pub(crate) observation_lineage_mismatch_count: usize,
+    pub(crate) unbounded_lineage_mismatch_count: usize,
+    pub(crate) identity_ready: bool,
+    pub(crate) next_lineage_ready: bool,
+    pub(crate) lineage_ready: bool,
+}
+
 /// Counts from validating a detached global directed-edge topology candidate.
 /// Readiness requires complete application evidence, one predecessor and one
 /// successor per edge, endpoint continuity, and closed cycles.
@@ -1956,6 +1982,217 @@ impl PartitionBorderGraph {
         self.global_face_next_application_plans.clear();
         self.global_topology_candidate = None;
         self.global_face_nodes.clear();
+        Ok(stats)
+    }
+
+    /// Validates that each detached closed successor cycle maps exactly once
+    /// to a candidate global face plan. Observation slots, qualified local
+    /// face references, and local-unbounded markers must agree with the
+    /// mapped plan; incomplete cycles remain evidence rather than becoming a
+    /// topology error.
+    pub(crate) fn validate_global_cycle_face_lineage(
+        &self,
+        execution_policy: &ExecutionPolicy,
+        identity: PartitionBorderGlobalFaceIdentityInvariantStats,
+        next_lineage: PartitionBorderGlobalNextLineageIntegrationStats,
+    ) -> crate::Result<PartitionBorderGlobalCycleFaceLineageStats> {
+        execution_policy.check_cancelled("partition_border_global_cycle_face_lineage")?;
+        let edge_count = self.global_face_edge_map.len();
+        execution_policy.check(
+            "partition_border_global_cycle_face_lineage_edges",
+            execution_policy.max_graph_edges,
+            edge_count,
+        )?;
+        let Some(candidate) = self.global_topology_candidate.as_ref() else {
+            return Err(crate::PolygonizeError::InternalInvariantViolation {
+                reason: "global cycle face lineage has no detached topology candidate".to_string(),
+            });
+        };
+        if candidate.next_global_dir_edge_ids.len() != edge_count {
+            return Err(crate::PolygonizeError::InternalInvariantViolation {
+                reason: format!(
+                    "global cycle face lineage successor length mismatch: candidate={}, edges={}",
+                    candidate.next_global_dir_edge_ids.len(),
+                    edge_count
+                ),
+            });
+        }
+        execution_policy.check(
+            "partition_border_global_cycle_face_lineage_cycles",
+            execution_policy.max_graph_nodes,
+            candidate.cycle_start_global_dir_edge_ids.len(),
+        )?;
+        execution_policy.check(
+            "partition_border_global_cycle_face_lineage_plans",
+            execution_policy.max_graph_nodes,
+            self.global_face_id_plans.len(),
+        )?;
+
+        let mut stats = PartitionBorderGlobalCycleFaceLineageStats {
+            edge_count,
+            cycle_count: candidate.cycle_start_global_dir_edge_ids.len(),
+            plan_count: self.global_face_id_plans.len(),
+            identity_ready: identity.invariants_ready,
+            next_lineage_ready: next_lineage.integration_ready,
+            ..Default::default()
+        };
+        let mut edge_slot_by_observation = BTreeMap::<PartitionBorderObservationId, usize>::new();
+        for (edge_index, edge) in self.global_face_edge_map.iter().enumerate() {
+            execution_policy.check_cancelled_every(
+                "partition_border_global_cycle_face_lineage_edges",
+                edge_index,
+            )?;
+            let observation_id = PartitionBorderObservationId {
+                partition_id: edge.partition_id,
+                local_dir_edge_id: edge.local_dir_edge_id,
+                edge_key: edge.edge_key,
+            };
+            if edge_slot_by_observation
+                .insert(observation_id, edge_index)
+                .is_some()
+            {
+                return Err(crate::PolygonizeError::InternalInvariantViolation {
+                    reason: format!(
+                        "global cycle face lineage duplicates observation {:?}",
+                        observation_id
+                    ),
+                });
+            }
+        }
+
+        let mut plan_by_face_id = BTreeMap::<usize, usize>::new();
+        for (plan_index, plan) in self.global_face_id_plans.iter().enumerate() {
+            execution_policy.check_cancelled_every(
+                "partition_border_global_cycle_face_lineage_plans",
+                plan_index,
+            )?;
+            let Some(face_id) = plan.candidate_global_face_id else {
+                continue;
+            };
+            if plan_by_face_id.insert(face_id, plan_index).is_some() {
+                stats.duplicate_face_id_plan_count += 1;
+            }
+            let unique_face_refs = plan.face_refs.iter().copied().collect::<BTreeSet<_>>();
+            stats.duplicate_plan_face_ref_count +=
+                plan.face_refs.len().saturating_sub(unique_face_refs.len());
+        }
+
+        let mut used_plans = BTreeSet::new();
+        for (cycle_index, &start) in candidate.cycle_start_global_dir_edge_ids.iter().enumerate() {
+            execution_policy.check_cancelled_every(
+                "partition_border_global_cycle_face_lineage_cycles",
+                cycle_index,
+            )?;
+            if start >= edge_count {
+                stats.invalid_cycle_count += 1;
+                continue;
+            }
+            let mut cycle_edges = BTreeSet::new();
+            let mut current = start;
+            let mut closed = true;
+            loop {
+                execution_policy.check_cancelled_every(
+                    "partition_border_global_cycle_face_lineage_cycle_edges",
+                    cycle_edges.len(),
+                )?;
+                if !cycle_edges.insert(current) {
+                    if current != start {
+                        stats.invalid_cycle_count += 1;
+                        closed = false;
+                    }
+                    break;
+                }
+                let Some(successor) = candidate.next_global_dir_edge_ids[current] else {
+                    stats.incomplete_cycle_count += 1;
+                    closed = false;
+                    break;
+                };
+                if successor >= edge_count {
+                    return Err(crate::PolygonizeError::InternalInvariantViolation {
+                        reason: format!(
+                            "global cycle face lineage successor {} exceeds {} edges",
+                            successor, edge_count
+                        ),
+                    });
+                }
+                current = successor;
+            }
+            if !closed {
+                continue;
+            }
+            stats.closed_cycle_count += 1;
+            let Some(face_id) = self
+                .global_face_id_by_cycle_start
+                .get(cycle_index)
+                .copied()
+                .flatten()
+            else {
+                stats.missing_face_id_count += 1;
+                continue;
+            };
+            let Some(&plan_index) = plan_by_face_id.get(&face_id) else {
+                stats.cycle_plan_mismatch_count += 1;
+                continue;
+            };
+            if !used_plans.insert(plan_index) {
+                stats.cycle_plan_mismatch_count += 1;
+                continue;
+            }
+            let plan = &self.global_face_id_plans[plan_index];
+            let mut plan_edges = BTreeSet::new();
+            for observation_id in &plan.boundary_observation_ids {
+                let Some(&edge_index) = edge_slot_by_observation.get(observation_id) else {
+                    stats.observation_lineage_mismatch_count += 1;
+                    continue;
+                };
+                plan_edges.insert(edge_index);
+            }
+            if plan_edges != cycle_edges || !plan.closed {
+                stats.cycle_plan_mismatch_count += 1;
+            }
+
+            let cycle_face_refs = cycle_edges
+                .iter()
+                .filter_map(|&edge_index| self.global_face_edge_map[edge_index].face_ref)
+                .collect::<BTreeSet<_>>();
+            let plan_face_refs = plan.face_refs.iter().copied().collect::<BTreeSet<_>>();
+            if cycle_face_refs != plan_face_refs {
+                stats.cycle_face_ref_mismatch_count += 1;
+            }
+            let cycle_unbounded_count = cycle_edges
+                .iter()
+                .filter(|&&edge_index| {
+                    self.global_face_edge_map[edge_index].local_face_is_unbounded
+                })
+                .count();
+            if cycle_unbounded_count != plan.local_unbounded_face_count {
+                stats.unbounded_lineage_mismatch_count += 1;
+            }
+            stats.mapped_cycle_count += 1;
+        }
+        stats.unmapped_plan_count = self
+            .global_face_id_plans
+            .iter()
+            .enumerate()
+            .filter(|(plan_index, plan)| {
+                plan.candidate_global_face_id.is_some() && !used_plans.contains(plan_index)
+            })
+            .count();
+        stats.lineage_ready = stats.identity_ready
+            && stats.next_lineage_ready
+            && stats.closed_cycle_count == stats.cycle_count
+            && stats.mapped_cycle_count == stats.cycle_count
+            && stats.plan_count == stats.cycle_count
+            && stats.incomplete_cycle_count == 0
+            && stats.invalid_cycle_count == 0
+            && stats.missing_face_id_count == 0
+            && stats.duplicate_face_id_plan_count == 0
+            && stats.unmapped_plan_count == 0
+            && stats.cycle_plan_mismatch_count == 0
+            && stats.cycle_face_ref_mismatch_count == 0
+            && stats.duplicate_plan_face_ref_count == 0
+            && stats.observation_lineage_mismatch_count == 0
+            && stats.unbounded_lineage_mismatch_count == 0;
         Ok(stats)
     }
 
@@ -12070,6 +12307,210 @@ mod tests {
             error,
             crate::PolygonizeError::Cancelled { ref stage }
                 if stage == "partition_border_global_next_lineage_integration"
+        ));
+    }
+
+    #[test]
+    fn global_cycle_face_lineage_maps_cycle_and_face_payload_without_mutation() {
+        let mut graph = exact_face_twin_graph();
+        let observations = graph.observations.values().cloned().collect::<Vec<_>>();
+        graph.global_face_edge_map = observations
+            .iter()
+            .enumerate()
+            .map(|(edge_index, observation)| PartitionBorderGlobalFaceEdge {
+                global_dir_edge_id: edge_index,
+                partition_id: observation.partition_id,
+                component_id: observation.face_ref.unwrap().component_id,
+                local_dir_edge_id: observation.local_dir_edge_id,
+                symmetric_global_dir_edge_id: 1 - edge_index,
+                local_face_successor_global_dir_edge_id: None,
+                cross_border_twin_global_dir_edge_id: Some(1 - edge_index),
+                from_global_node_id: Some(edge_index),
+                to_global_node_id: Some(1 - edge_index),
+                from: observation.from,
+                to: observation.to,
+                from_z_bits: observation.from_z_bits,
+                to_z_bits: observation.to_z_bits,
+                edge_key: observation.edge_key,
+                face_ref: observation.face_ref,
+                local_face_is_unbounded: observation.local_face_is_unbounded,
+                source_line_ids: observation.source_line_ids.clone(),
+            })
+            .collect();
+        graph.global_topology_candidate = Some(PartitionBorderGlobalTopologyCandidate {
+            next_global_dir_edge_ids: vec![Some(1), Some(0)],
+            cycle_start_global_dir_edge_ids: vec![0],
+        });
+        graph.global_face_id_by_cycle_start = vec![Some(0)];
+        graph.global_face_id_plans = vec![PartitionBorderGlobalFaceIdPlan {
+            candidate_global_face_id: Some(0),
+            component_index: 0,
+            boundary_observation_ids: observations
+                .iter()
+                .map(PartitionBorderHalfEdge::observation_id)
+                .collect(),
+            face_refs: observations
+                .iter()
+                .filter_map(|observation| observation.face_ref)
+                .collect(),
+            local_unbounded_face_count: 0,
+            closed: true,
+        }];
+        let before = graph.clone();
+        let stats = graph
+            .validate_global_cycle_face_lineage(
+                &ExecutionPolicy::default(),
+                PartitionBorderGlobalFaceIdentityInvariantStats {
+                    invariants_ready: true,
+                    ..Default::default()
+                },
+                PartitionBorderGlobalNextLineageIntegrationStats {
+                    integration_ready: true,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            stats,
+            PartitionBorderGlobalCycleFaceLineageStats {
+                edge_count: 2,
+                cycle_count: 1,
+                plan_count: 1,
+                closed_cycle_count: 1,
+                mapped_cycle_count: 1,
+                identity_ready: true,
+                next_lineage_ready: true,
+                lineage_ready: true,
+                ..Default::default()
+            }
+        );
+        assert_eq!(graph, before);
+    }
+
+    #[test]
+    fn global_cycle_face_lineage_rejects_face_and_observation_drift() {
+        let mut graph = exact_face_twin_graph();
+        let observations = graph.observations.values().cloned().collect::<Vec<_>>();
+        graph.global_face_edge_map = observations
+            .iter()
+            .enumerate()
+            .map(|(edge_index, observation)| PartitionBorderGlobalFaceEdge {
+                global_dir_edge_id: edge_index,
+                partition_id: observation.partition_id,
+                component_id: observation.face_ref.unwrap().component_id,
+                local_dir_edge_id: observation.local_dir_edge_id,
+                symmetric_global_dir_edge_id: 1 - edge_index,
+                local_face_successor_global_dir_edge_id: None,
+                cross_border_twin_global_dir_edge_id: Some(1 - edge_index),
+                from_global_node_id: Some(edge_index),
+                to_global_node_id: Some(1 - edge_index),
+                from: observation.from,
+                to: observation.to,
+                from_z_bits: observation.from_z_bits,
+                to_z_bits: observation.to_z_bits,
+                edge_key: observation.edge_key,
+                face_ref: observation.face_ref,
+                local_face_is_unbounded: observation.local_face_is_unbounded,
+                source_line_ids: observation.source_line_ids.clone(),
+            })
+            .collect();
+        graph.global_topology_candidate = Some(PartitionBorderGlobalTopologyCandidate {
+            next_global_dir_edge_ids: vec![Some(1), Some(0)],
+            cycle_start_global_dir_edge_ids: vec![0],
+        });
+        graph.global_face_id_by_cycle_start = vec![Some(0)];
+        graph.global_face_id_plans = vec![PartitionBorderGlobalFaceIdPlan {
+            candidate_global_face_id: Some(0),
+            component_index: 0,
+            boundary_observation_ids: vec![observations[0].observation_id()],
+            face_refs: vec![observations[0].face_ref.unwrap()],
+            local_unbounded_face_count: 0,
+            closed: true,
+        }];
+        let stats = graph
+            .validate_global_cycle_face_lineage(
+                &ExecutionPolicy::default(),
+                PartitionBorderGlobalFaceIdentityInvariantStats {
+                    invariants_ready: true,
+                    ..Default::default()
+                },
+                PartitionBorderGlobalNextLineageIntegrationStats {
+                    integration_ready: true,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert!(!stats.lineage_ready);
+        assert_eq!(stats.cycle_plan_mismatch_count, 1);
+        assert_eq!(stats.cycle_face_ref_mismatch_count, 1);
+    }
+
+    #[test]
+    fn global_cycle_face_lineage_is_bounded_and_cancellable() {
+        let mut graph = exact_face_twin_graph();
+        let observations = graph.observations.values().cloned().collect::<Vec<_>>();
+        graph.global_face_edge_map = observations
+            .iter()
+            .enumerate()
+            .map(|(edge_index, observation)| PartitionBorderGlobalFaceEdge {
+                global_dir_edge_id: edge_index,
+                partition_id: observation.partition_id,
+                component_id: observation.face_ref.unwrap().component_id,
+                local_dir_edge_id: observation.local_dir_edge_id,
+                symmetric_global_dir_edge_id: 1 - edge_index,
+                local_face_successor_global_dir_edge_id: None,
+                cross_border_twin_global_dir_edge_id: Some(1 - edge_index),
+                from_global_node_id: None,
+                to_global_node_id: None,
+                from: observation.from,
+                to: observation.to,
+                from_z_bits: observation.from_z_bits,
+                to_z_bits: observation.to_z_bits,
+                edge_key: observation.edge_key,
+                face_ref: observation.face_ref,
+                local_face_is_unbounded: observation.local_face_is_unbounded,
+                source_line_ids: observation.source_line_ids.clone(),
+            })
+            .collect();
+        graph.global_topology_candidate = Some(PartitionBorderGlobalTopologyCandidate {
+            next_global_dir_edge_ids: vec![Some(1), Some(0)],
+            cycle_start_global_dir_edge_ids: vec![0],
+        });
+        let error = graph
+            .validate_global_cycle_face_lineage(
+                &ExecutionPolicy {
+                    max_graph_edges: Some(0),
+                    ..Default::default()
+                },
+                PartitionBorderGlobalFaceIdentityInvariantStats::default(),
+                PartitionBorderGlobalNextLineageIntegrationStats::default(),
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::ResourceLimitExceeded {
+                ref stage,
+                limit: 0,
+                observed: 2,
+            } if stage == "partition_border_global_cycle_face_lineage_edges"
+        ));
+
+        let token = CancellationToken::new();
+        token.cancel();
+        let error = graph
+            .validate_global_cycle_face_lineage(
+                &ExecutionPolicy {
+                    cancellation_token: Some(token),
+                    ..Default::default()
+                },
+                PartitionBorderGlobalFaceIdentityInvariantStats::default(),
+                PartitionBorderGlobalNextLineageIntegrationStats::default(),
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::Cancelled { ref stage }
+                if stage == "partition_border_global_cycle_face_lineage"
         ));
     }
 

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -503,6 +503,26 @@ pub struct StitchingReport {
     pub partition_border_global_next_lineage_integration_twin_mismatch_count: usize,
     pub partition_border_global_next_lineage_integration_identity_ready: bool,
     pub partition_border_global_next_lineage_integration_ready: bool,
+    /// Detached candidate cycles mapped back to exact global face-plan
+    /// observation and qualified-face lineage.
+    pub partition_border_global_cycle_face_lineage_edge_count: usize,
+    pub partition_border_global_cycle_face_lineage_cycle_count: usize,
+    pub partition_border_global_cycle_face_lineage_plan_count: usize,
+    pub partition_border_global_cycle_face_lineage_closed_cycle_count: usize,
+    pub partition_border_global_cycle_face_lineage_mapped_cycle_count: usize,
+    pub partition_border_global_cycle_face_lineage_incomplete_cycle_count: usize,
+    pub partition_border_global_cycle_face_lineage_invalid_cycle_count: usize,
+    pub partition_border_global_cycle_face_lineage_missing_face_id_count: usize,
+    pub partition_border_global_cycle_face_lineage_duplicate_face_id_plan_count: usize,
+    pub partition_border_global_cycle_face_lineage_unmapped_plan_count: usize,
+    pub partition_border_global_cycle_face_lineage_cycle_plan_mismatch_count: usize,
+    pub partition_border_global_cycle_face_lineage_cycle_face_ref_mismatch_count: usize,
+    pub partition_border_global_cycle_face_lineage_duplicate_plan_face_ref_count: usize,
+    pub partition_border_global_cycle_face_lineage_observation_mismatch_count: usize,
+    pub partition_border_global_cycle_face_lineage_unbounded_mismatch_count: usize,
+    pub partition_border_global_cycle_face_lineage_identity_ready: bool,
+    pub partition_border_global_cycle_face_lineage_next_ready: bool,
+    pub partition_border_global_cycle_face_lineage_ready: bool,
     /// Unbounded-face candidates whose local cycles are closed.
     pub partition_border_global_unbounded_face_proof_closed_count: usize,
     /// Unbounded-face twins absent from the retained twin-position map.
@@ -2796,6 +2816,12 @@ impl<'a> TiledPolygonizer<'a> {
                 &self.execution_policy,
                 partition_border_global_face_identity_invariants,
             )?;
+        let partition_border_global_cycle_face_lineage = partition_border_graph
+            .validate_global_cycle_face_lineage(
+                &self.execution_policy,
+                partition_border_global_face_identity_invariants,
+                partition_border_global_next_lineage_integration,
+            )?;
         if let Some(trace) = trace.as_deref_mut() {
             trace.record_partition_border_reconciliation(partition_border_reconciliation);
             trace.record_partition_border_twin_application(partition_border_twin_application);
@@ -2888,6 +2914,9 @@ impl<'a> TiledPolygonizer<'a> {
             );
             trace.record_partition_border_global_next_lineage_integration(
                 partition_border_global_next_lineage_integration,
+            );
+            trace.record_partition_border_global_cycle_face_lineage(
+                partition_border_global_cycle_face_lineage,
             );
         }
         let unresolved = tile_reports.iter().any(Self::report_is_unresolved);
@@ -3423,6 +3452,43 @@ impl<'a> TiledPolygonizer<'a> {
                     partition_border_global_next_lineage_integration.identity_ready,
                 partition_border_global_next_lineage_integration_ready:
                     partition_border_global_next_lineage_integration.integration_ready,
+                partition_border_global_cycle_face_lineage_edge_count:
+                    partition_border_global_cycle_face_lineage.edge_count,
+                partition_border_global_cycle_face_lineage_cycle_count:
+                    partition_border_global_cycle_face_lineage.cycle_count,
+                partition_border_global_cycle_face_lineage_plan_count:
+                    partition_border_global_cycle_face_lineage.plan_count,
+                partition_border_global_cycle_face_lineage_closed_cycle_count:
+                    partition_border_global_cycle_face_lineage.closed_cycle_count,
+                partition_border_global_cycle_face_lineage_mapped_cycle_count:
+                    partition_border_global_cycle_face_lineage.mapped_cycle_count,
+                partition_border_global_cycle_face_lineage_incomplete_cycle_count:
+                    partition_border_global_cycle_face_lineage.incomplete_cycle_count,
+                partition_border_global_cycle_face_lineage_invalid_cycle_count:
+                    partition_border_global_cycle_face_lineage.invalid_cycle_count,
+                partition_border_global_cycle_face_lineage_missing_face_id_count:
+                    partition_border_global_cycle_face_lineage.missing_face_id_count,
+                partition_border_global_cycle_face_lineage_duplicate_face_id_plan_count:
+                    partition_border_global_cycle_face_lineage.duplicate_face_id_plan_count,
+                partition_border_global_cycle_face_lineage_unmapped_plan_count:
+                    partition_border_global_cycle_face_lineage.unmapped_plan_count,
+                partition_border_global_cycle_face_lineage_cycle_plan_mismatch_count:
+                    partition_border_global_cycle_face_lineage.cycle_plan_mismatch_count,
+                partition_border_global_cycle_face_lineage_cycle_face_ref_mismatch_count:
+                    partition_border_global_cycle_face_lineage.cycle_face_ref_mismatch_count,
+                partition_border_global_cycle_face_lineage_duplicate_plan_face_ref_count:
+                    partition_border_global_cycle_face_lineage.duplicate_plan_face_ref_count,
+                partition_border_global_cycle_face_lineage_observation_mismatch_count:
+                    partition_border_global_cycle_face_lineage
+                        .observation_lineage_mismatch_count,
+                partition_border_global_cycle_face_lineage_unbounded_mismatch_count:
+                    partition_border_global_cycle_face_lineage.unbounded_lineage_mismatch_count,
+                partition_border_global_cycle_face_lineage_identity_ready:
+                    partition_border_global_cycle_face_lineage.identity_ready,
+                partition_border_global_cycle_face_lineage_next_ready:
+                    partition_border_global_cycle_face_lineage.next_lineage_ready,
+                partition_border_global_cycle_face_lineage_ready:
+                    partition_border_global_cycle_face_lineage.lineage_ready,
                 partition_border_global_unbounded_face_proof_closed_count:
                     partition_border_global_unbounded_face_proof.closed_unbounded_face_count,
                 partition_border_global_unbounded_face_proof_unmapped_twin_count:

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -4,9 +4,10 @@ use crate::fingerprint::{coordinate_fingerprint, float_bits};
 use crate::graph::partition_border::{
     PartitionBorderCanonicalNodeValidationStats, PartitionBorderGlobalComponentCoverageStats,
     PartitionBorderGlobalComponentPayloadStats, PartitionBorderGlobalComponentReconciliationStats,
-    PartitionBorderGlobalFaceEdgeMapStats, PartitionBorderGlobalFaceEulerWitnessStats,
-    PartitionBorderGlobalFaceIdApplicationStats, PartitionBorderGlobalFaceIdMutationStats,
-    PartitionBorderGlobalFaceIdPlanStats, PartitionBorderGlobalFaceIdentityInvariantStats,
+    PartitionBorderGlobalCycleFaceLineageStats, PartitionBorderGlobalFaceEdgeMapStats,
+    PartitionBorderGlobalFaceEulerWitnessStats, PartitionBorderGlobalFaceIdApplicationStats,
+    PartitionBorderGlobalFaceIdMutationStats, PartitionBorderGlobalFaceIdPlanStats,
+    PartitionBorderGlobalFaceIdentityInvariantStats,
     PartitionBorderGlobalFaceIdentityMaterializationStats,
     PartitionBorderGlobalFaceIdentityPlanStats, PartitionBorderGlobalFaceMutationGateStats,
     PartitionBorderGlobalFaceNextApplicationStats, PartitionBorderGlobalFaceNextCandidateStats,
@@ -1264,6 +1265,37 @@ impl TraceRecorderV1 {
                 "twin_lineage_mismatch_count": stats.twin_lineage_mismatch_count,
                 "identity_ready": stats.identity_ready,
                 "integration_ready": stats.integration_ready,
+            }),
+        )
+    }
+
+    pub(crate) fn record_partition_border_global_cycle_face_lineage(
+        &mut self,
+        stats: PartitionBorderGlobalCycleFaceLineageStats,
+    ) -> bool {
+        self.record(
+            TraceStageV1::Graph,
+            "partition_border_global_cycle_face_lineage",
+            serde_json::json!({
+                "edge_count": stats.edge_count,
+                "cycle_count": stats.cycle_count,
+                "plan_count": stats.plan_count,
+                "closed_cycle_count": stats.closed_cycle_count,
+                "mapped_cycle_count": stats.mapped_cycle_count,
+                "incomplete_cycle_count": stats.incomplete_cycle_count,
+                "invalid_cycle_count": stats.invalid_cycle_count,
+                "missing_face_id_count": stats.missing_face_id_count,
+                "duplicate_face_id_plan_count": stats.duplicate_face_id_plan_count,
+                "unmapped_plan_count": stats.unmapped_plan_count,
+                "cycle_plan_mismatch_count": stats.cycle_plan_mismatch_count,
+                "cycle_face_ref_mismatch_count": stats.cycle_face_ref_mismatch_count,
+                "duplicate_plan_face_ref_count": stats.duplicate_plan_face_ref_count,
+                "observation_lineage_mismatch_count":
+                    stats.observation_lineage_mismatch_count,
+                "unbounded_lineage_mismatch_count": stats.unbounded_lineage_mismatch_count,
+                "identity_ready": stats.identity_ready,
+                "next_lineage_ready": stats.next_lineage_ready,
+                "lineage_ready": stats.lineage_ready,
             }),
         )
     }


### PR DESCRIPTION
## Stack
Parent: origin/main at 00b8cdd (merged PRs #1357 and #1358).
Children: none.
This PR is standalone because the prior stack is fully merged; no stack link is required.

## Delivered
- Added a bounded, cancellable, read-only detached cycle-to-face lineage validator.
- Requires every closed detached successor cycle to map exactly once to a candidate global face plan.
- Cross-checks edge observation slots, qualified local face references, candidate face IDs, duplicate plans, and local-unbounded marker lineage.
- Added trace and StitchingReport evidence fields.
- Added positive, drift-rejection, bounded, cancellable, and non-mutation regression coverage.
- Updated ROADMAP.md with the precise completed evidence item while keeping global topology promotion open.

## Contract impact
Additive internal trace/report evidence only. Local half-edge links, public face IDs, stitched output, provenance, Z behavior, serial/parallel equality, resource limits, and cancellation semantics remain unchanged. Incomplete cycles remain fail-closed evidence and do not become topology errors.

## Validation
- cargo test -p geo-polygonize-core --lib (377 passed)
- cargo test --workspace --no-default-features (passed)
- cargo clippy --workspace --all-targets --no-default-features -- -D warnings (passed)
- cargo fmt --all -- --check (passed)
- git diff --check (passed)
- Generated bindings restored after test execution.

## Agent handoff
Next branch: agent/p5-global-cycle-face-promotion-gate.
Next slice: combine exact cycle-to-face lineage with the detached unbounded proof and component coverage into a final cycle ownership/promotion gate, still without writing local topology or extracting stitched output.
Remaining risks: broad P5.3 global topology promotion, exactly-one global unbounded-face promotion, stitched extraction, untiled equivalence, differential fuzzing, and performance/peak-memory evidence remain open.