### PR TITLE
test(core): cover MCIndex normalized error parity

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -382,6 +382,7 @@ case, a dirty-bowtie fingerprint case, and a floating-microfaces compatibility
 fingerprint case. The focused fixture set also covers zero-length compatibility
 normalization and a profile-bearing provenance fingerprint case.
 The focused fixture set also covers the Z Ignore policy fingerprint.
+It also compares the Z conflict failure through the normalized-error contract.
 The focused comparisons execute under both default and no-default core builds;
 the full golden, compatibility, fuzz, real-world, serial/parallel, and
 normalized-error corpus gates remain open. A bounded seeded differential-fuzz

--- a/crates/geo-polygonize-core/src/noding/monotone.rs
+++ b/crates/geo-polygonize-core/src/noding/monotone.rs
@@ -533,11 +533,7 @@ mod tests {
         z: f64,
     }
 
-    fn assert_hybrid_matches_fixture_fingerprint(
-        source: &str,
-        expected_polygon_count: usize,
-        expected_dangle_count: usize,
-    ) {
+    fn fixture_inputs(source: &str) -> (Vec<Line3D>, Vec<SourceLineString>, PolygonizerOptions) {
         let fixture: Fixture = serde_json::from_str(source).unwrap();
         let mut options = fixture.options.unwrap_or_default();
         options.input_profile_id = fixture.profile_id;
@@ -570,6 +566,15 @@ mod tests {
                 kind: SourceChainKind::Original,
             })
             .collect();
+        (lines, chains, options)
+    }
+
+    fn assert_hybrid_matches_fixture_fingerprint(
+        source: &str,
+        expected_polygon_count: usize,
+        expected_dangle_count: usize,
+    ) {
+        let (lines, chains, options) = fixture_inputs(source);
         let snap_noder = SnapNoder::new(0.0);
         let expected = snap_noder.node(lines.clone());
         let (actual, _) =
@@ -1146,6 +1151,27 @@ mod tests {
             1,
             0,
         );
+    }
+
+    #[test]
+    fn hybrid_experiment_matches_z_conflict_normalized_error() {
+        let (lines, chains, mut options) =
+            fixture_inputs(include_str!("../../tests/fixtures/z/ignore_conflicts.json"));
+        options.z.policy = crate::ZPolicy::ErrorOnConflict;
+        options.z.conflict_tolerance = 0.0;
+        let snap_noder = SnapNoder::new(0.0);
+        let expected = snap_noder.node(lines.clone());
+        let (actual, _) =
+            node_hybrid_source_chains(lines, &chains, &snap_noder, &ExecutionPolicy::default())
+                .unwrap();
+        let expected_error =
+            normalize_polygonize_error(&polygonize(expected, &options).unwrap_err());
+        let actual_error = normalize_polygonize_error(&polygonize(actual, &options).unwrap_err());
+
+        assert_eq!(actual_error, expected_error);
+        assert_eq!(actual_error.family, "topology");
+        assert_eq!(actual_error.code, "z_conflict");
+        assert_eq!(actual_error.stage, "z_reconciliation");
     }
 
     #[test]


### PR DESCRIPTION
Adds a normalized-error differential check for the Z conflict fixture. The research-only MCIndex hybrid noder and the shared SnapNoder baseline now prove identical topology/z_conflict/z_reconciliation error contracts under the same options. No production dispatch changes; broader golden, compatibility, fuzz, real-world, serial/parallel, and promotion gates remain open.\n\nValidated locally:\n- 27 monotone tests\n- 433 default core library tests\n- 433 no-default core library tests\n- clippy -D warnings\n- rustfmt and diff checks