### PR TITLE
feat(core): materialize detached ring payloads

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -577,6 +577,9 @@ Blocked by #1288.
 - [x] Combine committed detached face identity, successor, cycle lineage,
   payload, geometry, and canonical ring evidence into one bounded final
   pre-extraction readiness record without promoting local topology or output.
+- [x] Materialize canonical detached ring payload evidence with face IDs,
+  source lineage, endpoint Z, and exactly-one-unbounded coverage only after the
+  final gate; retain it privately without merging stitched output.
 - [ ] Build global `next` links and deterministic global face IDs.
 - [ ] Identify exactly one global unbounded face.
 - [ ] Validate twin, cycle, source, Euler, and face-walk invariants.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -574,6 +574,9 @@ Blocked by #1288.
   overlap evidence without classifying or extracting stitched output; retain
   stable canonical ring payload, non-adjacent self-intersection, and reciprocal
   symmetric-edge coverage evidence as a separate pre-extraction gate.
+- [x] Combine committed detached face identity, successor, cycle lineage,
+  payload, geometry, and canonical ring evidence into one bounded final
+  pre-extraction readiness record without promoting local topology or output.
 - [ ] Build global `next` links and deterministic global face IDs.
 - [ ] Identify exactly one global unbounded face.
 - [ ] Validate twin, cycle, source, Euler, and face-walk invariants.

--- a/crates/geo-polygonize-core/src/graph/partition_border.rs
+++ b/crates/geo-polygonize-core/src/graph/partition_border.rs
@@ -696,6 +696,34 @@ pub(crate) struct PartitionBorderGlobalTopologyCandidate {
     pub(crate) cycle_start_global_dir_edge_ids: Vec<usize>,
 }
 
+/// One canonical detached ring payload retained after the complete evidence
+/// gate. This is private evidence and is not public stitched output.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct PartitionBorderGlobalFaceRingPayload {
+    pub(crate) candidate_global_face_id: usize,
+    pub(crate) cycle_start_global_dir_edge_id: usize,
+    pub(crate) edge_ids: Vec<usize>,
+    pub(crate) coords: Vec<[u64; 3]>,
+    pub(crate) source_line_ids: Vec<u32>,
+    pub(crate) unbounded: bool,
+}
+
+/// Counts atomic detached ring-payload materialization after the final gate.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct PartitionBorderGlobalFaceRingPayloadStats {
+    pub(crate) edge_count: usize,
+    pub(crate) cycle_count: usize,
+    pub(crate) materialized_cycle_count: usize,
+    pub(crate) coordinate_count: usize,
+    pub(crate) source_line_id_count: usize,
+    pub(crate) missing_face_id_count: usize,
+    pub(crate) missing_edge_face_id_count: usize,
+    pub(crate) invalid_cycle_count: usize,
+    pub(crate) canonical_ring_mismatch_count: usize,
+    pub(crate) unbounded_cycle_count: usize,
+    pub(crate) materialization_ready: bool,
+}
+
 /// Counts the one atomic commit of detached global successor links. Face IDs
 /// remain a separate roadmap slice; no local face identity or output is
 /// changed by this mutation.
@@ -1434,6 +1462,7 @@ pub struct PartitionBorderGraph {
     global_face_id_by_cycle_start: Vec<Option<usize>>,
     global_face_id_by_global_dir_edge_id: Vec<Option<usize>>,
     global_unbounded_face_id_by_cycle_start: Option<(usize, usize)>,
+    global_face_ring_payloads: Vec<PartitionBorderGlobalFaceRingPayload>,
 }
 
 impl PartitionBorderGraph {
@@ -1485,6 +1514,7 @@ impl PartitionBorderGraph {
         self.global_face_id_by_cycle_start.clear();
         self.global_face_id_by_global_dir_edge_id.clear();
         self.global_unbounded_face_id_by_cycle_start = None;
+        self.global_face_ring_payloads.clear();
         self.global_face_edge_map.clear();
         self.global_face_nodes.clear();
         Ok(())
@@ -1526,6 +1556,7 @@ impl PartitionBorderGraph {
         self.global_face_id_by_cycle_start.clear();
         self.global_face_id_by_global_dir_edge_id.clear();
         self.global_unbounded_face_id_by_cycle_start = None;
+        self.global_face_ring_payloads.clear();
         self.global_face_edge_map.clear();
         self.global_face_nodes.clear();
         Ok(())
@@ -1556,6 +1587,7 @@ impl PartitionBorderGraph {
         self.global_face_id_by_cycle_start.clear();
         self.global_face_id_by_global_dir_edge_id.clear();
         self.global_unbounded_face_id_by_cycle_start = None;
+        self.global_face_ring_payloads.clear();
     }
 
     pub fn node_count(&self) -> usize {
@@ -3020,6 +3052,185 @@ impl PartitionBorderGraph {
             cycle_count_mismatch_count,
             extraction_ready,
         })
+    }
+
+    /// Materializes canonical detached ring payloads after the complete
+    /// extraction gate. The payloads remain private evidence and are committed
+    /// atomically; local topology and public tiled output are untouched.
+    pub(crate) fn materialize_global_face_ring_payloads(
+        &mut self,
+        execution_policy: &ExecutionPolicy,
+        extraction_gate: PartitionBorderGlobalFaceExtractionGateStats,
+    ) -> crate::Result<PartitionBorderGlobalFaceRingPayloadStats> {
+        execution_policy.check_cancelled("partition_border_global_face_ring_payloads")?;
+        let edge_count = self.global_face_edge_map.len();
+        execution_policy.check(
+            "partition_border_global_face_ring_payloads_edges",
+            execution_policy.max_graph_edges,
+            edge_count,
+        )?;
+        let Some(candidate) = self.global_topology_candidate.as_ref() else {
+            return Err(crate::PolygonizeError::InternalInvariantViolation {
+                reason: "global face ring payloads have no detached topology candidate".to_string(),
+            });
+        };
+        let cycle_count = candidate.cycle_start_global_dir_edge_ids.len();
+        execution_policy.check(
+            "partition_border_global_face_ring_payloads_cycles",
+            execution_policy.max_graph_nodes,
+            cycle_count,
+        )?;
+        let mut stats = PartitionBorderGlobalFaceRingPayloadStats {
+            edge_count,
+            cycle_count,
+            ..Default::default()
+        };
+        let mut payloads = Vec::with_capacity(cycle_count);
+        for (cycle_index, &start) in candidate.cycle_start_global_dir_edge_ids.iter().enumerate() {
+            execution_policy.check_cancelled_every(
+                "partition_border_global_face_ring_payloads_cycles",
+                cycle_index,
+            )?;
+            let Some(face_id) = self
+                .global_face_id_by_cycle_start
+                .get(cycle_index)
+                .copied()
+                .flatten()
+            else {
+                stats.missing_face_id_count += 1;
+                continue;
+            };
+            if start >= edge_count {
+                stats.invalid_cycle_count += 1;
+                continue;
+            }
+            let mut edge_ids = Vec::new();
+            let mut coords = Vec::new();
+            let mut source_line_ids = BTreeSet::new();
+            let mut visited = BTreeSet::new();
+            let mut current = start;
+            let mut closed = true;
+            loop {
+                execution_policy.check_cancelled_every(
+                    "partition_border_global_face_ring_payloads_cycle_edges",
+                    visited.len(),
+                )?;
+                if !visited.insert(current) {
+                    if current != start {
+                        closed = false;
+                    }
+                    break;
+                }
+                let Some(edge) = self.global_face_edge_map.get(current) else {
+                    closed = false;
+                    break;
+                };
+                if self
+                    .global_face_id_by_global_dir_edge_id
+                    .get(current)
+                    .copied()
+                    .flatten()
+                    != Some(face_id)
+                {
+                    stats.missing_edge_face_id_count += 1;
+                    closed = false;
+                    break;
+                }
+                edge_ids.push(current);
+                coords.push(Coord3D::new(
+                    f64::from_bits(edge.from.xy_bits()[0]),
+                    f64::from_bits(edge.from.xy_bits()[1]),
+                    f64::from_bits(edge.from_z_bits),
+                ));
+                source_line_ids.extend(edge.source_line_ids.iter().copied());
+                let Some(successor) = candidate
+                    .next_global_dir_edge_ids
+                    .get(current)
+                    .copied()
+                    .flatten()
+                else {
+                    closed = false;
+                    break;
+                };
+                if successor >= edge_count {
+                    closed = false;
+                    break;
+                }
+                current = successor;
+            }
+            if !closed || coords.len() < 3 {
+                stats.invalid_cycle_count += 1;
+                continue;
+            }
+            coords.push(coords[0]);
+            let mut canonical_coords = coords.clone();
+            canonicalize_ring(&mut canonical_coords, None);
+            let mut rotated_coords = coords[..coords.len() - 1].to_vec();
+            rotated_coords.rotate_left(1);
+            rotated_coords.push(rotated_coords[0]);
+            canonicalize_ring(&mut rotated_coords, None);
+            if canonical_coords != rotated_coords {
+                stats.canonical_ring_mismatch_count += 1;
+            }
+            stats.coordinate_count = stats
+                .coordinate_count
+                .checked_add(canonical_coords.len())
+                .ok_or_else(|| crate::PolygonizeError::InternalInvariantViolation {
+                    reason: "global face ring payload coordinate count overflow".to_string(),
+                })?;
+            execution_policy.check(
+                "partition_border_global_face_ring_payloads_coordinates",
+                execution_policy.max_output_coordinates,
+                stats.coordinate_count,
+            )?;
+            stats.source_line_id_count = stats
+                .source_line_id_count
+                .checked_add(source_line_ids.len())
+                .ok_or_else(|| crate::PolygonizeError::InternalInvariantViolation {
+                    reason: "global face ring payload source count overflow".to_string(),
+                })?;
+            stats.materialized_cycle_count += 1;
+            stats.unbounded_cycle_count += usize::from(
+                self.global_unbounded_face_id_by_cycle_start
+                    .is_some_and(|(_, unbounded_start)| unbounded_start == start),
+            );
+            payloads.push(PartitionBorderGlobalFaceRingPayload {
+                candidate_global_face_id: face_id,
+                cycle_start_global_dir_edge_id: start,
+                edge_ids,
+                coords: canonical_coords
+                    .into_iter()
+                    .map(|coord| {
+                        [
+                            canonical_coordinate_bits(coord.x),
+                            canonical_coordinate_bits(coord.y),
+                            coord.z.to_bits(),
+                        ]
+                    })
+                    .collect(),
+                source_line_ids: source_line_ids.into_iter().collect(),
+                unbounded: self
+                    .global_unbounded_face_id_by_cycle_start
+                    .is_some_and(|(_, unbounded_start)| unbounded_start == start),
+            });
+        }
+        stats.materialization_ready = extraction_gate.extraction_ready
+            && stats.materialized_cycle_count == cycle_count
+            && stats.coordinate_count > 0
+            && stats.missing_face_id_count == 0
+            && stats.missing_edge_face_id_count == 0
+            && stats.invalid_cycle_count == 0
+            && stats.canonical_ring_mismatch_count == 0
+            && stats.unbounded_cycle_count == 1;
+        if stats.materialization_ready {
+            self.global_face_ring_payloads = payloads;
+        }
+        Ok(stats)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn global_face_ring_payloads(&self) -> &[PartitionBorderGlobalFaceRingPayload] {
+        &self.global_face_ring_payloads
     }
 
     #[cfg(test)]
@@ -5847,6 +6058,7 @@ impl PartitionBorderGraph {
         self.global_face_id_by_cycle_start.clear();
         self.global_face_id_by_global_dir_edge_id.clear();
         self.global_unbounded_face_id_by_cycle_start = None;
+        self.global_face_ring_payloads.clear();
         Ok(stats)
     }
 
@@ -6581,6 +6793,7 @@ impl PartitionBorderGraph {
         self.global_face_id_by_cycle_start.clear();
         self.global_face_id_by_global_dir_edge_id.clear();
         self.global_unbounded_face_id_by_cycle_start = None;
+        self.global_face_ring_payloads.clear();
         self.global_topology_candidate = Some(PartitionBorderGlobalTopologyCandidate {
             next_global_dir_edge_ids,
             cycle_start_global_dir_edge_ids,
@@ -13913,6 +14126,108 @@ mod tests {
             error,
             crate::PolygonizeError::Cancelled { ref stage }
                 if stage == "partition_border_global_face_extraction_gate"
+        ));
+    }
+
+    #[test]
+    fn global_face_ring_payloads_materialize_canonical_face_source_and_z_evidence() {
+        let mut graph = nested_global_face_cycle_geometry_graph();
+        graph.global_face_id_by_global_dir_edge_id = vec![
+            Some(0),
+            Some(0),
+            Some(0),
+            Some(0),
+            Some(1),
+            Some(1),
+            Some(1),
+            Some(1),
+        ];
+        let stats = graph
+            .materialize_global_face_ring_payloads(
+                &ExecutionPolicy::default(),
+                PartitionBorderGlobalFaceExtractionGateStats {
+                    edge_count: 8,
+                    cycle_count: 2,
+                    extraction_ready: true,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            stats,
+            PartitionBorderGlobalFaceRingPayloadStats {
+                edge_count: 8,
+                cycle_count: 2,
+                materialized_cycle_count: 2,
+                coordinate_count: 10,
+                source_line_id_count: 2,
+                unbounded_cycle_count: 1,
+                materialization_ready: true,
+                ..Default::default()
+            }
+        );
+        assert_eq!(graph.global_face_ring_payloads().len(), 2);
+        assert_eq!(
+            graph.global_face_ring_payloads()[0].candidate_global_face_id,
+            0
+        );
+        assert_eq!(graph.global_face_ring_payloads()[0].coords.len(), 5);
+        assert_eq!(
+            graph.global_face_ring_payloads()[0].source_line_ids,
+            vec![1]
+        );
+        assert!(!graph.global_face_ring_payloads()[0].unbounded);
+        assert!(graph.global_face_ring_payloads()[1].unbounded);
+    }
+
+    #[test]
+    fn global_face_ring_payloads_are_atomic_bounded_and_cancellable() {
+        let mut graph = nested_global_face_cycle_geometry_graph();
+        graph.global_face_id_by_global_dir_edge_id = vec![Some(0); 8];
+        let before = graph.clone();
+        let stats = graph
+            .materialize_global_face_ring_payloads(
+                &ExecutionPolicy::default(),
+                PartitionBorderGlobalFaceExtractionGateStats::default(),
+            )
+            .unwrap();
+        assert!(!stats.materialization_ready);
+        assert!(graph.global_face_ring_payloads().is_empty());
+        assert_eq!(graph, before);
+
+        let error = graph
+            .materialize_global_face_ring_payloads(
+                &ExecutionPolicy {
+                    max_graph_edges: Some(0),
+                    ..Default::default()
+                },
+                PartitionBorderGlobalFaceExtractionGateStats::default(),
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::ResourceLimitExceeded {
+                ref stage,
+                limit: 0,
+                observed: 8,
+            } if stage == "partition_border_global_face_ring_payloads_edges"
+        ));
+
+        let token = CancellationToken::new();
+        token.cancel();
+        let error = graph
+            .materialize_global_face_ring_payloads(
+                &ExecutionPolicy {
+                    cancellation_token: Some(token),
+                    ..Default::default()
+                },
+                PartitionBorderGlobalFaceExtractionGateStats::default(),
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::Cancelled { ref stage }
+                if stage == "partition_border_global_face_ring_payloads"
         ));
     }
 

--- a/crates/geo-polygonize-core/src/graph/partition_border.rs
+++ b/crates/geo-polygonize-core/src/graph/partition_border.rs
@@ -902,6 +902,25 @@ pub(crate) struct PartitionBorderGlobalFaceCycleGeometryStats {
     pub(crate) geometry_ready: bool,
 }
 
+/// Combines detached identity, lineage, and ring evidence at the boundary
+/// before a future stitched extraction. This is evidence only and never
+/// promotes local topology or output.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct PartitionBorderGlobalFaceExtractionGateStats {
+    pub(crate) edge_count: usize,
+    pub(crate) cycle_count: usize,
+    pub(crate) identity_invariants_ready: bool,
+    pub(crate) next_lineage_ready: bool,
+    pub(crate) cycle_face_lineage_ready: bool,
+    pub(crate) promotion_gate_ready: bool,
+    pub(crate) payload_lineage_ready: bool,
+    pub(crate) geometry_ready: bool,
+    pub(crate) ring_payload_ready: bool,
+    pub(crate) edge_count_mismatch_count: usize,
+    pub(crate) cycle_count_mismatch_count: usize,
+    pub(crate) extraction_ready: bool,
+}
+
 /// Counts from validating a detached global directed-edge topology candidate.
 /// Readiness requires complete application evidence, one predecessor and one
 /// successor per edge, endpoint continuity, and closed cycles.
@@ -2922,6 +2941,85 @@ impl PartitionBorderGraph {
             && stats.reciprocal_edge_count == edge_count
             && stats.reciprocal_edge_mismatch_count == 0;
         Ok(stats)
+    }
+
+    /// Combines the committed detached face-identity, lineage, and ring
+    /// evidence before a future stitched extraction. The result is a final
+    /// observational gate; it does not write links, IDs, or output payloads.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn validate_global_face_extraction_gate(
+        &self,
+        execution_policy: &ExecutionPolicy,
+        identity_invariants: PartitionBorderGlobalFaceIdentityInvariantStats,
+        next_lineage: PartitionBorderGlobalNextLineageIntegrationStats,
+        cycle_face_lineage: PartitionBorderGlobalCycleFaceLineageStats,
+        promotion_gate: PartitionBorderGlobalCycleFacePromotionGateStats,
+        payload_lineage: PartitionBorderGlobalFacePayloadLineageStats,
+        geometry: PartitionBorderGlobalFaceCycleGeometryStats,
+    ) -> crate::Result<PartitionBorderGlobalFaceExtractionGateStats> {
+        execution_policy.check_cancelled("partition_border_global_face_extraction_gate")?;
+        let edge_count = self.global_face_edge_map.len();
+        execution_policy.check(
+            "partition_border_global_face_extraction_gate_edges",
+            execution_policy.max_graph_edges,
+            edge_count,
+        )?;
+        let cycle_count = self
+            .global_topology_candidate
+            .as_ref()
+            .map_or(0, |candidate| {
+                candidate.cycle_start_global_dir_edge_ids.len()
+            });
+        execution_policy.check(
+            "partition_border_global_face_extraction_gate_cycles",
+            execution_policy.max_graph_nodes,
+            cycle_count,
+        )?;
+        let edge_count_mismatch_count = [
+            identity_invariants.edge_count,
+            next_lineage.edge_count,
+            cycle_face_lineage.edge_count,
+            promotion_gate.edge_count,
+            payload_lineage.edge_count,
+            geometry.edge_count,
+        ]
+        .into_iter()
+        .filter(|&count| count != edge_count)
+        .count();
+        let cycle_count_mismatch_count = [
+            identity_invariants.cycle_count,
+            next_lineage.cycle_count,
+            cycle_face_lineage.cycle_count,
+            promotion_gate.cycle_count,
+            payload_lineage.cycle_count,
+            geometry.cycle_count,
+        ]
+        .into_iter()
+        .filter(|&count| count != cycle_count)
+        .count();
+        let extraction_ready = edge_count_mismatch_count == 0
+            && cycle_count_mismatch_count == 0
+            && identity_invariants.invariants_ready
+            && next_lineage.integration_ready
+            && cycle_face_lineage.lineage_ready
+            && promotion_gate.gate_ready
+            && payload_lineage.lineage_ready
+            && geometry.geometry_ready
+            && geometry.ring_payload_ready;
+        Ok(PartitionBorderGlobalFaceExtractionGateStats {
+            edge_count,
+            cycle_count,
+            identity_invariants_ready: identity_invariants.invariants_ready,
+            next_lineage_ready: next_lineage.integration_ready,
+            cycle_face_lineage_ready: cycle_face_lineage.lineage_ready,
+            promotion_gate_ready: promotion_gate.gate_ready,
+            payload_lineage_ready: payload_lineage.lineage_ready,
+            geometry_ready: geometry.geometry_ready,
+            ring_payload_ready: geometry.ring_payload_ready,
+            edge_count_mismatch_count,
+            cycle_count_mismatch_count,
+            extraction_ready,
+        })
     }
 
     #[cfg(test)]
@@ -13645,6 +13743,177 @@ mod tests {
         assert_eq!(stats.reciprocal_edge_count, 7);
         assert_eq!(stats.reciprocal_edge_mismatch_count, 1);
         assert!(!stats.ring_payload_ready);
+    }
+
+    #[test]
+    fn global_face_extraction_gate_combines_detached_evidence_without_mutation() {
+        let graph = nested_global_face_cycle_geometry_graph();
+        let before = graph.clone();
+        let geometry = graph
+            .validate_global_face_cycle_geometry(
+                &ExecutionPolicy::default(),
+                PartitionBorderGlobalFacePayloadLineageStats {
+                    edge_count: 8,
+                    cycle_count: 2,
+                    lineage_ready: true,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let stats = graph
+            .validate_global_face_extraction_gate(
+                &ExecutionPolicy::default(),
+                PartitionBorderGlobalFaceIdentityInvariantStats {
+                    edge_count: 8,
+                    cycle_count: 2,
+                    invariants_ready: true,
+                    ..Default::default()
+                },
+                PartitionBorderGlobalNextLineageIntegrationStats {
+                    edge_count: 8,
+                    cycle_count: 2,
+                    integration_ready: true,
+                    ..Default::default()
+                },
+                PartitionBorderGlobalCycleFaceLineageStats {
+                    edge_count: 8,
+                    cycle_count: 2,
+                    lineage_ready: true,
+                    ..Default::default()
+                },
+                PartitionBorderGlobalCycleFacePromotionGateStats {
+                    edge_count: 8,
+                    cycle_count: 2,
+                    plan_count: 2,
+                    gate_ready: true,
+                    ..Default::default()
+                },
+                PartitionBorderGlobalFacePayloadLineageStats {
+                    edge_count: 8,
+                    cycle_count: 2,
+                    lineage_ready: true,
+                    ..Default::default()
+                },
+                geometry,
+            )
+            .unwrap();
+        assert_eq!(
+            stats,
+            PartitionBorderGlobalFaceExtractionGateStats {
+                edge_count: 8,
+                cycle_count: 2,
+                identity_invariants_ready: true,
+                next_lineage_ready: true,
+                cycle_face_lineage_ready: true,
+                promotion_gate_ready: true,
+                payload_lineage_ready: true,
+                geometry_ready: true,
+                ring_payload_ready: true,
+                extraction_ready: true,
+                ..Default::default()
+            }
+        );
+        assert_eq!(graph, before);
+
+        let stats = graph
+            .validate_global_face_extraction_gate(
+                &ExecutionPolicy::default(),
+                PartitionBorderGlobalFaceIdentityInvariantStats {
+                    edge_count: 7,
+                    cycle_count: 2,
+                    invariants_ready: true,
+                    ..Default::default()
+                },
+                PartitionBorderGlobalNextLineageIntegrationStats {
+                    edge_count: 8,
+                    cycle_count: 2,
+                    integration_ready: true,
+                    ..Default::default()
+                },
+                PartitionBorderGlobalCycleFaceLineageStats {
+                    edge_count: 8,
+                    cycle_count: 2,
+                    lineage_ready: true,
+                    ..Default::default()
+                },
+                PartitionBorderGlobalCycleFacePromotionGateStats {
+                    edge_count: 8,
+                    cycle_count: 2,
+                    plan_count: 2,
+                    gate_ready: true,
+                    ..Default::default()
+                },
+                PartitionBorderGlobalFacePayloadLineageStats {
+                    edge_count: 8,
+                    cycle_count: 2,
+                    lineage_ready: true,
+                    ..Default::default()
+                },
+                geometry,
+            )
+            .unwrap();
+        assert_eq!(stats.edge_count_mismatch_count, 1);
+        assert!(!stats.extraction_ready);
+    }
+
+    #[test]
+    fn global_face_extraction_gate_is_bounded_and_cancellable() {
+        let graph = nested_global_face_cycle_geometry_graph();
+        let geometry = graph
+            .validate_global_face_cycle_geometry(
+                &ExecutionPolicy::default(),
+                PartitionBorderGlobalFacePayloadLineageStats {
+                    edge_count: 8,
+                    cycle_count: 2,
+                    lineage_ready: true,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let error = graph
+            .validate_global_face_extraction_gate(
+                &ExecutionPolicy {
+                    max_graph_edges: Some(0),
+                    ..Default::default()
+                },
+                PartitionBorderGlobalFaceIdentityInvariantStats::default(),
+                PartitionBorderGlobalNextLineageIntegrationStats::default(),
+                PartitionBorderGlobalCycleFaceLineageStats::default(),
+                PartitionBorderGlobalCycleFacePromotionGateStats::default(),
+                PartitionBorderGlobalFacePayloadLineageStats::default(),
+                geometry,
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::ResourceLimitExceeded {
+                ref stage,
+                limit: 0,
+                observed: 8,
+            } if stage == "partition_border_global_face_extraction_gate_edges"
+        ));
+
+        let token = CancellationToken::new();
+        token.cancel();
+        let error = graph
+            .validate_global_face_extraction_gate(
+                &ExecutionPolicy {
+                    cancellation_token: Some(token),
+                    ..Default::default()
+                },
+                PartitionBorderGlobalFaceIdentityInvariantStats::default(),
+                PartitionBorderGlobalNextLineageIntegrationStats::default(),
+                PartitionBorderGlobalCycleFaceLineageStats::default(),
+                PartitionBorderGlobalCycleFacePromotionGateStats::default(),
+                PartitionBorderGlobalFacePayloadLineageStats::default(),
+                geometry,
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::Cancelled { ref stage }
+                if stage == "partition_border_global_face_extraction_gate"
+        ));
     }
 
     #[test]

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -597,6 +597,10 @@ pub struct StitchingReport {
     /// Whether detached ring payload evidence is ready for a future extraction gate.
     pub partition_border_global_face_cycle_geometry_ring_payload_ready: bool,
     pub partition_border_global_face_cycle_geometry_ready: bool,
+    /// Final detached pre-extraction evidence gate; no stitched output is promoted.
+    pub partition_border_global_face_extraction_gate_ready: bool,
+    pub partition_border_global_face_extraction_gate_edge_count_mismatch_count: usize,
+    pub partition_border_global_face_extraction_gate_cycle_count_mismatch_count: usize,
     /// Unbounded-face candidates whose local cycles are closed.
     pub partition_border_global_unbounded_face_proof_closed_count: usize,
     /// Unbounded-face twins absent from the retained twin-position map.
@@ -2913,6 +2917,16 @@ impl<'a> TiledPolygonizer<'a> {
                 &self.execution_policy,
                 partition_border_global_face_payload_lineage,
             )?;
+        let partition_border_global_face_extraction_gate = partition_border_graph
+            .validate_global_face_extraction_gate(
+                &self.execution_policy,
+                partition_border_global_face_identity_invariants,
+                partition_border_global_next_lineage_integration,
+                partition_border_global_cycle_face_lineage,
+                partition_border_global_cycle_face_promotion_gate,
+                partition_border_global_face_payload_lineage,
+                partition_border_global_face_cycle_geometry,
+            )?;
         if let Some(trace) = trace.as_deref_mut() {
             trace.record_partition_border_reconciliation(partition_border_reconciliation);
             trace.record_partition_border_twin_application(partition_border_twin_application);
@@ -3017,6 +3031,9 @@ impl<'a> TiledPolygonizer<'a> {
             );
             trace.record_partition_border_global_face_cycle_geometry(
                 partition_border_global_face_cycle_geometry,
+            );
+            trace.record_partition_border_global_face_extraction_gate(
+                partition_border_global_face_extraction_gate,
             );
         }
         let unresolved = tile_reports.iter().any(Self::report_is_unresolved);
@@ -3731,6 +3748,12 @@ impl<'a> TiledPolygonizer<'a> {
                     partition_border_global_face_cycle_geometry.ring_payload_ready,
                 partition_border_global_face_cycle_geometry_ready:
                     partition_border_global_face_cycle_geometry.geometry_ready,
+                partition_border_global_face_extraction_gate_ready:
+                    partition_border_global_face_extraction_gate.extraction_ready,
+                partition_border_global_face_extraction_gate_edge_count_mismatch_count:
+                    partition_border_global_face_extraction_gate.edge_count_mismatch_count,
+                partition_border_global_face_extraction_gate_cycle_count_mismatch_count:
+                    partition_border_global_face_extraction_gate.cycle_count_mismatch_count,
                 partition_border_global_unbounded_face_proof_closed_count:
                     partition_border_global_unbounded_face_proof.closed_unbounded_face_count,
                 partition_border_global_unbounded_face_proof_unmapped_twin_count:

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -601,6 +601,18 @@ pub struct StitchingReport {
     pub partition_border_global_face_extraction_gate_ready: bool,
     pub partition_border_global_face_extraction_gate_edge_count_mismatch_count: usize,
     pub partition_border_global_face_extraction_gate_cycle_count_mismatch_count: usize,
+    /// Detached canonical ring payloads retained after the extraction gate.
+    pub partition_border_global_face_ring_payload_edge_count: usize,
+    pub partition_border_global_face_ring_payload_cycle_count: usize,
+    pub partition_border_global_face_ring_payload_materialized_cycle_count: usize,
+    pub partition_border_global_face_ring_payload_coordinate_count: usize,
+    pub partition_border_global_face_ring_payload_source_line_id_count: usize,
+    pub partition_border_global_face_ring_payload_missing_face_id_count: usize,
+    pub partition_border_global_face_ring_payload_missing_edge_face_id_count: usize,
+    pub partition_border_global_face_ring_payload_invalid_cycle_count: usize,
+    pub partition_border_global_face_ring_payload_canonical_ring_mismatch_count: usize,
+    pub partition_border_global_face_ring_payload_unbounded_cycle_count: usize,
+    pub partition_border_global_face_ring_payload_ready: bool,
     /// Unbounded-face candidates whose local cycles are closed.
     pub partition_border_global_unbounded_face_proof_closed_count: usize,
     /// Unbounded-face twins absent from the retained twin-position map.
@@ -2927,6 +2939,11 @@ impl<'a> TiledPolygonizer<'a> {
                 partition_border_global_face_payload_lineage,
                 partition_border_global_face_cycle_geometry,
             )?;
+        let partition_border_global_face_ring_payloads = partition_border_graph
+            .materialize_global_face_ring_payloads(
+                &self.execution_policy,
+                partition_border_global_face_extraction_gate,
+            )?;
         if let Some(trace) = trace.as_deref_mut() {
             trace.record_partition_border_reconciliation(partition_border_reconciliation);
             trace.record_partition_border_twin_application(partition_border_twin_application);
@@ -3034,6 +3051,9 @@ impl<'a> TiledPolygonizer<'a> {
             );
             trace.record_partition_border_global_face_extraction_gate(
                 partition_border_global_face_extraction_gate,
+            );
+            trace.record_partition_border_global_face_ring_payloads(
+                partition_border_global_face_ring_payloads,
             );
         }
         let unresolved = tile_reports.iter().any(Self::report_is_unresolved);
@@ -3754,6 +3774,28 @@ impl<'a> TiledPolygonizer<'a> {
                     partition_border_global_face_extraction_gate.edge_count_mismatch_count,
                 partition_border_global_face_extraction_gate_cycle_count_mismatch_count:
                     partition_border_global_face_extraction_gate.cycle_count_mismatch_count,
+                partition_border_global_face_ring_payload_edge_count:
+                    partition_border_global_face_ring_payloads.edge_count,
+                partition_border_global_face_ring_payload_cycle_count:
+                    partition_border_global_face_ring_payloads.cycle_count,
+                partition_border_global_face_ring_payload_materialized_cycle_count:
+                    partition_border_global_face_ring_payloads.materialized_cycle_count,
+                partition_border_global_face_ring_payload_coordinate_count:
+                    partition_border_global_face_ring_payloads.coordinate_count,
+                partition_border_global_face_ring_payload_source_line_id_count:
+                    partition_border_global_face_ring_payloads.source_line_id_count,
+                partition_border_global_face_ring_payload_missing_face_id_count:
+                    partition_border_global_face_ring_payloads.missing_face_id_count,
+                partition_border_global_face_ring_payload_missing_edge_face_id_count:
+                    partition_border_global_face_ring_payloads.missing_edge_face_id_count,
+                partition_border_global_face_ring_payload_invalid_cycle_count:
+                    partition_border_global_face_ring_payloads.invalid_cycle_count,
+                partition_border_global_face_ring_payload_canonical_ring_mismatch_count:
+                    partition_border_global_face_ring_payloads.canonical_ring_mismatch_count,
+                partition_border_global_face_ring_payload_unbounded_cycle_count:
+                    partition_border_global_face_ring_payloads.unbounded_cycle_count,
+                partition_border_global_face_ring_payload_ready:
+                    partition_border_global_face_ring_payloads.materialization_ready,
                 partition_border_global_unbounded_face_proof_closed_count:
                     partition_border_global_unbounded_face_proof.closed_unbounded_face_count,
                 partition_border_global_unbounded_face_proof_unmapped_twin_count:

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -15,8 +15,9 @@ use crate::graph::partition_border::{
     PartitionBorderGlobalFaceNextMutationPlanStats,
     PartitionBorderGlobalFaceNodeReconciliationStats, PartitionBorderGlobalFacePayloadLineageStats,
     PartitionBorderGlobalFacePlanStats, PartitionBorderGlobalFacePlanValidationStats,
-    PartitionBorderGlobalFaceTransitionPlanStats, PartitionBorderGlobalFaceTwinTransitionStats,
-    PartitionBorderGlobalFaceWalkInvariantStats, PartitionBorderGlobalNextLineageIntegrationStats,
+    PartitionBorderGlobalFaceRingPayloadStats, PartitionBorderGlobalFaceTransitionPlanStats,
+    PartitionBorderGlobalFaceTwinTransitionStats, PartitionBorderGlobalFaceWalkInvariantStats,
+    PartitionBorderGlobalNextLineageIntegrationStats,
     PartitionBorderGlobalTopologyApplicationGateStats, PartitionBorderGlobalTopologyCandidateStats,
     PartitionBorderGlobalTopologyMutationGateStats, PartitionBorderGlobalTopologyMutationStats,
     PartitionBorderGlobalUnboundedFaceApplicationStats,
@@ -1426,6 +1427,29 @@ impl TraceRecorderV1 {
                 "edge_count_mismatch_count": stats.edge_count_mismatch_count,
                 "cycle_count_mismatch_count": stats.cycle_count_mismatch_count,
                 "extraction_ready": stats.extraction_ready,
+            }),
+        )
+    }
+
+    pub(crate) fn record_partition_border_global_face_ring_payloads(
+        &mut self,
+        stats: PartitionBorderGlobalFaceRingPayloadStats,
+    ) -> bool {
+        self.record(
+            TraceStageV1::Rings,
+            "partition_border_global_face_ring_payloads",
+            serde_json::json!({
+                "edge_count": stats.edge_count,
+                "cycle_count": stats.cycle_count,
+                "materialized_cycle_count": stats.materialized_cycle_count,
+                "coordinate_count": stats.coordinate_count,
+                "source_line_id_count": stats.source_line_id_count,
+                "missing_face_id_count": stats.missing_face_id_count,
+                "missing_edge_face_id_count": stats.missing_edge_face_id_count,
+                "invalid_cycle_count": stats.invalid_cycle_count,
+                "canonical_ring_mismatch_count": stats.canonical_ring_mismatch_count,
+                "unbounded_cycle_count": stats.unbounded_cycle_count,
+                "materialization_ready": stats.materialization_ready,
             }),
         )
     }

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -6,9 +6,9 @@ use crate::graph::partition_border::{
     PartitionBorderGlobalComponentPayloadStats, PartitionBorderGlobalComponentReconciliationStats,
     PartitionBorderGlobalCycleFaceLineageStats, PartitionBorderGlobalCycleFacePromotionGateStats,
     PartitionBorderGlobalFaceCycleGeometryStats, PartitionBorderGlobalFaceEdgeMapStats,
-    PartitionBorderGlobalFaceEulerWitnessStats, PartitionBorderGlobalFaceIdApplicationStats,
-    PartitionBorderGlobalFaceIdMutationStats, PartitionBorderGlobalFaceIdPlanStats,
-    PartitionBorderGlobalFaceIdentityInvariantStats,
+    PartitionBorderGlobalFaceEulerWitnessStats, PartitionBorderGlobalFaceExtractionGateStats,
+    PartitionBorderGlobalFaceIdApplicationStats, PartitionBorderGlobalFaceIdMutationStats,
+    PartitionBorderGlobalFaceIdPlanStats, PartitionBorderGlobalFaceIdentityInvariantStats,
     PartitionBorderGlobalFaceIdentityMaterializationStats,
     PartitionBorderGlobalFaceIdentityPlanStats, PartitionBorderGlobalFaceMutationGateStats,
     PartitionBorderGlobalFaceNextApplicationStats, PartitionBorderGlobalFaceNextCandidateStats,
@@ -1402,6 +1402,30 @@ impl TraceRecorderV1 {
                 "reciprocal_edge_mismatch_count": stats.reciprocal_edge_mismatch_count,
                 "ring_payload_ready": stats.ring_payload_ready,
                 "geometry_ready": stats.geometry_ready,
+            }),
+        )
+    }
+
+    pub(crate) fn record_partition_border_global_face_extraction_gate(
+        &mut self,
+        stats: PartitionBorderGlobalFaceExtractionGateStats,
+    ) -> bool {
+        self.record(
+            TraceStageV1::Graph,
+            "partition_border_global_face_extraction_gate",
+            serde_json::json!({
+                "edge_count": stats.edge_count,
+                "cycle_count": stats.cycle_count,
+                "identity_invariants_ready": stats.identity_invariants_ready,
+                "next_lineage_ready": stats.next_lineage_ready,
+                "cycle_face_lineage_ready": stats.cycle_face_lineage_ready,
+                "promotion_gate_ready": stats.promotion_gate_ready,
+                "payload_lineage_ready": stats.payload_lineage_ready,
+                "geometry_ready": stats.geometry_ready,
+                "ring_payload_ready": stats.ring_payload_ready,
+                "edge_count_mismatch_count": stats.edge_count_mismatch_count,
+                "cycle_count_mismatch_count": stats.cycle_count_mismatch_count,
+                "extraction_ready": stats.extraction_ready,
             }),
         )
     }


### PR DESCRIPTION
## Stack

- Parent: current `main` `879db48` (merged PR #1367; includes merged P5.3 evidence stack)
- Children: none
- This is a standalone bottom-of-stack PR from current `main`; no open parent remains to link natively.

## Delivered

- Added atomic detached canonical ring-payload materialization after the final extraction gate.
- Retains candidate global face ID, cycle start, traversed global edge IDs, canonical exact XY/Z coordinate bits, source-line unions, and unbounded identity.
- Added bounded coordinate/ring work and cancellation polling with fail-closed missing-face, invalid-cycle, and canonical-mismatch evidence.
- Exposed materialization counts/readiness through `StitchingReport` and bounded ring-stage trace output.
- Added regression fixtures for valid nested payloads, source/Z/canonical retention, gate refusal, limits, cancellation, and non-mutation.
- Updated P5.3 precisely; public stitched output remains untouched.

## Contract impact

Evidence-only. No local or detached successor links, face IDs, public polygons, shells, holes, dangles, cuts, invalid rings, provenance, or Z output are changed. Payload coordinates use canonical exact float bits and remain private graph evidence.

## Validation

- `cargo test -p geo-polygonize-core --lib global_face_ring_payloads` (2 passed)
- `cargo test -p geo-polygonize-core --lib global_face_` (43 passed)
- `cargo test --workspace --no-default-features` (passed; 391 core tests and tiled-equivalence 7/7 in 434.37s)
- `cargo clippy --workspace --all-targets --no-default-features -- -D warnings` (passed)
- `cargo doc -p geo-polygonize-core --no-deps` (passed)
- `cargo fmt --all -- --check` (passed)
- `git diff --check` (passed)
- Generated TypeScript bindings were restored after validation.

## Agent handoff

- Exact checkout: `3b6be40b5cd2d1f71f79f52a37b0e7121edf505c`
- Next branch: `agent/p5-detached-ring-classification-evidence`
- Next slice: classify the retained detached ring payloads into shell/hole candidates using the already-proven winding and containment evidence, retaining ambiguous touch cases fail-closed and still emitting no stitched output.
- Remaining risks: public stitched extraction, dangle/cut/invalid-ring handling, full untiled equivalence promotion, boundary-touch policy, differential fuzzing, performance evidence, and eligible-input documentation remain open.
