### PR TITLE
test(core): cover MCIndex source IDs and Z

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -374,11 +374,11 @@ Dedicated-runner baseline evidence is now available from #1290.
 
 Focused differential coverage now compares the hybrid adapter with the current
 SnapNoder on self-intersecting, road/contour, mixed-chain, duplicate/reversed,
-Z, bounded-resource, input-permutation, normalized-boundary-error,
-partial-overlap, and nested-ring cases. The full golden, compatibility, fuzz,
-real-world, serial/parallel, and normalized-error corpus gates remain open. A
-bounded seeded differential-fuzz corpus now exercises 12 generated cases
-against the same baseline.
+Z interpolation/source-ID preservation, bounded-resource, input-permutation,
+normalized-boundary-error, partial-overlap, and nested-ring cases. The full
+golden, compatibility, fuzz, real-world, serial/parallel, and normalized-error
+corpus gates remain open. A bounded seeded differential-fuzz corpus now
+exercises 12 generated cases against the same baseline.
 
 Hybrid candidate coverage uses the MCIndex traversal for original↔original
 pairs and a streaming fallback scan for any pair involving synthetic or

--- a/crates/geo-polygonize-core/src/noding/monotone.rs
+++ b/crates/geo-polygonize-core/src/noding/monotone.rs
@@ -776,7 +776,7 @@ mod tests {
     }
 
     #[test]
-    fn hybrid_experiment_uses_shared_split_and_validation_path() {
+    fn hybrid_experiment_preserves_source_ids_z_and_shared_path() {
         let lines = [
             Line3D::new(Coord3D::new(0.0, 0.0, 0.0), Coord3D::new(2.0, 0.0, 10.0), 1),
             Line3D::new(
@@ -828,6 +828,9 @@ mod tests {
         assert!(actual.iter().any(|segment| segment.start.z == 5.0));
         assert!(actual.iter().any(|segment| segment.start.z == 30.0));
         assert!(actual.iter().any(|segment| segment.start.z == 70.0));
+        let mut source_line_ids: Vec<_> = actual.iter().map(|segment| segment.line_id).collect();
+        source_line_ids.sort_unstable();
+        assert_eq!(source_line_ids, vec![1, 1, 2, 2, 3, 3]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Require canonical MCIndex output to retain every source line ID after splitting.
- Keep the existing interpolated-Z checks on the mixed-chain differential case.
- Record the focused provenance/Z coverage in ROADMAP.md.

The MCIndex adapter remains research-only and disconnected from public/default dispatch. The broader golden, compatibility, fuzz, real-world, serial/parallel, normalized-error, and benchmark promotion gates remain open.

## Validation

- cargo test -p geo-polygonize-core noding::monotone::tests --lib
- cargo test -p geo-polygonize-core --lib --quiet
- cargo test -p geo-polygonize-core --no-default-features --lib --quiet
- cargo clippy -p geo-polygonize-core --lib --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check