### PR TITLE
test(core): add MCIndex differential fuzz corpus

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -376,6 +376,8 @@ Focused differential coverage now compares the hybrid adapter with the current
 SnapNoder on self-intersecting, road/contour, mixed-chain, duplicate/reversed,
 Z, and bounded-resource cases. The full golden, compatibility, fuzz,
 real-world, serial/parallel, and normalized-error corpus gates remain open.
+A bounded seeded differential-fuzz corpus now exercises 12 generated cases
+against the same baseline.
 
 Hybrid candidate coverage uses the MCIndex traversal for original↔original
 pairs and a streaming fallback scan for any pair involving synthetic or

--- a/crates/geo-polygonize-core/src/noding/monotone.rs
+++ b/crates/geo-polygonize-core/src/noding/monotone.rs
@@ -478,6 +478,8 @@ mod tests {
     use super::*;
     use crate::types::{Coord3D, SourceChainKind};
     use crate::{CancellationToken, ExecutionPolicy};
+    use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
 
     fn line(start: (f64, f64), end: (f64, f64)) -> Line3D {
         Line3D::new(
@@ -917,6 +919,37 @@ mod tests {
                 ..
             }) if stage == "candidate_pairs"
         ));
+    }
+
+    #[test]
+    fn hybrid_experiment_matches_bounded_differential_fuzz_corpus() {
+        let mut rng = StdRng::seed_from_u64(0x1287_2026);
+        for case_index in 0..12 {
+            let segment_count = 24 + case_index % 4 * 8;
+            let mut lines = Vec::with_capacity(segment_count);
+            let mut chains = Vec::with_capacity(segment_count);
+            for segment_index in 0..segment_count {
+                let start = (rng.gen_range(-100.0..100.0), rng.gen_range(-100.0..100.0));
+                let mut end = (rng.gen_range(-100.0..100.0), rng.gen_range(-100.0..100.0));
+                if start == end {
+                    end.0 += 1.0;
+                }
+                lines.push(Line3D::new(
+                    Coord3D::new(start.0, start.1, 0.0),
+                    Coord3D::new(end.0, end.1, 0.0),
+                    segment_index as u32,
+                ));
+                chains.push(SourceLineString {
+                    segment_start: segment_index,
+                    segment_count: 1,
+                    source_id: Some(segment_index as u32),
+                    kind: SourceChainKind::Original,
+                });
+            }
+
+            let stats = assert_hybrid_matches_snap(lines, &chains);
+            assert!(stats.exact_intersection_calls <= stats.candidate_pairs);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Delivered

- add a deterministic seeded 12-case differential-fuzz corpus for the private MCIndex hybrid adapter
- compare every generated case with current SnapNoder output and retain candidate/exact accounting assertions
- record the bounded fuzz slice in P3.2

## Contract impact

Research-only tests and documentation. No public backend, default dispatch, or performance claim changes.

## Validation

- cargo test -p geo-polygonize-core hybrid_experiment_matches_bounded_differential_fuzz_corpus --lib
- cargo test -p geo-polygonize-core --lib (421 passed)
- cargo test -p geo-polygonize-core --no-default-features --lib (421 passed)
- cargo clippy -p geo-polygonize-core --lib --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check

## Remaining

Full golden, compatibility, fuzz breadth, real-world, serial/parallel, normalized-error corpus coverage, production-scale evidence, and the explicit accept/reject/promotion decision remain open.

Refs #1287