### PR TITLE
feat(core): validate detached ring payloads

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -571,7 +571,9 @@ Blocked by #1288.
   payloads, retaining winding, nested-containment, shell/hole orientation, and
   exactly-one-unbounded negative-orientation evidence; retain bounded proper
   crossing, endpoint/boundary-touch, and expected-versus-unexpected collinear
-  overlap evidence without classifying or extracting stitched output.
+  overlap evidence without classifying or extracting stitched output; retain
+  stable canonical ring payload, non-adjacent self-intersection, and reciprocal
+  symmetric-edge coverage evidence as a separate pre-extraction gate.
 - [ ] Build global `next` links and deterministic global face IDs.
 - [ ] Identify exactly one global unbounded face.
 - [ ] Validate twin, cycle, source, Euler, and face-walk invariants.

--- a/crates/geo-polygonize-core/src/graph/partition_border.rs
+++ b/crates/geo-polygonize-core/src/graph/partition_border.rs
@@ -1,4 +1,5 @@
 use crate::options::{ExecutionPolicy, ZOptions, ZPolicy};
+use crate::polygonizer::canonicalize_ring;
 use crate::types::{Coord3D, PartitionFaceRef, Polygon3D};
 use crate::utils::canonical_coordinate_bits;
 use geo::algorithm::line_intersection::{line_intersection, LineIntersection};
@@ -892,6 +893,12 @@ pub(crate) struct PartitionBorderGlobalFaceCycleGeometryStats {
     pub(crate) collinear_overlap_count: usize,
     pub(crate) unexpected_collinear_overlap_count: usize,
     pub(crate) interaction_ready: bool,
+    pub(crate) canonical_ring_count: usize,
+    pub(crate) canonical_ring_mismatch_count: usize,
+    pub(crate) self_intersection_count: usize,
+    pub(crate) reciprocal_edge_count: usize,
+    pub(crate) reciprocal_edge_mismatch_count: usize,
+    pub(crate) ring_payload_ready: bool,
     pub(crate) geometry_ready: bool,
 }
 
@@ -2714,6 +2721,16 @@ impl PartitionBorderGraph {
             stats.closed_cycle_count += 1;
             stats.checked_cycle_count += 1;
             coords.push(coords[0]);
+            let mut canonical_coords = coords.clone();
+            canonicalize_ring(&mut canonical_coords, None);
+            let mut rotated_coords = coords[..coords.len() - 1].to_vec();
+            rotated_coords.rotate_left(1);
+            rotated_coords.push(rotated_coords[0]);
+            canonicalize_ring(&mut rotated_coords, None);
+            stats.canonical_ring_count += 1;
+            if canonical_coords != rotated_coords {
+                stats.canonical_ring_mismatch_count += 1;
+            }
             let area = Polygon3D::ring_signed_area_2d(&coords);
             if !area.is_finite() || area == 0.0 {
                 stats.degenerate_cycle_count += 1;
@@ -2740,6 +2757,22 @@ impl PartitionBorderGraph {
                 continue;
             }
             valid_cycles.push((polygon, area));
+        }
+
+        for (edge_index, edge) in self.global_face_edge_map.iter().enumerate() {
+            execution_policy.check_cancelled_every(
+                "partition_border_global_face_cycle_geometry_reciprocal_edges",
+                edge_index,
+            )?;
+            let reciprocal = self
+                .global_face_edge_map
+                .get(edge.symmetric_global_dir_edge_id)
+                .is_some_and(|symmetric| symmetric.symmetric_global_dir_edge_id == edge_index);
+            if reciprocal {
+                stats.reciprocal_edge_count += 1;
+            } else {
+                stats.reciprocal_edge_mismatch_count += 1;
+            }
         }
 
         let containment_work = valid_cycles
@@ -2820,6 +2853,9 @@ impl PartitionBorderGraph {
                         intersection,
                         is_proper,
                     }) => {
+                        if same_cycle && !adjacent {
+                            stats.self_intersection_count += 1;
+                        }
                         if is_proper {
                             stats.proper_crossing_count += 1;
                         } else {
@@ -2878,6 +2914,13 @@ impl PartitionBorderGraph {
             && stats.degenerate_cycle_count == 0
             && stats.unbounded_cycle_count == 1
             && stats.unbounded_orientation_mismatch_count == 0;
+        stats.ring_payload_ready = stats.geometry_ready
+            && stats.interaction_ready
+            && stats.canonical_ring_count == cycle_count
+            && stats.canonical_ring_mismatch_count == 0
+            && stats.self_intersection_count == 0
+            && stats.reciprocal_edge_count == edge_count
+            && stats.reciprocal_edge_mismatch_count == 0;
         Ok(stats)
     }
 
@@ -13534,7 +13577,13 @@ mod tests {
         assert_eq!(stats.boundary_touch_count, 0);
         assert_eq!(stats.collinear_overlap_count, 0);
         assert_eq!(stats.unexpected_collinear_overlap_count, 0);
+        assert_eq!(stats.canonical_ring_count, 2);
+        assert_eq!(stats.canonical_ring_mismatch_count, 0);
+        assert_eq!(stats.self_intersection_count, 0);
+        assert_eq!(stats.reciprocal_edge_count, 8);
+        assert_eq!(stats.reciprocal_edge_mismatch_count, 0);
         assert!(stats.interaction_ready);
+        assert!(stats.ring_payload_ready);
         assert!(stats.geometry_ready);
         assert_eq!(graph, before);
     }
@@ -13564,6 +13613,38 @@ mod tests {
         assert!(stats.collinear_overlap_count > 0);
         assert!(stats.unexpected_collinear_overlap_count > 0);
         assert!(!stats.interaction_ready);
+    }
+
+    #[test]
+    fn global_face_cycle_geometry_rejects_self_intersection_and_reciprocal_drift() {
+        let graph =
+            cycle_geometry_graph(&[vec![(0.0, 0.0), (4.0, 4.0), (0.0, 4.0), (4.0, 0.0)]], 0);
+        let stats = graph
+            .validate_global_face_cycle_geometry(
+                &ExecutionPolicy::default(),
+                PartitionBorderGlobalFacePayloadLineageStats {
+                    lineage_ready: true,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert!(stats.self_intersection_count > 0);
+        assert!(!stats.ring_payload_ready);
+
+        let mut graph = nested_global_face_cycle_geometry_graph();
+        graph.global_face_edge_map[0].symmetric_global_dir_edge_id = usize::MAX;
+        let stats = graph
+            .validate_global_face_cycle_geometry(
+                &ExecutionPolicy::default(),
+                PartitionBorderGlobalFacePayloadLineageStats {
+                    lineage_ready: true,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert_eq!(stats.reciprocal_edge_count, 7);
+        assert_eq!(stats.reciprocal_edge_mismatch_count, 1);
+        assert!(!stats.ring_payload_ready);
     }
 
     #[test]

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -584,6 +584,18 @@ pub struct StitchingReport {
     pub partition_border_global_face_cycle_geometry_collinear_overlap_count: usize,
     pub partition_border_global_face_cycle_geometry_unexpected_collinear_overlap_count: usize,
     pub partition_border_global_face_cycle_geometry_interaction_ready: bool,
+    /// Closed detached cycles that canonicalize into stable coordinate/Z payloads.
+    pub partition_border_global_face_cycle_geometry_canonical_ring_count: usize,
+    /// Detached cycles whose canonical ring payload was not stable on repeat.
+    pub partition_border_global_face_cycle_geometry_canonical_ring_mismatch_count: usize,
+    /// Non-adjacent edge intersections within one detached cycle.
+    pub partition_border_global_face_cycle_geometry_self_intersection_count: usize,
+    /// Detached edges with reciprocal symmetric-edge coverage.
+    pub partition_border_global_face_cycle_geometry_reciprocal_edge_count: usize,
+    /// Detached edges with missing or non-reciprocal symmetric-edge coverage.
+    pub partition_border_global_face_cycle_geometry_reciprocal_edge_mismatch_count: usize,
+    /// Whether detached ring payload evidence is ready for a future extraction gate.
+    pub partition_border_global_face_cycle_geometry_ring_payload_ready: bool,
     pub partition_border_global_face_cycle_geometry_ready: bool,
     /// Unbounded-face candidates whose local cycles are closed.
     pub partition_border_global_unbounded_face_proof_closed_count: usize,
@@ -3705,6 +3717,18 @@ impl<'a> TiledPolygonizer<'a> {
                         .unexpected_collinear_overlap_count,
                 partition_border_global_face_cycle_geometry_interaction_ready:
                     partition_border_global_face_cycle_geometry.interaction_ready,
+                partition_border_global_face_cycle_geometry_canonical_ring_count:
+                    partition_border_global_face_cycle_geometry.canonical_ring_count,
+                partition_border_global_face_cycle_geometry_canonical_ring_mismatch_count:
+                    partition_border_global_face_cycle_geometry.canonical_ring_mismatch_count,
+                partition_border_global_face_cycle_geometry_self_intersection_count:
+                    partition_border_global_face_cycle_geometry.self_intersection_count,
+                partition_border_global_face_cycle_geometry_reciprocal_edge_count:
+                    partition_border_global_face_cycle_geometry.reciprocal_edge_count,
+                partition_border_global_face_cycle_geometry_reciprocal_edge_mismatch_count:
+                    partition_border_global_face_cycle_geometry.reciprocal_edge_mismatch_count,
+                partition_border_global_face_cycle_geometry_ring_payload_ready:
+                    partition_border_global_face_cycle_geometry.ring_payload_ready,
                 partition_border_global_face_cycle_geometry_ready:
                     partition_border_global_face_cycle_geometry.geometry_ready,
                 partition_border_global_unbounded_face_proof_closed_count:

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -1395,6 +1395,12 @@ impl TraceRecorderV1 {
                 "unexpected_collinear_overlap_count":
                     stats.unexpected_collinear_overlap_count,
                 "interaction_ready": stats.interaction_ready,
+                "canonical_ring_count": stats.canonical_ring_count,
+                "canonical_ring_mismatch_count": stats.canonical_ring_mismatch_count,
+                "self_intersection_count": stats.self_intersection_count,
+                "reciprocal_edge_count": stats.reciprocal_edge_count,
+                "reciprocal_edge_mismatch_count": stats.reciprocal_edge_mismatch_count,
+                "ring_payload_ready": stats.ring_payload_ready,
                 "geometry_ready": stats.geometry_ready,
             }),
         )


### PR DESCRIPTION
## Stack

- Parent: current `main` `c1d624c` (includes merged PR #1364 `9caa34b` and merged PR #1365)
- Children: none
- This is a standalone bottom-of-stack PR from current `main`; the prior roadmap PR is merged and cannot be represented as an open GitHub stack parent.

## Delivered

- Extended detached global face-cycle geometry evidence with stable canonical coordinate/Z ring payload checks across rotated cycle starts.
- Counted non-adjacent self-intersections inside detached cycles and fail-closed reciprocal symmetric-edge coverage drift.
- Added a separate `ring_payload_ready` evidence gate while preserving the existing geometry and interaction diagnostics.
- Exposed the new counts and readiness through `StitchingReport` and trace output.
- Added non-mutating regression fixtures for valid nested rings, a bow-tie self-intersection, and reciprocal-edge drift.
- Updated P5.3 precisely without claiming global face promotion or stitched extraction.

## Contract impact

Evidence-only. No local successors, detached topology, face IDs, tiled output, provenance, Z values, dangles, cuts, or invalid-ring results are changed. `ring_payload_ready` is diagnostic and is not an output-promotion gate.

## Validation

- `cargo test -p geo-polygonize-core --lib global_face_cycle_geometry` (4 passed)
- `cargo test -p geo-polygonize-core --lib` (387 passed)
- `cargo test --workspace --no-default-features` (passed; tiled-equivalence: 7 passed in 445.86s)
- `cargo clippy --workspace --all-targets --no-default-features -- -D warnings` (passed)
- `cargo doc -p geo-polygonize-core --no-deps` (passed)
- `cargo fmt --all -- --check` (passed)
- `git diff --check` (passed)
- Generated TypeScript bindings were restored after validation.

## Agent handoff

- Exact checkout: `31372a458a8f3ef944139063783a0a69d0431c56`
- Next branch: `agent/p5-global-next-face-identity`
- Next slice: implement the smallest deterministic detached global-next/face-identity promotion step only after the new ring-payload evidence is consumed; keep local topology and output untouched until a complete promotion proof exists.
- Remaining risks: this validates ring payload evidence but does not resolve boundary-touch policy, extract stitched shells/holes/dangles/cuts, compare full untiled output, or prove a global planar Euler arrangement.
