### PR TITLE
fix(core): normalize MCIndex zero-event output

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -374,10 +374,11 @@ Dedicated-runner baseline evidence is now available from #1290.
 
 Focused differential coverage now compares the hybrid adapter with the current
 SnapNoder on self-intersecting, road/contour, mixed-chain, duplicate/reversed,
-Z, bounded-resource, input-permutation, and normalized-boundary-error cases.
-The full golden, compatibility, fuzz, real-world, serial/parallel, and
-normalized-error corpus gates remain open. A bounded seeded differential-fuzz
-corpus now exercises 12 generated cases against the same baseline.
+Z, bounded-resource, input-permutation, normalized-boundary-error,
+partial-overlap, and nested-ring cases. The full golden, compatibility, fuzz,
+real-world, serial/parallel, and normalized-error corpus gates remain open. A
+bounded seeded differential-fuzz corpus now exercises 12 generated cases
+against the same baseline.
 
 Hybrid candidate coverage uses the MCIndex traversal for original↔original
 pairs and a streaming fallback scan for any pair involving synthetic or

--- a/crates/geo-polygonize-core/src/noding/monotone.rs
+++ b/crates/geo-polygonize-core/src/noding/monotone.rs
@@ -94,7 +94,9 @@ pub(crate) fn node_hybrid_source_chains(
     }
 
     let (noded, split_events) = if events.is_empty() {
-        (lines, 0)
+        let mut noded = lines;
+        snap_noder.normalize_and_dedup(&mut noded);
+        (noded, 0)
     } else {
         snap_noder.apply_split_events_for_research(&lines, events, execution_policy)?
     };
@@ -983,6 +985,30 @@ mod tests {
         let duplicate_stats =
             assert_hybrid_matches_snap(duplicate_and_reversed, &duplicate_and_reversed_chains);
         assert!(duplicate_stats.exact_intersection_calls > 0);
+    }
+
+    #[test]
+    fn hybrid_experiment_matches_overlap_and_nested_ring_cases() {
+        let (overlapping, overlapping_chains) = original_chains(&[
+            &[(0.0, 0.0), (4.0, 0.0)],
+            &[(1.0, 0.0), (3.0, 0.0)],
+            &[(2.0, -1.0), (2.0, 1.0)],
+        ]);
+        let overlap_stats = assert_hybrid_matches_snap(overlapping, &overlapping_chains);
+        assert!(overlap_stats.split_events > 0);
+
+        let (nested_rings, nested_ring_chains) = original_chains(&[
+            &[
+                (0.0, 0.0),
+                (10.0, 0.0),
+                (10.0, 10.0),
+                (0.0, 10.0),
+                (0.0, 0.0),
+            ],
+            &[(2.0, 2.0), (8.0, 2.0), (8.0, 8.0), (2.0, 8.0), (2.0, 2.0)],
+        ]);
+        let nested_stats = assert_hybrid_matches_snap(nested_rings, &nested_ring_chains);
+        assert_eq!(nested_stats.split_events, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Normalize and deduplicate hybrid MCIndex output even when no split events are emitted.
- Add differential coverage for partial collinear overlap and nested closed rings.
- Record the focused cases in ROADMAP.md.

The MCIndex adapter remains research-only and disconnected from public/default dispatch. The broader golden, compatibility, fuzz, real-world, provenance, Z, serial/parallel, normalized-error, and benchmark promotion gates remain open.

## Validation

- cargo test -p geo-polygonize-core noding::monotone::tests --lib
- cargo test -p geo-polygonize-core --lib --quiet
- cargo test -p geo-polygonize-core --no-default-features --lib --quiet
- cargo clippy -p geo-polygonize-core --lib --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check