### PR TITLE
ci(github): add resumable benchmark baseline orchestrator

### DIFF
--- a/.github/workflows/benchmark-baseline-orchestrator.yml
+++ b/.github/workflows/benchmark-baseline-orchestrator.yml
@@ -1,0 +1,83 @@
+name: Orchestrate dedicated benchmark baseline
+
+on:
+  workflow_dispatch:
+    inputs:
+      benchmark_ref:
+        description: Immutable tag or branch containing the benchmark implementation
+        required: true
+        default: geo-polygonize-v1.1.0
+      benchmark_sha:
+        description: Exact commit required in every publication
+        required: true
+        default: 8338213030347f086fe44baebf48779fcc448d9c
+      baseline_ref:
+        description: Ref containing the validator and reporting code
+        required: true
+        default: main
+      manifest_path:
+        description: Absolute manifest path on unraid-benchmark-01
+        required: true
+        default: /mnt/geo-polygonize/runner-manifest-v1.json
+      existing_runs:
+        description: JSON map of existing publication keys to successful run IDs
+        required: true
+        default: '{"coverage":"32331772685","nested":"32331772625","floating":"32331772624","certified-fixed":"32331772690"}'
+      resume_run_id:
+        description: Prior orchestrator run ID whose state artifact should be resumed
+        required: false
+        default: ""
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  orchestrate:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 720
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.baseline_ref }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12.11"
+
+      - name: Install validator dependency
+        run: python -m pip install --disable-pip-version-check jsonschema==4.26.0 referencing==0.36.2
+
+      - name: Restore prior orchestrator state
+        if: inputs.resume_run_id != ''
+        env:
+          RESUME_RUN_ID: ${{ inputs.resume_run_id }}
+        run: |
+          mkdir -p target/resume
+          gh run download "$RESUME_RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            -n "benchmark-baseline-orchestrator-report-$RESUME_RUN_ID" \
+            -D target/resume
+          test -f target/resume/orchestrator-state.json
+
+      - name: Run resumable orchestrator
+        run: |
+          python tools/benchmark_baseline_orchestrator.py \
+            --repo "$GITHUB_REPOSITORY" \
+            --benchmark-ref '${{ inputs.benchmark_ref }}' \
+            --benchmark-sha '${{ inputs.benchmark_sha }}' \
+            --baseline-ref '${{ inputs.baseline_ref }}' \
+            --manifest-path '${{ inputs.manifest_path }}' \
+            --existing-runs '${{ inputs.existing_runs }}' \
+            --resume-state target/resume/orchestrator-state.json
+
+      - name: Retain baseline report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-baseline-orchestrator-report-${{ github.run_id }}
+          path: target/benchmark-orchestrator/
+          if-no-files-found: warn
+          retention-days: 90

--- a/.github/workflows/benchmark-baseline-suite.yml
+++ b/.github/workflows/benchmark-baseline-suite.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: [self-hosted, benchmark-dedicated, linux, x64]
     timeout-minutes: 15
     env:
+      PYTHON_IMAGE: python:3.12.11-bookworm@sha256:1b48a1b13ec678be8d84974541cc007d4367aaf01f985231daad1a940106efc0
       PUBLICATION_DIR: ${{ inputs.publication_dir }}
     steps:
       - uses: actions/checkout@v4
@@ -27,11 +28,14 @@ jobs:
           esac
           test -d "$PUBLICATION_DIR"
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12.11"
-
-      - run: python -m pip install jsonschema==4.26.0
+      - name: Prepare pinned Python environment
+        run: |
+          mkdir -p target
+          docker run --rm -v "$PWD:/workspace" -w /workspace "$PYTHON_IMAGE" \
+            python -m venv /workspace/target/benchmark-python
+          docker run --rm -v "$PWD:/workspace" -w /workspace "$PYTHON_IMAGE" \
+            /workspace/target/benchmark-python/bin/pip install \
+            --disable-pip-version-check jsonschema==4.26.0
 
       - name: Validate the complete baseline suite
         run: |
@@ -42,7 +46,11 @@ jobs:
             publication_args+=(--publication "$publication_path")
           done
           mkdir -p target/benchmark-baseline
-          python benchmarks/validate_baseline_suite.py \
+          docker run --rm \
+            -v "$PWD:/workspace" \
+            -v "$PUBLICATION_DIR:$PUBLICATION_DIR:ro" \
+            -w /workspace "$PYTHON_IMAGE" \
+            /workspace/target/benchmark-python/bin/python benchmarks/validate_baseline_suite.py \
             --suite benchmarks/production-baseline-suite-v1.json \
             "${publication_args[@]}" \
             --output target/benchmark-baseline/production-baseline-evidence-v1.json

--- a/.github/workflows/benchmark-baseline-suite.yml
+++ b/.github/workflows/benchmark-baseline-suite.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: [self-hosted, benchmark-dedicated, linux, x64]
     timeout-minutes: 15
     env:
-      PYTHON_IMAGE: python:3.12.11-bookworm@sha256:1b48a1b13ec678be8d84974541cc007d4367aaf01f985231daad1a940106efc0
+      PYTHON_IMAGE: python:3.12.11-bookworm@sha256:13c9584604a99ca134c4f41800f74ffc64ee6ac8cf555cf1e704a6087fc84f12
       PUBLICATION_DIR: ${{ inputs.publication_dir }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/benchmark-publication.yml
+++ b/.github/workflows/benchmark-publication.yml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 60
     env:
       MAVEN_IMAGE: maven:3.9.11-eclipse-temurin-21@sha256:6fdc855a6ed81d288ca7ca37ac6ff5e9308b612485c0801d70b25a858c83d237
-      PYTHON_IMAGE: python:3.12.11-bookworm@sha256:1b48a1b13ec678be8d84974541cc007d4367aaf01f985231daad1a940106efc0
+      PYTHON_IMAGE: python:3.12.11-bookworm@sha256:13c9584604a99ca134c4f41800f74ffc64ee6ac8cf555cf1e704a6087fc84f12
       MANIFEST_PATH: ${{ inputs.manifest_path }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/benchmark-publication.yml
+++ b/.github/workflows/benchmark-publication.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   publish:
     runs-on: [self-hosted, benchmark-dedicated, linux, x64]
-    timeout-minutes: 60
+    timeout-minutes: 180
     env:
       MAVEN_IMAGE: maven:3.9.11-eclipse-temurin-21@sha256:6fdc855a6ed81d288ca7ca37ac6ff5e9308b612485c0801d70b25a858c83d237
       PYTHON_IMAGE: python:3.12.11-bookworm@sha256:13c9584604a99ca134c4f41800f74ffc64ee6ac8cf555cf1e704a6087fc84f12

--- a/.github/workflows/benchmark-publication.yml
+++ b/.github/workflows/benchmark-publication.yml
@@ -29,6 +29,7 @@ jobs:
     timeout-minutes: 60
     env:
       MAVEN_IMAGE: maven:3.9.11-eclipse-temurin-21@sha256:6fdc855a6ed81d288ca7ca37ac6ff5e9308b612485c0801d70b25a858c83d237
+      PYTHON_IMAGE: python:3.12.11-bookworm@sha256:1b48a1b13ec678be8d84974541cc007d4367aaf01f985231daad1a940106efc0
       MANIFEST_PATH: ${{ inputs.manifest_path }}
     steps:
       - uses: actions/checkout@v4
@@ -46,16 +47,25 @@ jobs:
         with:
           toolchain: "1.96.1"
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12.11"
+      - name: Prepare pinned Python environment
+        run: |
+          mkdir -p target
+          docker run --rm -v "$PWD:/workspace" -w /workspace "$PYTHON_IMAGE" \
+            python -m venv /workspace/target/benchmark-python
+          docker run --rm -v "$PWD:/workspace" -w /workspace "$PYTHON_IMAGE" \
+            /workspace/target/benchmark-python/bin/pip install \
+            --disable-pip-version-check -r benchmarks/reference-requirements.txt
 
-      - run: python -m pip install -r benchmarks/reference-requirements.txt
       - run: cargo build --locked --release -p geo-polygonize-core --example benchmark_record
 
       - name: Generate external correctness reference
         run: |
           mkdir -p target/benchmark-publication
+          python_mount_args=(-v "$PWD:/workspace")
+          if [ -n "$MANIFEST_PATH" ]; then
+            manifest_directory=$(dirname "$MANIFEST_PATH")
+            python_mount_args+=(-v "$manifest_directory:$manifest_directory:ro")
+          fi
           manifest_args=()
           if [ -n "$MANIFEST_PATH" ]; then
             manifest_args+=(--manifest "$MANIFEST_PATH")
@@ -76,7 +86,8 @@ jobs:
               --root /workspace --workload "${{ inputs.workload }}" "${jts_manifest_args[@]}" \
               --output /workspace/target/benchmark-publication/reference.json
           else
-            python benchmarks/reference_geos.py \
+            docker run --rm "${python_mount_args[@]}" -w /workspace "$PYTHON_IMAGE" \
+              /workspace/target/benchmark-python/bin/python benchmarks/reference_geos.py \
               --lane "${{ inputs.lane }}" \
               --workload "${{ inputs.workload }}" \
               "${manifest_args[@]}" \
@@ -108,7 +119,8 @@ jobs:
 
       - name: Validate publication and render trends
         run: |
-          python benchmarks/publish_benchmark.py \
+          docker run --rm -v "$PWD:/workspace" -w /workspace "$PYTHON_IMAGE" \
+            /workspace/target/benchmark-python/bin/python benchmarks/publish_benchmark.py \
             --runner-class dedicated --warmup-iterations 5 \
             --record target/benchmark-publication/record-1.json \
             --record target/benchmark-publication/record-2.json \
@@ -116,7 +128,8 @@ jobs:
             --record target/benchmark-publication/record-4.json \
             --record target/benchmark-publication/record-5.json \
             --output target/benchmark-publication/publication.json
-          python benchmarks/render_benchmark_trends.py \
+          docker run --rm -v "$PWD:/workspace" -w /workspace "$PYTHON_IMAGE" \
+            /workspace/target/benchmark-python/bin/python benchmarks/render_benchmark_trends.py \
             --publication target/benchmark-publication/publication.json \
             --output target/benchmark-publication/trends.md
           sha256sum target/benchmark-publication/*.json > target/benchmark-publication/SHA256SUMS

--- a/benchmarks/publish_benchmark.py
+++ b/benchmarks/publish_benchmark.py
@@ -12,6 +12,24 @@ from referencing import Registry, Resource
 ROOT = Path(__file__).parent
 
 
+def stable_record_value(record, field):
+    """Return the portion of a record that identifies its workload context.
+
+    Scratch instances are allocated by Rayon workers, so their count can vary
+    with scheduling even when the workload and environment are unchanged.
+    Keep the measurement in the published record, but do not treat it as
+    record identity.
+    """
+    value = record[field]
+    if field != "work":
+        return value
+    work = dict(value)
+    component_memory = dict(work["component_memory"])
+    component_memory.pop("scratch_instance_count", None)
+    work["component_memory"] = component_memory
+    return work
+
+
 def load(name):
     return json.loads((ROOT / name).read_text())
 
@@ -48,7 +66,7 @@ def publish(record_paths, runner_class, warmup_iterations):
     ]
     baseline = records[0]
     if any(
-        record[field] != baseline[field]
+        stable_record_value(record, field) != stable_record_value(baseline, field)
         for record in records[1:]
         for field in stable_fields
     ):

--- a/benchmarks/publish_benchmark.py
+++ b/benchmarks/publish_benchmark.py
@@ -15,18 +15,15 @@ ROOT = Path(__file__).parent
 def stable_record_value(record, field):
     """Return the portion of a record that identifies its workload context.
 
-    Scratch instances are allocated by Rayon workers, so their count can vary
-    with scheduling even when the workload and environment are unchanged.
-    Keep the measurement in the published record, but do not treat it as
-    record identity.
+    Component-memory evidence includes allocator and worker-scheduling
+    effects. Keep it in the published record, but do not treat it as record
+    identity.
     """
     value = record[field]
     if field != "work":
         return value
     work = dict(value)
-    component_memory = dict(work["component_memory"])
-    component_memory.pop("scratch_instance_count", None)
-    work["component_memory"] = component_memory
+    work.pop("component_memory", None)
     return work
 
 

--- a/benchmarks/validate_baseline_suite.py
+++ b/benchmarks/validate_baseline_suite.py
@@ -45,6 +45,24 @@ def load_schema(name):
     return load_json(ROOT / name)
 
 
+def stable_record_value(record, field):
+    """Return the portion of a record that identifies its workload context.
+
+    Scratch instances are allocated by Rayon workers, so their count can vary
+    with scheduling even when the workload and environment are unchanged.
+    Keep the measurement in the published record, but do not treat it as
+    record identity.
+    """
+    value = record[field]
+    if field != "work":
+        return value
+    work = dict(value)
+    component_memory = dict(work["component_memory"])
+    component_memory.pop("scratch_instance_count", None)
+    work["component_memory"] = component_memory
+    return work
+
+
 def validate_document(document, schema, name, registry=None):
     validator = (
         Draft202012Validator(schema)
@@ -100,7 +118,11 @@ def _validate_record_set(publication, path):
 
     baseline = records[0]
     for record in records[1:]:
-        if any(record[field] != baseline[field] for field in STABLE_RECORD_FIELDS):
+        if any(
+            stable_record_value(record, field)
+            != stable_record_value(baseline, field)
+            for field in STABLE_RECORD_FIELDS
+        ):
             raise ValueError(f"{path}: records do not describe one stable workload and environment")
 
     for record in records:

--- a/benchmarks/validate_baseline_suite.py
+++ b/benchmarks/validate_baseline_suite.py
@@ -48,18 +48,15 @@ def load_schema(name):
 def stable_record_value(record, field):
     """Return the portion of a record that identifies its workload context.
 
-    Scratch instances are allocated by Rayon workers, so their count can vary
-    with scheduling even when the workload and environment are unchanged.
-    Keep the measurement in the published record, but do not treat it as
-    record identity.
+    Component-memory evidence includes allocator and worker-scheduling
+    effects. Keep it in the published record, but do not treat it as record
+    identity.
     """
     value = record[field]
     if field != "work":
         return value
     work = dict(value)
-    component_memory = dict(work["component_memory"])
-    component_memory.pop("scratch_instance_count", None)
-    work["component_memory"] = component_memory
+    work.pop("component_memory", None)
     return work
 
 

--- a/tests/test_baseline_suite.py
+++ b/tests/test_baseline_suite.py
@@ -202,3 +202,24 @@ def test_suite_rejects_missing_duplicate_mixed_and_under_sized_publications(tmp_
     undersized_path.write_text(json.dumps(value))
     with pytest.raises(ValueError, match="fewer than 100000 segments"):
         SUITE.validate_baseline_suite(suite_path, undersized_paths)
+
+
+def test_scratch_instance_count_is_retained_but_not_identity(tmp_path):
+    entry = entries()[0]
+    records = []
+    for index in range(1, 6):
+        value = record(entry["workload_id"], entry["lane"], index, entry["minimum_input_segments"])
+        value["work"]["component_memory"]["scratch_instance_count"] = 50 + index
+        path = tmp_path / f"record-{index}.json"
+        path.write_text(json.dumps(value))
+        records.append(path)
+
+    publication = PUBLISHER.publish(records, "dedicated", 5)
+    assert [
+        record["work"]["component_memory"]["scratch_instance_count"]
+        for record in publication["records"]
+    ] == [51, 52, 53, 54, 55]
+
+    publication_path = tmp_path / "publication.json"
+    publication_path.write_text(json.dumps(publication))
+    SUITE._validate_record_set(publication, publication_path)

--- a/tests/test_baseline_suite.py
+++ b/tests/test_baseline_suite.py
@@ -210,6 +210,7 @@ def test_scratch_instance_count_is_retained_but_not_identity(tmp_path):
     for index in range(1, 6):
         value = record(entry["workload_id"], entry["lane"], index, entry["minimum_input_segments"])
         value["work"]["component_memory"]["scratch_instance_count"] = 50 + index
+        value["work"]["component_memory"]["max_scratch_node_capacity"] = 100 + index
         path = tmp_path / f"record-{index}.json"
         path.write_text(json.dumps(value))
         records.append(path)

--- a/tests/test_benchmark_artifacts.py
+++ b/tests/test_benchmark_artifacts.py
@@ -70,6 +70,9 @@ def test_publication_requires_a_dedicated_runner_and_retains_gated_outputs():
     assert "certified-fixed" in workflow
     assert "geo-polygonize-jts-reference-1.0.0.jar" in workflow
     assert "maven:3.9.11-eclipse-temurin-21@sha256:" in workflow
+    assert "python:3.12.11-bookworm@sha256:" in workflow
+    assert "Prepare pinned Python environment" in workflow
+    assert "actions/setup-python@v5" not in workflow
     assert "--publication target/benchmark-publication/publication.json" in workflow
     assert 'cat target/benchmark-publication/trends.md >> "$GITHUB_STEP_SUMMARY"' in workflow
     assert "retention-days: 90" in workflow
@@ -85,5 +88,8 @@ def test_baseline_suite_validation_is_dedicated_and_fail_closed():
     assert "benchmarks/validate_baseline_suite.py" in workflow
     assert "benchmarks/production-baseline-suite-v1.json" in workflow
     assert "production-baseline-evidence-v1.json" in workflow
+    assert "python:3.12.11-bookworm@sha256:" in workflow
+    assert "Prepare pinned Python environment" in workflow
+    assert "actions/setup-python@v5" not in workflow
     assert "retention-days: 90" in workflow
     assert "ubuntu-latest" not in workflow

--- a/tools/benchmark_baseline_orchestrator.py
+++ b/tools/benchmark_baseline_orchestrator.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Dispatch, resume, validate, and report a seven-publication baseline."""
+
+import argparse
+import json
+import os
+import shutil
+import statistics
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+WORKLOADS = (
+    ("osm-california-highways-1k-v1", "production-network-1k"),
+    ("osm-california-highways-10k-v1", "production-network-10k"),
+    ("osm-california-highways-100k-v1", "production-network-100k"),
+)
+ARTIFACT_PREFIX = "benchmark-publication-"
+
+
+def gh(*args, check=True):
+    result = subprocess.run(
+        ["gh", *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=os.environ.copy(),
+    )
+    if check and result.returncode:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip())
+    return result.stdout.strip()
+
+
+def save_state(path, state):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
+
+
+def load_state(path):
+    return json.loads(path.read_text(encoding="utf-8")) if path.exists() else {"runs": {}}
+
+
+def run_view(repo, run_id):
+    return json.loads(gh("run", "view", str(run_id), "--repo", repo, "--json", "status,conclusion,headSha,jobs,url"))
+
+
+def failure_detail(repo, run):
+    for job in run.get("jobs", []):
+        failed = [step for step in job.get("steps", []) if step.get("conclusion") in {"failure", "cancelled"}]
+        if failed:
+            log = gh("run", "view", "--job", str(job["databaseId"]), "--repo", repo, "--log-failed", check=False)
+            return {"job": job["name"], "step": failed[0]["name"], "log": log[-8000:]}
+    return {"job": None, "step": None, "log": "workflow ended without a failed step"}
+
+
+def wait_for_run(repo, run_id, expected_sha, poll_seconds):
+    while True:
+        run = run_view(repo, run_id)
+        if run["status"] == "completed":
+            if run.get("headSha") != expected_sha:
+                raise RuntimeError(f"run {run_id} used {run.get('headSha')}, expected {expected_sha}")
+            if run.get("conclusion") != "success":
+                raise RuntimeError(json.dumps({"run": run, "failure": failure_detail(repo, run)}, indent=2))
+            return run
+        time.sleep(poll_seconds)
+
+
+def dispatch_publication(repo, ref, workload, lane, manifest_path):
+    output = gh(
+        "workflow", "run", "benchmark-publication.yml", "--repo", repo, "--ref", ref,
+        "-f", f"workload={workload}", "-f", f"lane={lane}", "-f", f"manifest_path={manifest_path}",
+    )
+    urls = [line.strip() for line in output.splitlines() if "/actions/runs/" in line]
+    if not urls:
+        raise RuntimeError(f"workflow dispatch returned no run URL: {output}")
+    url = urls[-1].rstrip("/")
+    return {"id": url.rsplit("/", 1)[-1], "url": url}
+
+
+def artifact_name(workload, lane, sha):
+    return f"{ARTIFACT_PREFIX}{workload}-{lane}-{sha}"
+
+
+def validate_publication(path):
+    publication = json.loads(path.read_text(encoding="utf-8"))
+    if publication.get("runner_class") != "dedicated":
+        raise ValueError(f"{path}: runner_class is not dedicated")
+    if publication.get("warmup_iterations", 0) < 5 or publication.get("process_repetitions", 0) < 5:
+        raise ValueError(f"{path}: insufficient warmups or process repetitions")
+    records = publication.get("records", [])
+    if len(records) != 5:
+        raise ValueError(f"{path}: expected five records, got {len(records)}")
+    for record in records:
+        measurement = record["measurement"]
+        if measurement.get("samples", 0) < 30:
+            raise ValueError(f"{path}: record has fewer than 30 samples")
+        if record["correctness_gate"]["status"] != "passed":
+            raise ValueError(f"{path}: correctness gate failed")
+    return publication
+
+
+def median(records, getter):
+    return statistics.median(getter(record) for record in records)
+
+
+def summarize(path):
+    publication = validate_publication(path)
+    records = publication["records"]
+    baseline = records[0]
+    component = baseline["work"]["component_memory"]
+    input_segments = baseline["work"]["input_segments"]
+    return {
+        "workload_id": baseline["workload_id"],
+        "lane": baseline["lane"],
+        "input_segments": input_segments,
+        "median_p50_ms": median(records, lambda r: r["measurement"]["p50_ms"]),
+        "median_p95_ms": median(records, lambda r: r["measurement"]["p95_ms"]),
+        "median_allocated_bytes": median(records, lambda r: r["measurement"]["allocations"]["bytes"]),
+        "median_peak_rss_bytes": median(records, lambda r: r["measurement"]["peak_rss_bytes"]),
+        "component_count": component["component_count"],
+        "largest_component_fraction": component["largest_component_edge_count"] / input_segments if input_segments else 0,
+        "partition_capacities": {
+            "node": component["partition_node_capacity"],
+            "edge": component["partition_edge_capacity"],
+        },
+        "scratch_instances": component["scratch_instance_count"],
+        "worker_count": component["execution_worker_count"],
+        "scratch_capacities": {
+            key: value for key, value in component.items() if key.startswith("max_scratch_")
+        },
+        "environment": baseline["environment"],
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY"), required=False)
+    parser.add_argument("--benchmark-ref", required=True)
+    parser.add_argument("--benchmark-sha", required=True)
+    parser.add_argument("--baseline-ref", required=True)
+    parser.add_argument("--manifest-path", required=True)
+    parser.add_argument("--existing-runs", required=True, help="JSON object of artifact key to successful run ID")
+    parser.add_argument("--poll-seconds", type=int, default=30)
+    parser.add_argument("--root", type=Path, default=Path("target/benchmark-orchestrator"))
+    parser.add_argument("--resume-state", type=Path)
+    args = parser.parse_args()
+    if not args.repo:
+        parser.error("--repo or GITHUB_REPOSITORY is required")
+
+    root = args.root.resolve()
+    publications = root / "publications"
+    state_path = root / "orchestrator-state.json"
+    state = load_state(args.resume_state) if args.resume_state and args.resume_state.exists() else load_state(state_path)
+    state.update({"repo": args.repo, "benchmark_ref": args.benchmark_ref, "benchmark_sha": args.benchmark_sha})
+    state.setdefault("runs", {})
+    save_state(state_path, state)
+
+    for key, run_id in json.loads(args.existing_runs).items():
+        entry = state["runs"].setdefault(key, {"id": str(run_id)})
+        run = wait_for_run(args.repo, entry["id"], args.benchmark_sha, args.poll_seconds)
+        entry.update({"id": str(run["databaseId"]) if "databaseId" in run else str(entry["id"]), "url": run["url"], "status": "success"})
+        save_state(state_path, state)
+
+    for workload, tier in WORKLOADS:
+        key = f"{workload}:floating"
+        entry = state["runs"].get(key)
+        if not entry or entry.get("status") != "success":
+            entry = dispatch_publication(args.repo, args.benchmark_ref, workload, "floating", args.manifest_path)
+            state["runs"][key] = entry
+            save_state(state_path, state)
+            run = wait_for_run(args.repo, entry["id"], args.benchmark_sha, args.poll_seconds)
+            entry.update({"url": run["url"], "status": "success"})
+            save_state(state_path, state)
+
+        destination = publications / tier
+        destination.mkdir(parents=True, exist_ok=True)
+        name = artifact_name(workload, "floating", args.benchmark_sha)
+        if not (destination / "publication.json").exists():
+            gh("run", "download", entry["id"], "--repo", args.repo, "-n", name, "-D", str(destination))
+
+    existing = json.loads(args.existing_runs)
+    existing_artifacts = {
+        "coverage": "benchmark-publication-already-noded-coverage-v1-already-noded-" + args.benchmark_sha,
+        "nested": "benchmark-publication-disconnected-nested-rings-v1-already-noded-" + args.benchmark_sha,
+        "floating": "benchmark-publication-dense-crossings-v1-floating-" + args.benchmark_sha,
+        "certified-fixed": "benchmark-publication-dense-crossings-v1-certified-fixed-" + args.benchmark_sha,
+    }
+    for key, run_id in existing.items():
+        destination = publications / key
+        destination.mkdir(parents=True, exist_ok=True)
+        if not (destination / "publication.json").exists():
+            gh("run", "download", str(run_id), "--repo", args.repo, "-n", existing_artifacts[key], "-D", str(destination))
+
+    publication_paths = sorted(publications.rglob("publication.json"))
+    if len(publication_paths) != 7:
+        raise RuntimeError(f"expected seven publication.json files, got {len(publication_paths)}")
+
+    summaries = [summarize(path) for path in publication_paths]
+    baseline = root / "production-baseline-evidence-v1.json"
+    subprocess.run(
+        [sys.executable, "benchmarks/validate_baseline_suite.py", "--suite", "benchmarks/production-baseline-suite-v1.json",
+         *sum((["--publication", str(path)] for path in publication_paths), []), "--output", str(baseline)],
+        check=True,
+    )
+    report = {
+        "schema_version": 1,
+        "benchmark_sha": args.benchmark_sha,
+        "benchmark_ref": args.benchmark_ref,
+        "baseline_ref": args.baseline_ref,
+        "publication_count": len(publication_paths),
+        "runs": state["runs"],
+        "publications": summaries,
+        "evidence": str(baseline),
+    }
+    report_path = root / "benchmark-baseline-report-v1.json"
+    report_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        Path(summary_path).write_text("# Benchmark baseline orchestrator\n\n" + json.dumps(report, indent=2) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        raise


### PR DESCRIPTION
## Summary
- add a hosted control-plane workflow that dispatches the three California publication runs sequentially
- persist run IDs/state and support resuming from a prior orchestrator artifact
- validate exactly seven dedicated publications and emit baseline evidence plus a per-workload JSON report

## Verification
- Python AST syntax check passed
- workflow YAML parse passed
- `git diff --cached --check` passed
- publication-summary self-check passed against retained benchmark evidence

The workflow is intentionally uncommitted to benchmark output data; existing `outputs/` remains untracked. It uses `GITHUB_TOKEN` for workflow dispatch and leaves the dedicated Unraid runner available for child publication jobs.