### PR TITLE
test(core): normalize MCIndex operational errors

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -374,11 +374,12 @@ Dedicated-runner baseline evidence is now available from #1290.
 
 Focused differential coverage now compares the hybrid adapter with the current
 SnapNoder on self-intersecting, road/contour, mixed-chain, duplicate/reversed,
-Z interpolation/source-ID preservation, bounded-resource, input-permutation,
-normalized-boundary-error, partial-overlap, and nested-ring cases. The full
-golden, compatibility, fuzz, real-world, serial/parallel, and normalized-error
-corpus gates remain open. A bounded seeded differential-fuzz corpus now
-exercises 12 generated cases against the same baseline.
+Z interpolation/source-ID preservation, bounded-resource, normalized
+operational-error, input-permutation, normalized-boundary-error,
+partial-overlap, and nested-ring cases. The full golden, compatibility, fuzz,
+real-world, serial/parallel, and normalized-error corpus gates remain open. A
+bounded seeded differential-fuzz corpus now exercises 12 generated cases
+against the same baseline.
 
 Hybrid candidate coverage uses the MCIndex traversal for original↔original
 pairs and a streaming fallback scan for any pair involving synthetic or

--- a/crates/geo-polygonize-core/src/noding/monotone.rs
+++ b/crates/geo-polygonize-core/src/noding/monotone.rs
@@ -1042,6 +1042,48 @@ mod tests {
     }
 
     #[test]
+    fn hybrid_experiment_normalizes_operational_errors() {
+        let (lines, chains) = original_chains(&[
+            &[(0.0, 0.0), (2.0, 0.0)],
+            &[(1.0, -1.0), (1.0, 1.0)],
+            &[(0.0, -1.0), (2.0, 1.0)],
+        ]);
+        let limit_error = node_hybrid_source_chains(
+            lines.clone(),
+            &chains,
+            &SnapNoder::new(0.0),
+            &ExecutionPolicy {
+                max_candidate_pairs: Some(1),
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        let limit = normalize_polygonize_error(&limit_error);
+        assert_eq!(limit.family, "resource_limit");
+        assert_eq!(limit.code, "resource_limit_exceeded");
+        assert_eq!(limit.stage, "candidate_pairs");
+        assert_eq!(limit.limit.as_deref(), Some("1"));
+        assert!(limit.observed.is_some());
+
+        let token = CancellationToken::new();
+        token.cancel();
+        let cancelled_error = node_hybrid_source_chains(
+            lines,
+            &chains,
+            &SnapNoder::new(0.0),
+            &ExecutionPolicy {
+                cancellation_token: Some(token),
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        let cancelled = normalize_polygonize_error(&cancelled_error);
+        assert_eq!(cancelled.family, "cancelled");
+        assert_eq!(cancelled.code, "cancelled");
+        assert_eq!(cancelled.stage, "candidate_enumeration");
+    }
+
+    #[test]
     fn hybrid_experiment_matches_bounded_differential_fuzz_corpus() {
         let mut rng = StdRng::seed_from_u64(0x1287_2026);
         for case_index in 0..12 {


### PR DESCRIPTION
## Summary

- Add stable normalized-error assertions for candidate-budget exhaustion.
- Add stable normalized-error assertions for pre-cancelled candidate traversal.
- Record the focused operational-error coverage in ROADMAP.md.

The MCIndex adapter remains research-only and disconnected from public/default dispatch. The broader golden, compatibility, fuzz, real-world, serial/parallel, normalized-error, and benchmark promotion gates remain open.

## Validation

- cargo test -p geo-polygonize-core noding::monotone::tests --lib
- cargo test -p geo-polygonize-core --lib --quiet
- cargo test -p geo-polygonize-core --no-default-features --lib --quiet
- cargo clippy -p geo-polygonize-core --lib --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check