### PR TITLE
feat(core): gate detached cycle face promotion

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -559,6 +559,10 @@ Blocked by #1288.
   global face plan, validating observation slots, qualified local face
   lineage, and local-unbounded marker lineage without mutating topology or
   output.
+- [x] Cross-check detached cycle/face lineage against complete component
+  coverage and exactly-one-unbounded application evidence with explicit count
+  mismatches and bounded cancellation/limit handling; keep the promotion gate
+  evidence-only.
 - [ ] Build global `next` links and deterministic global face IDs.
 - [ ] Identify exactly one global unbounded face.
 - [ ] Validate twin, cycle, source, Euler, and face-walk invariants.

--- a/crates/geo-polygonize-core/src/graph/partition_border.rs
+++ b/crates/geo-polygonize-core/src/graph/partition_border.rs
@@ -814,6 +814,30 @@ pub(crate) struct PartitionBorderGlobalCycleFaceLineageStats {
     pub(crate) lineage_ready: bool,
 }
 
+/// Counts the detached evidence required before a future global face
+/// promotion. This is a cross-check after cycle-to-face lineage: it does not
+/// replace the pre-mutation gate and never promotes topology or output.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct PartitionBorderGlobalCycleFacePromotionGateStats {
+    pub(crate) edge_count: usize,
+    pub(crate) cycle_count: usize,
+    pub(crate) plan_count: usize,
+    pub(crate) component_count: usize,
+    pub(crate) face_count: usize,
+    pub(crate) covered_face_edge_count: usize,
+    pub(crate) candidate_unbounded_face_id_count: usize,
+    pub(crate) mapped_unbounded_cycle_count: usize,
+    pub(crate) lineage_ready: bool,
+    pub(crate) component_coverage_ready: bool,
+    pub(crate) unbounded_face_application_ready: bool,
+    pub(crate) edge_count_mismatch_count: usize,
+    pub(crate) cycle_count_mismatch_count: usize,
+    pub(crate) plan_count_mismatch_count: usize,
+    pub(crate) face_count_mismatch_count: usize,
+    pub(crate) unbounded_marker_mismatch_count: usize,
+    pub(crate) gate_ready: bool,
+}
+
 /// Counts from validating a detached global directed-edge topology candidate.
 /// Readiness requires complete application evidence, one predecessor and one
 /// successor per edge, endpoint continuity, and closed cycles.
@@ -2194,6 +2218,77 @@ impl PartitionBorderGraph {
             && stats.observation_lineage_mismatch_count == 0
             && stats.unbounded_lineage_mismatch_count == 0;
         Ok(stats)
+    }
+
+    /// Cross-checks cycle-to-face lineage against complete component coverage
+    /// and the conservative exactly-one-unbounded application proof. This is
+    /// a detached promotion boundary only; it does not mutate any topology or
+    /// output state.
+    pub(crate) fn validate_global_cycle_face_promotion_gate(
+        &self,
+        execution_policy: &ExecutionPolicy,
+        cycle_face_lineage: PartitionBorderGlobalCycleFaceLineageStats,
+        component_coverage: PartitionBorderGlobalComponentCoverageStats,
+        unbounded_face_application: PartitionBorderGlobalUnboundedFaceApplicationStats,
+    ) -> crate::Result<PartitionBorderGlobalCycleFacePromotionGateStats> {
+        execution_policy.check_cancelled("partition_border_global_cycle_face_promotion_gate")?;
+        let edge_count = self.global_face_edge_map.len();
+        execution_policy.check(
+            "partition_border_global_cycle_face_promotion_gate_edges",
+            execution_policy.max_graph_edges,
+            edge_count,
+        )?;
+        execution_policy.check(
+            "partition_border_global_cycle_face_promotion_gate_components",
+            execution_policy.max_graph_nodes,
+            self.global_components.len(),
+        )?;
+
+        let edge_count_mismatch_count = usize::from(cycle_face_lineage.edge_count != edge_count)
+            + usize::from(component_coverage.edge_count != edge_count);
+        let cycle_count_mismatch_count = usize::from(
+            cycle_face_lineage.cycle_count != unbounded_face_application.candidate_cycle_count,
+        );
+        let plan_count_mismatch_count =
+            usize::from(cycle_face_lineage.plan_count != cycle_face_lineage.cycle_count)
+                + usize::from(
+                    cycle_face_lineage.plan_count
+                        != unbounded_face_application.candidate_cycle_count,
+                );
+        let face_count_mismatch_count =
+            usize::from(component_coverage.face_count != unbounded_face_application.face_count);
+        let unbounded_marker_mismatch_count =
+            usize::from(unbounded_face_application.candidate_unbounded_face_id_count != 1)
+                + usize::from(unbounded_face_application.mapped_unbounded_cycle_count != 1);
+        let gate_ready = cycle_face_lineage.lineage_ready
+            && component_coverage.coverage_ready
+            && unbounded_face_application.application_ready
+            && edge_count_mismatch_count == 0
+            && cycle_count_mismatch_count == 0
+            && plan_count_mismatch_count == 0
+            && face_count_mismatch_count == 0
+            && unbounded_marker_mismatch_count == 0;
+
+        Ok(PartitionBorderGlobalCycleFacePromotionGateStats {
+            edge_count,
+            cycle_count: cycle_face_lineage.cycle_count,
+            plan_count: cycle_face_lineage.plan_count,
+            component_count: component_coverage.component_count,
+            face_count: component_coverage.face_count,
+            covered_face_edge_count: component_coverage.covered_face_edge_count,
+            candidate_unbounded_face_id_count: unbounded_face_application
+                .candidate_unbounded_face_id_count,
+            mapped_unbounded_cycle_count: unbounded_face_application.mapped_unbounded_cycle_count,
+            lineage_ready: cycle_face_lineage.lineage_ready,
+            component_coverage_ready: component_coverage.coverage_ready,
+            unbounded_face_application_ready: unbounded_face_application.application_ready,
+            edge_count_mismatch_count,
+            cycle_count_mismatch_count,
+            plan_count_mismatch_count,
+            face_count_mismatch_count,
+            unbounded_marker_mismatch_count,
+            gate_ready,
+        })
     }
 
     #[cfg(test)]
@@ -12511,6 +12606,170 @@ mod tests {
             error,
             crate::PolygonizeError::Cancelled { ref stage }
                 if stage == "partition_border_global_cycle_face_lineage"
+        ));
+    }
+
+    #[test]
+    fn global_cycle_face_promotion_gate_requires_matching_detached_evidence() {
+        let graph = exact_global_topology_candidate_graph();
+        let before = graph.clone();
+        let stats = graph
+            .validate_global_cycle_face_promotion_gate(
+                &ExecutionPolicy::default(),
+                PartitionBorderGlobalCycleFaceLineageStats {
+                    edge_count: 4,
+                    cycle_count: 1,
+                    plan_count: 1,
+                    lineage_ready: true,
+                    ..Default::default()
+                },
+                PartitionBorderGlobalComponentCoverageStats {
+                    component_count: 1,
+                    face_count: 2,
+                    edge_count: 4,
+                    face_edge_count: 4,
+                    covered_face_edge_count: 4,
+                    coverage_ready: true,
+                    ..Default::default()
+                },
+                PartitionBorderGlobalUnboundedFaceApplicationStats {
+                    face_count: 2,
+                    candidate_cycle_count: 1,
+                    local_unbounded_face_count: 1,
+                    candidate_unbounded_face_id_count: 1,
+                    mapped_unbounded_cycle_count: 1,
+                    proof_ready: true,
+                    application_ready: true,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            stats,
+            PartitionBorderGlobalCycleFacePromotionGateStats {
+                edge_count: 4,
+                cycle_count: 1,
+                plan_count: 1,
+                component_count: 1,
+                face_count: 2,
+                covered_face_edge_count: 4,
+                candidate_unbounded_face_id_count: 1,
+                mapped_unbounded_cycle_count: 1,
+                lineage_ready: true,
+                component_coverage_ready: true,
+                unbounded_face_application_ready: true,
+                gate_ready: true,
+                ..Default::default()
+            }
+        );
+        assert_eq!(graph, before);
+    }
+
+    #[test]
+    fn global_cycle_face_promotion_gate_rejects_count_and_marker_drift() {
+        let graph = exact_global_topology_candidate_graph();
+        let stats = graph
+            .validate_global_cycle_face_promotion_gate(
+                &ExecutionPolicy::default(),
+                PartitionBorderGlobalCycleFaceLineageStats {
+                    edge_count: 3,
+                    cycle_count: 2,
+                    plan_count: 1,
+                    lineage_ready: true,
+                    ..Default::default()
+                },
+                PartitionBorderGlobalComponentCoverageStats {
+                    component_count: 1,
+                    face_count: 3,
+                    edge_count: 3,
+                    coverage_ready: true,
+                    ..Default::default()
+                },
+                PartitionBorderGlobalUnboundedFaceApplicationStats {
+                    face_count: 2,
+                    candidate_cycle_count: 1,
+                    candidate_unbounded_face_id_count: 2,
+                    mapped_unbounded_cycle_count: 0,
+                    application_ready: true,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert!(!stats.gate_ready);
+        assert_eq!(stats.edge_count_mismatch_count, 2);
+        assert_eq!(stats.cycle_count_mismatch_count, 1);
+        assert_eq!(stats.plan_count_mismatch_count, 1);
+        assert_eq!(stats.face_count_mismatch_count, 1);
+        assert_eq!(stats.unbounded_marker_mismatch_count, 2);
+    }
+
+    #[test]
+    fn global_cycle_face_promotion_gate_is_bounded_and_cancellable() {
+        let graph = exact_global_topology_candidate_graph();
+        let inputs = (
+            PartitionBorderGlobalCycleFaceLineageStats {
+                edge_count: 4,
+                cycle_count: 1,
+                plan_count: 1,
+                lineage_ready: true,
+                ..Default::default()
+            },
+            PartitionBorderGlobalComponentCoverageStats {
+                component_count: 1,
+                face_count: 2,
+                edge_count: 4,
+                covered_face_edge_count: 4,
+                coverage_ready: true,
+                ..Default::default()
+            },
+            PartitionBorderGlobalUnboundedFaceApplicationStats {
+                face_count: 2,
+                candidate_cycle_count: 1,
+                local_unbounded_face_count: 1,
+                candidate_unbounded_face_id_count: 1,
+                mapped_unbounded_cycle_count: 1,
+                proof_ready: true,
+                application_ready: true,
+                ..Default::default()
+            },
+        );
+        let error = graph
+            .validate_global_cycle_face_promotion_gate(
+                &ExecutionPolicy {
+                    max_graph_edges: Some(0),
+                    ..Default::default()
+                },
+                inputs.0,
+                inputs.1,
+                inputs.2,
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::ResourceLimitExceeded {
+                ref stage,
+                limit: 0,
+                observed: 4,
+            } if stage == "partition_border_global_cycle_face_promotion_gate_edges"
+        ));
+
+        let token = CancellationToken::new();
+        token.cancel();
+        let error = graph
+            .validate_global_cycle_face_promotion_gate(
+                &ExecutionPolicy {
+                    cancellation_token: Some(token),
+                    ..Default::default()
+                },
+                inputs.0,
+                inputs.1,
+                inputs.2,
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::Cancelled { ref stage }
+                if stage == "partition_border_global_cycle_face_promotion_gate"
         ));
     }
 

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -523,6 +523,24 @@ pub struct StitchingReport {
     pub partition_border_global_cycle_face_lineage_identity_ready: bool,
     pub partition_border_global_cycle_face_lineage_next_ready: bool,
     pub partition_border_global_cycle_face_lineage_ready: bool,
+    /// Final detached cross-check before any future global face promotion.
+    pub partition_border_global_cycle_face_promotion_gate_edge_count: usize,
+    pub partition_border_global_cycle_face_promotion_gate_cycle_count: usize,
+    pub partition_border_global_cycle_face_promotion_gate_plan_count: usize,
+    pub partition_border_global_cycle_face_promotion_gate_component_count: usize,
+    pub partition_border_global_cycle_face_promotion_gate_face_count: usize,
+    pub partition_border_global_cycle_face_promotion_gate_covered_face_edge_count: usize,
+    pub partition_border_global_cycle_face_promotion_gate_candidate_unbounded_face_id_count: usize,
+    pub partition_border_global_cycle_face_promotion_gate_mapped_unbounded_cycle_count: usize,
+    pub partition_border_global_cycle_face_promotion_gate_lineage_ready: bool,
+    pub partition_border_global_cycle_face_promotion_gate_component_coverage_ready: bool,
+    pub partition_border_global_cycle_face_promotion_gate_unbounded_face_application_ready: bool,
+    pub partition_border_global_cycle_face_promotion_gate_edge_count_mismatch_count: usize,
+    pub partition_border_global_cycle_face_promotion_gate_cycle_count_mismatch_count: usize,
+    pub partition_border_global_cycle_face_promotion_gate_plan_count_mismatch_count: usize,
+    pub partition_border_global_cycle_face_promotion_gate_face_count_mismatch_count: usize,
+    pub partition_border_global_cycle_face_promotion_gate_unbounded_marker_mismatch_count: usize,
+    pub partition_border_global_cycle_face_promotion_gate_ready: bool,
     /// Unbounded-face candidates whose local cycles are closed.
     pub partition_border_global_unbounded_face_proof_closed_count: usize,
     /// Unbounded-face twins absent from the retained twin-position map.
@@ -2822,6 +2840,13 @@ impl<'a> TiledPolygonizer<'a> {
                 partition_border_global_face_identity_invariants,
                 partition_border_global_next_lineage_integration,
             )?;
+        let partition_border_global_cycle_face_promotion_gate = partition_border_graph
+            .validate_global_cycle_face_promotion_gate(
+                &self.execution_policy,
+                partition_border_global_cycle_face_lineage,
+                partition_border_global_component_coverage,
+                partition_border_global_unbounded_face_application,
+            )?;
         if let Some(trace) = trace.as_deref_mut() {
             trace.record_partition_border_reconciliation(partition_border_reconciliation);
             trace.record_partition_border_twin_application(partition_border_twin_application);
@@ -2917,6 +2942,9 @@ impl<'a> TiledPolygonizer<'a> {
             );
             trace.record_partition_border_global_cycle_face_lineage(
                 partition_border_global_cycle_face_lineage,
+            );
+            trace.record_partition_border_global_cycle_face_promotion_gate(
+                partition_border_global_cycle_face_promotion_gate,
             );
         }
         let unresolved = tile_reports.iter().any(Self::report_is_unresolved);
@@ -3489,6 +3517,48 @@ impl<'a> TiledPolygonizer<'a> {
                     partition_border_global_cycle_face_lineage.next_lineage_ready,
                 partition_border_global_cycle_face_lineage_ready:
                     partition_border_global_cycle_face_lineage.lineage_ready,
+                partition_border_global_cycle_face_promotion_gate_edge_count:
+                    partition_border_global_cycle_face_promotion_gate.edge_count,
+                partition_border_global_cycle_face_promotion_gate_cycle_count:
+                    partition_border_global_cycle_face_promotion_gate.cycle_count,
+                partition_border_global_cycle_face_promotion_gate_plan_count:
+                    partition_border_global_cycle_face_promotion_gate.plan_count,
+                partition_border_global_cycle_face_promotion_gate_component_count:
+                    partition_border_global_cycle_face_promotion_gate.component_count,
+                partition_border_global_cycle_face_promotion_gate_face_count:
+                    partition_border_global_cycle_face_promotion_gate.face_count,
+                partition_border_global_cycle_face_promotion_gate_covered_face_edge_count:
+                    partition_border_global_cycle_face_promotion_gate.covered_face_edge_count,
+                partition_border_global_cycle_face_promotion_gate_candidate_unbounded_face_id_count:
+                    partition_border_global_cycle_face_promotion_gate
+                        .candidate_unbounded_face_id_count,
+                partition_border_global_cycle_face_promotion_gate_mapped_unbounded_cycle_count:
+                    partition_border_global_cycle_face_promotion_gate
+                        .mapped_unbounded_cycle_count,
+                partition_border_global_cycle_face_promotion_gate_lineage_ready:
+                    partition_border_global_cycle_face_promotion_gate.lineage_ready,
+                partition_border_global_cycle_face_promotion_gate_component_coverage_ready:
+                    partition_border_global_cycle_face_promotion_gate.component_coverage_ready,
+                partition_border_global_cycle_face_promotion_gate_unbounded_face_application_ready:
+                    partition_border_global_cycle_face_promotion_gate
+                        .unbounded_face_application_ready,
+                partition_border_global_cycle_face_promotion_gate_edge_count_mismatch_count:
+                    partition_border_global_cycle_face_promotion_gate
+                        .edge_count_mismatch_count,
+                partition_border_global_cycle_face_promotion_gate_cycle_count_mismatch_count:
+                    partition_border_global_cycle_face_promotion_gate
+                        .cycle_count_mismatch_count,
+                partition_border_global_cycle_face_promotion_gate_plan_count_mismatch_count:
+                    partition_border_global_cycle_face_promotion_gate
+                        .plan_count_mismatch_count,
+                partition_border_global_cycle_face_promotion_gate_face_count_mismatch_count:
+                    partition_border_global_cycle_face_promotion_gate
+                        .face_count_mismatch_count,
+                partition_border_global_cycle_face_promotion_gate_unbounded_marker_mismatch_count:
+                    partition_border_global_cycle_face_promotion_gate
+                        .unbounded_marker_mismatch_count,
+                partition_border_global_cycle_face_promotion_gate_ready:
+                    partition_border_global_cycle_face_promotion_gate.gate_ready,
                 partition_border_global_unbounded_face_proof_closed_count:
                     partition_border_global_unbounded_face_proof.closed_unbounded_face_count,
                 partition_border_global_unbounded_face_proof_unmapped_twin_count:

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -4,10 +4,10 @@ use crate::fingerprint::{coordinate_fingerprint, float_bits};
 use crate::graph::partition_border::{
     PartitionBorderCanonicalNodeValidationStats, PartitionBorderGlobalComponentCoverageStats,
     PartitionBorderGlobalComponentPayloadStats, PartitionBorderGlobalComponentReconciliationStats,
-    PartitionBorderGlobalCycleFaceLineageStats, PartitionBorderGlobalFaceEdgeMapStats,
-    PartitionBorderGlobalFaceEulerWitnessStats, PartitionBorderGlobalFaceIdApplicationStats,
-    PartitionBorderGlobalFaceIdMutationStats, PartitionBorderGlobalFaceIdPlanStats,
-    PartitionBorderGlobalFaceIdentityInvariantStats,
+    PartitionBorderGlobalCycleFaceLineageStats, PartitionBorderGlobalCycleFacePromotionGateStats,
+    PartitionBorderGlobalFaceEdgeMapStats, PartitionBorderGlobalFaceEulerWitnessStats,
+    PartitionBorderGlobalFaceIdApplicationStats, PartitionBorderGlobalFaceIdMutationStats,
+    PartitionBorderGlobalFaceIdPlanStats, PartitionBorderGlobalFaceIdentityInvariantStats,
     PartitionBorderGlobalFaceIdentityMaterializationStats,
     PartitionBorderGlobalFaceIdentityPlanStats, PartitionBorderGlobalFaceMutationGateStats,
     PartitionBorderGlobalFaceNextApplicationStats, PartitionBorderGlobalFaceNextCandidateStats,
@@ -1296,6 +1296,35 @@ impl TraceRecorderV1 {
                 "identity_ready": stats.identity_ready,
                 "next_lineage_ready": stats.next_lineage_ready,
                 "lineage_ready": stats.lineage_ready,
+            }),
+        )
+    }
+
+    pub(crate) fn record_partition_border_global_cycle_face_promotion_gate(
+        &mut self,
+        stats: PartitionBorderGlobalCycleFacePromotionGateStats,
+    ) -> bool {
+        self.record(
+            TraceStageV1::Graph,
+            "partition_border_global_cycle_face_promotion_gate",
+            serde_json::json!({
+                "edge_count": stats.edge_count,
+                "cycle_count": stats.cycle_count,
+                "plan_count": stats.plan_count,
+                "component_count": stats.component_count,
+                "face_count": stats.face_count,
+                "covered_face_edge_count": stats.covered_face_edge_count,
+                "candidate_unbounded_face_id_count": stats.candidate_unbounded_face_id_count,
+                "mapped_unbounded_cycle_count": stats.mapped_unbounded_cycle_count,
+                "lineage_ready": stats.lineage_ready,
+                "component_coverage_ready": stats.component_coverage_ready,
+                "unbounded_face_application_ready": stats.unbounded_face_application_ready,
+                "edge_count_mismatch_count": stats.edge_count_mismatch_count,
+                "cycle_count_mismatch_count": stats.cycle_count_mismatch_count,
+                "plan_count_mismatch_count": stats.plan_count_mismatch_count,
+                "face_count_mismatch_count": stats.face_count_mismatch_count,
+                "unbounded_marker_mismatch_count": stats.unbounded_marker_mismatch_count,
+                "gate_ready": stats.gate_ready,
             }),
         )
     }


### PR DESCRIPTION
## Stack
Parent: `origin/main` at merged PR #1360 (`ac7b82f55416ce...`).
Children: none.
Standalone slice; no `gh stack link` relationship is required.

## Delivered
- Added a detached cycle/face promotion evidence gate.
- Cross-checks cycle/face lineage, complete component coverage, and exactly-one-unbounded application evidence.
- Reports explicit edge, cycle, plan, face, and unbounded-marker mismatch counts.
- Wired the gate into `StitchingReport` and bounded graph trace evidence.
- Added positive, drift-rejection, limit, cancellation, and non-mutation contract tests.
- Updated P5.3 without closing the broader global-output promotion items.

## Contract impact
The gate is evidence-only and fail-closed. It does not mutate local half-edge links, detached topology, face IDs, unbounded identity, stitched output, provenance, Z payloads, or fallback behavior. Existing readiness and canonical output contracts remain unchanged.

## Validation
- `cargo test -p geo-polygonize-core --lib global_cycle_face_promotion_gate` — 3 passed.
- `cargo test -p geo-polygonize-core --lib` — 380 passed.
- `cargo test --workspace --no-default-features` — passed.
- `cargo clippy --workspace --all-targets --no-default-features -- -D warnings` — passed.
- `cargo fmt --all -- --check` — passed.
- `cargo doc -p geo-polygonize-core --no-deps` — passed.
- `git diff --check` — passed.
- Restored generated TypeScript bindings produced by test/doc runs.

## Agent handoff
Next branch: `agent/p5-global-face-promotion-evidence`.
Next slice: use this gate to add the remaining detached promotion evidence needed for output extraction, starting with a cross-check that source/provenance/Z lineage is complete for every gate-ready face cycle. Keep the broad `next`/global-face/output-equivalence roadmap items open until actual stitched extraction and untiled differential evidence exist.
Remaining risk: this PR does not promote stitched output or claim full tiled/untiled equivalence; the gate is diagnostic evidence only.
