### PR TITLE
test(core): cover MCIndex provenance fixture parity

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -380,7 +380,7 @@ partial-overlap, nested-ring, and canonical feature-build fingerprint cases.
 The focused corpus also includes a fixture-backed square-with-hole fingerprint
 case, a dirty-bowtie fingerprint case, and a floating-microfaces compatibility
 fingerprint case. The focused fixture set also covers zero-length compatibility
-normalization.
+normalization and a profile-bearing provenance fingerprint case.
 The focused comparisons execute under both default and no-default core builds;
 the full golden, compatibility, fuzz, real-world, serial/parallel, and
 normalized-error corpus gates remain open. A bounded seeded differential-fuzz

--- a/crates/geo-polygonize-core/src/noding/monotone.rs
+++ b/crates/geo-polygonize-core/src/noding/monotone.rs
@@ -515,6 +515,7 @@ mod tests {
     #[derive(Deserialize)]
     struct Fixture {
         options: Option<PolygonizerOptions>,
+        profile_id: Option<String>,
         inputs: Vec<FixtureLine>,
     }
 
@@ -539,6 +540,7 @@ mod tests {
     ) {
         let fixture: Fixture = serde_json::from_str(source).unwrap();
         let mut options = fixture.options.unwrap_or_default();
+        options.input_profile_id = fixture.profile_id;
         options.diagnostics = DiagnosticsOptions {
             enabled: true,
             ..Default::default()
@@ -1124,6 +1126,15 @@ mod tests {
         assert_hybrid_matches_fixture_fingerprint(
             include_str!("../../tests/fixtures/compat/zero_length_segment.json"),
             0,
+            0,
+        );
+    }
+
+    #[test]
+    fn hybrid_experiment_matches_provenance_fixture_fingerprint() {
+        assert_hybrid_matches_fixture_fingerprint(
+            include_str!("../../tests/fixtures/provenance/mixed_boundary_with_profile.json"),
+            2,
             0,
         );
     }


### PR DESCRIPTION
Adds the profile-bearing provenance fixture to the research-only MCIndex hybrid differential path and preserves its input profile in the canonical options fingerprint. The test compares topology, diagnostics, provenance, and two-polygon output against the shared SnapNoder baseline. No production dispatch changes; broader golden, compatibility, fuzz, real-world, and promotion gates remain open.\n\nValidated locally:\n- 25 monotone tests\n- 431 default core library tests\n- 431 no-default core library tests\n- clippy -D warnings\n- rustfmt and diff checks