### PR TITLE
test(core): add component memory evidence report

### DIFF
--- a/.github/workflows/benchmark-baseline-suite.yml
+++ b/.github/workflows/benchmark-baseline-suite.yml
@@ -56,6 +56,22 @@ jobs:
             --output target/benchmark-baseline/production-baseline-evidence-v1.json
           cat target/benchmark-baseline/production-baseline-evidence-v1.json >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Emit component memory evidence
+        run: |
+          mapfile -t publication_paths < <(find "$PUBLICATION_DIR" -type f -name publication.json | sort)
+          publication_args=()
+          for publication_path in "${publication_paths[@]}"; do
+            publication_args+=(--publication "$publication_path")
+          done
+          docker run --rm \
+            -v "$PWD:/workspace" \
+            -v "$PUBLICATION_DIR:$PUBLICATION_DIR:ro" \
+            -w /workspace "$PYTHON_IMAGE" \
+            /workspace/target/benchmark-python/bin/python benchmarks/analyze_component_memory.py \
+            "${publication_args[@]}" \
+            --output target/benchmark-baseline/component-memory-evidence-v1.json
+          cat target/benchmark-baseline/component-memory-evidence-v1.json >> "$GITHUB_STEP_SUMMARY"
+
       - name: Retain baseline suite evidence
         uses: actions/upload-artifact@v4
         with:

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -166,6 +166,24 @@ python3 benchmarks/render_benchmark_trends.py \
 The renderer refuses invalid or diagnostic artifacts and emits no fabricated
 rows when one evidence class is absent.
 
+Create a deterministic component-memory report from one or more published
+artifacts after the individual publication gates pass:
+
+```bash
+python3 benchmarks/analyze_component_memory.py \
+  --publication artifacts/production-network-1k/publication.json \
+  --publication artifacts/production-network-10k/publication.json \
+  --publication artifacts/production-network-100k/publication.json \
+  --output artifacts/component-memory-evidence-v1.json
+```
+
+The report keeps the raw component, partition-capacity, scratch, worker, peak
+RSS, and allocation evidence and adds only deterministic ratios for component
+balance, partition-capacity overhead, and scratch instances per worker. It
+requires one implementation, environment, dedicated runner, and decision-
+quality publication class. It is measurement evidence, not a layout or
+execution-policy promotion decision.
+
 Use `--lane floating` with a parity-class workload that permits the floating
 profile to measure floating noding plus polygonization. The runner performs an
 untimed full-noding validation of that pipeline before collecting samples.

--- a/benchmarks/analyze_component_memory.py
+++ b/benchmarks/analyze_component_memory.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Summarize component-memory evidence from decision-quality publications."""
+
+import argparse
+import hashlib
+import json
+import statistics
+from pathlib import Path
+
+try:
+    from benchmarks.validate_baseline_suite import _load_publication
+except ModuleNotFoundError:
+    from validate_baseline_suite import _load_publication
+
+
+ROOT = Path(__file__).resolve().parent
+COMPONENT_MEMORY_FIELDS = (
+    "component_count",
+    "active_node_count",
+    "active_edge_count",
+    "largest_component_node_count",
+    "largest_component_edge_count",
+    "partition_node_capacity",
+    "partition_edge_capacity",
+    "global_graph_node_capacity",
+    "global_graph_edge_capacity",
+    "global_graph_directed_edge_capacity",
+    "global_graph_adjacency_capacity",
+    "scratch_instance_count",
+    "execution_worker_count",
+    "max_scratch_node_capacity",
+    "max_scratch_edge_capacity",
+    "max_scratch_directed_edge_capacity",
+    "max_scratch_adjacency_capacity",
+    "max_scratch_global_node_capacity",
+    "max_scratch_local_node_capacity",
+    "max_scratch_global_dir_edge_capacity",
+    "max_merged_output_item_count",
+    "max_merged_output_coordinate_capacity",
+)
+
+
+def _median(records, field):
+    return statistics.median_low(
+        record["work"]["component_memory"][field] for record in records
+    )
+
+
+def _ratio(numerator, denominator):
+    return numerator / denominator if denominator else 0.0
+
+
+def _component_summary(context):
+    baseline = context["baseline"]
+    records = context["records"]
+    component_memory = {
+        field: _median(records, field) for field in COMPONENT_MEMORY_FIELDS
+    }
+    active_nodes = component_memory["active_node_count"]
+    active_edges = component_memory["active_edge_count"]
+    workers = component_memory["execution_worker_count"]
+    return {
+        "workload_id": baseline["workload_id"],
+        "lane": baseline["lane"],
+        "publication_id": context["publication"]["publication_id"],
+        "publication_sha256": context["publication_sha256"],
+        "artifact_sha256": baseline["artifact_sha256"],
+        "record_count": len(records),
+        "input_segments": baseline["work"]["input_segments"],
+        "median_p50_ms": statistics.median(
+            record["measurement"]["p50_ms"] for record in records
+        ),
+        "median_allocated_bytes": statistics.median(
+            record["measurement"]["allocations"]["bytes"] for record in records
+        ),
+        "median_peak_rss_bytes": statistics.median(
+            record["measurement"]["peak_rss_bytes"] for record in records
+        ),
+        "component_memory": component_memory,
+        "derived": {
+            "largest_component_node_fraction": _ratio(
+                component_memory["largest_component_node_count"], active_nodes
+            ),
+            "largest_component_edge_fraction": _ratio(
+                component_memory["largest_component_edge_count"], active_edges
+            ),
+            "partition_node_capacity_over_active": _ratio(
+                component_memory["partition_node_capacity"], active_nodes
+            ),
+            "partition_edge_capacity_over_active": _ratio(
+                component_memory["partition_edge_capacity"], active_edges
+            ),
+            "scratch_instances_per_worker": _ratio(
+                component_memory["scratch_instance_count"], workers
+            ),
+        },
+    }
+
+
+def analyze_component_memory(publication_paths):
+    if not publication_paths:
+        raise ValueError("at least one publication is required")
+    contexts = [_load_publication(path) for path in publication_paths]
+    first = contexts[0]["baseline"]
+    environment_fields = ("architecture", "os", "compiler", "commit_sha")
+    environment = {
+        field: first["environment"][field] for field in environment_fields
+    }
+    implementation = first["implementation"]
+    for context in contexts:
+        baseline = context["baseline"]
+        if {
+            field: baseline["environment"][field] for field in environment_fields
+        } != environment:
+            raise ValueError("publications must use one environment")
+        if baseline["implementation"] != implementation:
+            raise ValueError("publications must use one implementation")
+        for record in context["records"]:
+            if "component_memory" not in record["work"]:
+                raise ValueError(
+                    f"{context['publication']['publication_id']}: component memory is required"
+                )
+
+    publications = sorted(
+        (_component_summary(context) for context in contexts),
+        key=lambda value: (value["workload_id"], value["lane"]),
+    )
+    digest = hashlib.sha256(
+        "".join(value["publication_sha256"] for value in publications).encode()
+    ).hexdigest()
+    return {
+        "schema_version": 1,
+        "report_id": f"component-memory-{digest[:16]}",
+        "policy_id": "benchmark-decision-v1",
+        "measurement_class": "decision-quality",
+        "runner_class": "dedicated",
+        "publication_count": len(publications),
+        "environment": environment,
+        "publications": publications,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--publication", action="append", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    report = analyze_component_memory(args.publication)
+    args.output.write_text(json.dumps(report, indent=2, allow_nan=False) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/component-memory-evidence-v1.schema.json
+++ b/benchmarks/component-memory-evidence-v1.schema.json
@@ -1,0 +1,161 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/graydonpleasants/geo-polygonize/benchmarks/component-memory-evidence-v1.schema.json",
+  "title": "geo-polygonize component memory evidence V1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "report_id",
+    "policy_id",
+    "measurement_class",
+    "runner_class",
+    "publication_count",
+    "environment",
+    "publications"
+  ],
+  "properties": {
+    "schema_version": {"const": 1},
+    "report_id": {"type": "string", "minLength": 1},
+    "policy_id": {"const": "benchmark-decision-v1"},
+    "measurement_class": {"const": "decision-quality"},
+    "runner_class": {"const": "dedicated"},
+    "publication_count": {"type": "integer", "minimum": 1},
+    "environment": {"$ref": "#/$defs/environment"},
+    "publications": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/publication"}
+    }
+  },
+  "$defs": {
+    "environment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["architecture", "os", "compiler", "commit_sha"],
+      "properties": {
+        "architecture": {"type": "string", "minLength": 1},
+        "os": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["name", "version"],
+          "properties": {
+            "name": {"type": "string", "minLength": 1},
+            "version": {"type": "string", "minLength": 1}
+          }
+        },
+        "compiler": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["name", "version"],
+          "properties": {
+            "name": {"type": "string", "minLength": 1},
+            "version": {"type": "string", "minLength": 1}
+          }
+        },
+        "commit_sha": {"type": "string", "pattern": "^[0-9a-f]{40}$"}
+      }
+    },
+    "component_memory": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "component_count",
+        "active_node_count",
+        "active_edge_count",
+        "largest_component_node_count",
+        "largest_component_edge_count",
+        "partition_node_capacity",
+        "partition_edge_capacity",
+        "global_graph_node_capacity",
+        "global_graph_edge_capacity",
+        "global_graph_directed_edge_capacity",
+        "global_graph_adjacency_capacity",
+        "scratch_instance_count",
+        "execution_worker_count",
+        "max_scratch_node_capacity",
+        "max_scratch_edge_capacity",
+        "max_scratch_directed_edge_capacity",
+        "max_scratch_adjacency_capacity",
+        "max_scratch_global_node_capacity",
+        "max_scratch_local_node_capacity",
+        "max_scratch_global_dir_edge_capacity",
+        "max_merged_output_item_count",
+        "max_merged_output_coordinate_capacity"
+      ],
+      "properties": {
+        "component_count": {"type": "integer", "minimum": 0},
+        "active_node_count": {"type": "integer", "minimum": 0},
+        "active_edge_count": {"type": "integer", "minimum": 0},
+        "largest_component_node_count": {"type": "integer", "minimum": 0},
+        "largest_component_edge_count": {"type": "integer", "minimum": 0},
+        "partition_node_capacity": {"type": "integer", "minimum": 0},
+        "partition_edge_capacity": {"type": "integer", "minimum": 0},
+        "global_graph_node_capacity": {"type": "integer", "minimum": 0},
+        "global_graph_edge_capacity": {"type": "integer", "minimum": 0},
+        "global_graph_directed_edge_capacity": {"type": "integer", "minimum": 0},
+        "global_graph_adjacency_capacity": {"type": "integer", "minimum": 0},
+        "scratch_instance_count": {"type": "integer", "minimum": 0},
+        "execution_worker_count": {"type": "integer", "minimum": 0},
+        "max_scratch_node_capacity": {"type": "integer", "minimum": 0},
+        "max_scratch_edge_capacity": {"type": "integer", "minimum": 0},
+        "max_scratch_directed_edge_capacity": {"type": "integer", "minimum": 0},
+        "max_scratch_adjacency_capacity": {"type": "integer", "minimum": 0},
+        "max_scratch_global_node_capacity": {"type": "integer", "minimum": 0},
+        "max_scratch_local_node_capacity": {"type": "integer", "minimum": 0},
+        "max_scratch_global_dir_edge_capacity": {"type": "integer", "minimum": 0},
+        "max_merged_output_item_count": {"type": "integer", "minimum": 0},
+        "max_merged_output_coordinate_capacity": {"type": "integer", "minimum": 0}
+      }
+    },
+    "publication": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "workload_id",
+        "lane",
+        "publication_id",
+        "publication_sha256",
+        "artifact_sha256",
+        "record_count",
+        "input_segments",
+        "median_p50_ms",
+        "median_allocated_bytes",
+        "median_peak_rss_bytes",
+        "component_memory",
+        "derived"
+      ],
+      "properties": {
+        "workload_id": {"type": "string", "minLength": 1},
+        "lane": {"type": "string", "minLength": 1},
+        "publication_id": {"type": "string", "minLength": 1},
+        "publication_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "artifact_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "record_count": {"type": "integer", "minimum": 5},
+        "input_segments": {"type": "integer", "minimum": 1},
+        "median_p50_ms": {"type": "number", "exclusiveMinimum": 0},
+        "median_allocated_bytes": {"type": "number", "minimum": 0},
+        "median_peak_rss_bytes": {"type": "number", "minimum": 0},
+        "component_memory": {"$ref": "#/$defs/component_memory"},
+        "derived": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "largest_component_node_fraction",
+            "largest_component_edge_fraction",
+            "partition_node_capacity_over_active",
+            "partition_edge_capacity_over_active",
+            "scratch_instances_per_worker"
+          ],
+          "properties": {
+            "largest_component_node_fraction": {"type": "number", "minimum": 0, "maximum": 1},
+            "largest_component_edge_fraction": {"type": "number", "minimum": 0, "maximum": 1},
+            "partition_node_capacity_over_active": {"type": "number", "minimum": 0},
+            "partition_edge_capacity_over_active": {"type": "number", "minimum": 0},
+            "scratch_instances_per_worker": {"type": "number", "minimum": 0}
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/geo-polygonize-core/src/graph/planar_graph.rs
+++ b/crates/geo-polygonize-core/src/graph/planar_graph.rs
@@ -1181,9 +1181,7 @@ impl PlanarGraph {
     /// Resets all traversal and marked flags so a new polygonization pass can run.
     pub fn reset_traversal_state(&mut self) {
         // Recalculate degrees based only on non-deleted edges
-        for d in &mut self.nodes_degree {
-            *d = 0;
-        }
+        self.nodes_degree.fill(0);
         for (i, outgoing) in self.nodes_outgoing.iter().enumerate() {
             for &de_idx in outgoing {
                 let de = &self.directed_edges[de_idx];
@@ -1193,9 +1191,7 @@ impl PlanarGraph {
             }
         }
 
-        for m in &mut self.nodes_marked {
-            *m = false;
-        }
+        self.nodes_marked.fill(false);
         self.clear_next_links();
         for de in &mut self.directed_edges {
             de.is_visited = false;

--- a/tests/test_component_memory.py
+++ b/tests/test_component_memory.py
@@ -1,0 +1,133 @@
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import validate
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_module(name, relative_path):
+    path = ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+PUBLISHER = load_module("publish_benchmark", "benchmarks/publish_benchmark.py")
+ANALYZER = load_module(
+    "analyze_component_memory", "benchmarks/analyze_component_memory.py"
+)
+
+
+COMPONENT_MEMORY_FIELDS = ANALYZER.COMPONENT_MEMORY_FIELDS
+
+
+def record(workload_id, index, commit="b" * 40):
+    return {
+        "schema_version": 1,
+        "record_id": f"{workload_id}-r{index}",
+        "workload_id": workload_id,
+        "artifact_sha256": "a" * 64,
+        "lane": "already-noded-polygonization",
+        "implementation": {"name": "core", "version": "1", "features": ["parallel"]},
+        "correctness_gate": {
+            "status": "passed",
+            "validation": {"promised": True, "result": "passed"},
+            "compatibility": {"expected": "parity", "observed": "equal"},
+            "fingerprint": {
+                "outcome": "equal",
+                "actual_sha256": "a" * 64,
+                "reference_sha256": "a" * 64,
+            },
+        },
+        "topology": {
+            "polygons": 1,
+            "rings": 1,
+            "dangles": 0,
+            "cut_edges": 0,
+            "invalid_rings": 0,
+            "provenance_sources": 1,
+        },
+        "measurement": {
+            "p50_ms": 10 + index / 100,
+            "p95_ms": 12 + index / 100,
+            "throughput": {"value": 100, "unit": "input-segments/second"},
+            "samples": 30,
+            "phase_times_ms": {"polygonize": 10},
+            "allocations": {"count": 10, "bytes": 1000 + index},
+            "peak_rss_bytes": 2000 + index,
+        },
+        "work": {
+            "input_line_strings": 4,
+            "input_segments": 100,
+            "input_coordinates": 200,
+            "output_polygons": 1,
+            "output_coordinates": 5,
+            "candidate_pairs": 1,
+            "exact_predicate_calls": 1,
+            "split_events": 1,
+            "segment_expansion": {
+                "input_segments": 100,
+                "noded_segments": 100,
+                "ratio": 1,
+            },
+            "component_memory": {
+                field: 1 for field in COMPONENT_MEMORY_FIELDS
+            },
+        },
+        "environment": {
+            "architecture": "x86_64",
+            "os": {"name": "Linux", "version": "test"},
+            "compiler": {"name": "rustc", "version": "test"},
+            "dependencies": {"core": "1"},
+            "commit_sha": commit,
+        },
+    }
+
+
+def write_publication(tmp_path, workload_id="balanced-components-v1"):
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    records = []
+    for index in range(1, 6):
+        path = tmp_path / f"record-{index}.json"
+        path.write_text(json.dumps(record(workload_id, index)))
+        records.append(path)
+    publication = PUBLISHER.publish(records, "dedicated", 5)
+    path = tmp_path / "publication.json"
+    path.write_text(json.dumps(publication, indent=2) + "\n")
+    return path
+
+
+def test_component_memory_report_is_schema_valid_and_deterministic(tmp_path):
+    publication = write_publication(tmp_path)
+    report = ANALYZER.analyze_component_memory([publication])
+
+    assert report["publication_count"] == 1
+    assert report["report_id"].startswith("component-memory-")
+    summary = report["publications"][0]
+    assert summary["component_memory"]["component_count"] == 1
+    assert summary["derived"]["largest_component_edge_fraction"] == 1
+    assert summary["derived"]["scratch_instances_per_worker"] == 1
+    validate(
+        report,
+        json.loads(
+            (ROOT / "benchmarks/component-memory-evidence-v1.schema.json").read_text()
+        ),
+    )
+    assert report == ANALYZER.analyze_component_memory([publication])
+
+
+def test_component_memory_report_rejects_mixed_environments(tmp_path):
+    first = write_publication(tmp_path / "first", "first-v1")
+    second = write_publication(tmp_path / "second", "second-v1")
+    value = json.loads(second.read_text())
+    for record_value in value["records"]:
+        record_value["environment"]["commit_sha"] = "c" * 40
+    second.write_text(json.dumps(value))
+
+    with pytest.raises(ValueError, match="one environment"):
+        ANALYZER.analyze_component_memory([first, second])


### PR DESCRIPTION
## Summary

- add a schema-validated component-memory evidence report over decision-quality publications
- retain raw component, partition-capacity, scratch, worker, allocation, and peak-RSS measurements
- add deterministic component-balance and capacity/scratch ratios
- emit the report from the dedicated baseline-suite workflow

This is the first P2.2 evidence slice. It does not change polygonization, graph layout, execution thresholds, or public APIs.

## Validation

- `python3 -m pytest -q tests/test_component_memory.py tests/test_baseline_suite.py tests/test_benchmark_artifacts.py`
- `cargo test -p geo-polygonize-core --lib --quiet`
- `actionlint .github/workflows/benchmark-baseline-suite.yml`
- `cargo fmt --all -- --check`

The unfiltered local pytest run also exercised the repository but reported the existing native Python-extension-not-built failures; the pure-Python tests passed.
