### PR TITLE
feat(core): add private extraction readiness gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,37 @@
 # AI Agent Instructions
 
+## Native Stacked Pull Requests
+
+GitHub supports native stacked pull requests in public preview. A stack is a
+same-repository chain where each pull request targets the head branch of the
+pull request below it. Matching base branches creates the eligible chain, but
+the GitHub stack metadata and stack map must also be created with `gh stack`
+or the website's **Create stack** action.
+
+Use the GitHub CLI stack extension for new work:
+
+1. Start from the trunk with `gh stack init BRANCH-NAME`.
+2. Add dependent layers with `gh stack add BRANCH-NAME`.
+3. Commit each focused layer, then run `gh stack submit` to push branches and
+   create/link the draft pull requests.
+
+For existing branches or pull requests, use `gh stack link` with the complete
+bottom-to-top sequence, for example `gh stack link 1376 1377`. Use
+`gh stack init BRANCH1 BRANCH2` followed by `gh stack submit` when local stack
+tracking is also needed. Creating pull requests through an API or connector
+with a dependent base branch alone is not sufficient to guarantee the stack
+object or stack map exists.
+
+Maintain stacks with `gh stack view`, `gh stack rebase`, `gh stack push`, and
+`gh stack sync --prune` after the bottom layer merges. Make lower-layer fixes
+on that branch, then rebase the upstack; merge from the bottom upward. Keep
+the working tree clean before restructuring with `gh stack modify`. All stack
+branches must live in this repository; cross-fork stacks are unsupported.
+
+Check the installed extension with `gh stack --help`; the current GitHub
+documentation requires GitHub CLI 2.90.0 or later and Git 2.20 or later.
+Reference: <https://docs.github.com/en/pull-requests/how-tos/create-pull-requests/creating-stacked-pull-requests>.
+
 ## Pull Request and Commit Standards
 
 ### PR Titles

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -602,6 +602,9 @@ Blocked by #1288.
   untouched.
 - [x] Identify exactly one global unbounded face and carry its private
   cycle/edge identity into the detached global topology records.
+- [x] Consolidate private global topology, shell/hole payload, and non-polygon
+  evidence into one fail-closed extraction-readiness record; keep output
+  promotion deferred.
 - [ ] Validate twin, cycle, source, Euler, and face-walk invariants.
 - [ ] Extract stitched shells, holes, dangles, cuts, invalid rings, provenance,
   and Z only after validation.

--- a/crates/geo-polygonize-core/src/graph/partition_border.rs
+++ b/crates/geo-polygonize-core/src/graph/partition_border.rs
@@ -898,6 +898,30 @@ pub(crate) struct PartitionBorderGlobalNonPolygonExtractionStats {
     pub(crate) payload_ready: bool,
 }
 
+/// Combines private global topology, shell/hole payload, and non-polygon
+/// evidence after each producer has committed atomically. This is a final
+/// readiness record only; it never promotes topology or public output.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct PartitionBorderGlobalExtractionReadinessStats {
+    pub(crate) edge_count: usize,
+    pub(crate) topology_edge_count: usize,
+    pub(crate) candidate_shell_count: usize,
+    pub(crate) candidate_hole_count: usize,
+    pub(crate) candidate_coordinate_count: usize,
+    pub(crate) materialized_candidate_count: usize,
+    pub(crate) non_polygon_payload_count: usize,
+    pub(crate) missing_topology_count: usize,
+    pub(crate) missing_ring_candidate_count: usize,
+    pub(crate) missing_ring_payload_count: usize,
+    pub(crate) missing_non_polygon_payload_count: usize,
+    pub(crate) evidence_mismatch_count: usize,
+    pub(crate) topology_ready: bool,
+    pub(crate) ring_candidate_ready: bool,
+    pub(crate) ring_payload_ready: bool,
+    pub(crate) non_polygon_payload_ready: bool,
+    pub(crate) extraction_ready: bool,
+}
+
 /// Counts the one atomic commit of detached global successor links. Face IDs
 /// remain a separate roadmap slice; no local face identity or output is
 /// changed by this mutation.
@@ -4252,6 +4276,93 @@ impl PartitionBorderGraph {
         } else {
             stats.evidence_mismatch_count += 1;
         }
+        Ok(stats)
+    }
+
+    /// Combines the committed private extraction evidence into one bounded,
+    /// fail-closed readiness record without changing graph or output state.
+    pub(crate) fn validate_global_extraction_readiness(
+        &self,
+        execution_policy: &ExecutionPolicy,
+        topology_stats: PartitionBorderGlobalFaceTopologyStats,
+        ring_candidate_stats: PartitionBorderGlobalFaceRingExtractionReadinessStats,
+        ring_payload_stats: PartitionBorderGlobalFaceRingExtractionPayloadStats,
+        non_polygon_stats: PartitionBorderGlobalNonPolygonExtractionStats,
+    ) -> crate::Result<PartitionBorderGlobalExtractionReadinessStats> {
+        execution_policy.check_cancelled("partition_border_global_extraction_readiness")?;
+        let edge_count = self.global_face_edge_map.len();
+        execution_policy.check(
+            "partition_border_global_extraction_readiness_edges",
+            execution_policy.max_graph_edges,
+            edge_count,
+        )?;
+        execution_policy.check(
+            "partition_border_global_extraction_readiness_candidates",
+            execution_policy.max_output_polygons,
+            ring_candidate_stats.candidate_shell_count,
+        )?;
+        execution_policy.check(
+            "partition_border_global_extraction_readiness_coordinates",
+            execution_policy.max_output_coordinates,
+            ring_candidate_stats.candidate_coordinate_count,
+        )?;
+
+        let topology_ready = topology_stats.topology_ready
+            && topology_stats.edge_count == edge_count
+            && self.global_face_topology_edges.len() == topology_stats.edge_count;
+        let ring_candidate_ready = ring_candidate_stats.candidate_ready
+            && self.global_face_ring_extraction_candidates.len()
+                == ring_candidate_stats.candidate_shell_count;
+        let ring_payload_ready = ring_payload_stats.payload_ready
+            && ring_payload_stats.candidate_count == ring_candidate_stats.candidate_shell_count
+            && ring_payload_stats.materialized_candidate_count
+                == ring_candidate_stats.candidate_shell_count
+            && self.global_face_ring_extraction_payloads.len()
+                == ring_payload_stats.candidate_count;
+        let non_polygon_payload_count = non_polygon_stats
+            .dangle_count
+            .checked_add(non_polygon_stats.cut_edge_count)
+            .and_then(|count| count.checked_add(non_polygon_stats.invalid_ring_count))
+            .ok_or_else(|| crate::PolygonizeError::InternalInvariantViolation {
+                reason: "global extraction non-polygon payload count overflow".to_string(),
+            })?;
+        let non_polygon_payload_ready = non_polygon_stats.payload_ready
+            && self.global_non_polygon_extraction_payloads.len() == non_polygon_payload_count;
+        let mut stats = PartitionBorderGlobalExtractionReadinessStats {
+            edge_count,
+            topology_edge_count: topology_stats.edge_count,
+            candidate_shell_count: ring_candidate_stats.candidate_shell_count,
+            candidate_hole_count: ring_candidate_stats.candidate_hole_count,
+            candidate_coordinate_count: ring_candidate_stats.candidate_coordinate_count,
+            materialized_candidate_count: ring_payload_stats.materialized_candidate_count,
+            non_polygon_payload_count,
+            missing_topology_count: usize::from(!topology_ready),
+            missing_ring_candidate_count: usize::from(!ring_candidate_ready),
+            missing_ring_payload_count: usize::from(!ring_payload_ready),
+            missing_non_polygon_payload_count: usize::from(!non_polygon_payload_ready),
+            topology_ready,
+            ring_candidate_ready,
+            ring_payload_ready,
+            non_polygon_payload_ready,
+            ..Default::default()
+        };
+        stats.evidence_mismatch_count = topology_stats
+            .evidence_mismatch_count
+            .checked_add(ring_candidate_stats.evidence_mismatch_count)
+            .and_then(|count| count.checked_add(ring_payload_stats.evidence_mismatch_count))
+            .and_then(|count| count.checked_add(non_polygon_stats.evidence_mismatch_count))
+            .and_then(|count| count.checked_add(stats.missing_topology_count))
+            .and_then(|count| count.checked_add(stats.missing_ring_candidate_count))
+            .and_then(|count| count.checked_add(stats.missing_ring_payload_count))
+            .and_then(|count| count.checked_add(stats.missing_non_polygon_payload_count))
+            .ok_or_else(|| crate::PolygonizeError::InternalInvariantViolation {
+                reason: "global extraction evidence mismatch count overflow".to_string(),
+            })?;
+        stats.extraction_ready = stats.topology_ready
+            && stats.ring_candidate_ready
+            && stats.ring_payload_ready
+            && stats.non_polygon_payload_ready
+            && stats.evidence_mismatch_count == 0;
         Ok(stats)
     }
 
@@ -14439,6 +14550,124 @@ mod tests {
             error,
             crate::PolygonizeError::Cancelled { ref stage }
                 if stage == "partition_border_global_face_topology"
+        ));
+    }
+
+    #[test]
+    fn global_extraction_readiness_combines_private_payloads_atomically() {
+        let (mut graph, payload_stats, classification_stats, assembly_stats) =
+            prepared_global_face_ring_extraction_graph();
+        graph.global_next_global_dir_edge_ids = graph
+            .global_topology_candidate
+            .as_ref()
+            .unwrap()
+            .next_global_dir_edge_ids
+            .clone();
+        let topology_stats = graph
+            .materialize_global_face_topology(
+                &ExecutionPolicy::default(),
+                PartitionBorderGlobalFaceExtractionGateStats {
+                    edge_count: 12,
+                    extraction_ready: true,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let ring_candidate_stats = graph
+            .materialize_global_face_ring_extraction_candidates(
+                &ExecutionPolicy::default(),
+                payload_stats,
+                classification_stats,
+                assembly_stats,
+            )
+            .unwrap();
+        let ring_payload_stats = graph
+            .materialize_global_face_ring_extraction_payloads(
+                &ExecutionPolicy::default(),
+                ring_candidate_stats,
+            )
+            .unwrap();
+        let non_polygon_stats = graph
+            .materialize_global_non_polygon_extraction_payloads(&ExecutionPolicy::default())
+            .unwrap();
+        let observations_before = graph.observations.clone();
+        let edges_before = graph.global_face_edge_map.clone();
+        let topology_before = graph.global_face_topology_edges.clone();
+        let stats = graph
+            .validate_global_extraction_readiness(
+                &ExecutionPolicy::default(),
+                topology_stats,
+                ring_candidate_stats,
+                ring_payload_stats,
+                non_polygon_stats,
+            )
+            .unwrap();
+        assert_eq!(stats.edge_count, 12);
+        assert_eq!(stats.topology_edge_count, 12);
+        assert_eq!(stats.candidate_shell_count, 1);
+        assert_eq!(stats.candidate_hole_count, 1);
+        assert_eq!(stats.candidate_coordinate_count, 10);
+        assert_eq!(stats.materialized_candidate_count, 1);
+        assert_eq!(stats.non_polygon_payload_count, 0);
+        assert_eq!(stats.evidence_mismatch_count, 0);
+        assert!(stats.extraction_ready);
+        assert_eq!(graph.observations, observations_before);
+        assert_eq!(graph.global_face_edge_map, edges_before);
+        assert_eq!(graph.global_face_topology_edges, topology_before);
+
+        let mut incomplete = graph.clone();
+        incomplete.global_face_topology_edges.clear();
+        let stats = incomplete
+            .validate_global_extraction_readiness(
+                &ExecutionPolicy::default(),
+                topology_stats,
+                ring_candidate_stats,
+                ring_payload_stats,
+                non_polygon_stats,
+            )
+            .unwrap();
+        assert_eq!(stats.missing_topology_count, 1);
+        assert!(!stats.extraction_ready);
+
+        let error = graph
+            .validate_global_extraction_readiness(
+                &ExecutionPolicy {
+                    max_output_polygons: Some(0),
+                    ..Default::default()
+                },
+                topology_stats,
+                ring_candidate_stats,
+                ring_payload_stats,
+                non_polygon_stats,
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::ResourceLimitExceeded {
+                ref stage,
+                limit: 0,
+                observed: 1,
+            } if stage == "partition_border_global_extraction_readiness_candidates"
+        ));
+
+        let token = CancellationToken::new();
+        token.cancel();
+        let error = graph
+            .validate_global_extraction_readiness(
+                &ExecutionPolicy {
+                    cancellation_token: Some(token),
+                    ..Default::default()
+                },
+                topology_stats,
+                ring_candidate_stats,
+                ring_payload_stats,
+                non_polygon_stats,
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::PolygonizeError::Cancelled { ref stage }
+                if stage == "partition_border_global_extraction_readiness"
         ));
     }
 

--- a/crates/geo-polygonize-core/src/tiling.rs
+++ b/crates/geo-polygonize-core/src/tiling.rs
@@ -692,6 +692,25 @@ pub struct StitchingReport {
     pub partition_border_global_non_polygon_extraction_invalid_coordinate_count: usize,
     pub partition_border_global_non_polygon_extraction_evidence_mismatch_count: usize,
     pub partition_border_global_non_polygon_extraction_ready: bool,
+    /// Consolidated private extraction readiness after all detached payloads
+    /// and topology records have committed atomically.
+    pub partition_border_global_extraction_readiness_edge_count: usize,
+    pub partition_border_global_extraction_readiness_topology_edge_count: usize,
+    pub partition_border_global_extraction_readiness_candidate_shell_count: usize,
+    pub partition_border_global_extraction_readiness_candidate_hole_count: usize,
+    pub partition_border_global_extraction_readiness_candidate_coordinate_count: usize,
+    pub partition_border_global_extraction_readiness_materialized_candidate_count: usize,
+    pub partition_border_global_extraction_readiness_non_polygon_payload_count: usize,
+    pub partition_border_global_extraction_readiness_missing_topology_count: usize,
+    pub partition_border_global_extraction_readiness_missing_ring_candidate_count: usize,
+    pub partition_border_global_extraction_readiness_missing_ring_payload_count: usize,
+    pub partition_border_global_extraction_readiness_missing_non_polygon_payload_count: usize,
+    pub partition_border_global_extraction_readiness_evidence_mismatch_count: usize,
+    pub partition_border_global_extraction_readiness_topology_ready: bool,
+    pub partition_border_global_extraction_readiness_ring_candidate_ready: bool,
+    pub partition_border_global_extraction_readiness_ring_payload_ready: bool,
+    pub partition_border_global_extraction_readiness_non_polygon_payload_ready: bool,
+    pub partition_border_global_extraction_readiness_ready: bool,
     /// Unbounded-face candidates whose local cycles are closed.
     pub partition_border_global_unbounded_face_proof_closed_count: usize,
     /// Unbounded-face twins absent from the retained twin-position map.
@@ -3093,6 +3112,14 @@ impl<'a> TiledPolygonizer<'a> {
             )?;
         let partition_border_global_non_polygon_extraction = partition_border_graph
             .materialize_global_non_polygon_extraction_payloads(&self.execution_policy)?;
+        let partition_border_global_extraction_readiness = partition_border_graph
+            .validate_global_extraction_readiness(
+                &self.execution_policy,
+                partition_border_global_face_topology,
+                partition_border_global_face_ring_extraction_readiness,
+                partition_border_global_face_ring_extraction_payloads,
+                partition_border_global_non_polygon_extraction,
+            )?;
         if let Some(trace) = trace.as_deref_mut() {
             trace.record_partition_border_reconciliation(partition_border_reconciliation);
             trace.record_partition_border_twin_application(partition_border_twin_application);
@@ -3221,6 +3248,9 @@ impl<'a> TiledPolygonizer<'a> {
             );
             trace.record_partition_border_global_non_polygon_extraction(
                 partition_border_global_non_polygon_extraction,
+            );
+            trace.record_partition_border_global_extraction_readiness(
+                partition_border_global_extraction_readiness,
             );
         }
         let unresolved = tile_reports.iter().any(Self::report_is_unresolved);
@@ -4119,6 +4149,41 @@ impl<'a> TiledPolygonizer<'a> {
                     partition_border_global_non_polygon_extraction.evidence_mismatch_count,
                 partition_border_global_non_polygon_extraction_ready:
                     partition_border_global_non_polygon_extraction.payload_ready,
+                partition_border_global_extraction_readiness_edge_count:
+                    partition_border_global_extraction_readiness.edge_count,
+                partition_border_global_extraction_readiness_topology_edge_count:
+                    partition_border_global_extraction_readiness.topology_edge_count,
+                partition_border_global_extraction_readiness_candidate_shell_count:
+                    partition_border_global_extraction_readiness.candidate_shell_count,
+                partition_border_global_extraction_readiness_candidate_hole_count:
+                    partition_border_global_extraction_readiness.candidate_hole_count,
+                partition_border_global_extraction_readiness_candidate_coordinate_count:
+                    partition_border_global_extraction_readiness.candidate_coordinate_count,
+                partition_border_global_extraction_readiness_materialized_candidate_count:
+                    partition_border_global_extraction_readiness.materialized_candidate_count,
+                partition_border_global_extraction_readiness_non_polygon_payload_count:
+                    partition_border_global_extraction_readiness.non_polygon_payload_count,
+                partition_border_global_extraction_readiness_missing_topology_count:
+                    partition_border_global_extraction_readiness.missing_topology_count,
+                partition_border_global_extraction_readiness_missing_ring_candidate_count:
+                    partition_border_global_extraction_readiness.missing_ring_candidate_count,
+                partition_border_global_extraction_readiness_missing_ring_payload_count:
+                    partition_border_global_extraction_readiness.missing_ring_payload_count,
+                partition_border_global_extraction_readiness_missing_non_polygon_payload_count:
+                    partition_border_global_extraction_readiness
+                        .missing_non_polygon_payload_count,
+                partition_border_global_extraction_readiness_evidence_mismatch_count:
+                    partition_border_global_extraction_readiness.evidence_mismatch_count,
+                partition_border_global_extraction_readiness_topology_ready:
+                    partition_border_global_extraction_readiness.topology_ready,
+                partition_border_global_extraction_readiness_ring_candidate_ready:
+                    partition_border_global_extraction_readiness.ring_candidate_ready,
+                partition_border_global_extraction_readiness_ring_payload_ready:
+                    partition_border_global_extraction_readiness.ring_payload_ready,
+                partition_border_global_extraction_readiness_non_polygon_payload_ready:
+                    partition_border_global_extraction_readiness.non_polygon_payload_ready,
+                partition_border_global_extraction_readiness_ready:
+                    partition_border_global_extraction_readiness.extraction_ready,
                 partition_border_global_unbounded_face_proof_closed_count:
                     partition_border_global_unbounded_face_proof.closed_unbounded_face_count,
                 partition_border_global_unbounded_face_proof_unmapped_twin_count:

--- a/crates/geo-polygonize-core/src/trace.rs
+++ b/crates/geo-polygonize-core/src/trace.rs
@@ -5,10 +5,11 @@ use crate::graph::partition_border::{
     PartitionBorderCanonicalNodeValidationStats, PartitionBorderGlobalComponentCoverageStats,
     PartitionBorderGlobalComponentPayloadStats, PartitionBorderGlobalComponentReconciliationStats,
     PartitionBorderGlobalCycleFaceLineageStats, PartitionBorderGlobalCycleFacePromotionGateStats,
-    PartitionBorderGlobalFaceCycleGeometryStats, PartitionBorderGlobalFaceEdgeMapStats,
-    PartitionBorderGlobalFaceEulerWitnessStats, PartitionBorderGlobalFaceExtractionGateStats,
-    PartitionBorderGlobalFaceIdApplicationStats, PartitionBorderGlobalFaceIdMutationStats,
-    PartitionBorderGlobalFaceIdPlanStats, PartitionBorderGlobalFaceIdentityInvariantStats,
+    PartitionBorderGlobalExtractionReadinessStats, PartitionBorderGlobalFaceCycleGeometryStats,
+    PartitionBorderGlobalFaceEdgeMapStats, PartitionBorderGlobalFaceEulerWitnessStats,
+    PartitionBorderGlobalFaceExtractionGateStats, PartitionBorderGlobalFaceIdApplicationStats,
+    PartitionBorderGlobalFaceIdMutationStats, PartitionBorderGlobalFaceIdPlanStats,
+    PartitionBorderGlobalFaceIdentityInvariantStats,
     PartitionBorderGlobalFaceIdentityMaterializationStats,
     PartitionBorderGlobalFaceIdentityPlanStats, PartitionBorderGlobalFaceMutationGateStats,
     PartitionBorderGlobalFaceNextApplicationStats, PartitionBorderGlobalFaceNextCandidateStats,
@@ -1600,6 +1601,35 @@ impl TraceRecorderV1 {
                 "invalid_coordinate_count": stats.invalid_coordinate_count,
                 "evidence_mismatch_count": stats.evidence_mismatch_count,
                 "payload_ready": stats.payload_ready,
+            }),
+        )
+    }
+
+    pub(crate) fn record_partition_border_global_extraction_readiness(
+        &mut self,
+        stats: PartitionBorderGlobalExtractionReadinessStats,
+    ) -> bool {
+        self.record(
+            TraceStageV1::Rings,
+            "partition_border_global_extraction_readiness",
+            serde_json::json!({
+                "edge_count": stats.edge_count,
+                "topology_edge_count": stats.topology_edge_count,
+                "candidate_shell_count": stats.candidate_shell_count,
+                "candidate_hole_count": stats.candidate_hole_count,
+                "candidate_coordinate_count": stats.candidate_coordinate_count,
+                "materialized_candidate_count": stats.materialized_candidate_count,
+                "non_polygon_payload_count": stats.non_polygon_payload_count,
+                "missing_topology_count": stats.missing_topology_count,
+                "missing_ring_candidate_count": stats.missing_ring_candidate_count,
+                "missing_ring_payload_count": stats.missing_ring_payload_count,
+                "missing_non_polygon_payload_count": stats.missing_non_polygon_payload_count,
+                "evidence_mismatch_count": stats.evidence_mismatch_count,
+                "topology_ready": stats.topology_ready,
+                "ring_candidate_ready": stats.ring_candidate_ready,
+                "ring_payload_ready": stats.ring_payload_ready,
+                "non_polygon_payload_ready": stats.non_polygon_payload_ready,
+                "extraction_ready": stats.extraction_ready,
             }),
         )
     }


### PR DESCRIPTION
## What changed

- combine committed private global topology, shell/hole candidates and payloads, and non-polygon payloads into one final readiness record
- verify producer stats match the actual atomically committed buffers, including topology and candidate/payload coverage
- retain bounded output-coordinate/polygon checks, cancellation, mismatch accounting, and fail-closed readiness
- expose additive StitchingReport counters and one bounded trace event
- mark the consolidated private-evidence roadmap slice complete

## Why

This is the child proof boundary after the unbounded-face topology layer. It gives a future promotion phase one deterministic readiness result without mutating local topology, tiled polygons, public stitched output, or Polygon3D behavior.

## Stack

- parent: #1376 `feat(core): materialize private unbounded face topology`
- base branch: `agent/p5-unbounded-face-topology`

## Validation

- `cargo test -p geo-polygonize-core --lib` (405 passed)
- `cargo test -p geo-polygonize-core --test tiling_equivalence` (7 passed)
- `cargo clippy -p geo-polygonize-core --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Global stitched output, public promotion, fuzzing, and performance claims remain deferred until the full invariant/equivalence promotion gate exists.