### PR TITLE
fix(core): avoid face-ring materialization in layout benchmark

### DIFF
--- a/crates/geo-polygonize-core/src/polygonizer.rs
+++ b/crates/geo-polygonize-core/src/polygonizer.rs
@@ -436,8 +436,12 @@ impl Polygonizer {
         self.options.validate()?;
         self.build_graph(self.input_lines.clone(), None)?;
         self.graph.sort_edges();
-        self.graph.prune_dangles();
-        self.graph.get_edge_rings_with_graph_ids(false, false);
+        self.graph
+            .prune_dangles_with_execution_policy(&self.execution_policy)?;
+        self.graph.delete_cut_edges_with_execution_policy(
+            &self.execution_policy,
+            !matches!(self.options.noding.guarantee, NodingGuarantee::Unchecked),
+        )?;
         self.graph.benchmark_adjacency_layout(samples)
     }
 

--- a/crates/geo-polygonize-core/src/polygonizer_tests.rs
+++ b/crates/geo-polygonize-core/src/polygonizer_tests.rs
@@ -710,6 +710,28 @@ mod tests {
     }
 
     #[test]
+    fn adjacency_layout_benchmark_does_not_materialize_face_rings() {
+        let mut poly = Polygonizer::new();
+        poly.options_mut().node_input = false;
+        poly.add_geometry(
+            LineString::from(vec![
+                (0.0, 0.0),
+                (10.0, 0.0),
+                (10.0, 10.0),
+                (0.0, 10.0),
+                (0.0, 0.0),
+            ])
+            .into(),
+        );
+        poly.add_geometry(LineString::from(vec![(10.0, 0.0), (20.0, 0.0)]).into());
+
+        let evidence = poly.benchmark_adjacency_layout(3).unwrap();
+        assert!(evidence.conformance);
+        assert_eq!(evidence.samples, 3);
+        assert!(evidence.csr_storage_words < evidence.nested_storage_words);
+    }
+
+    #[test]
     fn component_memory_shape_contract_is_shared_by_feature_builds() {
         // This test intentionally runs in both the default (parallel) and
         // --no-default-features (serial) builds. Shape/capacity evidence must


### PR DESCRIPTION
## Summary

- keep the shadow CSR candidate on the production dangle/cut-edge graph snapshot
- avoid full face-ring materialization, which panicked on California 10k during candidate setup
- add a regression test covering a ring plus cut edge

## Validation

- cargo test -p geo-polygonize-core --lib
- cargo test -p geo-polygonize-core --no-default-features --lib
- cargo test -p geo-polygonize-core --test benchmark_record_schema
- cargo check -p geo-polygonize-core --example benchmark_record
- cargo clippy -p geo-polygonize-core --lib --all-targets -- -D warnings
- cargo fmt --all -- --check

Refs #1291