### PR TITLE
test(core): lock ambiguous tiled readiness boundary

### DIFF
--- a/crates/geo-polygonize-core/src/tiling_tests.rs
+++ b/crates/geo-polygonize-core/src/tiling_tests.rs
@@ -3306,6 +3306,16 @@ mod tests {
                 .stitching_report
                 .partition_border_global_stitched_output_ready
         );
+        // The internal grid borders produce ambiguous four-observation
+        // buckets. Keep the tiled result usable, but fail closed until a
+        // face-qualified pairing contract exists for those spans.
+        assert!(result.stitched_output.is_none());
+        assert_eq!(result.stitching_report.partition_border_twin_count, 0);
+        assert!(
+            !result
+                .stitching_report
+                .partition_border_global_extraction_readiness_ready
+        );
         assert_eq!(
             stitched_event.payload["ready"],
             result.stitched_output.is_some()


### PR DESCRIPTION
## Summary

Add a focused integration regression for the tiled grid fixture whose shared internal borders produce ambiguous four-observation buckets.

The test asserts that:

- existing tiled polygon output remains available;
- no unambiguous border twins are claimed;
- private extraction readiness and stitched sidecar output remain fail-closed.

This records the current promotion boundary without changing production code, public output, topology, or the roadmap.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked -p geo-polygonize-core --lib tiling::tests::tests::test_tiled_polygonization_grid -- --exact --nocapture`
- `cargo clippy --locked -p geo-polygonize-core --all-targets -- -D warnings`
- `git diff --check`

Local checks only; CI is not being watched.