### PR TITLE
feat(core): retain non-polygon extraction evidence

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -593,6 +593,10 @@ Blocked by #1288.
 - [x] Materialize private stitched shell/hole payloads from ready candidates,
   retaining raw XYZ bits and merged source IDs with atomic limits and
   fail-closed evidence; do not expose public polygon output.
+- [x] Retain tile-local dangle, cut-edge, and invalid-ring geometry as
+  deterministic private XYZ evidence with duplicate and finite-coordinate
+  checks; defer source-lineage promotion until the upstream payload contract
+  carries it explicitly.
 - [ ] Build global `next` links and deterministic global face IDs.
 - [ ] Identify exactly one global unbounded face.
 - [ ] Validate twin, cycle, source, Euler, and face-walk invariants.

--- a/crates/geo-polygonize-core/src/graph/partition_border.rs
+++ b/crates/geo-polygonize-core/src/graph/partition_border.rs
@@ -836,6 +836,35 @@ pub(crate) struct PartitionBorderGlobalFaceRingExtractionPayloadStats {
     pub(crate) payload_ready: bool,
 }
 
+/// A tile-local non-polygon output retained as private detached evidence.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub(crate) enum PartitionBorderGlobalNonPolygonPayloadKind {
+    Dangle,
+    CutEdge,
+    InvalidRing,
+}
+
+/// Raw XYZ bits for one private dangle, cut edge, or invalid ring.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct PartitionBorderGlobalNonPolygonExtractionPayload {
+    pub(crate) partition_id: usize,
+    pub(crate) kind: PartitionBorderGlobalNonPolygonPayloadKind,
+    pub(crate) coordinate_bits: Vec<[u64; 3]>,
+}
+
+/// Counts private non-polygon extraction evidence.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct PartitionBorderGlobalNonPolygonExtractionStats {
+    pub(crate) dangle_count: usize,
+    pub(crate) cut_edge_count: usize,
+    pub(crate) invalid_ring_count: usize,
+    pub(crate) coordinate_count: usize,
+    pub(crate) duplicate_payload_count: usize,
+    pub(crate) invalid_coordinate_count: usize,
+    pub(crate) evidence_mismatch_count: usize,
+    pub(crate) payload_ready: bool,
+}
+
 /// Counts the one atomic commit of detached global successor links. Face IDs
 /// remain a separate roadmap slice; no local face identity or output is
 /// changed by this mutation.
@@ -1579,6 +1608,9 @@ pub struct PartitionBorderGraph {
     global_face_ring_candidate_assemblies: Vec<PartitionBorderGlobalFaceRingCandidateAssembly>,
     global_face_ring_extraction_candidates: Vec<PartitionBorderGlobalFaceRingExtractionCandidate>,
     global_face_ring_extraction_payloads: Vec<PartitionBorderGlobalFaceRingExtractionPayload>,
+    global_non_polygon_extraction_payload_candidates:
+        Vec<PartitionBorderGlobalNonPolygonExtractionPayload>,
+    global_non_polygon_extraction_payloads: Vec<PartitionBorderGlobalNonPolygonExtractionPayload>,
 }
 
 impl PartitionBorderGraph {
@@ -1635,6 +1667,9 @@ impl PartitionBorderGraph {
         self.global_face_ring_candidate_assemblies.clear();
         self.global_face_ring_extraction_candidates.clear();
         self.global_face_ring_extraction_payloads.clear();
+        self.global_non_polygon_extraction_payload_candidates
+            .clear();
+        self.global_non_polygon_extraction_payloads.clear();
         self.global_face_edge_map.clear();
         self.global_face_nodes.clear();
         Ok(())
@@ -1681,6 +1716,9 @@ impl PartitionBorderGraph {
         self.global_face_ring_candidate_assemblies.clear();
         self.global_face_ring_extraction_candidates.clear();
         self.global_face_ring_extraction_payloads.clear();
+        self.global_non_polygon_extraction_payload_candidates
+            .clear();
+        self.global_non_polygon_extraction_payloads.clear();
         self.global_face_edge_map.clear();
         self.global_face_nodes.clear();
         Ok(())
@@ -1716,6 +1754,9 @@ impl PartitionBorderGraph {
         self.global_face_ring_candidate_assemblies.clear();
         self.global_face_ring_extraction_candidates.clear();
         self.global_face_ring_extraction_payloads.clear();
+        self.global_non_polygon_extraction_payload_candidates
+            .clear();
+        self.global_non_polygon_extraction_payloads.clear();
     }
 
     pub fn node_count(&self) -> usize {
@@ -4067,6 +4108,114 @@ impl PartitionBorderGraph {
         Ok(stats)
     }
 
+    /// Retains tile-local dangles, cut edges, and invalid rings as private
+    /// raw XYZ evidence. The geometry is not merged into public output.
+    pub(crate) fn retain_global_non_polygon_extraction_payloads(
+        &mut self,
+        execution_policy: &ExecutionPolicy,
+        partition_id: usize,
+        dangles: Vec<Vec<Coord3D>>,
+        cut_edges: Vec<Vec<Coord3D>>,
+        invalid_rings: Vec<Vec<Coord3D>>,
+    ) -> crate::Result<()> {
+        let mut retain = |kind, payloads: Vec<Vec<Coord3D>>| -> crate::Result<()> {
+            for (payload_index, coords) in payloads.into_iter().enumerate() {
+                execution_policy.check_cancelled_every(
+                    "partition_border_global_non_polygon_extraction_payloads",
+                    payload_index,
+                )?;
+                let coordinate_bits = coords
+                    .into_iter()
+                    .map(|coord| {
+                        [
+                            canonical_coordinate_bits(coord.x),
+                            canonical_coordinate_bits(coord.y),
+                            canonical_coordinate_bits(coord.z),
+                        ]
+                    })
+                    .collect();
+                self.global_non_polygon_extraction_payload_candidates.push(
+                    PartitionBorderGlobalNonPolygonExtractionPayload {
+                        partition_id,
+                        kind,
+                        coordinate_bits,
+                    },
+                );
+            }
+            Ok(())
+        };
+        retain(PartitionBorderGlobalNonPolygonPayloadKind::Dangle, dangles)?;
+        retain(
+            PartitionBorderGlobalNonPolygonPayloadKind::CutEdge,
+            cut_edges,
+        )?;
+        retain(
+            PartitionBorderGlobalNonPolygonPayloadKind::InvalidRing,
+            invalid_rings,
+        )
+    }
+
+    /// Canonicalizes private non-polygon evidence without promoting it to
+    /// public dangle, cut-edge, or invalid-ring output.
+    pub(crate) fn materialize_global_non_polygon_extraction_payloads(
+        &mut self,
+        execution_policy: &ExecutionPolicy,
+    ) -> crate::Result<PartitionBorderGlobalNonPolygonExtractionStats> {
+        execution_policy
+            .check_cancelled("partition_border_global_non_polygon_extraction_payloads")?;
+        let mut payloads = self
+            .global_non_polygon_extraction_payload_candidates
+            .clone();
+        payloads.sort_unstable_by(|left, right| {
+            (left.kind, &left.coordinate_bits, left.partition_id).cmp(&(
+                right.kind,
+                &right.coordinate_bits,
+                right.partition_id,
+            ))
+        });
+        let mut stats = PartitionBorderGlobalNonPolygonExtractionStats::default();
+        for (payload_index, payload) in payloads.iter().enumerate() {
+            execution_policy.check_cancelled_every(
+                "partition_border_global_non_polygon_extraction_payloads",
+                payload_index,
+            )?;
+            match payload.kind {
+                PartitionBorderGlobalNonPolygonPayloadKind::Dangle => stats.dangle_count += 1,
+                PartitionBorderGlobalNonPolygonPayloadKind::CutEdge => stats.cut_edge_count += 1,
+                PartitionBorderGlobalNonPolygonPayloadKind::InvalidRing => {
+                    stats.invalid_ring_count += 1
+                }
+            }
+            stats.coordinate_count = stats
+                .coordinate_count
+                .checked_add(payload.coordinate_bits.len())
+                .ok_or_else(|| crate::PolygonizeError::InternalInvariantViolation {
+                    reason: "global non-polygon coordinate count overflow".to_string(),
+                })?;
+            if !payload
+                .coordinate_bits
+                .iter()
+                .all(|bits| bits.iter().all(|value| f64::from_bits(*value).is_finite()))
+            {
+                stats.invalid_coordinate_count += 1;
+            }
+            if payload_index > 0
+                && payloads[payload_index - 1].kind == payload.kind
+                && payloads[payload_index - 1].coordinate_bits == payload.coordinate_bits
+            {
+                stats.duplicate_payload_count += 1;
+            }
+        }
+        stats.payload_ready =
+            stats.invalid_coordinate_count == 0 && stats.duplicate_payload_count == 0;
+        if stats.payload_ready {
+            self.global_non_polygon_extraction_payloads = payloads;
+        } else {
+            stats.evidence_mismatch_count += 1;
+        }
+        Ok(stats)
+    }
+
     #[cfg(test)]
     pub(crate) fn global_face_ring_payloads(&self) -> &[PartitionBorderGlobalFaceRingPayload] {
         &self.global_face_ring_payloads
@@ -4098,6 +4247,13 @@ impl PartitionBorderGraph {
         &self,
     ) -> &[PartitionBorderGlobalFaceRingExtractionPayload] {
         &self.global_face_ring_extraction_payloads
+    }
+
+    #[cfg(test)]
+    pub(crate) fn global_non_polygon_extraction_payloads(
+        &self,
+    ) -> &[PartitionBorderGlobalNonPolygonExtractionPayload] {
+        &self.global_non_polygon_extraction_payloads
     }
 
     #[cfg(test)]
@@ -6930,6 +7086,9 @@ impl PartitionBorderGraph {
         self.global_face_ring_candidate_assemblies.clear();
         self.global_face_ring_extraction_candidates.clear();
         self.global_face_ring_extraction_payloads.clear();
+        self.global_non_polygon_extraction_payload_candidates
+            .clear();
+        self.global_non_polygon_extraction_payloads.clear();
         Ok(stats)
     }
 
@@ -7669,6 +7828,9 @@ impl PartitionBorderGraph {
         self.global_face_ring_candidate_assemblies.clear();
         self.global_face_ring_extraction_candidates.clear();
         self.global_face_ring_extraction_payloads.clear();
+        self.global_non_polygon_extraction_payload_candidates
+            .clear();
+        self.global_non_polygon_extraction_payloads.clear();
         self.global_topology_candidate = Some(PartitionBorderGlobalTopologyCandidate {
             next_global_dir_edge_ids,
             cycle_start_global_dir_edge_ids,
@@ -15837,6 +15999,160 @@ mod tests {
             error,
             crate::PolygonizeError::Cancelled { ref stage }
                 if stage == "partition_border_global_face_ring_extraction_payloads"
+        ));
+    }
+
+    #[test]
+    fn global_non_polygon_extraction_payloads_are_deterministic_and_atomic() {
+        let mut graph = PartitionBorderGraph::default();
+        graph
+            .retain_global_non_polygon_extraction_payloads(
+                &ExecutionPolicy::default(),
+                2,
+                vec![vec![
+                    Coord3D::new(0.0, 0.0, 3.0),
+                    Coord3D::new(1.0, 0.0, 3.0),
+                ]],
+                vec![vec![
+                    Coord3D::new(2.0, 0.0, 4.0),
+                    Coord3D::new(3.0, 0.0, 4.0),
+                ]],
+                vec![vec![
+                    Coord3D::new(4.0, 0.0, 5.0),
+                    Coord3D::new(5.0, 0.0, 5.0),
+                    Coord3D::new(4.0, 0.0, 5.0),
+                ]],
+            )
+            .unwrap();
+        let stats = graph
+            .materialize_global_non_polygon_extraction_payloads(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(
+            stats,
+            PartitionBorderGlobalNonPolygonExtractionStats {
+                dangle_count: 1,
+                cut_edge_count: 1,
+                invalid_ring_count: 1,
+                coordinate_count: 7,
+                payload_ready: true,
+                ..Default::default()
+            }
+        );
+        let payloads = graph.global_non_polygon_extraction_payloads();
+        assert_eq!(payloads.len(), 3);
+        assert_eq!(
+            payloads[0].kind,
+            PartitionBorderGlobalNonPolygonPayloadKind::Dangle
+        );
+        assert_eq!(payloads[0].coordinate_bits[0][2], 3.0f64.to_bits());
+        assert_eq!(
+            payloads[1].kind,
+            PartitionBorderGlobalNonPolygonPayloadKind::CutEdge
+        );
+        assert_eq!(
+            payloads[2].kind,
+            PartitionBorderGlobalNonPolygonPayloadKind::InvalidRing
+        );
+
+        let before = payloads.to_vec();
+        graph
+            .retain_global_non_polygon_extraction_payloads(
+                &ExecutionPolicy::default(),
+                3,
+                vec![vec![Coord3D::new(f64::NAN, 0.0, 0.0)]],
+                Vec::new(),
+                Vec::new(),
+            )
+            .unwrap();
+        let stats = graph
+            .materialize_global_non_polygon_extraction_payloads(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(stats.invalid_coordinate_count, 1);
+        assert!(!stats.payload_ready);
+        assert_eq!(graph.global_non_polygon_extraction_payloads(), before);
+
+        let mut reordered = PartitionBorderGraph::default();
+        reordered
+            .retain_global_non_polygon_extraction_payloads(
+                &ExecutionPolicy::default(),
+                2,
+                Vec::new(),
+                Vec::new(),
+                vec![vec![
+                    Coord3D::new(4.0, 0.0, 5.0),
+                    Coord3D::new(5.0, 0.0, 5.0),
+                    Coord3D::new(4.0, 0.0, 5.0),
+                ]],
+            )
+            .unwrap();
+        reordered
+            .retain_global_non_polygon_extraction_payloads(
+                &ExecutionPolicy::default(),
+                2,
+                Vec::new(),
+                vec![vec![
+                    Coord3D::new(2.0, 0.0, 4.0),
+                    Coord3D::new(3.0, 0.0, 4.0),
+                ]],
+                Vec::new(),
+            )
+            .unwrap();
+        reordered
+            .retain_global_non_polygon_extraction_payloads(
+                &ExecutionPolicy::default(),
+                2,
+                vec![vec![
+                    Coord3D::new(0.0, 0.0, 3.0),
+                    Coord3D::new(1.0, 0.0, 3.0),
+                ]],
+                Vec::new(),
+                Vec::new(),
+            )
+            .unwrap();
+        reordered
+            .materialize_global_non_polygon_extraction_payloads(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(
+            graph.global_non_polygon_extraction_payloads(),
+            reordered.global_non_polygon_extraction_payloads()
+        );
+    }
+
+    #[test]
+    fn global_non_polygon_extraction_payloads_reject_duplicates_and_cancellation() {
+        let mut duplicate = PartitionBorderGraph::default();
+        let dangle = vec![Coord3D::new(0.0, 0.0, 0.0), Coord3D::new(1.0, 0.0, 0.0)];
+        duplicate
+            .retain_global_non_polygon_extraction_payloads(
+                &ExecutionPolicy::default(),
+                0,
+                vec![dangle.clone(), dangle],
+                Vec::new(),
+                Vec::new(),
+            )
+            .unwrap();
+        let stats = duplicate
+            .materialize_global_non_polygon_extraction_payloads(&ExecutionPolicy::default())
+            .unwrap();
+        assert_eq!(stats.duplicate_payload_count, 1);
+        assert!(!stats.payload_ready);
+        assert!(duplicate
+            .global_non_polygon_extraction_payloads()
+            .is_empty());
+
+        let mut cancelled = PartitionBorderGraph::default();
+        let token = CancellationToken::new();
+        token.cancel();
+        let error = cancelled
+            .materialize_global_non_polygon_extraction_payloads(&ExecutionPolicy {
+                cancellation_token: Some(token),
+                ..Default::default()
+            })
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::Cancelled { ref stage }
+                if stage == "partition_border_global_non_polygon_extraction_payloads"
         ));
     }
 

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -664,6 +664,15 @@ pub struct StitchingReport {
     pub partition_border_global_face_ring_extraction_payload_source_lineage_mismatch_count: usize,
     pub partition_border_global_face_ring_extraction_payload_evidence_mismatch_count: usize,
     pub partition_border_global_face_ring_extraction_payload_ready: bool,
+    /// Private non-polygon extraction evidence retained from tile-local output.
+    pub partition_border_global_non_polygon_extraction_dangle_count: usize,
+    pub partition_border_global_non_polygon_extraction_cut_edge_count: usize,
+    pub partition_border_global_non_polygon_extraction_invalid_ring_count: usize,
+    pub partition_border_global_non_polygon_extraction_coordinate_count: usize,
+    pub partition_border_global_non_polygon_extraction_duplicate_payload_count: usize,
+    pub partition_border_global_non_polygon_extraction_invalid_coordinate_count: usize,
+    pub partition_border_global_non_polygon_extraction_evidence_mismatch_count: usize,
+    pub partition_border_global_non_polygon_extraction_ready: bool,
     /// Unbounded-face candidates whose local cycles are closed.
     pub partition_border_global_unbounded_face_proof_closed_count: usize,
     /// Unbounded-face twins absent from the retained twin-position map.
@@ -875,6 +884,9 @@ type TileProcessResult = (
     Vec<PartitionBorderLocalFaceGraph>,
     bool,
     crate::graph::planar_graph::PartitionBoundaryNodingStats,
+    Vec<Vec<Coord3D>>,
+    Vec<Vec<Coord3D>>,
+    Vec<Vec<Coord3D>>,
 );
 
 #[derive(Debug)]
@@ -1469,16 +1481,22 @@ impl<'a> TiledPolygonizer<'a> {
                 Vec::new(),
                 false,
                 crate::graph::planar_graph::PartitionBoundaryNodingStats::default(),
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
             ));
         }
 
         // Run polygonization
         let (result, border_observations, local_face_graphs, boundary_noding_stats) = local_poly
             .polygonize_with_partition_border_export_and_stats(partition_id, tile_bbox)?;
+        let dangles = result.dangles;
+        let cut_edges = result.cut_edges;
+        let invalid_rings = result.invalid_rings;
         report.polygon_count = result.polygons.len();
-        report.dangle_count = result.dangles.len();
-        report.cut_edge_count = result.cut_edges.len();
-        report.invalid_ring_count = result.invalid_rings.len();
+        report.dangle_count = dangles.len();
+        report.cut_edge_count = cut_edges.len();
+        report.invalid_ring_count = invalid_rings.len();
         // Ownership check:
         let mut valid_polys = Vec::new();
         let mut ownership_decisions = Vec::new();
@@ -1554,6 +1572,9 @@ impl<'a> TiledPolygonizer<'a> {
             local_face_graphs,
             capture_budget.is_some_and(|budget| budget.truncated()),
             boundary_noding_stats,
+            dangles,
+            cut_edges,
+            invalid_rings,
         ))
     }
 
@@ -2649,6 +2670,9 @@ impl<'a> TiledPolygonizer<'a> {
                     local_face_graphs,
                     capture_truncated,
                     boundary_noding_stats,
+                    dangles,
+                    cut_edges,
+                    invalid_rings,
                 ) = self.process_tile_with_retries(
                     tile_index,
                     tile,
@@ -2715,6 +2739,13 @@ impl<'a> TiledPolygonizer<'a> {
                         return Err(error);
                     }
                 }
+                partition_border_graph.retain_global_non_polygon_extraction_payloads(
+                    &self.execution_policy,
+                    tile_index,
+                    dangles,
+                    cut_edges,
+                    invalid_rings,
+                )?;
                 partition_border_local_face_graphs.extend(local_face_graphs);
                 tile_polygons.push(polygons);
                 tile_reports.push(report);
@@ -2774,11 +2805,29 @@ impl<'a> TiledPolygonizer<'a> {
                 })
                 .collect();
 
-            for result in tile_results? {
-                let (polygons, report, _, border_observations, local_face_graphs, _, _) = result;
+            for (partition_id, result) in tile_results?.into_iter().enumerate() {
+                let (
+                    polygons,
+                    report,
+                    _,
+                    border_observations,
+                    local_face_graphs,
+                    _,
+                    _,
+                    dangles,
+                    cut_edges,
+                    invalid_rings,
+                ) = result;
                 for observation in border_observations {
                     partition_border_graph.insert(observation)?;
                 }
+                partition_border_graph.retain_global_non_polygon_extraction_payloads(
+                    &self.execution_policy,
+                    partition_id,
+                    dangles,
+                    cut_edges,
+                    invalid_rings,
+                )?;
                 partition_border_local_face_graphs.extend(local_face_graphs);
                 tile_polygons.push(polygons);
                 tile_reports.push(report);
@@ -3018,6 +3067,8 @@ impl<'a> TiledPolygonizer<'a> {
                 &self.execution_policy,
                 partition_border_global_face_ring_extraction_readiness,
             )?;
+        let partition_border_global_non_polygon_extraction = partition_border_graph
+            .materialize_global_non_polygon_extraction_payloads(&self.execution_policy)?;
         if let Some(trace) = trace.as_deref_mut() {
             trace.record_partition_border_reconciliation(partition_border_reconciliation);
             trace.record_partition_border_twin_application(partition_border_twin_application);
@@ -3140,6 +3191,9 @@ impl<'a> TiledPolygonizer<'a> {
             );
             trace.record_partition_border_global_face_ring_extraction_payloads(
                 partition_border_global_face_ring_extraction_payloads,
+            );
+            trace.record_partition_border_global_non_polygon_extraction(
+                partition_border_global_non_polygon_extraction,
             );
         }
         let unresolved = tile_reports.iter().any(Self::report_is_unresolved);
@@ -3988,6 +4042,22 @@ impl<'a> TiledPolygonizer<'a> {
                         .evidence_mismatch_count,
                 partition_border_global_face_ring_extraction_payload_ready:
                     partition_border_global_face_ring_extraction_payloads.payload_ready,
+                partition_border_global_non_polygon_extraction_dangle_count:
+                    partition_border_global_non_polygon_extraction.dangle_count,
+                partition_border_global_non_polygon_extraction_cut_edge_count:
+                    partition_border_global_non_polygon_extraction.cut_edge_count,
+                partition_border_global_non_polygon_extraction_invalid_ring_count:
+                    partition_border_global_non_polygon_extraction.invalid_ring_count,
+                partition_border_global_non_polygon_extraction_coordinate_count:
+                    partition_border_global_non_polygon_extraction.coordinate_count,
+                partition_border_global_non_polygon_extraction_duplicate_payload_count:
+                    partition_border_global_non_polygon_extraction.duplicate_payload_count,
+                partition_border_global_non_polygon_extraction_invalid_coordinate_count:
+                    partition_border_global_non_polygon_extraction.invalid_coordinate_count,
+                partition_border_global_non_polygon_extraction_evidence_mismatch_count:
+                    partition_border_global_non_polygon_extraction.evidence_mismatch_count,
+                partition_border_global_non_polygon_extraction_ready:
+                    partition_border_global_non_polygon_extraction.payload_ready,
                 partition_border_global_unbounded_face_proof_closed_count:
                     partition_border_global_unbounded_face_proof.closed_unbounded_face_count,
                 partition_border_global_unbounded_face_proof_unmapped_twin_count:

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -22,6 +22,7 @@ use crate::graph::partition_border::{
     PartitionBorderGlobalFaceRingPayloadStats, PartitionBorderGlobalFaceTransitionPlanStats,
     PartitionBorderGlobalFaceTwinTransitionStats, PartitionBorderGlobalFaceWalkInvariantStats,
     PartitionBorderGlobalNextLineageIntegrationStats,
+    PartitionBorderGlobalNonPolygonExtractionStats,
     PartitionBorderGlobalTopologyApplicationGateStats, PartitionBorderGlobalTopologyCandidateStats,
     PartitionBorderGlobalTopologyMutationGateStats, PartitionBorderGlobalTopologyMutationStats,
     PartitionBorderGlobalUnboundedFaceApplicationStats,
@@ -1548,6 +1549,26 @@ impl TraceRecorderV1 {
                 "duplicate_payload_count": stats.duplicate_payload_count,
                 "invalid_payload_count": stats.invalid_payload_count,
                 "source_lineage_mismatch_count": stats.source_lineage_mismatch_count,
+                "evidence_mismatch_count": stats.evidence_mismatch_count,
+                "payload_ready": stats.payload_ready,
+            }),
+        )
+    }
+
+    pub(crate) fn record_partition_border_global_non_polygon_extraction(
+        &mut self,
+        stats: PartitionBorderGlobalNonPolygonExtractionStats,
+    ) -> bool {
+        self.record(
+            TraceStageV1::Rings,
+            "partition_border_global_non_polygon_extraction",
+            serde_json::json!({
+                "dangle_count": stats.dangle_count,
+                "cut_edge_count": stats.cut_edge_count,
+                "invalid_ring_count": stats.invalid_ring_count,
+                "coordinate_count": stats.coordinate_count,
+                "duplicate_payload_count": stats.duplicate_payload_count,
+                "invalid_coordinate_count": stats.invalid_coordinate_count,
                 "evidence_mismatch_count": stats.evidence_mismatch_count,
                 "payload_ready": stats.payload_ready,
             }),


### PR DESCRIPTION
## Summary

- retain tile-local dangles, cut edges, and invalid rings as private deterministic XYZ evidence
- reject duplicate payloads and non-finite coordinates with atomic committed state
- add additive StitchingReport counters and one bounded trace event
- preserve public tiled polygon output and defer source-lineage promotion until the upstream non-polygon payload contract carries source IDs

Stacked on #1373.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings`
- `cargo test -p geo-polygonize-core --lib` (402 passed)
- `cargo test -p geo-polygonize-core --test tiling_equivalence` (7 passed)