### PR TITLE
test(core): cover MCIndex golden fixture parity

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -377,6 +377,8 @@ SnapNoder on self-intersecting, road/contour, mixed-chain, duplicate/reversed,
 Z interpolation/source-ID preservation, bounded-resource, normalized
 operational-error, input-permutation, normalized-boundary-error,
 partial-overlap, nested-ring, and canonical feature-build fingerprint cases.
+The focused corpus also includes a fixture-backed square-with-hole fingerprint
+case.
 The focused comparisons execute under both default and no-default core builds;
 the full golden, compatibility, fuzz, real-world, serial/parallel, and
 normalized-error corpus gates remain open. A bounded seeded differential-fuzz

--- a/crates/geo-polygonize-core/src/noding/monotone.rs
+++ b/crates/geo-polygonize-core/src/noding/monotone.rs
@@ -480,11 +480,12 @@ mod tests {
     use super::*;
     use crate::types::{Coord3D, SourceChainKind};
     use crate::{
-        normalize_polygonize_error, polygonize, CancellationToken, ExecutionPolicy,
-        PolygonizerOptions, TopologyFingerprintV1,
+        normalize_polygonize_error, polygonize, CancellationToken, DiagnosticsOptions,
+        ExecutionPolicy, PolygonizerOptions, ProvenanceOptions, TopologyFingerprintV1,
     };
     use rand::rngs::StdRng;
     use rand::{Rng, SeedableRng};
+    use serde::Deserialize;
 
     fn line(start: (f64, f64), end: (f64, f64)) -> Line3D {
         Line3D::new(
@@ -1013,6 +1014,81 @@ mod tests {
         let actual_fingerprint =
             TopologyFingerprintV1::try_from_result(&actual_result, &options).unwrap();
 
+        assert_eq!(actual_fingerprint, expected_fingerprint);
+    }
+
+    #[test]
+    fn hybrid_experiment_matches_square_with_hole_fixture_fingerprint() {
+        #[derive(Deserialize)]
+        struct Fixture {
+            options: Option<PolygonizerOptions>,
+            inputs: Vec<FixtureLine>,
+        }
+
+        #[derive(Deserialize)]
+        struct FixtureLine {
+            start: FixtureCoordinate,
+            end: FixtureCoordinate,
+            id: u32,
+        }
+
+        #[derive(Deserialize)]
+        struct FixtureCoordinate {
+            x: f64,
+            y: f64,
+            z: f64,
+        }
+
+        let fixture: Fixture = serde_json::from_str(include_str!(
+            "../../tests/fixtures/basic/square_with_hole.json"
+        ))
+        .unwrap();
+        let mut options = fixture.options.unwrap_or_default();
+        options.diagnostics = DiagnosticsOptions {
+            enabled: true,
+            ..Default::default()
+        };
+        options.provenance = ProvenanceOptions {
+            enabled: true,
+            include_boundary_line_ids: true,
+        };
+        let lines: Vec<_> = fixture
+            .inputs
+            .into_iter()
+            .map(|input| {
+                Line3D::new(
+                    Coord3D::new(input.start.x, input.start.y, input.start.z),
+                    Coord3D::new(input.end.x, input.end.y, input.end.z),
+                    input.id,
+                )
+            })
+            .collect();
+        let chains: Vec<_> = lines
+            .iter()
+            .enumerate()
+            .map(|(segment_start, line)| SourceLineString {
+                segment_start,
+                segment_count: 1,
+                source_id: Some(line.line_id),
+                kind: SourceChainKind::Original,
+            })
+            .collect();
+        let snap_noder = SnapNoder::new(0.0);
+        let expected = snap_noder.node(lines.clone());
+        let (actual, _) =
+            node_hybrid_source_chains(lines, &chains, &snap_noder, &ExecutionPolicy::default())
+                .unwrap();
+        let expected_result = polygonize(expected, &options).unwrap();
+        let actual_result = polygonize(actual, &options).unwrap();
+        let expected_fingerprint =
+            TopologyFingerprintV1::try_from_result(&expected_result, &options).unwrap();
+        let actual_fingerprint =
+            TopologyFingerprintV1::try_from_result(&actual_result, &options).unwrap();
+
+        assert_eq!(actual_result.polygons.len(), 2);
+        assert!(actual_result.dangles.is_empty());
+        assert!(actual_result.cut_edges.is_empty());
+        assert!(actual_result.invalid_rings.is_empty());
         assert_eq!(actual_fingerprint, expected_fingerprint);
     }
 


### PR DESCRIPTION
Adds a fixture-backed square-with-hole compatibility check for the research-only MCIndex hybrid noder. It compares the canonical topology fingerprint, diagnostics, provenance, and no-dangle/cut-edge/invalid-ring expectations against the shared SnapNoder baseline. No production dispatch changes; broader golden, compatibility, fuzz, real-world, and promotion gates remain open.\n\nValidated locally:\n- 21 monotone tests\n- 427 default core library tests\n- 427 no-default core library tests\n- clippy -D warnings\n- rustfmt and diff checks