### PR TITLE
test(core): cover MCIndex feature-build parity

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -376,10 +376,11 @@ Focused differential coverage now compares the hybrid adapter with the current
 SnapNoder on self-intersecting, road/contour, mixed-chain, duplicate/reversed,
 Z interpolation/source-ID preservation, bounded-resource, normalized
 operational-error, input-permutation, normalized-boundary-error,
-partial-overlap, and nested-ring cases. The full golden, compatibility, fuzz,
-real-world, serial/parallel, and normalized-error corpus gates remain open. A
-bounded seeded differential-fuzz corpus now exercises 12 generated cases
-against the same baseline.
+partial-overlap, nested-ring, and canonical feature-build fingerprint cases.
+The focused comparisons execute under both default and no-default core builds;
+the full golden, compatibility, fuzz, real-world, serial/parallel, and
+normalized-error corpus gates remain open. A bounded seeded differential-fuzz
+corpus now exercises 12 generated cases against the same baseline.
 
 Hybrid candidate coverage uses the MCIndex traversal for original↔original
 pairs and a streaming fallback scan for any pair involving synthetic or

--- a/crates/geo-polygonize-core/src/noding/monotone.rs
+++ b/crates/geo-polygonize-core/src/noding/monotone.rs
@@ -479,7 +479,10 @@ fn invalid_range(start: usize, count: usize) -> PolygonizeError {
 mod tests {
     use super::*;
     use crate::types::{Coord3D, SourceChainKind};
-    use crate::{normalize_polygonize_error, CancellationToken, ExecutionPolicy};
+    use crate::{
+        normalize_polygonize_error, polygonize, CancellationToken, ExecutionPolicy,
+        PolygonizerOptions, TopologyFingerprintV1,
+    };
     use rand::rngs::StdRng;
     use rand::{Rng, SeedableRng};
 
@@ -988,6 +991,29 @@ mod tests {
         let duplicate_stats =
             assert_hybrid_matches_snap(duplicate_and_reversed, &duplicate_and_reversed_chains);
         assert!(duplicate_stats.exact_intersection_calls > 0);
+    }
+
+    #[test]
+    fn hybrid_experiment_matches_canonical_feature_build_fingerprint() {
+        let (lines, chains) = original_chains(&[
+            &[(0.0, 0.0), (4.0, 0.0), (4.0, 4.0), (0.0, 4.0), (0.0, 0.0)],
+            &[(0.0, 0.0), (4.0, 4.0)],
+            &[(0.0, 4.0), (4.0, 0.0)],
+        ]);
+        let snap_noder = SnapNoder::new(0.0);
+        let expected = snap_noder.node(lines.clone());
+        let (actual, _) =
+            node_hybrid_source_chains(lines, &chains, &snap_noder, &ExecutionPolicy::default())
+                .unwrap();
+        let options = PolygonizerOptions::default();
+        let expected_result = polygonize(expected, &options).unwrap();
+        let actual_result = polygonize(actual, &options).unwrap();
+        let expected_fingerprint =
+            TopologyFingerprintV1::try_from_result(&expected_result, &options).unwrap();
+        let actual_fingerprint =
+            TopologyFingerprintV1::try_from_result(&actual_result, &options).unwrap();
+
+        assert_eq!(actual_fingerprint, expected_fingerprint);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Compare hybrid MCIndex output with SnapNoder through the canonical topology fingerprint.
- Execute the same research differential case in default and no-default core builds.
- Record the focused feature-build parity coverage in ROADMAP.md.

The MCIndex adapter remains research-only and disconnected from public/default dispatch. The broader golden, compatibility, fuzz, real-world, serial/parallel, normalized-error, and benchmark promotion gates remain open.

## Validation

- cargo test -p geo-polygonize-core noding::monotone::tests --lib
- cargo test -p geo-polygonize-core --no-default-features noding::monotone::tests::hybrid_experiment_matches_canonical_feature_build_fingerprint --lib
- cargo test -p geo-polygonize-core --lib --quiet
- cargo test -p geo-polygonize-core --no-default-features --lib --quiet
- cargo clippy -p geo-polygonize-core --lib --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check