### PR TITLE
test(core): cover MCIndex Z fixture parity

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -381,6 +381,7 @@ The focused corpus also includes a fixture-backed square-with-hole fingerprint
 case, a dirty-bowtie fingerprint case, and a floating-microfaces compatibility
 fingerprint case. The focused fixture set also covers zero-length compatibility
 normalization and a profile-bearing provenance fingerprint case.
+The focused fixture set also covers the Z Ignore policy fingerprint.
 The focused comparisons execute under both default and no-default core builds;
 the full golden, compatibility, fuzz, real-world, serial/parallel, and
 normalized-error corpus gates remain open. A bounded seeded differential-fuzz

--- a/crates/geo-polygonize-core/src/noding/monotone.rs
+++ b/crates/geo-polygonize-core/src/noding/monotone.rs
@@ -1140,6 +1140,15 @@ mod tests {
     }
 
     #[test]
+    fn hybrid_experiment_matches_z_ignore_fixture_fingerprint() {
+        assert_hybrid_matches_fixture_fingerprint(
+            include_str!("../../tests/fixtures/z/ignore_conflicts.json"),
+            1,
+            0,
+        );
+    }
+
+    #[test]
     fn hybrid_experiment_matches_overlap_and_nested_ring_cases() {
         let (overlapping, overlapping_chains) = original_chains(&[
             &[(0.0, 0.0), (4.0, 0.0)],


### PR DESCRIPTION
Adds the Z Ignore compatibility fixture to the research-only MCIndex hybrid differential path. The test compares the canonical topology fingerprint, diagnostics, provenance, and one-polygon output against the shared SnapNoder baseline while preserving the fixture’s Z policy. No production dispatch changes; broader golden, compatibility, fuzz, real-world, and promotion gates remain open.\n\nValidated locally:\n- 26 monotone tests\n- 432 default core library tests\n- 432 no-default core library tests\n- clippy -D warnings\n- rustfmt and diff checks