### PR TITLE
feat(core): validate detached cycle geometry

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -567,6 +567,10 @@ Blocked by #1288.
   lineage, endpoint Z, face metadata, and reconciled global-node payloads;
   retain missing or corrupt payloads as bounded evidence without mutating
   topology or output.
+- [x] Validate detached cycle geometry from the committed successor and node
+  payloads, retaining winding, nested-containment, shell/hole orientation, and
+  exactly-one-unbounded negative-orientation evidence without classifying or
+  extracting stitched output.
 - [ ] Build global `next` links and deterministic global face IDs.
 - [ ] Identify exactly one global unbounded face.
 - [ ] Validate twin, cycle, source, Euler, and face-walk invariants.

--- a/crates/geo-polygonize-core/src/graph/partition_border.rs
+++ b/crates/geo-polygonize-core/src/graph/partition_border.rs
@@ -1,7 +1,8 @@
 use crate::options::{ExecutionPolicy, ZOptions, ZPolicy};
-use crate::types::{Coord3D, PartitionFaceRef};
+use crate::types::{Coord3D, PartitionFaceRef, Polygon3D};
 use crate::utils::canonical_coordinate_bits;
-use geo_types::Rect;
+use geo::{Contains, InteriorPoint};
+use geo_types::{LineString, Polygon, Rect};
 use std::collections::{BTreeMap, BTreeSet};
 
 use super::planar_graph::{DirEdgeId, FaceId};
@@ -857,6 +858,31 @@ pub(crate) struct PartitionBorderGlobalFacePayloadLineageStats {
     pub(crate) face_lineage_mismatch_count: usize,
     pub(crate) node_lineage_mismatch_count: usize,
     pub(crate) lineage_ready: bool,
+}
+
+/// Counts detached cycle geometry evidence after payload lineage. This is a
+/// diagnostic boundary only: it does not classify or extract stitched output.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct PartitionBorderGlobalFaceCycleGeometryStats {
+    pub(crate) edge_count: usize,
+    pub(crate) cycle_count: usize,
+    pub(crate) checked_cycle_count: usize,
+    pub(crate) closed_cycle_count: usize,
+    pub(crate) missing_node_count: usize,
+    pub(crate) node_discontinuity_count: usize,
+    pub(crate) repeated_edge_count: usize,
+    pub(crate) missing_face_id_count: usize,
+    pub(crate) missing_interior_point_count: usize,
+    pub(crate) degenerate_cycle_count: usize,
+    pub(crate) positive_cycle_count: usize,
+    pub(crate) negative_cycle_count: usize,
+    pub(crate) unbounded_cycle_count: usize,
+    pub(crate) unbounded_orientation_mismatch_count: usize,
+    pub(crate) containment_pair_count: usize,
+    pub(crate) contained_cycle_count: usize,
+    pub(crate) nested_opposite_orientation_pair_count: usize,
+    pub(crate) nested_same_orientation_pair_count: usize,
+    pub(crate) geometry_ready: bool,
 }
 
 /// Counts from validating a detached global directed-edge topology candidate.
@@ -2546,6 +2572,204 @@ impl PartitionBorderGraph {
             && stats.z_lineage_mismatch_count == 0
             && stats.face_lineage_mismatch_count == 0
             && stats.node_lineage_mismatch_count == 0;
+        Ok(stats)
+    }
+
+    /// Validates detached cycle geometry after payload lineage. Positive and
+    /// negative winding, nesting, and the unbounded marker are retained as
+    /// evidence; no shell, hole, face, or output classification is applied.
+    pub(crate) fn validate_global_face_cycle_geometry(
+        &self,
+        execution_policy: &ExecutionPolicy,
+        payload_lineage: PartitionBorderGlobalFacePayloadLineageStats,
+    ) -> crate::Result<PartitionBorderGlobalFaceCycleGeometryStats> {
+        execution_policy.check_cancelled("partition_border_global_face_cycle_geometry")?;
+        let edge_count = self.global_face_edge_map.len();
+        execution_policy.check(
+            "partition_border_global_face_cycle_geometry_edges",
+            execution_policy.max_graph_edges,
+            edge_count,
+        )?;
+        let Some(candidate) = self.global_topology_candidate.as_ref() else {
+            return Err(crate::PolygonizeError::InternalInvariantViolation {
+                reason: "global face cycle geometry has no detached topology candidate".to_string(),
+            });
+        };
+        if candidate.next_global_dir_edge_ids.len() != edge_count {
+            return Err(crate::PolygonizeError::InternalInvariantViolation {
+                reason: format!(
+                    "global face cycle geometry successor length mismatch: candidate={}, edges={}",
+                    candidate.next_global_dir_edge_ids.len(),
+                    edge_count
+                ),
+            });
+        }
+        let cycle_count = candidate.cycle_start_global_dir_edge_ids.len();
+        execution_policy.check(
+            "partition_border_global_face_cycle_geometry_cycles",
+            execution_policy.max_graph_nodes,
+            cycle_count,
+        )?;
+
+        let mut stats = PartitionBorderGlobalFaceCycleGeometryStats {
+            edge_count,
+            cycle_count,
+            ..Default::default()
+        };
+        let unbounded_start = self
+            .global_unbounded_face_id_by_cycle_start
+            .map(|(_, start)| start);
+        let mut valid_cycles = Vec::<(Polygon<f64>, f64)>::new();
+
+        for (cycle_index, &start) in candidate.cycle_start_global_dir_edge_ids.iter().enumerate() {
+            execution_policy.check_cancelled_every(
+                "partition_border_global_face_cycle_geometry_cycles",
+                cycle_index,
+            )?;
+            if start >= edge_count {
+                stats.repeated_edge_count += 1;
+                continue;
+            }
+            if self
+                .global_face_id_by_cycle_start
+                .get(cycle_index)
+                .copied()
+                .flatten()
+                .is_none()
+            {
+                stats.missing_face_id_count += 1;
+            }
+
+            let mut coords = Vec::new();
+            let mut visited = BTreeSet::new();
+            let mut current = start;
+            let mut closed = true;
+            loop {
+                execution_policy.check_cancelled_every(
+                    "partition_border_global_face_cycle_geometry_cycle_edges",
+                    visited.len(),
+                )?;
+                if !visited.insert(current) {
+                    if current != start {
+                        stats.repeated_edge_count += 1;
+                        closed = false;
+                    }
+                    break;
+                }
+                let Some(edge) = self.global_face_edge_map.get(current) else {
+                    closed = false;
+                    break;
+                };
+                for (node_id, key) in [
+                    (edge.from_global_node_id, edge.from),
+                    (edge.to_global_node_id, edge.to),
+                ] {
+                    let valid_node = node_id
+                        .and_then(|node_id| self.global_face_nodes.get(node_id))
+                        .is_some_and(|node| node.key == key);
+                    if !valid_node {
+                        stats.missing_node_count += 1;
+                    }
+                }
+                coords.push(Coord3D::new(
+                    f64::from_bits(edge.from.xy_bits()[0]),
+                    f64::from_bits(edge.from.xy_bits()[1]),
+                    f64::from_bits(edge.from_z_bits),
+                ));
+                let Some(successor) = candidate
+                    .next_global_dir_edge_ids
+                    .get(current)
+                    .copied()
+                    .flatten()
+                else {
+                    closed = false;
+                    break;
+                };
+                if successor >= edge_count {
+                    closed = false;
+                    break;
+                }
+                if self.global_face_edge_map[successor].from != edge.to {
+                    stats.node_discontinuity_count += 1;
+                }
+                current = successor;
+            }
+            if !closed || coords.len() < 3 {
+                continue;
+            }
+            stats.closed_cycle_count += 1;
+            stats.checked_cycle_count += 1;
+            coords.push(coords[0]);
+            let area = Polygon3D::ring_signed_area_2d(&coords);
+            if !area.is_finite() || area == 0.0 {
+                stats.degenerate_cycle_count += 1;
+                continue;
+            }
+            if area > 0.0 {
+                stats.positive_cycle_count += 1;
+            } else {
+                stats.negative_cycle_count += 1;
+            }
+            let unbounded = unbounded_start == Some(start);
+            if unbounded {
+                stats.unbounded_cycle_count += 1;
+                if area >= 0.0 {
+                    stats.unbounded_orientation_mismatch_count += 1;
+                }
+            }
+            let polygon = Polygon::new(
+                LineString(coords.iter().copied().map(Coord3D::to_coord_2d).collect()),
+                Vec::new(),
+            );
+            if polygon.interior_point().is_none() {
+                stats.missing_interior_point_count += 1;
+                continue;
+            }
+            valid_cycles.push((polygon, area));
+        }
+
+        let containment_work = valid_cycles
+            .len()
+            .checked_mul(valid_cycles.len())
+            .ok_or_else(|| crate::PolygonizeError::InternalInvariantViolation {
+                reason: "global face cycle containment work count overflow".to_string(),
+            })?;
+        execution_policy.check(
+            "partition_border_global_face_cycle_geometry_containment",
+            execution_policy.max_candidate_pairs,
+            containment_work,
+        )?;
+        let mut contained_cycles = BTreeSet::new();
+        for (outer_index, (outer, outer_area)) in valid_cycles.iter().enumerate() {
+            for (inner_index, (inner, inner_area)) in valid_cycles.iter().enumerate() {
+                execution_policy.check_cancelled_every(
+                    "partition_border_global_face_cycle_geometry_containment",
+                    outer_index * valid_cycles.len() + inner_index,
+                )?;
+                if outer_index == inner_index || !outer.contains(inner.exterior()) {
+                    continue;
+                }
+                stats.containment_pair_count += 1;
+                contained_cycles.insert(inner_index);
+                if outer_area.is_sign_positive() != inner_area.is_sign_positive() {
+                    stats.nested_opposite_orientation_pair_count += 1;
+                } else {
+                    stats.nested_same_orientation_pair_count += 1;
+                }
+            }
+        }
+        stats.contained_cycle_count = contained_cycles.len();
+        stats.geometry_ready = payload_lineage.lineage_ready
+            && stats.checked_cycle_count == cycle_count
+            && stats.closed_cycle_count == cycle_count
+            && stats.missing_node_count == 0
+            && stats.node_discontinuity_count == 0
+            && stats.repeated_edge_count == 0
+            && stats.missing_face_id_count == 0
+            && stats.missing_interior_point_count == 0
+            && stats.degenerate_cycle_count == 0
+            && stats.unbounded_cycle_count == 1
+            && stats.unbounded_orientation_mismatch_count == 0;
         Ok(stats)
     }
 
@@ -13076,6 +13300,163 @@ mod tests {
             })
             .collect();
         graph
+    }
+
+    fn nested_global_face_cycle_geometry_graph() -> PartitionBorderGraph {
+        let rings = [
+            [(0.0, 0.0), (10.0, 0.0), (10.0, 10.0), (0.0, 10.0)],
+            [(2.0, 2.0), (2.0, 8.0), (8.0, 8.0), (8.0, 2.0)],
+        ];
+        let mut graph = PartitionBorderGraph::default();
+        let mut node_ids = BTreeMap::new();
+        for (x, y) in rings.iter().flatten().copied() {
+            let key = PartitionBorderNodeKey::from_coord(coord(x, y, 0.0));
+            let node_id = node_ids.len();
+            node_ids.entry(key).or_insert_with(|| {
+                graph.global_face_nodes.push(PartitionBorderGlobalFaceNode {
+                    global_node_id: node_id,
+                    key,
+                    observation_ids: Vec::new(),
+                    source_line_ids: vec![1],
+                    representative_line_ids: vec![1],
+                    face_refs: Vec::new(),
+                    z_bits: vec![0.0f64.to_bits()],
+                    selected_z_bits: 0.0f64.to_bits(),
+                    selected_z_policy: ZPolicy::default(),
+                    conflict_tolerance_bits: 0,
+                    z_conflict: false,
+                    incident_global_dir_edge_ids: Vec::new(),
+                });
+                node_id
+            });
+        }
+        let mut next = vec![None; 8];
+        for (ring_index, ring) in rings.iter().enumerate() {
+            let offset = ring_index * 4;
+            for edge_index in 0..4 {
+                let from = ring[edge_index];
+                let to = ring[(edge_index + 1) % 4];
+                let from_key = PartitionBorderNodeKey::from_coord(coord(from.0, from.1, 0.0));
+                let to_key = PartitionBorderNodeKey::from_coord(coord(to.0, to.1, 0.0));
+                let global_index = offset + edge_index;
+                next[global_index] = Some(offset + (edge_index + 1) % 4);
+                graph
+                    .global_face_edge_map
+                    .push(PartitionBorderGlobalFaceEdge {
+                        global_dir_edge_id: global_index,
+                        partition_id: 0,
+                        component_id: 0,
+                        local_dir_edge_id: global_index,
+                        symmetric_global_dir_edge_id: global_index,
+                        local_face_successor_global_dir_edge_id: None,
+                        cross_border_twin_global_dir_edge_id: None,
+                        from_global_node_id: Some(node_ids[&from_key]),
+                        to_global_node_id: Some(node_ids[&to_key]),
+                        from: from_key,
+                        to: to_key,
+                        from_z_bits: 0.0f64.to_bits(),
+                        to_z_bits: 0.0f64.to_bits(),
+                        edge_key: PartitionBorderEdgeKey::new(from_key, to_key).unwrap(),
+                        face_ref: None,
+                        local_face_is_unbounded: ring_index == 1,
+                        source_line_ids: vec![1],
+                    });
+            }
+        }
+        graph.global_topology_candidate = Some(PartitionBorderGlobalTopologyCandidate {
+            next_global_dir_edge_ids: next,
+            cycle_start_global_dir_edge_ids: vec![0, 4],
+        });
+        graph.global_face_id_by_cycle_start = vec![Some(0), Some(1)];
+        graph.global_unbounded_face_id_by_cycle_start = Some((1, 4));
+        graph
+    }
+
+    #[test]
+    fn global_face_cycle_geometry_reports_nested_opposite_winding() {
+        let graph = nested_global_face_cycle_geometry_graph();
+        let before = graph.clone();
+        let stats = graph
+            .validate_global_face_cycle_geometry(
+                &ExecutionPolicy::default(),
+                PartitionBorderGlobalFacePayloadLineageStats {
+                    lineage_ready: true,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert_eq!(stats.edge_count, 8);
+        assert_eq!(stats.cycle_count, 2);
+        assert_eq!(stats.checked_cycle_count, 2);
+        assert_eq!(stats.positive_cycle_count, 1);
+        assert_eq!(stats.negative_cycle_count, 1);
+        assert_eq!(stats.unbounded_cycle_count, 1);
+        assert_eq!(stats.containment_pair_count, 1);
+        assert_eq!(stats.contained_cycle_count, 1);
+        assert_eq!(stats.nested_opposite_orientation_pair_count, 1);
+        assert_eq!(stats.nested_same_orientation_pair_count, 0);
+        assert!(stats.geometry_ready);
+        assert_eq!(graph, before);
+    }
+
+    #[test]
+    fn global_face_cycle_geometry_is_bounded_and_cancellable() {
+        let graph = nested_global_face_cycle_geometry_graph();
+        let error = graph
+            .validate_global_face_cycle_geometry(
+                &ExecutionPolicy {
+                    max_graph_edges: Some(0),
+                    ..Default::default()
+                },
+                PartitionBorderGlobalFacePayloadLineageStats::default(),
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::ResourceLimitExceeded {
+                ref stage,
+                limit: 0,
+                observed: 8,
+            } if stage == "partition_border_global_face_cycle_geometry_edges"
+        ));
+
+        let error = graph
+            .validate_global_face_cycle_geometry(
+                &ExecutionPolicy {
+                    max_candidate_pairs: Some(0),
+                    ..Default::default()
+                },
+                PartitionBorderGlobalFacePayloadLineageStats {
+                    lineage_ready: true,
+                    ..Default::default()
+                },
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::ResourceLimitExceeded {
+                ref stage,
+                limit: 0,
+                observed: 4,
+            } if stage == "partition_border_global_face_cycle_geometry_containment"
+        ));
+
+        let token = CancellationToken::new();
+        token.cancel();
+        let error = graph
+            .validate_global_face_cycle_geometry(
+                &ExecutionPolicy {
+                    cancellation_token: Some(token),
+                    ..Default::default()
+                },
+                PartitionBorderGlobalFacePayloadLineageStats::default(),
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::Cancelled { ref stage }
+                if stage == "partition_border_global_face_cycle_geometry"
+        ));
     }
 
     #[test]

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -556,6 +556,26 @@ pub struct StitchingReport {
     pub partition_border_global_face_payload_lineage_face_mismatch_count: usize,
     pub partition_border_global_face_payload_lineage_node_mismatch_count: usize,
     pub partition_border_global_face_payload_lineage_ready: bool,
+    /// Detached cycle winding and containment evidence; no output is promoted.
+    pub partition_border_global_face_cycle_geometry_edge_count: usize,
+    pub partition_border_global_face_cycle_geometry_cycle_count: usize,
+    pub partition_border_global_face_cycle_geometry_checked_cycle_count: usize,
+    pub partition_border_global_face_cycle_geometry_closed_cycle_count: usize,
+    pub partition_border_global_face_cycle_geometry_missing_node_count: usize,
+    pub partition_border_global_face_cycle_geometry_node_discontinuity_count: usize,
+    pub partition_border_global_face_cycle_geometry_repeated_edge_count: usize,
+    pub partition_border_global_face_cycle_geometry_missing_face_id_count: usize,
+    pub partition_border_global_face_cycle_geometry_missing_interior_point_count: usize,
+    pub partition_border_global_face_cycle_geometry_degenerate_cycle_count: usize,
+    pub partition_border_global_face_cycle_geometry_positive_cycle_count: usize,
+    pub partition_border_global_face_cycle_geometry_negative_cycle_count: usize,
+    pub partition_border_global_face_cycle_geometry_unbounded_cycle_count: usize,
+    pub partition_border_global_face_cycle_geometry_unbounded_orientation_mismatch_count: usize,
+    pub partition_border_global_face_cycle_geometry_containment_pair_count: usize,
+    pub partition_border_global_face_cycle_geometry_contained_cycle_count: usize,
+    pub partition_border_global_face_cycle_geometry_nested_opposite_orientation_pair_count: usize,
+    pub partition_border_global_face_cycle_geometry_nested_same_orientation_pair_count: usize,
+    pub partition_border_global_face_cycle_geometry_ready: bool,
     /// Unbounded-face candidates whose local cycles are closed.
     pub partition_border_global_unbounded_face_proof_closed_count: usize,
     /// Unbounded-face twins absent from the retained twin-position map.
@@ -2867,6 +2887,11 @@ impl<'a> TiledPolygonizer<'a> {
                 &self.execution_policy,
                 partition_border_global_cycle_face_promotion_gate,
             )?;
+        let partition_border_global_face_cycle_geometry = partition_border_graph
+            .validate_global_face_cycle_geometry(
+                &self.execution_policy,
+                partition_border_global_face_payload_lineage,
+            )?;
         if let Some(trace) = trace.as_deref_mut() {
             trace.record_partition_border_reconciliation(partition_border_reconciliation);
             trace.record_partition_border_twin_application(partition_border_twin_application);
@@ -2968,6 +2993,9 @@ impl<'a> TiledPolygonizer<'a> {
             );
             trace.record_partition_border_global_face_payload_lineage(
                 partition_border_global_face_payload_lineage,
+            );
+            trace.record_partition_border_global_face_cycle_geometry(
+                partition_border_global_face_cycle_geometry,
             );
         }
         let unresolved = tile_reports.iter().any(Self::report_is_unresolved);
@@ -3610,6 +3638,47 @@ impl<'a> TiledPolygonizer<'a> {
                     partition_border_global_face_payload_lineage.node_lineage_mismatch_count,
                 partition_border_global_face_payload_lineage_ready:
                     partition_border_global_face_payload_lineage.lineage_ready,
+                partition_border_global_face_cycle_geometry_edge_count:
+                    partition_border_global_face_cycle_geometry.edge_count,
+                partition_border_global_face_cycle_geometry_cycle_count:
+                    partition_border_global_face_cycle_geometry.cycle_count,
+                partition_border_global_face_cycle_geometry_checked_cycle_count:
+                    partition_border_global_face_cycle_geometry.checked_cycle_count,
+                partition_border_global_face_cycle_geometry_closed_cycle_count:
+                    partition_border_global_face_cycle_geometry.closed_cycle_count,
+                partition_border_global_face_cycle_geometry_missing_node_count:
+                    partition_border_global_face_cycle_geometry.missing_node_count,
+                partition_border_global_face_cycle_geometry_node_discontinuity_count:
+                    partition_border_global_face_cycle_geometry.node_discontinuity_count,
+                partition_border_global_face_cycle_geometry_repeated_edge_count:
+                    partition_border_global_face_cycle_geometry.repeated_edge_count,
+                partition_border_global_face_cycle_geometry_missing_face_id_count:
+                    partition_border_global_face_cycle_geometry.missing_face_id_count,
+                partition_border_global_face_cycle_geometry_missing_interior_point_count:
+                    partition_border_global_face_cycle_geometry.missing_interior_point_count,
+                partition_border_global_face_cycle_geometry_degenerate_cycle_count:
+                    partition_border_global_face_cycle_geometry.degenerate_cycle_count,
+                partition_border_global_face_cycle_geometry_positive_cycle_count:
+                    partition_border_global_face_cycle_geometry.positive_cycle_count,
+                partition_border_global_face_cycle_geometry_negative_cycle_count:
+                    partition_border_global_face_cycle_geometry.negative_cycle_count,
+                partition_border_global_face_cycle_geometry_unbounded_cycle_count:
+                    partition_border_global_face_cycle_geometry.unbounded_cycle_count,
+                partition_border_global_face_cycle_geometry_unbounded_orientation_mismatch_count:
+                    partition_border_global_face_cycle_geometry
+                        .unbounded_orientation_mismatch_count,
+                partition_border_global_face_cycle_geometry_containment_pair_count:
+                    partition_border_global_face_cycle_geometry.containment_pair_count,
+                partition_border_global_face_cycle_geometry_contained_cycle_count:
+                    partition_border_global_face_cycle_geometry.contained_cycle_count,
+                partition_border_global_face_cycle_geometry_nested_opposite_orientation_pair_count:
+                    partition_border_global_face_cycle_geometry
+                        .nested_opposite_orientation_pair_count,
+                partition_border_global_face_cycle_geometry_nested_same_orientation_pair_count:
+                    partition_border_global_face_cycle_geometry
+                        .nested_same_orientation_pair_count,
+                partition_border_global_face_cycle_geometry_ready:
+                    partition_border_global_face_cycle_geometry.geometry_ready,
                 partition_border_global_unbounded_face_proof_closed_count:
                     partition_border_global_unbounded_face_proof.closed_unbounded_face_count,
                 partition_border_global_unbounded_face_proof_unmapped_twin_count:

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -5,9 +5,10 @@ use crate::graph::partition_border::{
     PartitionBorderCanonicalNodeValidationStats, PartitionBorderGlobalComponentCoverageStats,
     PartitionBorderGlobalComponentPayloadStats, PartitionBorderGlobalComponentReconciliationStats,
     PartitionBorderGlobalCycleFaceLineageStats, PartitionBorderGlobalCycleFacePromotionGateStats,
-    PartitionBorderGlobalFaceEdgeMapStats, PartitionBorderGlobalFaceEulerWitnessStats,
-    PartitionBorderGlobalFaceIdApplicationStats, PartitionBorderGlobalFaceIdMutationStats,
-    PartitionBorderGlobalFaceIdPlanStats, PartitionBorderGlobalFaceIdentityInvariantStats,
+    PartitionBorderGlobalFaceCycleGeometryStats, PartitionBorderGlobalFaceEdgeMapStats,
+    PartitionBorderGlobalFaceEulerWitnessStats, PartitionBorderGlobalFaceIdApplicationStats,
+    PartitionBorderGlobalFaceIdMutationStats, PartitionBorderGlobalFaceIdPlanStats,
+    PartitionBorderGlobalFaceIdentityInvariantStats,
     PartitionBorderGlobalFaceIdentityMaterializationStats,
     PartitionBorderGlobalFaceIdentityPlanStats, PartitionBorderGlobalFaceMutationGateStats,
     PartitionBorderGlobalFaceNextApplicationStats, PartitionBorderGlobalFaceNextCandidateStats,
@@ -1351,6 +1352,40 @@ impl TraceRecorderV1 {
                 "face_lineage_mismatch_count": stats.face_lineage_mismatch_count,
                 "node_lineage_mismatch_count": stats.node_lineage_mismatch_count,
                 "lineage_ready": stats.lineage_ready,
+            }),
+        )
+    }
+
+    pub(crate) fn record_partition_border_global_face_cycle_geometry(
+        &mut self,
+        stats: PartitionBorderGlobalFaceCycleGeometryStats,
+    ) -> bool {
+        self.record(
+            TraceStageV1::Graph,
+            "partition_border_global_face_cycle_geometry",
+            serde_json::json!({
+                "edge_count": stats.edge_count,
+                "cycle_count": stats.cycle_count,
+                "checked_cycle_count": stats.checked_cycle_count,
+                "closed_cycle_count": stats.closed_cycle_count,
+                "missing_node_count": stats.missing_node_count,
+                "node_discontinuity_count": stats.node_discontinuity_count,
+                "repeated_edge_count": stats.repeated_edge_count,
+                "missing_face_id_count": stats.missing_face_id_count,
+                "missing_interior_point_count": stats.missing_interior_point_count,
+                "degenerate_cycle_count": stats.degenerate_cycle_count,
+                "positive_cycle_count": stats.positive_cycle_count,
+                "negative_cycle_count": stats.negative_cycle_count,
+                "unbounded_cycle_count": stats.unbounded_cycle_count,
+                "unbounded_orientation_mismatch_count":
+                    stats.unbounded_orientation_mismatch_count,
+                "containment_pair_count": stats.containment_pair_count,
+                "contained_cycle_count": stats.contained_cycle_count,
+                "nested_opposite_orientation_pair_count":
+                    stats.nested_opposite_orientation_pair_count,
+                "nested_same_orientation_pair_count":
+                    stats.nested_same_orientation_pair_count,
+                "geometry_ready": stats.geometry_ready,
             }),
         )
     }


### PR DESCRIPTION
## Stack

- Parent: merged PR #1362 (`08346fa4c7f61daeee5d1a0da531a51452a419bc`, `origin/main`)
- Children: none
- This is a standalone bottom-of-stack PR from current `main`; no open parent exists for `gh stack link`.

## Delivered

- Added detached global cycle geometry evidence after payload-lineage validation.
- Reconstructs committed successor cycles from canonical global node keys and checks closedness, node identity, endpoint continuity, face-ID presence, finite/non-degenerate signed area, and exactly one negatively wound unbounded cycle.
- Reuses existing `Polygon3D::ring_signed_area_2d` and `geo` containment/interior-point helpers to report nested containment plus opposite/same orientation relationships.
- Added explicit graph-edge, cycle-count, containment-work, and cancellation boundaries.
- Added non-mutating nested shell/hole-winding and bounded/cancellable regression tests.
- Added the corresponding trace and `StitchingReport` fields.
- Updated P5.3 precisely; global `next`/face-ID construction, stitched extraction, and untiled equivalence remain open.

## Contract impact

Evidence-only. No local `next` links, local face IDs, global production topology, tiled output, provenance, or Z payloads are changed. `geometry_ready` is diagnostic and is not an output-promotion gate.

## Validation

- `cargo test -p geo-polygonize-core --lib global_face_cycle_geometry` (2 passed)
- `cargo test -p geo-polygonize-core --lib` (385 passed)
- `cargo test --workspace --no-default-features` (passed; tiled-equivalence suite included)
- `cargo clippy --workspace --all-targets --no-default-features -- -D warnings` (passed)
- `cargo doc -p geo-polygonize-core --no-deps` (passed)
- `cargo fmt --all -- --check` (passed)
- `git diff --check` (passed)

## Agent handoff

- Exact checkout: `1ad3c3c3d457925fcfd46798d8b75d70c1422631`
- Next branch: `agent/p5-global-face-cycle-crossing-evidence`
- Next slice: use validated detached cycle geometry to add explicit crossing/overlap and boundary-touch evidence before any shell/hole extraction or production topology promotion.
- Remaining risks: containment is diagnostic and bounded, not a full arrangement nesting proof; detached output extraction, dangles/cuts/invalid rings, and full untiled equivalence remain unimplemented.
