### PR TITLE
feat(core): validate detached face payload lineage

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -563,6 +563,10 @@ Blocked by #1288.
   coverage and exactly-one-unbounded application evidence with explicit count
   mismatches and bounded cancellation/limit handling; keep the promotion gate
   evidence-only.
+- [x] Cross-check every detached gate-ready face cycle against active source
+  lineage, endpoint Z, face metadata, and reconciled global-node payloads;
+  retain missing or corrupt payloads as bounded evidence without mutating
+  topology or output.
 - [ ] Build global `next` links and deterministic global face IDs.
 - [ ] Identify exactly one global unbounded face.
 - [ ] Validate twin, cycle, source, Euler, and face-walk invariants.

--- a/crates/geo-polygonize-core/src/graph/partition_border.rs
+++ b/crates/geo-polygonize-core/src/graph/partition_border.rs
@@ -838,6 +838,27 @@ pub(crate) struct PartitionBorderGlobalCycleFacePromotionGateStats {
     pub(crate) gate_ready: bool,
 }
 
+/// Counts detached face-cycle payload lineage after the promotion gate. Each
+/// edge must still agree with its source observation and both endpoint nodes;
+/// this remains evidence only and never promotes stitched output.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct PartitionBorderGlobalFacePayloadLineageStats {
+    pub(crate) edge_count: usize,
+    pub(crate) cycle_count: usize,
+    pub(crate) plan_count: usize,
+    pub(crate) checked_edge_count: usize,
+    pub(crate) checked_cycle_count: usize,
+    pub(crate) missing_face_id_count: usize,
+    pub(crate) missing_plan_count: usize,
+    pub(crate) missing_observation_count: usize,
+    pub(crate) source_incomplete_edge_count: usize,
+    pub(crate) source_lineage_mismatch_count: usize,
+    pub(crate) z_lineage_mismatch_count: usize,
+    pub(crate) face_lineage_mismatch_count: usize,
+    pub(crate) node_lineage_mismatch_count: usize,
+    pub(crate) lineage_ready: bool,
+}
+
 /// Counts from validating a detached global directed-edge topology candidate.
 /// Readiness requires complete application evidence, one predecessor and one
 /// successor per edge, endpoint continuity, and closed cycles.
@@ -2289,6 +2310,243 @@ impl PartitionBorderGraph {
             unbounded_marker_mismatch_count,
             gate_ready,
         })
+    }
+
+    /// Cross-checks every gate-ready detached face edge against its retained
+    /// observation, source/Z/face payload, and reconciled endpoint nodes.
+    /// Cycle plans are checked as well so no face can become ready with a
+    /// missing boundary observation. This never mutates graph or output state.
+    pub(crate) fn validate_global_face_payload_lineage(
+        &self,
+        execution_policy: &ExecutionPolicy,
+        promotion_gate: PartitionBorderGlobalCycleFacePromotionGateStats,
+    ) -> crate::Result<PartitionBorderGlobalFacePayloadLineageStats> {
+        execution_policy.check_cancelled("partition_border_global_face_payload_lineage")?;
+        let edge_count = self.global_face_edge_map.len();
+        execution_policy.check(
+            "partition_border_global_face_payload_lineage_edges",
+            execution_policy.max_graph_edges,
+            edge_count,
+        )?;
+        let Some(candidate) = self.global_topology_candidate.as_ref() else {
+            return Err(crate::PolygonizeError::InternalInvariantViolation {
+                reason: "global face payload lineage has no detached topology candidate"
+                    .to_string(),
+            });
+        };
+        if candidate.next_global_dir_edge_ids.len() != edge_count {
+            return Err(crate::PolygonizeError::InternalInvariantViolation {
+                reason: format!(
+                    "global face payload lineage successor length mismatch: candidate={}, edges={}",
+                    candidate.next_global_dir_edge_ids.len(),
+                    edge_count
+                ),
+            });
+        }
+        let cycle_count = candidate.cycle_start_global_dir_edge_ids.len();
+        execution_policy.check(
+            "partition_border_global_face_payload_lineage_cycles",
+            execution_policy.max_graph_nodes,
+            cycle_count,
+        )?;
+
+        let mut stats = PartitionBorderGlobalFacePayloadLineageStats {
+            edge_count,
+            cycle_count,
+            plan_count: self.global_face_id_plans.len(),
+            ..Default::default()
+        };
+        let mut edge_index_by_observation = BTreeMap::<PartitionBorderObservationId, usize>::new();
+        for (edge_index, edge) in self.global_face_edge_map.iter().enumerate() {
+            execution_policy.check_cancelled_every(
+                "partition_border_global_face_payload_lineage_edges",
+                edge_index,
+            )?;
+            let observation_id = PartitionBorderObservationId {
+                partition_id: edge.partition_id,
+                local_dir_edge_id: edge.local_dir_edge_id,
+                edge_key: edge.edge_key,
+            };
+            if edge_index_by_observation
+                .insert(observation_id, edge_index)
+                .is_some()
+            {
+                return Err(crate::PolygonizeError::InternalInvariantViolation {
+                    reason: format!(
+                        "global face payload lineage duplicates observation {:?}",
+                        observation_id
+                    ),
+                });
+            }
+            stats.checked_edge_count += 1;
+            if edge.source_line_ids.is_empty() {
+                stats.source_incomplete_edge_count += 1;
+            }
+            let local_lineage = self.local_face_graphs.iter().find_map(|graph| {
+                if graph.partition_id == edge.partition_id
+                    && graph.component_id == edge.component_id
+                {
+                    graph
+                        .directed_edges
+                        .iter()
+                        .find(|local_edge| local_edge.local_dir_edge_id == edge.local_dir_edge_id)
+                } else {
+                    None
+                }
+            });
+            if let Some(local_edge) = local_lineage {
+                if edge.source_line_ids != local_edge.source_line_ids {
+                    stats.source_lineage_mismatch_count += 1;
+                }
+                if edge.from_z_bits != local_edge.from_z_bits
+                    || edge.to_z_bits != local_edge.to_z_bits
+                {
+                    stats.z_lineage_mismatch_count += 1;
+                }
+                if edge.from != local_edge.from
+                    || edge.to != local_edge.to
+                    || edge.edge_key != local_edge.edge_key
+                    || edge.face_ref != local_edge.face_ref
+                    || edge.local_face_is_unbounded != local_edge.local_face_is_unbounded
+                {
+                    stats.face_lineage_mismatch_count += 1;
+                }
+            } else if let Some(observation) = self.observations.get(&observation_id) {
+                if edge.source_line_ids != observation.source_line_ids {
+                    stats.source_lineage_mismatch_count += 1;
+                }
+                if edge.from_z_bits != observation.from_z_bits
+                    || edge.to_z_bits != observation.to_z_bits
+                {
+                    stats.z_lineage_mismatch_count += 1;
+                }
+                if edge.from != observation.from
+                    || edge.to != observation.to
+                    || edge.edge_key != observation.edge_key
+                    || edge.face_ref != observation.face_ref
+                    || edge.local_face_is_unbounded != observation.local_face_is_unbounded
+                {
+                    stats.face_lineage_mismatch_count += 1;
+                }
+            } else {
+                stats.missing_observation_count += 1;
+            }
+
+            for (node_id, key, z_bits) in [
+                (edge.from_global_node_id, edge.from, edge.from_z_bits),
+                (edge.to_global_node_id, edge.to, edge.to_z_bits),
+            ] {
+                let Some(node_id) = node_id else {
+                    stats.node_lineage_mismatch_count += 1;
+                    continue;
+                };
+                let Some(node) = self.global_face_nodes.get(node_id) else {
+                    stats.node_lineage_mismatch_count += 1;
+                    continue;
+                };
+                if node.global_node_id != node_id
+                    || node.key != key
+                    || !edge
+                        .source_line_ids
+                        .iter()
+                        .all(|source_line_id| node.source_line_ids.contains(source_line_id))
+                    || !node.z_bits.contains(&z_bits)
+                    || edge
+                        .face_ref
+                        .is_some_and(|face_ref| !node.face_refs.contains(&face_ref))
+                {
+                    stats.node_lineage_mismatch_count += 1;
+                }
+            }
+        }
+
+        let mut plan_by_face_id = BTreeMap::<usize, usize>::new();
+        for (plan_index, plan) in self.global_face_id_plans.iter().enumerate() {
+            if let Some(face_id) = plan.candidate_global_face_id {
+                if plan_by_face_id.insert(face_id, plan_index).is_some() {
+                    stats.face_lineage_mismatch_count += 1;
+                }
+            }
+        }
+        for (cycle_index, &start) in candidate.cycle_start_global_dir_edge_ids.iter().enumerate() {
+            execution_policy.check_cancelled_every(
+                "partition_border_global_face_payload_lineage_cycles",
+                cycle_index,
+            )?;
+            if start >= edge_count {
+                stats.face_lineage_mismatch_count += 1;
+                continue;
+            }
+            let Some(face_id) = self
+                .global_face_id_by_cycle_start
+                .get(cycle_index)
+                .copied()
+                .flatten()
+            else {
+                stats.missing_face_id_count += 1;
+                continue;
+            };
+            let Some(&plan_index) = plan_by_face_id.get(&face_id) else {
+                stats.missing_plan_count += 1;
+                continue;
+            };
+            let plan = &self.global_face_id_plans[plan_index];
+            let mut plan_edges = BTreeSet::new();
+            for observation_id in &plan.boundary_observation_ids {
+                let Some(&edge_index) = edge_index_by_observation.get(observation_id) else {
+                    stats.missing_observation_count += 1;
+                    continue;
+                };
+                plan_edges.insert(edge_index);
+            }
+            let mut cycle_edges = BTreeSet::new();
+            let mut current = start;
+            let mut closed = true;
+            loop {
+                execution_policy.check_cancelled_every(
+                    "partition_border_global_face_payload_lineage_cycle_edges",
+                    cycle_edges.len(),
+                )?;
+                if !cycle_edges.insert(current) {
+                    if current != start {
+                        closed = false;
+                    }
+                    break;
+                }
+                let Some(successor) = candidate
+                    .next_global_dir_edge_ids
+                    .get(current)
+                    .copied()
+                    .flatten()
+                else {
+                    closed = false;
+                    break;
+                };
+                if successor >= edge_count {
+                    closed = false;
+                    break;
+                }
+                current = successor;
+            }
+            if !closed || plan_edges != cycle_edges {
+                stats.face_lineage_mismatch_count += 1;
+            } else {
+                stats.checked_cycle_count += 1;
+            }
+        }
+
+        stats.lineage_ready = promotion_gate.gate_ready
+            && stats.checked_edge_count == edge_count
+            && stats.checked_cycle_count == cycle_count
+            && stats.missing_face_id_count == 0
+            && stats.missing_plan_count == 0
+            && stats.missing_observation_count == 0
+            && stats.source_incomplete_edge_count == 0
+            && stats.source_lineage_mismatch_count == 0
+            && stats.z_lineage_mismatch_count == 0
+            && stats.face_lineage_mismatch_count == 0
+            && stats.node_lineage_mismatch_count == 0;
+        Ok(stats)
     }
 
     #[cfg(test)]
@@ -12770,6 +13028,154 @@ mod tests {
             error,
             crate::PolygonizeError::Cancelled { ref stage }
                 if stage == "partition_border_global_cycle_face_promotion_gate"
+        ));
+    }
+
+    fn prepared_global_face_payload_lineage_graph() -> PartitionBorderGraph {
+        let mut graph = exact_global_topology_candidate_graph();
+        graph
+            .reconcile_global_topology_candidate(&ExecutionPolicy::default())
+            .unwrap();
+        let candidate = graph.global_topology_candidate.clone().unwrap();
+        graph.global_face_id_by_cycle_start = (0..candidate.cycle_start_global_dir_edge_ids.len())
+            .map(Some)
+            .collect();
+        graph.global_face_id_plans = candidate
+            .cycle_start_global_dir_edge_ids
+            .iter()
+            .enumerate()
+            .map(|(face_id, &start)| {
+                let mut boundary_observation_ids = Vec::new();
+                let mut face_refs = BTreeSet::new();
+                let mut local_unbounded_face_count = 0;
+                let mut current = start;
+                loop {
+                    let edge = &graph.global_face_edge_map[current];
+                    boundary_observation_ids.push(PartitionBorderObservationId {
+                        partition_id: edge.partition_id,
+                        local_dir_edge_id: edge.local_dir_edge_id,
+                        edge_key: edge.edge_key,
+                    });
+                    if let Some(face_ref) = edge.face_ref {
+                        face_refs.insert(face_ref);
+                    }
+                    local_unbounded_face_count += usize::from(edge.local_face_is_unbounded);
+                    current = candidate.next_global_dir_edge_ids[current].unwrap();
+                    if current == start {
+                        break;
+                    }
+                }
+                PartitionBorderGlobalFaceIdPlan {
+                    candidate_global_face_id: Some(face_id),
+                    component_index: 0,
+                    boundary_observation_ids,
+                    face_refs: face_refs.into_iter().collect(),
+                    local_unbounded_face_count,
+                    closed: true,
+                }
+            })
+            .collect();
+        graph
+    }
+
+    #[test]
+    fn global_face_payload_lineage_preserves_source_z_face_and_node_payloads() {
+        let graph = prepared_global_face_payload_lineage_graph();
+        let before = graph.clone();
+        let stats = graph
+            .validate_global_face_payload_lineage(
+                &ExecutionPolicy::default(),
+                PartitionBorderGlobalCycleFacePromotionGateStats {
+                    edge_count: 4,
+                    cycle_count: 2,
+                    plan_count: 2,
+                    gate_ready: true,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            stats,
+            PartitionBorderGlobalFacePayloadLineageStats {
+                edge_count: 4,
+                cycle_count: 2,
+                plan_count: 2,
+                checked_edge_count: 4,
+                checked_cycle_count: 2,
+                lineage_ready: true,
+                ..Default::default()
+            }
+        );
+        assert_eq!(graph, before);
+    }
+
+    #[test]
+    fn global_face_payload_lineage_rejects_provenance_z_and_node_drift() {
+        let mut graph = prepared_global_face_payload_lineage_graph();
+        graph.global_face_edge_map[0].source_line_ids.push(99);
+        graph.global_face_edge_map[0].from_z_bits = 77;
+        graph.global_face_nodes[0].observation_ids.clear();
+        let stats = graph
+            .validate_global_face_payload_lineage(
+                &ExecutionPolicy::default(),
+                PartitionBorderGlobalCycleFacePromotionGateStats {
+                    edge_count: 4,
+                    cycle_count: 2,
+                    plan_count: 2,
+                    gate_ready: true,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert!(!stats.lineage_ready);
+        assert_eq!(stats.source_lineage_mismatch_count, 1);
+        assert_eq!(stats.z_lineage_mismatch_count, 1);
+        assert!(stats.node_lineage_mismatch_count > 0);
+    }
+
+    #[test]
+    fn global_face_payload_lineage_is_bounded_and_cancellable() {
+        let graph = prepared_global_face_payload_lineage_graph();
+        let gate = PartitionBorderGlobalCycleFacePromotionGateStats {
+            edge_count: 4,
+            cycle_count: 2,
+            plan_count: 2,
+            gate_ready: true,
+            ..Default::default()
+        };
+        let error = graph
+            .validate_global_face_payload_lineage(
+                &ExecutionPolicy {
+                    max_graph_edges: Some(0),
+                    ..Default::default()
+                },
+                gate,
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::ResourceLimitExceeded {
+                ref stage,
+                limit: 0,
+                observed: 4,
+            } if stage == "partition_border_global_face_payload_lineage_edges"
+        ));
+
+        let token = CancellationToken::new();
+        token.cancel();
+        let error = graph
+            .validate_global_face_payload_lineage(
+                &ExecutionPolicy {
+                    cancellation_token: Some(token),
+                    ..Default::default()
+                },
+                gate,
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::Cancelled { ref stage }
+                if stage == "partition_border_global_face_payload_lineage"
         ));
     }
 

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -541,6 +541,21 @@ pub struct StitchingReport {
     pub partition_border_global_cycle_face_promotion_gate_face_count_mismatch_count: usize,
     pub partition_border_global_cycle_face_promotion_gate_unbounded_marker_mismatch_count: usize,
     pub partition_border_global_cycle_face_promotion_gate_ready: bool,
+    /// Detached face-cycle source, Z, observation, and global-node lineage.
+    pub partition_border_global_face_payload_lineage_edge_count: usize,
+    pub partition_border_global_face_payload_lineage_cycle_count: usize,
+    pub partition_border_global_face_payload_lineage_plan_count: usize,
+    pub partition_border_global_face_payload_lineage_checked_edge_count: usize,
+    pub partition_border_global_face_payload_lineage_checked_cycle_count: usize,
+    pub partition_border_global_face_payload_lineage_missing_face_id_count: usize,
+    pub partition_border_global_face_payload_lineage_missing_plan_count: usize,
+    pub partition_border_global_face_payload_lineage_missing_observation_count: usize,
+    pub partition_border_global_face_payload_lineage_source_incomplete_edge_count: usize,
+    pub partition_border_global_face_payload_lineage_source_mismatch_count: usize,
+    pub partition_border_global_face_payload_lineage_z_mismatch_count: usize,
+    pub partition_border_global_face_payload_lineage_face_mismatch_count: usize,
+    pub partition_border_global_face_payload_lineage_node_mismatch_count: usize,
+    pub partition_border_global_face_payload_lineage_ready: bool,
     /// Unbounded-face candidates whose local cycles are closed.
     pub partition_border_global_unbounded_face_proof_closed_count: usize,
     /// Unbounded-face twins absent from the retained twin-position map.
@@ -2847,6 +2862,11 @@ impl<'a> TiledPolygonizer<'a> {
                 partition_border_global_component_coverage,
                 partition_border_global_unbounded_face_application,
             )?;
+        let partition_border_global_face_payload_lineage = partition_border_graph
+            .validate_global_face_payload_lineage(
+                &self.execution_policy,
+                partition_border_global_cycle_face_promotion_gate,
+            )?;
         if let Some(trace) = trace.as_deref_mut() {
             trace.record_partition_border_reconciliation(partition_border_reconciliation);
             trace.record_partition_border_twin_application(partition_border_twin_application);
@@ -2945,6 +2965,9 @@ impl<'a> TiledPolygonizer<'a> {
             );
             trace.record_partition_border_global_cycle_face_promotion_gate(
                 partition_border_global_cycle_face_promotion_gate,
+            );
+            trace.record_partition_border_global_face_payload_lineage(
+                partition_border_global_face_payload_lineage,
             );
         }
         let unresolved = tile_reports.iter().any(Self::report_is_unresolved);
@@ -3559,6 +3582,34 @@ impl<'a> TiledPolygonizer<'a> {
                         .unbounded_marker_mismatch_count,
                 partition_border_global_cycle_face_promotion_gate_ready:
                     partition_border_global_cycle_face_promotion_gate.gate_ready,
+                partition_border_global_face_payload_lineage_edge_count:
+                    partition_border_global_face_payload_lineage.edge_count,
+                partition_border_global_face_payload_lineage_cycle_count:
+                    partition_border_global_face_payload_lineage.cycle_count,
+                partition_border_global_face_payload_lineage_plan_count:
+                    partition_border_global_face_payload_lineage.plan_count,
+                partition_border_global_face_payload_lineage_checked_edge_count:
+                    partition_border_global_face_payload_lineage.checked_edge_count,
+                partition_border_global_face_payload_lineage_checked_cycle_count:
+                    partition_border_global_face_payload_lineage.checked_cycle_count,
+                partition_border_global_face_payload_lineage_missing_face_id_count:
+                    partition_border_global_face_payload_lineage.missing_face_id_count,
+                partition_border_global_face_payload_lineage_missing_plan_count:
+                    partition_border_global_face_payload_lineage.missing_plan_count,
+                partition_border_global_face_payload_lineage_missing_observation_count:
+                    partition_border_global_face_payload_lineage.missing_observation_count,
+                partition_border_global_face_payload_lineage_source_incomplete_edge_count:
+                    partition_border_global_face_payload_lineage.source_incomplete_edge_count,
+                partition_border_global_face_payload_lineage_source_mismatch_count:
+                    partition_border_global_face_payload_lineage.source_lineage_mismatch_count,
+                partition_border_global_face_payload_lineage_z_mismatch_count:
+                    partition_border_global_face_payload_lineage.z_lineage_mismatch_count,
+                partition_border_global_face_payload_lineage_face_mismatch_count:
+                    partition_border_global_face_payload_lineage.face_lineage_mismatch_count,
+                partition_border_global_face_payload_lineage_node_mismatch_count:
+                    partition_border_global_face_payload_lineage.node_lineage_mismatch_count,
+                partition_border_global_face_payload_lineage_ready:
+                    partition_border_global_face_payload_lineage.lineage_ready,
                 partition_border_global_unbounded_face_proof_closed_count:
                     partition_border_global_unbounded_face_proof.closed_unbounded_face_count,
                 partition_border_global_unbounded_face_proof_unmapped_twin_count:

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -12,10 +12,10 @@ use crate::graph::partition_border::{
     PartitionBorderGlobalFaceIdentityPlanStats, PartitionBorderGlobalFaceMutationGateStats,
     PartitionBorderGlobalFaceNextApplicationStats, PartitionBorderGlobalFaceNextCandidateStats,
     PartitionBorderGlobalFaceNextMutationPlanStats,
-    PartitionBorderGlobalFaceNodeReconciliationStats, PartitionBorderGlobalFacePlanStats,
-    PartitionBorderGlobalFacePlanValidationStats, PartitionBorderGlobalFaceTransitionPlanStats,
-    PartitionBorderGlobalFaceTwinTransitionStats, PartitionBorderGlobalFaceWalkInvariantStats,
-    PartitionBorderGlobalNextLineageIntegrationStats,
+    PartitionBorderGlobalFaceNodeReconciliationStats, PartitionBorderGlobalFacePayloadLineageStats,
+    PartitionBorderGlobalFacePlanStats, PartitionBorderGlobalFacePlanValidationStats,
+    PartitionBorderGlobalFaceTransitionPlanStats, PartitionBorderGlobalFaceTwinTransitionStats,
+    PartitionBorderGlobalFaceWalkInvariantStats, PartitionBorderGlobalNextLineageIntegrationStats,
     PartitionBorderGlobalTopologyApplicationGateStats, PartitionBorderGlobalTopologyCandidateStats,
     PartitionBorderGlobalTopologyMutationGateStats, PartitionBorderGlobalTopologyMutationStats,
     PartitionBorderGlobalUnboundedFaceApplicationStats,
@@ -1325,6 +1325,32 @@ impl TraceRecorderV1 {
                 "face_count_mismatch_count": stats.face_count_mismatch_count,
                 "unbounded_marker_mismatch_count": stats.unbounded_marker_mismatch_count,
                 "gate_ready": stats.gate_ready,
+            }),
+        )
+    }
+
+    pub(crate) fn record_partition_border_global_face_payload_lineage(
+        &mut self,
+        stats: PartitionBorderGlobalFacePayloadLineageStats,
+    ) -> bool {
+        self.record(
+            TraceStageV1::Graph,
+            "partition_border_global_face_payload_lineage",
+            serde_json::json!({
+                "edge_count": stats.edge_count,
+                "cycle_count": stats.cycle_count,
+                "plan_count": stats.plan_count,
+                "checked_edge_count": stats.checked_edge_count,
+                "checked_cycle_count": stats.checked_cycle_count,
+                "missing_face_id_count": stats.missing_face_id_count,
+                "missing_plan_count": stats.missing_plan_count,
+                "missing_observation_count": stats.missing_observation_count,
+                "source_incomplete_edge_count": stats.source_incomplete_edge_count,
+                "source_lineage_mismatch_count": stats.source_lineage_mismatch_count,
+                "z_lineage_mismatch_count": stats.z_lineage_mismatch_count,
+                "face_lineage_mismatch_count": stats.face_lineage_mismatch_count,
+                "node_lineage_mismatch_count": stats.node_lineage_mismatch_count,
+                "lineage_ready": stats.lineage_ready,
             }),
         )
     }


### PR DESCRIPTION
## Stack
Parent: `origin/main` at merged PR #1361 (`39e458f96b16799...`).
Children: none.
Standalone slice; no `gh stack link` relationship is required.

## Delivered
- Added detached face-cycle payload lineage evidence after the promotion gate.
- Cross-checks every active global edge against local face-graph or retained observation geometry, source provenance, endpoint Z, and face metadata.
- Cross-checks reconciled endpoint global-node keys, source sets, Z candidates, and qualified face references.
- Verifies every candidate face plan covers exactly the detached successor cycle that owns its face ID.
- Added bounded cancellation/limit handling, non-mutation coverage, and corruption regressions.
- Wired the evidence into `StitchingReport` and the bounded graph trace.
- Updated P5.3 without closing global output extraction or untiled equivalence.

## Contract impact
This is evidence-only and fail-closed. It does not mutate local half-edge links, detached topology, face IDs, unbounded identity, stitched output, provenance, Z payloads, or fallback behavior. Existing canonical output and stable facade contracts remain unchanged.

## Validation
- `cargo test -p geo-polygonize-core --lib global_face_payload_lineage` — 3 passed.
- `cargo test -p geo-polygonize-core --lib` — 383 passed.
- `cargo test --workspace --no-default-features` — passed.
- `cargo clippy --workspace --all-targets --no-default-features -- -D warnings` — passed.
- `cargo fmt --all -- --check` — passed.
- `cargo doc -p geo-polygonize-core --no-deps` — passed.
- `git diff --check` — passed.
- Restored generated TypeScript bindings produced by test/doc runs.

## Agent handoff
Next branch: `agent/p5-global-face-cycle-output-evidence`.
Next slice: add detached cycle-level shell/hole orientation and containment evidence using the already validated face IDs and payload lineage. Keep actual stitched extraction, dangles/cuts/invalid-ring output, and full untiled differential equivalence open until those contracts are independently proven.
Remaining risk: this PR does not promote stitched output or claim arbitrary tiled/untiled equivalence; it only proves retained payload lineage for gate-ready detached face cycles.
