### PR TITLE
feat(core): assemble detached ring candidates

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -584,6 +584,9 @@ Blocked by #1288.
   candidates using winding and containment depth; keep the unbounded cycle
   separate and reject crossings, touches, unexpected overlaps, and same-winding
   nesting without promoting stitched output.
+- [x] Assemble deterministic private shell-to-hole candidate groups from the
+  classified rings; require every bounded hole to have one containing shell and
+  retain unassigned or multiply-contained holes without promoting output.
 - [ ] Build global `next` links and deterministic global face IDs.
 - [ ] Identify exactly one global unbounded face.
 - [ ] Validate twin, cycle, source, Euler, and face-walk invariants.

--- a/crates/geo-polygonize-core/src/graph/partition_border.rs
+++ b/crates/geo-polygonize-core/src/graph/partition_border.rs
@@ -754,6 +754,28 @@ pub(crate) struct PartitionBorderGlobalFaceRingClassificationStats {
     pub(crate) classification_ready: bool,
 }
 
+/// One private shell with its deterministically assigned hole candidates.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct PartitionBorderGlobalFaceRingCandidateAssembly {
+    pub(crate) shell_candidate_global_face_id: usize,
+    pub(crate) shell_cycle_start_global_dir_edge_id: usize,
+    pub(crate) hole_candidate_global_face_ids: Vec<usize>,
+}
+
+/// Counts atomic shell/hole candidate assembly after ring classification.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct PartitionBorderGlobalFaceRingCandidateAssemblyStats {
+    pub(crate) cycle_count: usize,
+    pub(crate) shell_candidate_count: usize,
+    pub(crate) hole_candidate_count: usize,
+    pub(crate) assembled_shell_count: usize,
+    pub(crate) assigned_hole_count: usize,
+    pub(crate) unassigned_hole_count: usize,
+    pub(crate) ambiguous_hole_count: usize,
+    pub(crate) evidence_mismatch_count: usize,
+    pub(crate) candidate_ready: bool,
+}
+
 /// Counts the one atomic commit of detached global successor links. Face IDs
 /// remain a separate roadmap slice; no local face identity or output is
 /// changed by this mutation.
@@ -1494,6 +1516,7 @@ pub struct PartitionBorderGraph {
     global_unbounded_face_id_by_cycle_start: Option<(usize, usize)>,
     global_face_ring_payloads: Vec<PartitionBorderGlobalFaceRingPayload>,
     global_face_ring_classifications: Vec<PartitionBorderGlobalFaceRingClassification>,
+    global_face_ring_candidate_assemblies: Vec<PartitionBorderGlobalFaceRingCandidateAssembly>,
 }
 
 impl PartitionBorderGraph {
@@ -1547,6 +1570,7 @@ impl PartitionBorderGraph {
         self.global_unbounded_face_id_by_cycle_start = None;
         self.global_face_ring_payloads.clear();
         self.global_face_ring_classifications.clear();
+        self.global_face_ring_candidate_assemblies.clear();
         self.global_face_edge_map.clear();
         self.global_face_nodes.clear();
         Ok(())
@@ -1590,6 +1614,7 @@ impl PartitionBorderGraph {
         self.global_unbounded_face_id_by_cycle_start = None;
         self.global_face_ring_payloads.clear();
         self.global_face_ring_classifications.clear();
+        self.global_face_ring_candidate_assemblies.clear();
         self.global_face_edge_map.clear();
         self.global_face_nodes.clear();
         Ok(())
@@ -1622,6 +1647,7 @@ impl PartitionBorderGraph {
         self.global_unbounded_face_id_by_cycle_start = None;
         self.global_face_ring_payloads.clear();
         self.global_face_ring_classifications.clear();
+        self.global_face_ring_candidate_assemblies.clear();
     }
 
     pub fn node_count(&self) -> usize {
@@ -3405,6 +3431,130 @@ impl PartitionBorderGraph {
         Ok(stats)
     }
 
+    /// Assembles private shell-to-hole candidate groups from classified rings.
+    /// The groups are evidence only and are committed atomically.
+    pub(crate) fn assemble_global_face_ring_candidates(
+        &mut self,
+        execution_policy: &ExecutionPolicy,
+        classification_stats: PartitionBorderGlobalFaceRingClassificationStats,
+    ) -> crate::Result<PartitionBorderGlobalFaceRingCandidateAssemblyStats> {
+        execution_policy.check_cancelled("partition_border_global_face_ring_candidate_assembly")?;
+        let cycle_count = classification_stats.cycle_count;
+        execution_policy.check(
+            "partition_border_global_face_ring_candidate_assembly_cycles",
+            execution_policy.max_graph_nodes,
+            cycle_count,
+        )?;
+        let mut stats = PartitionBorderGlobalFaceRingCandidateAssemblyStats {
+            cycle_count,
+            shell_candidate_count: classification_stats.shell_candidate_count,
+            hole_candidate_count: classification_stats.hole_candidate_count,
+            ..Default::default()
+        };
+        if !classification_stats.classification_ready
+            || self.global_face_ring_payloads.len() != cycle_count
+            || self.global_face_ring_classifications.len() != cycle_count
+        {
+            stats.evidence_mismatch_count += 1;
+            return Ok(stats);
+        }
+        let pair_work = cycle_count.checked_mul(cycle_count).ok_or_else(|| {
+            crate::PolygonizeError::InternalInvariantViolation {
+                reason: "global face ring candidate pair count overflow".to_string(),
+            }
+        })?;
+        execution_policy.check(
+            "partition_border_global_face_ring_candidate_assembly_pairs",
+            execution_policy.max_candidate_pairs,
+            pair_work,
+        )?;
+
+        let mut polygons = Vec::with_capacity(cycle_count);
+        for (index, payload) in self.global_face_ring_payloads.iter().enumerate() {
+            execution_policy.check_cancelled_every(
+                "partition_border_global_face_ring_candidate_assembly_cycles",
+                index,
+            )?;
+            let coords = payload
+                .coords
+                .iter()
+                .map(|bits| Coord3D::new(f64::from_bits(bits[0]), f64::from_bits(bits[1]), 0.0))
+                .collect::<Vec<_>>();
+            if coords.len() < 4 || coords.first() != coords.last() {
+                stats.evidence_mismatch_count += 1;
+                return Ok(stats);
+            }
+            polygons.push(Polygon::new(
+                LineString(coords.iter().map(|coord| coord.to_coord_2d()).collect()),
+                Vec::new(),
+            ));
+        }
+
+        let shell_indices = self
+            .global_face_ring_classifications
+            .iter()
+            .enumerate()
+            .filter_map(|(index, classification)| classification.shell_candidate.then_some(index))
+            .collect::<Vec<_>>();
+        let hole_indices = self
+            .global_face_ring_classifications
+            .iter()
+            .enumerate()
+            .filter_map(|(index, classification)| classification.hole_candidate.then_some(index))
+            .collect::<Vec<_>>();
+        let mut holes_by_shell = vec![Vec::new(); shell_indices.len()];
+        for (hole_work, &hole_index) in hole_indices.iter().enumerate() {
+            execution_policy.check_cancelled_every(
+                "partition_border_global_face_ring_candidate_assembly_pairs",
+                hole_work,
+            )?;
+            let containing_shells = shell_indices
+                .iter()
+                .enumerate()
+                .filter_map(|(shell_index, &candidate_index)| {
+                    polygons[candidate_index]
+                        .contains(polygons[hole_index].exterior())
+                        .then_some(shell_index)
+                })
+                .collect::<Vec<_>>();
+            match containing_shells.as_slice() {
+                [] => stats.unassigned_hole_count += 1,
+                [shell_index] => {
+                    holes_by_shell[*shell_index].push(hole_index);
+                    stats.assigned_hole_count += 1;
+                }
+                _ => stats.ambiguous_hole_count += 1,
+            }
+        }
+
+        let mut assemblies = Vec::with_capacity(shell_indices.len());
+        for (shell_index, &payload_index) in shell_indices.iter().enumerate() {
+            let classification = &self.global_face_ring_classifications[payload_index];
+            let mut hole_candidate_global_face_ids = holes_by_shell[shell_index]
+                .iter()
+                .map(|&hole_index| {
+                    self.global_face_ring_classifications[hole_index].candidate_global_face_id
+                })
+                .collect::<Vec<_>>();
+            hole_candidate_global_face_ids.sort_unstable();
+            assemblies.push(PartitionBorderGlobalFaceRingCandidateAssembly {
+                shell_candidate_global_face_id: classification.candidate_global_face_id,
+                shell_cycle_start_global_dir_edge_id: classification.cycle_start_global_dir_edge_id,
+                hole_candidate_global_face_ids,
+            });
+        }
+        stats.assembled_shell_count = assemblies.len();
+        stats.candidate_ready = stats.evidence_mismatch_count == 0
+            && stats.unassigned_hole_count == 0
+            && stats.ambiguous_hole_count == 0
+            && stats.assembled_shell_count == stats.shell_candidate_count
+            && stats.assigned_hole_count == stats.hole_candidate_count;
+        if stats.candidate_ready {
+            self.global_face_ring_candidate_assemblies = assemblies;
+        }
+        Ok(stats)
+    }
+
     #[cfg(test)]
     pub(crate) fn global_face_ring_payloads(&self) -> &[PartitionBorderGlobalFaceRingPayload] {
         &self.global_face_ring_payloads
@@ -3415,6 +3565,13 @@ impl PartitionBorderGraph {
         &self,
     ) -> &[PartitionBorderGlobalFaceRingClassification] {
         &self.global_face_ring_classifications
+    }
+
+    #[cfg(test)]
+    pub(crate) fn global_face_ring_candidate_assemblies(
+        &self,
+    ) -> &[PartitionBorderGlobalFaceRingCandidateAssembly] {
+        &self.global_face_ring_candidate_assemblies
     }
 
     #[cfg(test)]
@@ -6244,6 +6401,7 @@ impl PartitionBorderGraph {
         self.global_unbounded_face_id_by_cycle_start = None;
         self.global_face_ring_payloads.clear();
         self.global_face_ring_classifications.clear();
+        self.global_face_ring_candidate_assemblies.clear();
         Ok(stats)
     }
 
@@ -6980,6 +7138,7 @@ impl PartitionBorderGraph {
         self.global_unbounded_face_id_by_cycle_start = None;
         self.global_face_ring_payloads.clear();
         self.global_face_ring_classifications.clear();
+        self.global_face_ring_candidate_assemblies.clear();
         self.global_topology_candidate = Some(PartitionBorderGlobalTopologyCandidate {
             next_global_dir_edge_ids,
             cycle_start_global_dir_edge_ids,
@@ -14480,6 +14639,16 @@ mod tests {
             1
         );
         assert!(graph.global_face_ring_classifications()[1].unbounded);
+        let assembly_stats = graph
+            .assemble_global_face_ring_candidates(&ExecutionPolicy::default(), stats)
+            .unwrap();
+        assert_eq!(assembly_stats.assembled_shell_count, 1);
+        assert_eq!(assembly_stats.assigned_hole_count, 0);
+        assert!(assembly_stats.candidate_ready);
+        assert_eq!(graph.global_face_ring_candidate_assemblies().len(), 1);
+        assert!(graph.global_face_ring_candidate_assemblies()[0]
+            .hole_candidate_global_face_ids
+            .is_empty());
     }
 
     #[test]
@@ -14546,6 +14715,99 @@ mod tests {
                 limit: 0,
                 observed: 4,
             } if stage == "partition_border_global_face_ring_classification_pairs"
+        ));
+    }
+
+    #[test]
+    fn global_face_ring_candidate_assembly_assigns_contained_holes() {
+        let mut graph = cycle_geometry_graph(
+            &[
+                vec![(0.0, 0.0), (20.0, 0.0), (20.0, 20.0), (0.0, 20.0)],
+                vec![(2.0, 2.0), (2.0, 8.0), (8.0, 8.0), (8.0, 2.0)],
+                vec![(30.0, 30.0), (30.0, 40.0), (40.0, 40.0), (40.0, 30.0)],
+            ],
+            2,
+        );
+        graph.global_face_id_by_global_dir_edge_id = vec![
+            Some(0),
+            Some(0),
+            Some(0),
+            Some(0),
+            Some(1),
+            Some(1),
+            Some(1),
+            Some(1),
+            Some(2),
+            Some(2),
+            Some(2),
+            Some(2),
+        ];
+        let payload_stats = graph
+            .materialize_global_face_ring_payloads(
+                &ExecutionPolicy::default(),
+                PartitionBorderGlobalFaceExtractionGateStats {
+                    edge_count: 12,
+                    cycle_count: 3,
+                    extraction_ready: true,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let geometry_stats = graph
+            .validate_global_face_cycle_geometry(
+                &ExecutionPolicy::default(),
+                PartitionBorderGlobalFacePayloadLineageStats {
+                    edge_count: 12,
+                    cycle_count: 3,
+                    lineage_ready: true,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let classification_stats = graph
+            .classify_global_face_ring_payloads(
+                &ExecutionPolicy::default(),
+                payload_stats,
+                geometry_stats,
+            )
+            .unwrap();
+        assert!(classification_stats.classification_ready);
+        let assembly_stats = graph
+            .assemble_global_face_ring_candidates(&ExecutionPolicy::default(), classification_stats)
+            .unwrap();
+        assert_eq!(
+            assembly_stats,
+            PartitionBorderGlobalFaceRingCandidateAssemblyStats {
+                cycle_count: 3,
+                shell_candidate_count: 1,
+                hole_candidate_count: 1,
+                assembled_shell_count: 1,
+                assigned_hole_count: 1,
+                candidate_ready: true,
+                ..Default::default()
+            }
+        );
+        assert_eq!(
+            graph.global_face_ring_candidate_assemblies()[0].hole_candidate_global_face_ids,
+            vec![1]
+        );
+
+        let error = graph
+            .assemble_global_face_ring_candidates(
+                &ExecutionPolicy {
+                    max_candidate_pairs: Some(0),
+                    ..Default::default()
+                },
+                classification_stats,
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::ResourceLimitExceeded {
+                ref stage,
+                limit: 0,
+                observed: 9,
+            } if stage == "partition_border_global_face_ring_candidate_assembly_pairs"
         ));
     }
 

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -627,6 +627,16 @@ pub struct StitchingReport {
     pub partition_border_global_face_ring_classification_invalid_cycle_count: usize,
     pub partition_border_global_face_ring_classification_evidence_mismatch_count: usize,
     pub partition_border_global_face_ring_classification_ready: bool,
+    /// Detached shell-to-hole candidate assembly evidence.
+    pub partition_border_global_face_ring_candidate_assembly_cycle_count: usize,
+    pub partition_border_global_face_ring_candidate_assembly_shell_candidate_count: usize,
+    pub partition_border_global_face_ring_candidate_assembly_hole_candidate_count: usize,
+    pub partition_border_global_face_ring_candidate_assembly_assembled_shell_count: usize,
+    pub partition_border_global_face_ring_candidate_assembly_assigned_hole_count: usize,
+    pub partition_border_global_face_ring_candidate_assembly_unassigned_hole_count: usize,
+    pub partition_border_global_face_ring_candidate_assembly_ambiguous_hole_count: usize,
+    pub partition_border_global_face_ring_candidate_assembly_evidence_mismatch_count: usize,
+    pub partition_border_global_face_ring_candidate_assembly_ready: bool,
     /// Unbounded-face candidates whose local cycles are closed.
     pub partition_border_global_unbounded_face_proof_closed_count: usize,
     /// Unbounded-face twins absent from the retained twin-position map.
@@ -2964,6 +2974,11 @@ impl<'a> TiledPolygonizer<'a> {
                 partition_border_global_face_ring_payloads,
                 partition_border_global_face_cycle_geometry,
             )?;
+        let partition_border_global_face_ring_candidate_assembly = partition_border_graph
+            .assemble_global_face_ring_candidates(
+                &self.execution_policy,
+                partition_border_global_face_ring_classification,
+            )?;
         if let Some(trace) = trace.as_deref_mut() {
             trace.record_partition_border_reconciliation(partition_border_reconciliation);
             trace.record_partition_border_twin_application(partition_border_twin_application);
@@ -3077,6 +3092,9 @@ impl<'a> TiledPolygonizer<'a> {
             );
             trace.record_partition_border_global_face_ring_classification(
                 partition_border_global_face_ring_classification,
+            );
+            trace.record_partition_border_global_face_ring_candidate_assembly(
+                partition_border_global_face_ring_candidate_assembly,
             );
         }
         let unresolved = tile_reports.iter().any(Self::report_is_unresolved);
@@ -3846,6 +3864,24 @@ impl<'a> TiledPolygonizer<'a> {
                     partition_border_global_face_ring_classification.evidence_mismatch_count,
                 partition_border_global_face_ring_classification_ready:
                     partition_border_global_face_ring_classification.classification_ready,
+                partition_border_global_face_ring_candidate_assembly_cycle_count:
+                    partition_border_global_face_ring_candidate_assembly.cycle_count,
+                partition_border_global_face_ring_candidate_assembly_shell_candidate_count:
+                    partition_border_global_face_ring_candidate_assembly.shell_candidate_count,
+                partition_border_global_face_ring_candidate_assembly_hole_candidate_count:
+                    partition_border_global_face_ring_candidate_assembly.hole_candidate_count,
+                partition_border_global_face_ring_candidate_assembly_assembled_shell_count:
+                    partition_border_global_face_ring_candidate_assembly.assembled_shell_count,
+                partition_border_global_face_ring_candidate_assembly_assigned_hole_count:
+                    partition_border_global_face_ring_candidate_assembly.assigned_hole_count,
+                partition_border_global_face_ring_candidate_assembly_unassigned_hole_count:
+                    partition_border_global_face_ring_candidate_assembly.unassigned_hole_count,
+                partition_border_global_face_ring_candidate_assembly_ambiguous_hole_count:
+                    partition_border_global_face_ring_candidate_assembly.ambiguous_hole_count,
+                partition_border_global_face_ring_candidate_assembly_evidence_mismatch_count:
+                    partition_border_global_face_ring_candidate_assembly.evidence_mismatch_count,
+                partition_border_global_face_ring_candidate_assembly_ready:
+                    partition_border_global_face_ring_candidate_assembly.candidate_ready,
                 partition_border_global_unbounded_face_proof_closed_count:
                     partition_border_global_unbounded_face_proof.closed_unbounded_face_count,
                 partition_border_global_unbounded_face_proof_unmapped_twin_count:

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -15,6 +15,7 @@ use crate::graph::partition_border::{
     PartitionBorderGlobalFaceNextMutationPlanStats,
     PartitionBorderGlobalFaceNodeReconciliationStats, PartitionBorderGlobalFacePayloadLineageStats,
     PartitionBorderGlobalFacePlanStats, PartitionBorderGlobalFacePlanValidationStats,
+    PartitionBorderGlobalFaceRingCandidateAssemblyStats,
     PartitionBorderGlobalFaceRingClassificationStats, PartitionBorderGlobalFaceRingPayloadStats,
     PartitionBorderGlobalFaceTransitionPlanStats, PartitionBorderGlobalFaceTwinTransitionStats,
     PartitionBorderGlobalFaceWalkInvariantStats, PartitionBorderGlobalNextLineageIntegrationStats,
@@ -1476,6 +1477,27 @@ impl TraceRecorderV1 {
                 "invalid_cycle_count": stats.invalid_cycle_count,
                 "evidence_mismatch_count": stats.evidence_mismatch_count,
                 "classification_ready": stats.classification_ready,
+            }),
+        )
+    }
+
+    pub(crate) fn record_partition_border_global_face_ring_candidate_assembly(
+        &mut self,
+        stats: PartitionBorderGlobalFaceRingCandidateAssemblyStats,
+    ) -> bool {
+        self.record(
+            TraceStageV1::Rings,
+            "partition_border_global_face_ring_candidate_assembly",
+            serde_json::json!({
+                "cycle_count": stats.cycle_count,
+                "shell_candidate_count": stats.shell_candidate_count,
+                "hole_candidate_count": stats.hole_candidate_count,
+                "assembled_shell_count": stats.assembled_shell_count,
+                "assigned_hole_count": stats.assigned_hole_count,
+                "unassigned_hole_count": stats.unassigned_hole_count,
+                "ambiguous_hole_count": stats.ambiguous_hole_count,
+                "evidence_mismatch_count": stats.evidence_mismatch_count,
+                "candidate_ready": stats.candidate_ready,
             }),
         )
     }


### PR DESCRIPTION
## Stack

Parent: #1369 (`23a1cdf`, draft). Children: none.

## Delivered

- Assemble private shell-to-hole candidate groups from the retained classified rings.
- Assign each bounded hole only when exactly one containing shell is proven.
- Retain unassigned and multiply-contained holes as fail-closed evidence.
- Keep candidate groups atomic and deterministic; do not mutate topology or public tiled output.
- Add bounded report and trace counters for candidate assembly.

## Contract impact

Additive internal `StitchingReport` and trace evidence only. No global `next` links, face IDs, stitched polygons, provenance output, Z output, or fallback behavior are changed.

## Validation

- `cargo test -p geo-polygonize-core --lib global_face_ring` (5 passed)
- `cargo test -p geo-polygonize-core --lib` (394 passed)
- `cargo clippy -p geo-polygonize-core --all-targets --no-default-features -- -D warnings`
- `cargo doc -p geo-polygonize-core --no-deps`
- `cargo test --workspace --no-default-features` (all passed; tiling-equivalence 7/7, 426.19s)
- `cargo fmt --all -- --check`
- `git diff --check`

Generated bindings were restored before commit.

## Agent handoff

Parent: #1369. Children: none. Next branch: `agent/p5-detached-ring-extraction-readiness`, to prove deterministic private polygon candidate payload completeness (shell, assigned holes, source lineage, endpoint Z) before any stitched extraction; keep ambiguous or incomplete evidence fail-closed.
