### PR TITLE
fix(core): normalize MCIndex zero-length output

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -379,7 +379,8 @@ operational-error, input-permutation, normalized-boundary-error,
 partial-overlap, nested-ring, and canonical feature-build fingerprint cases.
 The focused corpus also includes a fixture-backed square-with-hole fingerprint
 case, a dirty-bowtie fingerprint case, and a floating-microfaces compatibility
-fingerprint case.
+fingerprint case. The focused fixture set also covers zero-length compatibility
+normalization.
 The focused comparisons execute under both default and no-default core builds;
 the full golden, compatibility, fuzz, real-world, serial/parallel, and
 normalized-error corpus gates remain open. A bounded seeded differential-fuzz

--- a/crates/geo-polygonize-core/src/noding/monotone.rs
+++ b/crates/geo-polygonize-core/src/noding/monotone.rs
@@ -93,13 +93,13 @@ pub(crate) fn node_hybrid_source_chains(
         })?;
     }
 
-    let (noded, split_events) = if events.is_empty() {
-        let mut noded = lines;
-        snap_noder.normalize_and_dedup(&mut noded);
-        (noded, 0)
+    let (mut noded, split_events) = if events.is_empty() {
+        (lines, 0)
     } else {
         snap_noder.apply_split_events_for_research(&lines, events, execution_policy)?
     };
+    noded.retain(|line| line.start.to_coord_2d() != line.end.to_coord_2d());
+    snap_noder.normalize_and_dedup(&mut noded);
     work_stats.split_events = split_events;
     ValidatingNoder::new().validate_with_execution_policy(&noded, execution_policy)?;
     Ok((noded, work_stats))
@@ -1116,6 +1116,15 @@ mod tests {
             include_str!("../../tests/fixtures/compat/floating_microfaces.json"),
             2,
             4,
+        );
+    }
+
+    #[test]
+    fn hybrid_experiment_matches_zero_length_fixture_fingerprint() {
+        assert_hybrid_matches_fixture_fingerprint(
+            include_str!("../../tests/fixtures/compat/zero_length_segment.json"),
+            0,
+            0,
         );
     }
 


### PR DESCRIPTION
Makes the research-only MCIndex hybrid adapter match the shared SnapNoder contract for zero-length input: degenerate segments are removed before normalization and validation. Adds the zero-length compatibility fixture to the canonical fingerprint differential path. No production dispatch changes; broader golden, compatibility, fuzz, real-world, and promotion gates remain open.\n\nValidated locally:\n- 24 monotone tests\n- 430 default core library tests\n- 430 no-default core library tests\n- clippy -D warnings\n- rustfmt and diff checks