### PR TITLE
perf(core): route MCIndex through shared noding path

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -357,7 +357,7 @@ Tracked by
 - [x] Cover original ↔ original, original ↔ fallback, and fallback ↔ fallback
   pairs without misses or duplicate exact work.
 - [x] Preserve source-chain/segment/parametric identity through preprocessing.
-- [ ] Use the shared exact/split/dissolve/validation path.
+- [x] Use the shared exact/split/dissolve/validation path.
 - [ ] Pass golden, compatibility, fuzz, real-world, provenance, Z,
   serial/parallel, and normalized-error conformance.
 - [ ] Measure build cost, candidate reduction, allocations, peak RSS, end-to-end
@@ -366,10 +366,11 @@ Tracked by
 
 The research prototype now owns cached flat-tree traversal and a
 `CandidatePair`-compatible visitor with bounded policy accounting and
-cancellation checks. It remains disconnected from split/dissolve/validation
-and production dispatch until the remaining conformance and decision-quality
-comparison gates are complete. Dedicated-runner baseline evidence is now
-available from #1290.
+cancellation checks. Its source-chain-preserving hybrid adapter routes emitted
+pairs through the shared exact, split, normalization/dissolve, and independent
+validation path. It remains disconnected from production dispatch until the
+remaining conformance and decision-quality comparison gates are complete.
+Dedicated-runner baseline evidence is now available from #1290.
 
 Hybrid candidate coverage uses the MCIndex traversal for original↔original
 pairs and a streaming fallback scan for any pair involving synthetic or

--- a/crates/geo-polygonize-core/src/noding/monotone.rs
+++ b/crates/geo-polygonize-core/src/noding/monotone.rs
@@ -1,8 +1,11 @@
 //! Research-only MCIndex-style monotone-chain candidate prototype.
 
-use crate::diagnostics::ExecutionWorkTracker;
+use crate::diagnostics::{ExecutionWorkTracker, NodingWorkStats};
 use crate::index::{IndexedEnvelope, RStarBackend};
+use crate::noding::snap::SnapNoder;
+use crate::noding::validate::ValidatingNoder;
 use crate::noding::{CandidatePair, ExactCandidate};
+use crate::options::ExecutionPolicy;
 use crate::types::{Line3D, SourceChainKind, SourceLineString, SourceSegmentIdentity};
 use crate::{PolygonizeError, Result};
 use rstar::AABB;
@@ -59,6 +62,45 @@ struct MonotoneChainNode {
 struct MonotoneChainRoot {
     node: usize,
     bounds: Bounds,
+}
+
+/// Run one source-chain-preserving MCIndex experiment through the shared split,
+/// normalization, and validation path.
+///
+/// The input must already be the immutable segment representation described by
+/// `source_chains`; preprocessing that reorders or replaces segments belongs
+/// outside this research-only adapter until its identity mapping is explicit.
+pub(crate) fn node_hybrid_source_chains(
+    lines: Vec<Line3D>,
+    source_chains: &[SourceLineString],
+    snap_noder: &SnapNoder,
+    execution_policy: &ExecutionPolicy,
+) -> Result<(Vec<Line3D>, NodingWorkStats)> {
+    let coverage = source_chain_coverage(lines.len(), source_chains)?;
+    if coverage.segment_identities.iter().any(Option::is_none) {
+        return Err(PolygonizeError::InvalidGeometry {
+            reason: "MCIndex experiment requires complete source-chain coverage".to_string(),
+        });
+    }
+
+    let mut events = Vec::new();
+    let mut work_stats = NodingWorkStats::default();
+    {
+        let mut tracker = ExecutionWorkTracker::new(Some(execution_policy), Some(&mut work_stats));
+        visit_hybrid_exact_candidates(&lines, source_chains, &mut tracker, |exact| {
+            snap_noder.append_exact_candidate_splits(exact, &mut events);
+            Ok(())
+        })?;
+    }
+
+    let (noded, split_events) = if events.is_empty() {
+        (lines, 0)
+    } else {
+        snap_noder.apply_split_events_for_research(&lines, events, execution_policy)?
+    };
+    work_stats.split_events = split_events;
+    ValidatingNoder::new().validate_with_execution_policy(&noded, execution_policy)?;
+    Ok((noded, work_stats))
 }
 
 struct MonotoneChainTree {
@@ -710,6 +752,83 @@ mod tests {
                 second: 1
             }
         );
+    }
+
+    #[test]
+    fn hybrid_experiment_uses_shared_split_and_validation_path() {
+        let lines = [
+            Line3D::new(Coord3D::new(0.0, 0.0, 0.0), Coord3D::new(2.0, 0.0, 10.0), 1),
+            Line3D::new(
+                Coord3D::new(0.0, -1.0, 20.0),
+                Coord3D::new(2.0, 1.0, 40.0),
+                2,
+            ),
+            Line3D::new(
+                Coord3D::new(0.0, 1.0, 60.0),
+                Coord3D::new(2.0, -1.0, 80.0),
+                3,
+            ),
+        ];
+        let chains = [
+            SourceLineString {
+                segment_start: 0,
+                segment_count: 1,
+                source_id: Some(1),
+                kind: SourceChainKind::Original,
+            },
+            SourceLineString {
+                segment_start: 1,
+                segment_count: 1,
+                source_id: Some(2),
+                kind: SourceChainKind::Synthetic,
+            },
+            SourceLineString {
+                segment_start: 2,
+                segment_count: 1,
+                source_id: None,
+                kind: SourceChainKind::Unavailable,
+            },
+        ];
+        let snap_noder = SnapNoder::new(0.0);
+        let expected = snap_noder.node(lines.to_vec());
+
+        let (actual, stats) = node_hybrid_source_chains(
+            lines.to_vec(),
+            &chains,
+            &snap_noder,
+            &ExecutionPolicy::default(),
+        )
+        .unwrap();
+
+        assert_eq!(actual, expected);
+        assert_eq!(stats.candidate_pairs, 3);
+        assert_eq!(stats.exact_intersection_calls, 3);
+        assert_eq!(stats.split_events, 3);
+        assert!(actual.iter().any(|segment| segment.start.z == 5.0));
+        assert!(actual.iter().any(|segment| segment.start.z == 30.0));
+        assert!(actual.iter().any(|segment| segment.start.z == 70.0));
+    }
+
+    #[test]
+    fn hybrid_experiment_rejects_incomplete_source_identity() {
+        let lines = [line((0.0, 0.0), (1.0, 0.0)), line((0.0, 1.0), (1.0, 1.0))];
+        let chains = [SourceLineString {
+            segment_start: 0,
+            segment_count: 1,
+            source_id: Some(1),
+            kind: SourceChainKind::Original,
+        }];
+
+        assert!(matches!(
+            node_hybrid_source_chains(
+                lines.to_vec(),
+                &chains,
+                &SnapNoder::new(0.0),
+                &ExecutionPolicy::default(),
+            ),
+            Err(PolygonizeError::InvalidGeometry { reason })
+                if reason.contains("complete source-chain coverage")
+        ));
     }
 
     #[test]

--- a/crates/geo-polygonize-core/src/noding/snap.rs
+++ b/crates/geo-polygonize-core/src/noding/snap.rs
@@ -289,7 +289,7 @@ impl SnapNoder {
                 NodingStrategy::Scalar => false, // Fallback to SIMD logic which handles scalar internally
             };
 
-            let mut events = if !use_grid {
+            let events = if !use_grid {
                 // STRATEGY A: Small Input -> SIMD Brute Force
                 if trace.is_some() {
                     let mut tracker =
@@ -353,174 +353,22 @@ impl SnapNoder {
                 break;
             }
 
-            // Sort and dedup events by (line_index, split_point) to stabilize near-equal repeats.
-            if let Some(execution_policy) = execution_policy {
-                execution_policy.check_uncancellable_sort("noding_candidate_sort", events.len())?;
-            }
-            events.sort_unstable_by(|a, b| {
-                a.0.cmp(&b.0)
-                    .then(a.1.x.total_cmp(&b.1.x))
-                    .then(a.1.y.total_cmp(&b.1.y))
-            });
-            events.dedup_by(|a, b| {
-                a.0 == b.0 && a.1.x == b.1.x && a.1.y == b.1.y
-                // Note: We don't check Z for dedup because for a given line index and X,Y,
-                // Z should be consistent (interpolated from the same line).
-            });
-            let split_event_count = events.len();
-            split_events += split_event_count;
-            if let Some(execution_policy) = execution_policy {
-                execution_policy.check_cancelled("split_application")?;
-                execution_policy.check_split_events(split_events)?;
-            }
+            let split_event_count = self.apply_split_events(
+                &lines,
+                events,
+                execution_policy,
+                &mut split_events,
+                &mut new_lines,
+                iteration_index,
+                trace.as_deref_mut(),
+            )?;
             if let Some(work_stats) = work_stats.as_deref_mut() {
                 work_stats.split_events += split_event_count;
             }
 
             // Early bailout heuristic to avoid epsilon-thrashing on tiny residual updates.
             // Apply this iteration first, then exit before running another pass.
-            let should_bail_early = events.len() < 3;
-
-            // Apply splits. Copy untouched line ranges in bulk and only rebuild lines with split events.
-            new_lines.clear();
-            let estimated_len = lines.len().checked_add(events.len()).ok_or_else(|| {
-                PolygonizeError::InternalInvariantViolation {
-                    reason: "noded segment capacity overflow".to_string(),
-                }
-            })?;
-            new_lines.reserve(
-                execution_policy
-                    .and_then(|policy| policy.max_noded_segments)
-                    .map_or(estimated_len, |limit| estimated_len.min(limit)),
-            );
-
-            let mut event_idx = 0;
-            let mut src_idx = 0;
-            // Buffer to reuse for collecting points on the current split line.
-            let mut points = Vec::new();
-
-            while event_idx < events.len() {
-                let line_idx = events[event_idx].0;
-
-                // Copy untouched lines directly.
-                if src_idx < line_idx {
-                    if let Some(execution_policy) = execution_policy {
-                        execution_policy.check(
-                            "noded_segments",
-                            execution_policy.max_noded_segments,
-                            new_lines
-                                .len()
-                                .checked_add(line_idx - src_idx)
-                                .ok_or_else(|| PolygonizeError::InternalInvariantViolation {
-                                    reason: "noded segment count overflow".to_string(),
-                                })?,
-                        )?;
-                    }
-                    new_lines.extend_from_slice(&lines[src_idx..line_idx]);
-                }
-
-                points.clear();
-                while event_idx < events.len() && events[event_idx].0 == line_idx {
-                    if let Some(execution_policy) = execution_policy {
-                        execution_policy.check_cancelled_every("split_application", event_idx)?;
-                    }
-                    points.push(events[event_idx].1);
-                    event_idx += 1;
-                }
-
-                let line = lines[line_idx];
-                points.push(line.start);
-                points.push(line.end);
-
-                // Filter out invalid points (NaN/Inf)
-                points.retain(|p| p.x.is_finite() && p.y.is_finite());
-
-                // Sort by parametric t value (dot product of (p - start) with direction vector)
-                let start = line.start;
-                let dx = line.end.x - start.x;
-                let dy = line.end.y - start.y;
-                let len_sq = dx * dx + dy * dy;
-
-                if len_sq > 0.0 {
-                    if let Some(execution_policy) = execution_policy {
-                        execution_policy
-                            .check_uncancellable_sort("split_point_sort", points.len())?;
-                    }
-                    points.sort_unstable_by(|a, b| {
-                        let ta = ((a.x - start.x) * dx + (a.y - start.y) * dy) / len_sq;
-                        let tb = ((b.x - start.x) * dx + (b.y - start.y) * dy) / len_sq;
-                        ta.total_cmp(&tb)
-                    });
-                } else {
-                    // Fallback to sort by X, then Y if segment is a zero-length point
-                    if let Some(execution_policy) = execution_policy {
-                        execution_policy
-                            .check_uncancellable_sort("split_point_sort", points.len())?;
-                    }
-                    points.sort_unstable_by(|a, b| a.x.total_cmp(&b.x).then(a.y.total_cmp(&b.y)));
-                }
-
-                // Dedup by 2D coordinates
-                points.dedup_by(|a, b| a.x == b.x && a.y == b.y);
-
-                // Create replacement segments for the split line.
-                for (replacement_index, w) in points.windows(2).enumerate() {
-                    if let Some(execution_policy) = execution_policy {
-                        execution_policy
-                            .check_cancelled_every("split_application", replacement_index)?;
-                    }
-                    let p0 = w[0];
-                    let p1 = w[1];
-                    // Check 2D equality
-                    if p0.x != p1.x || p0.y != p1.y {
-                        if let Some(execution_policy) = execution_policy {
-                            execution_policy.check(
-                                "noded_segments",
-                                execution_policy.max_noded_segments,
-                                new_lines.len().checked_add(1).ok_or_else(|| {
-                                    PolygonizeError::InternalInvariantViolation {
-                                        reason: "noded segment count overflow".to_string(),
-                                    }
-                                })?,
-                            )?;
-                        }
-                        new_lines.push(Line3D::new(p0, p1, line.line_id));
-                        if let Some(trace) = trace.as_deref_mut() {
-                            trace.budget.capture(
-                                &mut trace.splits,
-                                FloatingSplitTrace {
-                                    iteration_index,
-                                    source_segment: line_idx,
-                                    source_id: line.line_id,
-                                    start: p0,
-                                    end: p1,
-                                },
-                            );
-                        }
-                    }
-                }
-
-                src_idx = line_idx + 1;
-            }
-
-            // Copy any untouched trailing lines.
-            if src_idx < lines.len() {
-                if let Some(execution_policy) = execution_policy {
-                    execution_policy.check(
-                        "noded_segments",
-                        execution_policy.max_noded_segments,
-                        new_lines
-                            .len()
-                            .checked_add(lines.len() - src_idx)
-                            .ok_or_else(|| PolygonizeError::InternalInvariantViolation {
-                                reason: "noded segment count overflow".to_string(),
-                            })?,
-                    )?;
-                }
-                new_lines.extend_from_slice(&lines[src_idx..]);
-            }
-
-            self.normalize_and_dedup(&mut new_lines);
+            let should_bail_early = split_event_count < 3;
             std::mem::swap(&mut lines, &mut new_lines);
 
             if let Some(stats) = stats.as_deref_mut() {
@@ -537,6 +385,187 @@ impl SnapNoder {
         }
 
         Ok(lines)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn apply_split_events(
+        &self,
+        lines: &[Line3D],
+        mut events: Vec<(usize, Coord3D)>,
+        execution_policy: Option<&ExecutionPolicy>,
+        split_events: &mut usize,
+        new_lines: &mut Vec<Line3D>,
+        iteration_index: usize,
+        mut trace: Option<&mut FloatingTraceCapture>,
+    ) -> crate::Result<usize> {
+        // Sort and dedup events by (line_index, split_point) to stabilize near-equal repeats.
+        if let Some(execution_policy) = execution_policy {
+            execution_policy.check_uncancellable_sort("noding_candidate_sort", events.len())?;
+        }
+        events.sort_unstable_by(|a, b| {
+            a.0.cmp(&b.0)
+                .then(a.1.x.total_cmp(&b.1.x))
+                .then(a.1.y.total_cmp(&b.1.y))
+        });
+        events.dedup_by(|a, b| {
+            a.0 == b.0 && a.1.x == b.1.x && a.1.y == b.1.y
+            // Note: We don't check Z for dedup because for a given line index and X,Y,
+            // Z should be consistent (interpolated from the same line).
+        });
+        let split_event_count = events.len();
+        *split_events += split_event_count;
+        if let Some(execution_policy) = execution_policy {
+            execution_policy.check_cancelled("split_application")?;
+            execution_policy.check_split_events(*split_events)?;
+        }
+
+        // Apply splits. Copy untouched line ranges in bulk and only rebuild lines with split events.
+        new_lines.clear();
+        let estimated_len = lines.len().checked_add(events.len()).ok_or_else(|| {
+            PolygonizeError::InternalInvariantViolation {
+                reason: "noded segment capacity overflow".to_string(),
+            }
+        })?;
+        new_lines.reserve(
+            execution_policy
+                .and_then(|policy| policy.max_noded_segments)
+                .map_or(estimated_len, |limit| estimated_len.min(limit)),
+        );
+
+        let mut event_idx = 0;
+        let mut src_idx = 0;
+        let mut points = Vec::new();
+
+        while event_idx < events.len() {
+            let line_idx = events[event_idx].0;
+
+            if src_idx < line_idx {
+                if let Some(execution_policy) = execution_policy {
+                    execution_policy.check(
+                        "noded_segments",
+                        execution_policy.max_noded_segments,
+                        new_lines
+                            .len()
+                            .checked_add(line_idx - src_idx)
+                            .ok_or_else(|| PolygonizeError::InternalInvariantViolation {
+                                reason: "noded segment count overflow".to_string(),
+                            })?,
+                    )?;
+                }
+                new_lines.extend_from_slice(&lines[src_idx..line_idx]);
+            }
+
+            points.clear();
+            while event_idx < events.len() && events[event_idx].0 == line_idx {
+                if let Some(execution_policy) = execution_policy {
+                    execution_policy.check_cancelled_every("split_application", event_idx)?;
+                }
+                points.push(events[event_idx].1);
+                event_idx += 1;
+            }
+
+            let line = lines[line_idx];
+            points.push(line.start);
+            points.push(line.end);
+            points.retain(|p| p.x.is_finite() && p.y.is_finite());
+
+            let start = line.start;
+            let dx = line.end.x - start.x;
+            let dy = line.end.y - start.y;
+            let len_sq = dx * dx + dy * dy;
+
+            if let Some(execution_policy) = execution_policy {
+                execution_policy.check_uncancellable_sort("split_point_sort", points.len())?;
+            }
+            if len_sq > 0.0 {
+                points.sort_unstable_by(|a, b| {
+                    let ta = ((a.x - start.x) * dx + (a.y - start.y) * dy) / len_sq;
+                    let tb = ((b.x - start.x) * dx + (b.y - start.y) * dy) / len_sq;
+                    ta.total_cmp(&tb)
+                });
+            } else {
+                points.sort_unstable_by(|a, b| a.x.total_cmp(&b.x).then(a.y.total_cmp(&b.y)));
+            }
+
+            points.dedup_by(|a, b| a.x == b.x && a.y == b.y);
+
+            for (replacement_index, w) in points.windows(2).enumerate() {
+                if let Some(execution_policy) = execution_policy {
+                    execution_policy
+                        .check_cancelled_every("split_application", replacement_index)?;
+                }
+                let p0 = w[0];
+                let p1 = w[1];
+                if p0.x != p1.x || p0.y != p1.y {
+                    if let Some(execution_policy) = execution_policy {
+                        execution_policy.check(
+                            "noded_segments",
+                            execution_policy.max_noded_segments,
+                            new_lines.len().checked_add(1).ok_or_else(|| {
+                                PolygonizeError::InternalInvariantViolation {
+                                    reason: "noded segment count overflow".to_string(),
+                                }
+                            })?,
+                        )?;
+                    }
+                    new_lines.push(Line3D::new(p0, p1, line.line_id));
+                    if let Some(trace) = trace.as_deref_mut() {
+                        trace.budget.capture(
+                            &mut trace.splits,
+                            FloatingSplitTrace {
+                                iteration_index,
+                                source_segment: line_idx,
+                                source_id: line.line_id,
+                                start: p0,
+                                end: p1,
+                            },
+                        );
+                    }
+                }
+            }
+
+            src_idx = line_idx + 1;
+        }
+
+        if src_idx < lines.len() {
+            if let Some(execution_policy) = execution_policy {
+                execution_policy.check(
+                    "noded_segments",
+                    execution_policy.max_noded_segments,
+                    new_lines
+                        .len()
+                        .checked_add(lines.len() - src_idx)
+                        .ok_or_else(|| PolygonizeError::InternalInvariantViolation {
+                            reason: "noded segment count overflow".to_string(),
+                        })?,
+                )?;
+            }
+            new_lines.extend_from_slice(&lines[src_idx..]);
+        }
+
+        self.normalize_and_dedup(new_lines);
+        Ok(split_event_count)
+    }
+
+    pub(crate) fn apply_split_events_for_research(
+        &self,
+        lines: &[Line3D],
+        events: Vec<(usize, Coord3D)>,
+        execution_policy: &ExecutionPolicy,
+    ) -> crate::Result<(Vec<Line3D>, usize)> {
+        let mut split_events = 0;
+        let mut new_lines = Vec::new();
+        let split_event_count = self.apply_split_events(
+            lines,
+            events,
+            Some(execution_policy),
+            &mut split_events,
+            &mut new_lines,
+            0,
+            None,
+        )?;
+        debug_assert_eq!(split_events, split_event_count);
+        Ok((new_lines, split_event_count))
     }
 
     fn auto_prefers_simd(&self, lines: &[Line3D]) -> bool {


### PR DESCRIPTION
## Delivered

- extract the existing split-event application into a shared SnapNoder path
- add a private source-chain-preserving MCIndex hybrid adapter using the shared exact, split, normalization/dissolve, and independent validation stages
- enforce complete source-chain coverage and exercise original, synthetic, unavailable, Z, cancellation-accounting, and baseline-equivalence cases
- update P3.2 to record the completed conformance slice

## Contract impact

Research-only. No public backend, default dispatch, or certified hot-pixel behavior changes. The adapter intentionally stops at the explicit preprocessing identity boundary until iterative source mapping is complete.

## Validation

- cargo test -p geo-polygonize-core monotone --lib
- cargo test -p geo-polygonize-core --lib (418 passed)
- cargo test -p geo-polygonize-core --no-default-features --lib (418 passed)
- cargo test -p geo-polygonize-core --test benchmark_record_schema
- cargo check -p geo-polygonize-core --example benchmark_record
- cargo clippy -p geo-polygonize-core --lib --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check

## Remaining

Golden, compatibility, fuzz, real-world, serial/parallel, normalized-error, production-scale evidence, and the explicit accept/reject/promotion decision remain open.

Refs #1287