### PR TITLE
perf(core): benchmark packed CSR adjacency

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -310,6 +310,10 @@ into production; use the seven-entry #1290 suite as the common baseline for
 the timing decision. Production component-memory records now also carry the
 current row/inner capacities and an equivalent packed-CSR offset/edge word
 estimate; this is memory evidence only, not a timing or dispatch decision.
+The benchmark record now also carries a correctness-gated, shadow-only packed
+CSR traversal timing on the same graph snapshot; the end-to-end layout and
+execution comparison remains open until that candidate is measured as part of
+the seven-workload publication and compared against the promotion gate.
 
 ## P2.3 Remaining arrangement payload work
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -99,6 +99,10 @@ capacities, scratch-state instances, configured execution workers, and merged
 output buffering.
 Those fields are element capacities rather than byte estimates; use them with
 allocation and peak-RSS measurements when evaluating a layout change.
+Decision-quality records also carry an optional `measurement.layout_candidate`
+shadow result. It checks packed-CSR component and face-successor traversal
+against the current adjacency lists and times those shared operations; it does
+not change production dispatch or establish an end-to-end layout decision.
 
 Run the benchmark in five separate processes with unique `--repetition` values,
 then gate the records before publication:

--- a/benchmarks/benchmark-record-v1.schema.json
+++ b/benchmarks/benchmark-record-v1.schema.json
@@ -170,7 +170,33 @@
             "bytes": {"type": "integer", "minimum": 0}
           }
         },
-        "peak_rss_bytes": {"type": "integer", "minimum": 0}
+        "peak_rss_bytes": {"type": "integer", "minimum": 0},
+        "layout_candidate": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "candidate_id",
+            "conformance",
+            "samples",
+            "node_count",
+            "nested_storage_words",
+            "csr_storage_words",
+            "nested_traversal_p50_ns",
+            "csr_materialization_ns",
+            "csr_traversal_p50_ns"
+          ],
+          "properties": {
+            "candidate_id": {"const": "packed-csr-adjacency-v1"},
+            "conformance": {"const": true},
+            "samples": {"type": "integer", "minimum": 1},
+            "node_count": {"type": "integer", "minimum": 0},
+            "nested_storage_words": {"type": "integer", "minimum": 0},
+            "csr_storage_words": {"type": "integer", "minimum": 0},
+            "nested_traversal_p50_ns": {"type": "integer", "minimum": 0},
+            "csr_materialization_ns": {"type": "integer", "minimum": 0},
+            "csr_traversal_p50_ns": {"type": "integer", "minimum": 0}
+          }
+        }
       }
     },
     "work": {

--- a/crates/geo-polygonize-core/examples/benchmark_record.rs
+++ b/crates/geo-polygonize-core/examples/benchmark_record.rs
@@ -3,9 +3,9 @@ static ALLOC: dhat::Alloc = dhat::Alloc;
 
 use clap::{Parser, ValueEnum};
 use geo_polygonize_core::{
-    normalize_polygonize_error, polygonize, ComponentMemoryStats, Coord3D, CoordinateFingerprintV1,
-    Line3D, NodingGuarantee, NormalizedPolygonizeErrorV1, Polygonizer, PolygonizerOptions,
-    PolygonizerResult, PrecisionModel, TopologyFingerprintV1,
+    normalize_polygonize_error, polygonize, AdjacencyLayoutBenchmark, ComponentMemoryStats,
+    Coord3D, CoordinateFingerprintV1, Line3D, NodingGuarantee, NormalizedPolygonizeErrorV1,
+    Polygonizer, PolygonizerOptions, PolygonizerResult, PrecisionModel, TopologyFingerprintV1,
 };
 use geojson::{GeoJson, Value as GeoJsonValue};
 use serde::{Deserialize, Serialize};
@@ -412,6 +412,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         return Ok(());
     }
 
+    let layout_candidate = benchmark_adjacency_layout(&lines, &correctness_options, args.samples)
+        .map_err(|error| format!("CSR layout candidate failed: {error}"))?;
+
     let mut timed_options = options.clone();
     timed_options.diagnostics.timings = true;
     for _ in 0..args.warmup_iterations {
@@ -504,6 +507,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 "bytes": samples.allocated_bytes / args.samples as u64,
             },
             "peak_rss_bytes": args.peak_rss_bytes.expect("required before timing"),
+            "layout_candidate": layout_candidate,
         },
         "work": {
             "input_line_strings": workload.size.line_strings,
@@ -709,6 +713,16 @@ fn polygonize_with_component_memory(
     polygonizer.add_lines(lines);
     let result = polygonizer.polygonize()?;
     Ok((result, polygonizer.component_memory_stats()))
+}
+
+fn benchmark_adjacency_layout(
+    lines: &[Line3D],
+    options: &PolygonizerOptions,
+    samples: usize,
+) -> geo_polygonize_core::Result<AdjacencyLayoutBenchmark> {
+    let mut polygonizer = Polygonizer::with_options(options.clone());
+    polygonizer.add_lines(lines.to_vec());
+    polygonizer.benchmark_adjacency_layout(samples)
 }
 
 fn reduced_reference_outcome(reference: &ReferenceResult) -> BenchmarkReducedOutcomeV1 {

--- a/crates/geo-polygonize-core/src/graph/layout_benchmark.rs
+++ b/crates/geo-polygonize-core/src/graph/layout_benchmark.rs
@@ -1,0 +1,212 @@
+use super::planar_graph::{DirEdgeId, PlanarGraph};
+use crate::{PolygonizeError, Result};
+use std::hint::black_box;
+use std::time::Instant;
+
+// ponytail: benchmark the smallest shared adjacency operations; integrate the
+// layout only after end-to-end production evidence justifies replacing lists.
+pub(crate) struct CsrAdjacency {
+    pub(crate) offsets: Vec<usize>,
+    pub(crate) directed_edges: Vec<DirEdgeId>,
+}
+
+#[doc(hidden)]
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize)]
+pub struct AdjacencyLayoutBenchmark {
+    pub candidate_id: &'static str,
+    pub conformance: bool,
+    pub samples: usize,
+    pub node_count: usize,
+    pub nested_storage_words: usize,
+    pub csr_storage_words: usize,
+    pub nested_traversal_p50_ns: u64,
+    pub csr_materialization_ns: u64,
+    pub csr_traversal_p50_ns: u64,
+}
+
+trait AdjacencyView {
+    fn node_count(&self) -> usize;
+    fn outgoing(&self, node: usize) -> &[DirEdgeId];
+}
+
+impl AdjacencyView for PlanarGraph {
+    fn node_count(&self) -> usize {
+        self.nodes_outgoing.len()
+    }
+
+    fn outgoing(&self, node: usize) -> &[DirEdgeId] {
+        &self.nodes_outgoing[node]
+    }
+}
+
+impl AdjacencyView for CsrAdjacency {
+    fn node_count(&self) -> usize {
+        self.offsets.len().saturating_sub(1)
+    }
+
+    fn outgoing(&self, node: usize) -> &[DirEdgeId] {
+        &self.directed_edges[self.offsets[node]..self.offsets[node + 1]]
+    }
+}
+
+impl CsrAdjacency {
+    pub(crate) fn from_graph(graph: &PlanarGraph) -> Self {
+        let mut offsets = Vec::with_capacity(graph.nodes_outgoing.len() + 1);
+        let mut directed_edges = Vec::new();
+        offsets.push(0);
+        for outgoing in &graph.nodes_outgoing {
+            directed_edges.extend_from_slice(outgoing);
+            offsets.push(directed_edges.len());
+        }
+        Self {
+            offsets,
+            directed_edges,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn active_component_ids(&self, graph: &PlanarGraph) -> Vec<Option<usize>> {
+        active_component_ids(self, graph)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn outgoing(&self, node: usize) -> &[DirEdgeId] {
+        &self.directed_edges[self.offsets[node]..self.offsets[node + 1]]
+    }
+
+    #[cfg(test)]
+    pub(crate) fn next_links(&self, graph: &PlanarGraph) -> Vec<Option<DirEdgeId>> {
+        next_links(self, graph)
+    }
+}
+
+fn is_active(graph: &PlanarGraph, directed_idx: DirEdgeId) -> bool {
+    let directed = &graph.directed_edges[directed_idx];
+    !directed.is_marked && !graph.edges[directed.edge_idx].deleted
+}
+
+fn active_component_ids<V: AdjacencyView>(view: &V, graph: &PlanarGraph) -> Vec<Option<usize>> {
+    let mut seeds = (0..view.node_count())
+        .filter(|&node| {
+            view.outgoing(node)
+                .iter()
+                .copied()
+                .any(|edge| is_active(graph, edge))
+        })
+        .collect::<Vec<_>>();
+    seeds.sort_unstable_by(|&left, &right| {
+        graph.nodes_x[left]
+            .total_cmp(&graph.nodes_x[right])
+            .then_with(|| graph.nodes_y[left].total_cmp(&graph.nodes_y[right]))
+            .then(left.cmp(&right))
+    });
+
+    let mut component_ids = vec![None; view.node_count()];
+    let mut stack = Vec::new();
+    let mut next_component_id = 0;
+    for seed in seeds {
+        if component_ids[seed].is_some() {
+            continue;
+        }
+        let component_id = next_component_id;
+        next_component_id += 1;
+        component_ids[seed] = Some(component_id);
+        stack.push(seed);
+        while let Some(node) = stack.pop() {
+            for &directed_idx in view.outgoing(node) {
+                if !is_active(graph, directed_idx) {
+                    continue;
+                }
+                let neighbor = graph.directed_edges[directed_idx].dst;
+                if component_ids[neighbor].is_none() {
+                    component_ids[neighbor] = Some(component_id);
+                    stack.push(neighbor);
+                }
+            }
+        }
+    }
+    component_ids
+}
+
+fn next_links<V: AdjacencyView>(view: &V, graph: &PlanarGraph) -> Vec<Option<DirEdgeId>> {
+    let mut links = vec![None; graph.directed_edges.len()];
+    for node in 0..view.node_count() {
+        let active = view
+            .outgoing(node)
+            .iter()
+            .copied()
+            .filter(|&directed_idx| is_active(graph, directed_idx))
+            .collect::<Vec<_>>();
+        let Some(&last) = active.last() else {
+            continue;
+        };
+        let mut next = last;
+        for directed_idx in active {
+            links[directed_idx] = Some(next);
+            next = directed_idx;
+        }
+    }
+    links
+}
+
+fn elapsed_ns(started: Instant) -> u64 {
+    started.elapsed().as_nanos().min(u64::MAX as u128) as u64
+}
+
+fn median_low(values: &mut [u64]) -> u64 {
+    values.sort_unstable();
+    values[(values.len() - 1) / 2]
+}
+
+pub(crate) fn benchmark(graph: &PlanarGraph, samples: usize) -> Result<AdjacencyLayoutBenchmark> {
+    if samples == 0 {
+        return Err(PolygonizeError::InvalidArgumentType {
+            field: "samples".to_string(),
+            expected: "a positive integer".to_string(),
+            actual: "0".to_string(),
+        });
+    }
+
+    let materialization_started = Instant::now();
+    let csr = CsrAdjacency::from_graph(graph);
+    let csr_materialization_ns = elapsed_ns(materialization_started);
+    let mut nested_samples = Vec::with_capacity(samples);
+    let mut csr_samples = Vec::with_capacity(samples);
+
+    for _ in 0..samples {
+        let nested_started = Instant::now();
+        let nested_components = black_box(active_component_ids(graph, graph));
+        let nested_next = black_box(next_links(graph, graph));
+        nested_samples.push(elapsed_ns(nested_started));
+
+        let csr_started = Instant::now();
+        let csr_components = black_box(active_component_ids(&csr, graph));
+        let csr_next = black_box(next_links(&csr, graph));
+        csr_samples.push(elapsed_ns(csr_started));
+
+        if nested_components != csr_components || nested_next != csr_next {
+            return Err(PolygonizeError::InternalInvariantViolation {
+                reason: "packed CSR adjacency diverged from nested adjacency".to_string(),
+            });
+        }
+    }
+
+    let nested_storage_words = graph.nodes_outgoing.capacity() * 3
+        + graph
+            .nodes_outgoing
+            .iter()
+            .map(Vec::capacity)
+            .sum::<usize>();
+    let csr_storage_words = csr.offsets.len() + csr.directed_edges.len();
+    Ok(AdjacencyLayoutBenchmark {
+        candidate_id: "packed-csr-adjacency-v1",
+        conformance: true,
+        samples,
+        node_count: graph.nodes_outgoing.len(),
+        nested_storage_words,
+        csr_storage_words,
+        nested_traversal_p50_ns: median_low(&mut nested_samples),
+        csr_materialization_ns,
+        csr_traversal_p50_ns: median_low(&mut csr_samples),
+    })
+}

--- a/crates/geo-polygonize-core/src/graph/mod.rs
+++ b/crates/geo-polygonize-core/src/graph/mod.rs
@@ -1,5 +1,7 @@
+pub(crate) mod layout_benchmark;
 pub mod partition_border;
 pub mod planar_graph;
+pub use layout_benchmark::AdjacencyLayoutBenchmark;
 pub(crate) use planar_graph::ExtractedRing;
 pub use planar_graph::{DirEdgeId, EdgeId, NodeId, PlanarGraph};
 

--- a/crates/geo-polygonize-core/src/graph/planar_graph.rs
+++ b/crates/geo-polygonize-core/src/graph/planar_graph.rs
@@ -432,6 +432,14 @@ impl PlanarGraph {
         }
     }
 
+    #[doc(hidden)]
+    pub fn benchmark_adjacency_layout(
+        &self,
+        samples: usize,
+    ) -> crate::Result<crate::graph::AdjacencyLayoutBenchmark> {
+        crate::graph::layout_benchmark::benchmark(self, samples)
+    }
+
     /// Creates a canonical partition-border observation for a directed local
     /// edge. The caller supplies the already-classified border side; this
     /// method only transfers arrangement identity, direction, provenance, and

--- a/crates/geo-polygonize-core/src/graph/tests.rs
+++ b/crates/geo-polygonize-core/src/graph/tests.rs
@@ -1,105 +1,12 @@
 #[cfg(test)]
 #[allow(clippy::module_inception)]
 mod tests {
-    use crate::graph::planar_graph::{DirEdgeId, PlanarGraph};
+    use crate::graph::layout_benchmark::CsrAdjacency;
+    use crate::graph::planar_graph::PlanarGraph;
     use crate::types::{Coord3D, Line3D};
     use crate::{CancellationToken, ExecutionPolicy, PolygonizeError};
     use geo_types::{Coord, LineString};
     use std::collections::BTreeSet;
-
-    // ponytail: shadow-only CSR oracle; integrate only after decision-quality
-    // layout timing proves it beats the current adjacency lists.
-    struct CsrAdjacency {
-        offsets: Vec<usize>,
-        directed_edges: Vec<DirEdgeId>,
-    }
-
-    impl CsrAdjacency {
-        fn from_graph(graph: &PlanarGraph) -> Self {
-            let mut offsets = Vec::with_capacity(graph.nodes_outgoing.len() + 1);
-            let mut directed_edges = Vec::new();
-            offsets.push(0);
-            for outgoing in &graph.nodes_outgoing {
-                directed_edges.extend_from_slice(outgoing);
-                offsets.push(directed_edges.len());
-            }
-            Self {
-                offsets,
-                directed_edges,
-            }
-        }
-
-        fn outgoing(&self, node: usize) -> &[DirEdgeId] {
-            &self.directed_edges[self.offsets[node]..self.offsets[node + 1]]
-        }
-
-        fn active_component_ids(&self, graph: &PlanarGraph) -> Vec<Option<usize>> {
-            let is_active = |directed_idx: DirEdgeId| {
-                let directed = &graph.directed_edges[directed_idx];
-                !directed.is_marked && !graph.edges[directed.edge_idx].deleted
-            };
-            let mut seeds = (0..graph.nodes_x.len())
-                .filter(|&node| self.outgoing(node).iter().copied().any(is_active))
-                .collect::<Vec<_>>();
-            seeds.sort_unstable_by(|&left, &right| {
-                graph.nodes_x[left]
-                    .total_cmp(&graph.nodes_x[right])
-                    .then_with(|| graph.nodes_y[left].total_cmp(&graph.nodes_y[right]))
-                    .then(left.cmp(&right))
-            });
-
-            let mut component_ids = vec![None; graph.nodes_x.len()];
-            let mut stack = Vec::new();
-            let mut next_component_id = 0;
-            for seed in seeds {
-                if component_ids[seed].is_some() {
-                    continue;
-                }
-                let component_id = next_component_id;
-                next_component_id += 1;
-                component_ids[seed] = Some(component_id);
-                stack.push(seed);
-                while let Some(node) = stack.pop() {
-                    for &directed_idx in self.outgoing(node) {
-                        if !is_active(directed_idx) {
-                            continue;
-                        }
-                        let neighbor = graph.directed_edges[directed_idx].dst;
-                        if component_ids[neighbor].is_none() {
-                            component_ids[neighbor] = Some(component_id);
-                            stack.push(neighbor);
-                        }
-                    }
-                }
-            }
-            component_ids
-        }
-
-        fn next_links(&self, graph: &PlanarGraph) -> Vec<Option<DirEdgeId>> {
-            let is_active = |directed_idx: DirEdgeId| {
-                let directed = &graph.directed_edges[directed_idx];
-                !directed.is_marked && !graph.edges[directed.edge_idx].deleted
-            };
-            let mut links = vec![None; graph.directed_edges.len()];
-            for node in 0..graph.nodes_x.len() {
-                let active = self
-                    .outgoing(node)
-                    .iter()
-                    .copied()
-                    .filter(|&directed_idx| is_active(directed_idx))
-                    .collect::<Vec<_>>();
-                let Some(&last) = active.last() else {
-                    continue;
-                };
-                let mut next = last;
-                for directed_idx in active {
-                    links[directed_idx] = Some(next);
-                    next = directed_idx;
-                }
-            }
-            links
-        }
-    }
 
     #[test]
     fn test_graph_construction() {
@@ -569,6 +476,10 @@ mod tests {
                 .map(|directed| directed.next_idx)
                 .collect::<Vec<_>>()
         );
+        let evidence = graph.benchmark_adjacency_layout(3).unwrap();
+        assert!(evidence.conformance);
+        assert_eq!(evidence.samples, 3);
+        assert!(evidence.csr_storage_words < evidence.nested_storage_words);
     }
 
     #[test]

--- a/crates/geo-polygonize-core/src/lib.rs
+++ b/crates/geo-polygonize-core/src/lib.rs
@@ -59,6 +59,8 @@ pub use fingerprint::{
     normalize_polygonize_error, CoordinateFingerprintV1, ErrorWitnessV1, FingerprintDiffV1,
     NormalizedPolygonizeErrorV1, TopologyFingerprintV1, TOPOLOGY_FINGERPRINT_V1_SCHEMA_VERSION,
 };
+#[doc(hidden)]
+pub use graph::AdjacencyLayoutBenchmark;
 pub use options::{
     CancellationToken, ContainmentOptions, DeterminismOptions, DiagnosticsOptions, ExecutionPolicy,
     NodingBackend, NodingGuarantee, NodingOptions, OutputFilterOptions, PolygonizerOptions,

--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -428,6 +428,19 @@ impl Polygonizer {
         self.component_memory_stats.clone()
     }
 
+    #[doc(hidden)]
+    pub fn benchmark_adjacency_layout(
+        &mut self,
+        samples: usize,
+    ) -> Result<crate::graph::AdjacencyLayoutBenchmark> {
+        self.options.validate()?;
+        self.build_graph(self.input_lines.clone(), None)?;
+        self.graph.sort_edges();
+        self.graph.prune_dangles();
+        self.graph.get_edge_rings_with_graph_ids(false, false);
+        self.graph.benchmark_adjacency_layout(samples)
+    }
+
     fn with_trace(mut self, trace: TraceRecorderV1) -> Self {
         self.trace = Some(trace);
         self

--- a/crates/geo-polygonize-core/tests/benchmark_record_schema.rs
+++ b/crates/geo-polygonize-core/tests/benchmark_record_schema.rs
@@ -93,6 +93,16 @@ fn benchmark_schema_requires_measurement_work_and_environment_evidence() {
             "peak_rss_bytes",
         ]))
     );
+    let layout_candidate = &properties["measurement"]["properties"]["layout_candidate"];
+    assert_eq!(layout_candidate["additionalProperties"], false);
+    assert!(required(layout_candidate).is_superset(&HashSet::from([
+        "candidate_id",
+        "conformance",
+        "samples",
+        "nested_traversal_p50_ns",
+        "csr_materialization_ns",
+        "csr_traversal_p50_ns",
+    ])));
     assert!(required(&properties["work"]).is_superset(&HashSet::from([
         "candidate_pairs",
         "exact_predicate_calls",

--- a/tests/test_publish_benchmark.py
+++ b/tests/test_publish_benchmark.py
@@ -51,6 +51,17 @@ def record(index, p50=100.0):
             "phase_times_ms": {"polygonize": p50},
             "allocations": {"count": 1, "bytes": 1},
             "peak_rss_bytes": 1,
+            "layout_candidate": {
+                "candidate_id": "packed-csr-adjacency-v1",
+                "conformance": True,
+                "samples": 30,
+                "node_count": 1,
+                "nested_storage_words": 4,
+                "csr_storage_words": 2,
+                "nested_traversal_p50_ns": 10,
+                "csr_materialization_ns": 5,
+                "csr_traversal_p50_ns": 4,
+            },
         },
         "work": {
             "input_line_strings": 1,


### PR DESCRIPTION
## Summary
- add a correctness-gated packed-CSR shadow candidate for component and face-successor adjacency traversal
- record nested/CSR storage words, materialization cost, and traversal p50 in benchmark records
- keep production layout and dispatch unchanged until the seven-workload promotion gate is rerun

## Validation
- cargo test -p geo-polygonize-core --no-default-features --lib
- cargo test -p geo-polygonize-core --test benchmark_record_schema
- cargo check -p geo-polygonize-core --example benchmark_record
- cargo clippy -p geo-polygonize-core --lib --all-targets -- -D warnings
- cargo fmt --all -- --check
- PYTHONPATH=. pytest -q tests/test_publish_benchmark.py tests/test_component_memory.py tests/test_benchmark_artifacts.py tests/test_baseline_suite.py

Refs #1291