### PR TITLE
feat(core): materialize private unbounded face topology

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -600,7 +600,8 @@ Blocked by #1288.
 - [x] Build private global `next` links and deterministic global face IDs from
   validated detached edge slots; keep local topology and tiled output
   untouched.
-- [ ] Identify exactly one global unbounded face.
+- [x] Identify exactly one global unbounded face and carry its private
+  cycle/edge identity into the detached global topology records.
 - [ ] Validate twin, cycle, source, Euler, and face-walk invariants.
 - [ ] Extract stitched shells, holes, dangles, cuts, invalid rings, provenance,
   and Z only after validation.

--- a/crates/geo-polygonize-core/src/graph/partition_border.rs
+++ b/crates/geo-polygonize-core/src/graph/partition_border.rs
@@ -704,6 +704,7 @@ pub(crate) struct PartitionBorderGlobalFaceTopologyEdge {
     pub(crate) global_dir_edge_id: usize,
     pub(crate) next_global_dir_edge_id: usize,
     pub(crate) global_face_id: usize,
+    pub(crate) unbounded: bool,
 }
 
 /// Counts atomic detached global edge-topology materialization.
@@ -718,7 +719,13 @@ pub(crate) struct PartitionBorderGlobalFaceTopologyStats {
     pub(crate) node_discontinuity_count: usize,
     pub(crate) missing_face_id_count: usize,
     pub(crate) non_contiguous_face_id_count: usize,
+    pub(crate) unbounded_edge_count: usize,
+    pub(crate) unbounded_face_id_count: usize,
+    pub(crate) unbounded_cycle_start_count: usize,
+    pub(crate) missing_unbounded_identity_count: usize,
+    pub(crate) unbounded_identity_mismatch_count: usize,
     pub(crate) evidence_mismatch_count: usize,
+    pub(crate) unbounded_face_ready: bool,
     pub(crate) topology_ready: bool,
 }
 
@@ -8377,6 +8384,79 @@ impl PartitionBorderGraph {
             stats.evidence_mismatch_count += 1;
         }
 
+        let mut unbounded_edge_ids = BTreeSet::new();
+        match self.global_unbounded_face_id_by_cycle_start {
+            Some((unbounded_face_id, unbounded_cycle_start)) => {
+                stats.unbounded_face_id_count = self
+                    .global_face_id_by_cycle_start
+                    .iter()
+                    .filter(|face_id| **face_id == Some(unbounded_face_id))
+                    .count();
+                stats.unbounded_cycle_start_count = self
+                    .global_topology_candidate
+                    .as_ref()
+                    .map(|candidate| {
+                        candidate
+                            .cycle_start_global_dir_edge_ids
+                            .iter()
+                            .filter(|cycle_start| **cycle_start == unbounded_cycle_start)
+                            .count()
+                    })
+                    .unwrap_or_default();
+                if stats.unbounded_face_id_count != 1
+                    || stats.unbounded_cycle_start_count != 1
+                    || unbounded_cycle_start >= edge_count
+                    || self.global_face_id_by_global_dir_edge_id.len() != edge_count
+                {
+                    stats.unbounded_identity_mismatch_count += 1;
+                } else {
+                    let mut current = unbounded_cycle_start;
+                    let mut closed = false;
+                    loop {
+                        execution_policy.check_cancelled_every(
+                            "partition_border_global_face_topology_unbounded_edges",
+                            unbounded_edge_ids.len(),
+                        )?;
+                        if current >= edge_count {
+                            break;
+                        }
+                        if !unbounded_edge_ids.insert(current) {
+                            closed = current == unbounded_cycle_start;
+                            break;
+                        }
+                        if self
+                            .global_face_id_by_global_dir_edge_id
+                            .get(current)
+                            .copied()
+                            .flatten()
+                            != Some(unbounded_face_id)
+                        {
+                            break;
+                        }
+                        let Some(successor) = self
+                            .global_next_global_dir_edge_ids
+                            .get(current)
+                            .copied()
+                            .flatten()
+                        else {
+                            break;
+                        };
+                        current = successor;
+                    }
+                    if !closed || unbounded_edge_ids.is_empty() {
+                        unbounded_edge_ids.clear();
+                        stats.unbounded_identity_mismatch_count += 1;
+                    }
+                }
+            }
+            None => stats.missing_unbounded_identity_count += 1,
+        }
+        stats.unbounded_face_ready = stats.unbounded_face_id_count == 1
+            && stats.unbounded_cycle_start_count == 1
+            && stats.missing_unbounded_identity_count == 0
+            && stats.unbounded_identity_mismatch_count == 0
+            && !unbounded_edge_ids.is_empty();
+
         let mut predecessor_counts = vec![0usize; edge_count];
         let mut face_ids = BTreeSet::new();
         let mut topology = Vec::with_capacity(edge_count);
@@ -8420,10 +8500,12 @@ impl PartitionBorderGraph {
             };
             stats.face_id_count += 1;
             face_ids.insert(global_face_id);
+            stats.unbounded_edge_count += usize::from(unbounded_edge_ids.contains(&edge_index));
             topology.push(PartitionBorderGlobalFaceTopologyEdge {
                 global_dir_edge_id: edge_index,
                 next_global_dir_edge_id,
                 global_face_id,
+                unbounded: unbounded_edge_ids.contains(&edge_index),
             });
         }
         let expected_face_ids = (0..face_ids.len()).collect::<BTreeSet<_>>();
@@ -8440,6 +8522,8 @@ impl PartitionBorderGraph {
             && stats.node_discontinuity_count == 0
             && stats.missing_face_id_count == 0
             && stats.non_contiguous_face_id_count == 0
+            && stats.unbounded_face_ready
+            && stats.unbounded_edge_count == unbounded_edge_ids.len()
             && topology.len() == edge_count;
         if stats.topology_ready {
             self.global_face_topology_edges = topology;
@@ -14218,7 +14302,16 @@ mod tests {
             .unwrap()
             .next_global_dir_edge_ids
             .clone();
-        graph.global_face_id_by_global_dir_edge_id = vec![Some(0), Some(0), Some(1), Some(1)];
+        let cycle_starts = graph
+            .global_topology_candidate
+            .as_ref()
+            .unwrap()
+            .cycle_start_global_dir_edge_ids
+            .clone();
+        graph.global_face_id_by_global_dir_edge_id = vec![Some(0), Some(1), Some(0), Some(1)];
+        graph.global_face_id_by_cycle_start = vec![Some(0), Some(1)];
+        let unbounded_cycle_start = cycle_starts[0];
+        graph.global_unbounded_face_id_by_cycle_start = Some((0, unbounded_cycle_start));
         let observations_before = graph.observations.clone();
         let edges_before = graph.global_face_edge_map.clone();
         let stats = graph
@@ -14241,6 +14334,12 @@ mod tests {
             .iter()
             .enumerate()
             .all(|(index, edge)| edge.global_dir_edge_id == index));
+        assert_eq!(stats.unbounded_edge_count, 2);
+        assert!(stats.unbounded_face_ready);
+        assert!(graph
+            .global_face_topology_edges()
+            .iter()
+            .all(|edge| edge.unbounded == (edge.global_face_id == 0)));
         assert_eq!(graph.observations, observations_before);
         assert_eq!(graph.global_face_edge_map, edges_before);
 
@@ -14273,6 +14372,23 @@ mod tests {
             )
             .unwrap();
         assert!(stats.node_discontinuity_count > 0);
+        assert!(!stats.topology_ready);
+        assert_eq!(graph.global_face_topology_edges(), before);
+
+        graph.global_face_edge_map[0].to_global_node_id = Some(1);
+        graph.global_unbounded_face_id_by_cycle_start = None;
+        let stats = graph
+            .materialize_global_face_topology(
+                &ExecutionPolicy::default(),
+                PartitionBorderGlobalFaceExtractionGateStats {
+                    edge_count: 4,
+                    extraction_ready: true,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert_eq!(stats.missing_unbounded_identity_count, 1);
+        assert!(!stats.unbounded_face_ready);
         assert!(!stats.topology_ready);
         assert_eq!(graph.global_face_topology_edges(), before);
     }

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -487,7 +487,13 @@ pub struct StitchingReport {
     pub partition_border_global_face_topology_node_discontinuity_count: usize,
     pub partition_border_global_face_topology_missing_face_id_count: usize,
     pub partition_border_global_face_topology_non_contiguous_face_id_count: usize,
+    pub partition_border_global_face_topology_unbounded_edge_count: usize,
+    pub partition_border_global_face_topology_unbounded_face_id_count: usize,
+    pub partition_border_global_face_topology_unbounded_cycle_start_count: usize,
+    pub partition_border_global_face_topology_missing_unbounded_identity_count: usize,
+    pub partition_border_global_face_topology_unbounded_identity_mismatch_count: usize,
     pub partition_border_global_face_topology_evidence_mismatch_count: usize,
+    pub partition_border_global_face_topology_unbounded_face_ready: bool,
     pub partition_border_global_face_topology_ready: bool,
     /// Final detached global face-identity invariant evidence.
     pub partition_border_global_face_identity_invariant_twin_count: usize,
@@ -3713,8 +3719,20 @@ impl<'a> TiledPolygonizer<'a> {
                     partition_border_global_face_topology.missing_face_id_count,
                 partition_border_global_face_topology_non_contiguous_face_id_count:
                     partition_border_global_face_topology.non_contiguous_face_id_count,
+                partition_border_global_face_topology_unbounded_edge_count:
+                    partition_border_global_face_topology.unbounded_edge_count,
+                partition_border_global_face_topology_unbounded_face_id_count:
+                    partition_border_global_face_topology.unbounded_face_id_count,
+                partition_border_global_face_topology_unbounded_cycle_start_count:
+                    partition_border_global_face_topology.unbounded_cycle_start_count,
+                partition_border_global_face_topology_missing_unbounded_identity_count:
+                    partition_border_global_face_topology.missing_unbounded_identity_count,
+                partition_border_global_face_topology_unbounded_identity_mismatch_count:
+                    partition_border_global_face_topology.unbounded_identity_mismatch_count,
                 partition_border_global_face_topology_evidence_mismatch_count:
                     partition_border_global_face_topology.evidence_mismatch_count,
+                partition_border_global_face_topology_unbounded_face_ready:
+                    partition_border_global_face_topology.unbounded_face_ready,
                 partition_border_global_face_topology_ready:
                     partition_border_global_face_topology.topology_ready,
                 partition_border_global_face_identity_invariant_twin_count:

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -1239,7 +1239,13 @@ impl TraceRecorderV1 {
                 "node_discontinuity_count": stats.node_discontinuity_count,
                 "missing_face_id_count": stats.missing_face_id_count,
                 "non_contiguous_face_id_count": stats.non_contiguous_face_id_count,
+                "unbounded_edge_count": stats.unbounded_edge_count,
+                "unbounded_face_id_count": stats.unbounded_face_id_count,
+                "unbounded_cycle_start_count": stats.unbounded_cycle_start_count,
+                "missing_unbounded_identity_count": stats.missing_unbounded_identity_count,
+                "unbounded_identity_mismatch_count": stats.unbounded_identity_mismatch_count,
                 "evidence_mismatch_count": stats.evidence_mismatch_count,
+                "unbounded_face_ready": stats.unbounded_face_ready,
                 "topology_ready": stats.topology_ready,
             }),
         )


### PR DESCRIPTION
## What changed

- carry the already-proven unique global unbounded face identity into private global edge-topology records
- mark unbounded edge membership only after a closed face-ID-consistent walk
- keep the commit atomic and fail closed on missing, duplicate, or mismatched identity evidence
- expose only additive StitchingReport counters and one bounded trace event
- mark the roadmap identity slice complete

## Why

This is the next private proof boundary after global face topology materialization. It gives future extraction code an explicit per-edge unbounded marker without changing local topology, tiled polygons, public stitched output, or Polygon3D behavior.

## Validation

- `cargo test -p geo-polygonize-core --lib` (404 passed)
- `cargo test -p geo-polygonize-core --test tiling_equivalence` (7 passed)
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Global stitched output, public promotion, fuzzing, and performance claims remain deferred until the full equivalence gate exists.