### PR TITLE
test(core): cover MCIndex serial-parallel parity

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -383,6 +383,8 @@ fingerprint case. The focused fixture set also covers zero-length compatibility
 normalization and a profile-bearing provenance fingerprint case.
 The focused fixture set also covers the Z Ignore policy fingerprint.
 It also compares the Z conflict failure through the normalized-error contract.
+The square-with-hole parity case also verifies the native serial/parallel graph
+dispatch selected by the corresponding feature build.
 The focused comparisons execute under both default and no-default core builds;
 the full golden, compatibility, fuzz, real-world, serial/parallel, and
 normalized-error corpus gates remain open. A bounded seeded differential-fuzz

--- a/crates/geo-polygonize-core/src/noding/monotone.rs
+++ b/crates/geo-polygonize-core/src/noding/monotone.rs
@@ -479,6 +479,7 @@ fn invalid_range(start: usize, count: usize) -> PolygonizeError {
 mod tests {
     use super::*;
     use crate::types::{Coord3D, SourceChainKind};
+    use crate::utils::parallel::{par_flat_map_dispatches, reset_par_flat_map_dispatches};
     use crate::{
         normalize_polygonize_error, polygonize, CancellationToken, DiagnosticsOptions,
         ExecutionPolicy, PolygonizerOptions, ProvenanceOptions, TopologyFingerprintV1,
@@ -1101,11 +1102,17 @@ mod tests {
 
     #[test]
     fn hybrid_experiment_matches_square_with_hole_fixture_fingerprint() {
+        reset_par_flat_map_dispatches();
         assert_hybrid_matches_fixture_fingerprint(
             include_str!("../../tests/fixtures/basic/square_with_hole.json"),
             2,
             0,
         );
+        if cfg!(feature = "parallel") && !cfg!(target_arch = "wasm32") {
+            assert!(par_flat_map_dispatches() > 0);
+        } else {
+            assert_eq!(par_flat_map_dispatches(), 0);
+        }
     }
 
     #[test]


### PR DESCRIPTION
Extends the existing square-with-hole hybrid fingerprint parity test with native graph-dispatch evidence: the default parallel build must record a Rayon-backed graph dispatch, while the no-default build must remain serial. Both modes retain the same canonical fingerprint comparison. No production dispatch changes; broader golden, compatibility, fuzz, real-world, and promotion gates remain open.\n\nValidated locally:\n- 27 monotone tests\n- 433 default core library tests\n- 433 no-default core library tests\n- focused serial/parallel parity test in both modes\n- clippy -D warnings\n- rustfmt and diff checks