### PR TITLE
test(core): record MCIndex candidate reduction

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -385,6 +385,9 @@ The focused fixture set also covers the Z Ignore policy fingerprint.
 It also compares the Z conflict failure through the normalized-error contract.
 The square-with-hole parity case also verifies the native serial/parallel graph
 dispatch selected by the corresponding feature build.
+The existing grid_10 fixture now records exact-intersection candidate reduction
+against all possible segment pairs; dedicated production-scale measurement gates
+remain open.
 The focused comparisons execute under both default and no-default core builds;
 the full golden, compatibility, fuzz, real-world, serial/parallel, and
 normalized-error corpus gates remain open. A bounded seeded differential-fuzz

--- a/crates/geo-polygonize-core/src/noding/monotone.rs
+++ b/crates/geo-polygonize-core/src/noding/monotone.rs
@@ -1078,6 +1078,17 @@ mod tests {
     }
 
     #[test]
+    fn hybrid_experiment_records_grid_candidate_reduction() {
+        let (lines, chains, _) =
+            fixture_inputs(include_str!("../../tests/fixtures/benchmark/grid_10.json"));
+        let possible_pairs = lines.len() * lines.len().saturating_sub(1) / 2;
+        let stats = assert_hybrid_matches_snap(lines, &chains);
+
+        assert!(stats.exact_intersection_calls < possible_pairs);
+        assert!(stats.candidate_pairs >= stats.exact_intersection_calls);
+    }
+
+    #[test]
     fn hybrid_experiment_matches_canonical_feature_build_fingerprint() {
         let (lines, chains) = original_chains(&[
             &[(0.0, 0.0), (4.0, 0.0), (4.0, 4.0), (0.0, 4.0), (0.0, 0.0)],


### PR DESCRIPTION
Adds bounded candidate-reduction evidence on the existing grid_10 fixture. The hybrid adapter still matches the SnapNoder output exactly, while its exact-intersection calls remain below the all-pairs segment baseline. This is focused evidence only; production-scale timing, allocation, RSS, Wasm, code-size, and compile-time gates remain open.\n\nValidated locally:\n- 28 monotone tests\n- 434 default core library tests\n- 434 no-default core library tests\n- clippy -D warnings\n- rustfmt and diff checks