### PR TITLE
perf(core): bypass scratch for single component

### DIFF
--- a/crates/geo-polygonize-core/src/graph/planar_graph.rs
+++ b/crates/geo-polygonize-core/src/graph/planar_graph.rs
@@ -2509,6 +2509,19 @@ impl PlanarGraph {
         Ok((partitions, memory_stats))
     }
 
+    fn active_component_count_with_execution_policy(
+        &self,
+        execution_policy: &ExecutionPolicy,
+    ) -> crate::Result<usize> {
+        let component_ids =
+            self.active_component_ids_with_execution_policy(Some(execution_policy))?;
+        Ok(component_ids
+            .iter()
+            .flatten()
+            .max()
+            .map_or(0, |component| component + 1))
+    }
+
     fn load_component_scratch(
         &self,
         scratch: &mut ComponentScratch,
@@ -2578,8 +2591,67 @@ impl PlanarGraph {
         Ok(())
     }
 
+    fn process_single_component_with_execution_policy(
+        &mut self,
+        include_graph_ids: bool,
+        include_source_ids: bool,
+        execution_policy: &ExecutionPolicy,
+        noding_postcondition_validated: bool,
+    ) -> crate::Result<ComponentProcessingResult> {
+        self.sort_edges_with_execution_policy(execution_policy)?;
+        let is_active = |directed_idx: DirEdgeId| {
+            let directed = &self.directed_edges[directed_idx];
+            !directed.is_marked && !self.edges[directed.edge_idx].deleted
+        };
+        let active_node_count = self
+            .nodes_outgoing
+            .iter()
+            .filter(|outgoing| outgoing.iter().copied().any(is_active))
+            .count();
+        let active_edge_count = self
+            .edges
+            .iter()
+            .filter(|edge| {
+                let [forward_idx, reverse_idx] = edge.dir_edges;
+                !edge.deleted && is_active(forward_idx) && is_active(reverse_idx)
+            })
+            .count();
+        let mut memory_stats = ComponentMemoryStats {
+            component_count: 1,
+            active_node_count,
+            active_edge_count,
+            largest_component_node_count: active_node_count,
+            largest_component_edge_count: active_edge_count,
+            global_graph_node_capacity: self.nodes_x.capacity(),
+            global_graph_edge_capacity: self.edges.capacity(),
+            global_graph_directed_edge_capacity: self.directed_edges.capacity(),
+            global_graph_adjacency_capacity: self.nodes_outgoing.iter().map(Vec::capacity).sum(),
+            execution_worker_count: 1,
+            ..Default::default()
+        };
+        let output = (
+            self.prune_dangles_with_execution_policy(execution_policy)?,
+            self.delete_cut_edges_with_execution_policy(
+                execution_policy,
+                noding_postcondition_validated,
+            )?,
+            Vec::new(),
+            self.get_edge_rings_with_graph_ids_and_execution_policy(
+                include_graph_ids,
+                include_source_ids,
+                execution_policy,
+                noding_postcondition_validated,
+            )?,
+        );
+        memory_stats.observe_merged_output(
+            component_output_item_count(&output),
+            component_output_coordinate_capacity(&output),
+        );
+        Ok((output, Vec::new(), Vec::new(), false, memory_stats))
+    }
+
     pub(crate) fn process_components_with_execution_policy(
-        &self,
+        &mut self,
         include_graph_ids: bool,
         include_source_ids: bool,
         execution_policy: &ExecutionPolicy,
@@ -2587,6 +2659,17 @@ impl PlanarGraph {
         capture_byte_limit: Option<usize>,
         border_export: Option<PartitionBorderExport>,
     ) -> crate::Result<ComponentProcessingResult> {
+        if border_export.is_none()
+            && capture_byte_limit.is_none()
+            && self.active_component_count_with_execution_policy(execution_policy)? == 1
+        {
+            return self.process_single_component_with_execution_policy(
+                include_graph_ids,
+                include_source_ids,
+                execution_policy,
+                noding_postcondition_validated,
+            );
+        }
         let (partitions, mut memory_stats) = self.active_component_partitions(execution_policy)?;
         let mut merged = ComponentOutput::default();
         let mut border_observations = Vec::new();

--- a/crates/geo-polygonize-core/src/polygonizer_tests.rs
+++ b/crates/geo-polygonize-core/src/polygonizer_tests.rs
@@ -680,6 +680,36 @@ mod tests {
     }
 
     #[test]
+    fn diagnostics_report_single_component_skips_partition_scratch_storage() {
+        let mut poly = Polygonizer::new();
+        poly.options_mut().node_input = false;
+        poly.options_mut().diagnostics.enabled = true;
+        poly.add_geometry(
+            LineString::from(vec![
+                (0.0, 0.0),
+                (10.0, 0.0),
+                (10.0, 10.0),
+                (0.0, 10.0),
+                (0.0, 0.0),
+            ])
+            .into(),
+        );
+
+        let result = poly.polygonize().unwrap();
+        let stats = poly.component_memory_stats();
+        assert_eq!(result.polygons.len(), 1);
+        assert_eq!(stats.component_count, 1);
+        assert_eq!(stats.active_node_count, 4);
+        assert_eq!(stats.active_edge_count, 4);
+        assert_eq!(stats.partition_node_capacity, 0);
+        assert_eq!(stats.partition_edge_capacity, 0);
+        assert_eq!(stats.scratch_instance_count, 0);
+        assert_eq!(stats.max_scratch_node_capacity, 0);
+        assert_eq!(stats.max_scratch_edge_capacity, 0);
+        assert!(stats.max_merged_output_item_count > 0);
+    }
+
+    #[test]
     fn component_memory_shape_contract_is_shared_by_feature_builds() {
         // This test intentionally runs in both the default (parallel) and
         // --no-default-features (serial) builds. Shape/capacity evidence must


### PR DESCRIPTION
## Summary

- Process exactly one active, untraced, non-border-export graph in place.
- Skip component partition vectors and reusable scratch reconstruction for that case.
- Preserve the existing component path for multiple components, trace capture, and border export.
- Add diagnostics coverage proving the single-component path reports zero partition/scratch storage.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p geo-polygonize-core --lib` (414 passed)
- `cargo test -p geo-polygonize-core --no-default-features --lib` (414 passed)
- `cargo clippy -p geo-polygonize-core --lib -- -D warnings`

This is the implementation/equivalence slice for #1291; production-scale timing and peak-RSS comparison remain the next evidence gate.